### PR TITLE
fix(ci): build images from the repo root

### DIFF
--- a/packages/internal-scripts/src/build-and-push-image.ts
+++ b/packages/internal-scripts/src/build-and-push-image.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import { $ } from 'bun';
 import { writeSummary } from '#shared/actions.ts';
 import { optionalEnv, requiredEnv } from '#shared/env.ts';
+import { repoRoot } from '#shared/paths.ts';
 
 const imageUri = `${requiredEnv('IMAGE_REPOSITORY')}:${requiredEnv('IMAGE_TAG')}`;
 const dockerfile = requiredEnv('DOCKERFILE');
@@ -45,4 +46,6 @@ const argv = [
 
 // Echoed so a failing CI build can be reproduced by copy-paste.
 core.info(`$ ${argv.map((arg) => $.escape(arg)).join(' ')}`);
-await $`${argv}`;
+// `bun run --filter` runs from the package directory, so the context and
+// dockerfile inputs would resolve against packages/internal-scripts.
+await $`${argv}`.cwd(repoRoot);

--- a/packages/internal-scripts/src/build-and-push-image.ts
+++ b/packages/internal-scripts/src/build-and-push-image.ts
@@ -46,6 +46,4 @@ const argv = [
 
 // Echoed so a failing CI build can be reproduced by copy-paste.
 core.info(`$ ${argv.map((arg) => $.escape(arg)).join(' ')}`);
-// `bun run --filter` runs from the package directory, so the context and
-// dockerfile inputs would resolve against packages/internal-scripts.
 await $`${argv}`.cwd(repoRoot);


### PR DESCRIPTION
The first CD run failed with `lstat apps: no such file or directory`.

`bun run --filter` runs a script from its own package directory, so the composite action's relative inputs (`context: .`, `dockerfile: apps/api/Dockerfile`) resolved against `packages/internal-scripts`. The other scripts already guard against this via `shared/paths.ts`; this one didn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)