### PR TITLE
fix(ci): publish the api_github_client_id terraform output

### DIFF
--- a/packages/internal-scripts/src/terraform-apply.ts
+++ b/packages/internal-scripts/src/terraform-apply.ts
@@ -7,6 +7,7 @@ const PLAN_FILE = 'tfplan';
 // Consumed by the deploy steps that follow, under these exact names.
 const DEPLOY_OUTPUTS = [
   'api_hostname',
+  'api_github_client_id',
   'api_s3_bucket',
   'api_s3_endpoint',
   'pg_backup_bucket',


### PR DESCRIPTION
`cd.yml` reads `API_GITHUB_CLIENT_ID` from `steps.tf.outputs`, but `terraform-apply` only sets the outputs listed in `DEPLOY_OUTPUTS` — so it resolved to an empty string and the SSM deploy failed on the missing variable.

The repository variable itself was fine; it just never made it back out of the Terraform step.