### PR TITLE
fix(infra): correct the DLM managed policy ARN

### DIFF
--- a/infra/terraform/dlm.tf
+++ b/infra/terraform/dlm.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role" "dlm" {
 
 resource "aws_iam_role_policy_attachment" "dlm" {
   role       = aws_iam_role.dlm.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSDataLifecycleManagerServiceRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole"
 }
 
 # Block-level counterpart to pg-backup's nightly logical dump, and the only


### PR DESCRIPTION
AWS-managed service-role policies live under a `service-role/` path. Without it the attach fails with NoSuchEntity, which only surfaces at apply time — `terraform validate` cannot check a managed policy ARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)