### PR TITLE
fix(infra): region-qualify the bucket names

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,8 +83,7 @@ jobs:
       - name: Terraform apply
         id: tf
         # The AWS provider retries some failures far longer than a deploy should
-        # wait, and the job default is six hours. Note a kill here strands the
-        # state lock: the next run needs `terraform force-unlock`.
+        # wait, and the job default is six hours.
         timeout-minutes: 15
         env:
           TF_VAR_region: ${{ env.AWS_REGION }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,6 +82,10 @@ jobs:
 
       - name: Terraform apply
         id: tf
+        # The AWS provider retries some failures far longer than a deploy should
+        # wait, and the job default is six hours. Note a kill here strands the
+        # state lock: the next run needs `terraform force-unlock`.
+        timeout-minutes: 15
         env:
           TF_VAR_region: ${{ env.AWS_REGION }}
           TF_VAR_api_hostname: ${{ vars.API_HOSTNAME }}

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -1,13 +1,17 @@
 # Three buckets rather than one with prefix-scoped rules: each has a different
 # lifecycle, and each feeds exactly one config value, so no name is ever
-# rewritten on the way to the box. Account-id suffix for globally unique names.
+# rewritten on the way to the box.
+#
+# Region suffix because the S3 namespace is global while a bucket is not: AWS
+# holds a deleted name for up to hours, so an unqualified name collides with the
+# one the previous region just released.
 
 # --- Deploy bundles ---
 #
 # The runtime bundle CI uploads and the instance downloads (compose files,
 # on-box scripts). Disposable — every deploy writes a new one.
 resource "aws_s3_bucket" "deploy" {
-  bucket        = "nibrun-deploy-${data.aws_caller_identity.current.account_id}"
+  bucket        = "${local.resource_name_prefix}-deploy-${var.region}"
   force_destroy = true
 
   tags = {
@@ -41,7 +45,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "deploy" {
 # Written nightly by the pg-backup sidecar. Longer retention than the bundles,
 # and never force-destroyed.
 resource "aws_s3_bucket" "backups" {
-  bucket = "nibrun-backups-${data.aws_caller_identity.current.account_id}"
+  bucket = "${local.resource_name_prefix}-backups-${var.region}"
 
   tags = {
     Name = "${local.resource_name_prefix}-backups"
@@ -88,7 +92,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "backups" {
 # The binaries users upload. Customer data that outlives any single deploy, so
 # it is versioned and never force-destroyed.
 resource "aws_s3_bucket" "artifacts" {
-  bucket = "nibrun-artifacts-${data.aws_caller_identity.current.account_id}"
+  bucket = "${local.resource_name_prefix}-artifacts-${var.region}"
 
   tags = {
     Name = "${local.resource_name_prefix}-artifacts"


### PR DESCRIPTION
The three buckets were deleted manually before the region move. AWS holds a deleted bucket name in the global namespace for hours, so recreating them in eu-central-1 returned `OperationAborted` on every attempt — the apply retried for 20+ minutes and never got them.

Region replaces the account id in the name, so a region move can no longer collide with the name the previous region just released. The buckets were empty, and nothing outside `s3.tf` referenced the names.

Also caps `terraform apply` at 15 minutes — the job was on the 6-hour default.

Plan against current state: `14 to add, 0 to change, 0 to destroy`. The existing instance, EIP and volume are untouched; the additions are the buckets, their sub-resources, and the 3 IAM policies that were blocked behind them.