### PR TITLE
feat(infra): add Dozzle to the stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,10 @@ API_S3_SECRET_ACCESS_KEY=nibrun-local-secret
 # Loopback only (127.0.0.1). S3 API, then the MinIO web console.
 API_S3_PORT=9000
 API_S3_CONSOLE_PORT=9001
+
+# --- Logs ---
+# Dozzle reads the Docker socket and serves every container's logs, with no
+# login of its own. Loopback only (127.0.0.1); SSH-tunnel from your laptop to
+# reach it remotely.
+
+DOZZLE_PORT=8080

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,6 +88,7 @@ jobs:
         env:
           TF_VAR_region: ${{ env.AWS_REGION }}
           TF_VAR_api_hostname: ${{ vars.API_HOSTNAME }}
+          TF_VAR_dozzle_hostname: ${{ vars.DOZZLE_HOSTNAME }}
           TF_VAR_api_github_client_id: ${{ vars.API_GITHUB_CLIENT_ID }}
           TF_VAR_api_github_client_secret: ${{ secrets.API_GITHUB_CLIENT_SECRET }}
           TF_VAR_caddy_tls_cert: ${{ vars.CADDY_TLS_CERT }}
@@ -116,6 +117,7 @@ jobs:
           DATA_VOLUME_ID: ${{ steps.tf.outputs.data_volume_id }}
           API_IMAGE_URI: ${{ steps.api_image.outputs.image-uri }}
           API_HOSTNAME: ${{ steps.tf.outputs.api_hostname }}
+          DOZZLE_HOSTNAME: ${{ steps.tf.outputs.dozzle_hostname }}
           API_GITHUB_CLIENT_ID: ${{ steps.tf.outputs.api_github_client_id }}
           API_S3_BUCKET: ${{ steps.tf.outputs.api_s3_bucket }}
           API_S3_ENDPOINT: ${{ steps.tf.outputs.api_s3_endpoint }}

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           TF_VAR_region: ${{ env.AWS_REGION }}
           TF_VAR_api_hostname: ${{ vars.API_HOSTNAME }}
+          TF_VAR_dozzle_hostname: ${{ vars.DOZZLE_HOSTNAME }}
           TF_VAR_api_github_client_id: ${{ vars.API_GITHUB_CLIENT_ID }}
           TF_VAR_api_github_client_secret: ${{ secrets.API_GITHUB_CLIENT_SECRET }}
           TF_VAR_caddy_tls_cert: ${{ vars.CADDY_TLS_CERT }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ logs
 _.log
 report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
+# Dozzle's user list — rendered on the box from SSM, holds a password hash.
+dozzle/data/
+
 # dotenv environment variable files
 .env
 .env.development.local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,10 +52,26 @@ services:
       start_period: 15s
     environment:
       - API_HOSTNAME
+      - DOZZLE_HOSTNAME
     volumes:
       - ./caddy:/etc/caddy:ro
     networks:
       - nibrun
+
+  # Local reaches Dozzle over loopback and needs no login; here it is behind a
+  # public hostname, so it grows one. Simple auth over forward-proxy because the
+  # edge has no identity to forward — Authenticated Origin Pulls proves the
+  # request came from Cloudflare, not who is making it.
+  #
+  # The user list is built into dozzle/data by on_box_deploy.sh, which hashes
+  # the password it reads from SSM. Mounting the directory rather than the file
+  # means the deploy can replace the file without the container holding the old
+  # inode.
+  dozzle:
+    environment:
+      - DOZZLE_AUTH_PROVIDER=simple
+    volumes:
+      - ./dozzle/data:/data
 
   # Both exist only to stand in for S3 locally. An inactive profile is how a
   # service gets switched off from an override file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-# Local stack: Postgres, MinIO, and the API. Copy .env.example to .env first.
+# Local stack: Postgres, MinIO, the API, and Dozzle. Copy .env.example to .env
+# first.
 #
 # Anything truly opinionated (internal service URLs, container ports, bucket
 # bootstrap) lives here, not in .env.
@@ -110,6 +111,30 @@ services:
         condition: service_healthy
       minio-prepare:
         condition: service_completed_successfully
+    networks:
+      - nibrun
+
+  # Every container's logs, read off the Docker socket, in local and prod alike.
+  # Loopback-only and unauthenticated on purpose: reaching it on the box takes an
+  # SSM port-forward, which already costs AWS credentials. The change that gives
+  # it a public route is the change that has to give it DOZZLE_AUTH_PROVIDER.
+  dozzle:
+    image: amir20/dozzle:v10.6
+    container_name: dozzle
+    environment:
+      - DOZZLE_NO_ANALYTICS=true
+    volumes:
+      # `:ro` covers the socket file, not the Docker API behind it — Dozzle only
+      # ever issues read calls, but nothing here is what stops it.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    ports:
+      - "127.0.0.1:${DOZZLE_PORT}:8080"
+    healthcheck:
+      test: ["CMD", "/dozzle", "healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: always
     networks:
       - nibrun
 

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -29,7 +29,7 @@ terraform apply # prompts for every variable without a default
 ```
 
 Then point an A record at `terraform output public_ip`, **proxied** (orange
-cloud).
+cloud) — one per hostname, `api_hostname` and `dozzle_hostname`.
 
 Sign-in needs a GitHub OAuth App whose callback URL is
 `https://<api_hostname>/api/auth/callback/github`.
@@ -40,6 +40,22 @@ halves are the proxy's TLS inputs; and **Authenticated Origin Pulls → Global**
 on. Enable that last one before the first deploy carrying a proxy — Caddy
 requires the client certificate it turns on, and without it every visitor gets a
 `525`.
+
+The certificate must name **every** hostname the proxy serves — both of them
+today. Caddy serves the one pair from every site block, so a hostname missing
+from it fails the handshake rather than falling back to anything. Adding a
+hostname later means reissuing that certificate and updating both halves, not
+issuing a second one.
+
+Dozzle's password is generated like every other secret. Read it back with:
+
+```sh
+aws ssm get-parameter --name "$(terraform -chdir=infra/terraform output -raw ssm_secret_prefix)/dozzle_password" \
+  --with-decryption --query Parameter.Value --output text
+```
+
+The username is `admin`. Rotating it is a matter of overwriting that parameter —
+the box rebuilds the hashed user list from it on the next deploy.
 
 ## Deploying
 

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -47,16 +47,6 @@ from it fails the handshake rather than falling back to anything. Adding a
 hostname later means reissuing that certificate and updating both halves, not
 issuing a second one.
 
-Dozzle's password is generated like every other secret. Read it back with:
-
-```sh
-aws ssm get-parameter --name "$(terraform -chdir=infra/terraform output -raw ssm_secret_prefix)/dozzle_password" \
-  --with-decryption --query Parameter.Value --output text
-```
-
-The username is `admin`. Rotating it is a matter of overwriting that parameter —
-the box rebuilds the hashed user list from it on the next deploy.
-
 ## Deploying
 
 `.github/workflows/cd.yml`, on every push to main: build both images, apply

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -4,7 +4,7 @@ AWS, one stack, one box. `bootstrap/` is one-time CloudFormation, `terraform/`
 owns the resources, `pg-backup/` is the nightly dump sidecar, `caddy/` is the
 proxy's static config. `deploy/` holds only the two scripts that run *on* the
 box, which is why they are shell — the instance has no Bun. Everything CI runs
-lives in `@repo/internal-scripts`. The EC2 instance runs the compose stack — api and Postgres — behind an
+lives in `@repo/internal-scripts`. The EC2 instance runs the compose stack — api, Postgres and Dozzle — behind an
 elastic IP, with a persistent EBS volume at `/data` and three S3 buckets:
 artifacts for user uploads, backups for Postgres dumps, deploy for runtime
 bundles. MinIO stands in for S3 locally only — `docker-compose.prod.yml` parks
@@ -15,9 +15,9 @@ loopback and on the compose network, which is the path fleet-host agents take
 later. Compute hosts and the CDN still come later.
 
 Config carries its component's prefix — `API_`, `POSTGRES_`, `PG_BACKUP_`,
-`CADDY_` — and keeps one name from the Terraform output through the SSM command
-to the `.env` the box writes. Nothing is aliased in transit, so nothing can
-drift.
+`CADDY_`, `DOZZLE_` — and keeps one name from the Terraform output through the
+SSM command to the `.env` the box writes. Nothing is aliased in transit, so
+nothing can drift.
 
 ## First run
 

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,24 +1,32 @@
 # The public edge, and the only thing on the box listening off-loopback.
 # Cloudflare terminates the visitor's TLS; this terminates the edge-to-origin
-# leg. One hostname, one upstream — routing for user apps is a later phase.
+# leg. Two hostnames, two upstreams — routing for user apps is a later phase.
 {
 	# No ACME: the certificate is a Cloudflare Origin Certificate, which the
-	# deploy fetches from SSM and writes into tls/ next to this file.
+	# deploy fetches from SSM and writes into tls/ next to this file. It names
+	# every hostname below, so both sites serve the same pair.
 	auto_https off
 }
 
-https://{$API_HOSTNAME} {
-	# Authenticated Origin Pulls. The origin IP is discoverable, so the edge has
-	# to prove it is the edge: without a client certificate signed by
-	# Cloudflare's origin-pull CA the handshake is refused before any request is
-	# read. Turning this on also makes Caddy enforce SNI == Host, which closes
-	# Host-header spoofing along with it.
+# Authenticated Origin Pulls. The origin IP is discoverable, so the edge has to
+# prove it is the edge: without a client certificate signed by Cloudflare's
+# origin-pull CA the handshake is refused before any request is read. Turning
+# this on also makes Caddy enforce SNI == Host, which closes Host-header
+# spoofing along with it.
+#
+# A snippet because every site needs it identically, and a site that quietly
+# went without would accept connections straight from the origin IP.
+(origin_tls) {
 	tls /etc/caddy/tls/origin.crt /etc/caddy/tls/origin.key {
 		client_auth {
 			mode require_and_verify
 			trust_pool file /etc/caddy/cloudflare-origin-pull-ca.pem
 		}
 	}
+}
+
+https://{$API_HOSTNAME} {
+	import origin_tls
 
 	# The api serves nothing under /internal yet. Denying the namespace before
 	# it exists is the point: fleet-host agents reach the api over the private
@@ -39,4 +47,17 @@ https://{$API_HOSTNAME} {
 			lb_try_interval 250ms
 		}
 	}
+}
+
+# Container logs. Dozzle authenticates its own visitors (simple auth, prod only)
+# — the edge only gets them here, and deliberately does not add a second gate in
+# front of the login page.
+https://{$DOZZLE_HOSTNAME} {
+	import origin_tls
+
+	# Log streaming is a websocket; reverse_proxy upgrades it as-is. No
+	# lb_try_duration: nothing recreates this container on deploy, so there is no
+	# gap to ride out, and holding a request open would only delay the 502 that
+	# says Dozzle is actually down.
+	reverse_proxy dozzle:8080
 }

--- a/infra/deploy/on_box_deploy.sh
+++ b/infra/deploy/on_box_deploy.sh
@@ -24,6 +24,7 @@ API_DB_NAME="${API_DB_NAME:-nibrun}"
 API_DB_PORT="${API_DB_PORT:-5432}"
 API_S3_PORT="${API_S3_PORT:-9000}"
 API_S3_CONSOLE_PORT="${API_S3_CONSOLE_PORT:-9001}"
+DOZZLE_PORT="${DOZZLE_PORT:-8080}"
 
 log "Ensuring the persistent data volume is mounted and holds the data-bearing volumes"
 bash ensure_data_volume.sh
@@ -84,6 +85,8 @@ API_S3_CONSOLE_PORT=${API_S3_CONSOLE_PORT}
 
 PG_BACKUP_IMAGE_URI=${PG_BACKUP_IMAGE_URI}
 PG_BACKUP_BUCKET=${PG_BACKUP_BUCKET}
+
+DOZZLE_PORT=${DOZZLE_PORT}
 EOF
 
 compose="docker compose -f docker-compose.yml -f docker-compose.prod.yml"

--- a/infra/deploy/on_box_deploy.sh
+++ b/infra/deploy/on_box_deploy.sh
@@ -11,7 +11,7 @@ log() { echo "=== [on_box_deploy $(date -u +%H:%M:%S)] $* ==="; }
 : "${API_IMAGE_URI:?}" "${API_HOSTNAME:?}" "${API_GITHUB_CLIENT_ID:?}" \
   "${API_S3_BUCKET:?}" "${API_S3_ENDPOINT:?}" "${PG_BACKUP_IMAGE_URI:?}" \
   "${PG_BACKUP_BUCKET:?}" "${SSM_SECRET_PREFIX:?}" "${AWS_REGION:?}" \
-  "${DATA_VOLUME_ID:?}"
+  "${DATA_VOLUME_ID:?}" "${DOZZLE_HOSTNAME:?}"
 
 # Per-deployment values no infrastructure resource feeds, still overridable from
 # the deploy so they never have to be edited here. The host port bindings are
@@ -86,6 +86,7 @@ API_S3_CONSOLE_PORT=${API_S3_CONSOLE_PORT}
 PG_BACKUP_IMAGE_URI=${PG_BACKUP_IMAGE_URI}
 PG_BACKUP_BUCKET=${PG_BACKUP_BUCKET}
 
+DOZZLE_HOSTNAME=${DOZZLE_HOSTNAME}
 DOZZLE_PORT=${DOZZLE_PORT}
 EOF
 
@@ -93,6 +94,20 @@ compose="docker compose -f docker-compose.yml -f docker-compose.prod.yml"
 
 log "Pulling images"
 $compose pull
+
+# Dozzle reads a user list holding a bcrypt hash, never the password itself, so
+# something has to do the hashing. Doing it here rather than in Terraform keeps
+# the salt out of state and makes rotation a matter of changing the parameter:
+# the file is rebuilt from it on every deploy. `generate` writes the file to
+# stdout and compose's own chatter to stderr, so the redirect stays clean, and
+# running it through compose takes the image version from docker-compose.yml
+# rather than repeating it here.
+log "Writing the Dozzle user list"
+mkdir -p dozzle/data
+$compose run --rm --no-deps -T --entrypoint /dozzle dozzle generate \
+  --name Admin --email "admin@${API_HOSTNAME}" \
+  --password "$(secret dozzle_password)" admin > dozzle/data/users.yml.new
+mv dozzle/data/users.yml.new dozzle/data/users.yml
 
 log "Starting services (up -d --remove-orphans)"
 $compose up -d --remove-orphans

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -14,6 +14,10 @@ output "api_hostname" {
   value = var.api_hostname
 }
 
+output "dozzle_hostname" {
+  value = var.dozzle_hostname
+}
+
 output "api_github_client_id" {
   description = "Public half of the GitHub OAuth App credentials; the secret half is read from SSM on the box."
   value       = var.api_github_client_id

--- a/infra/terraform/ssm.tf
+++ b/infra/terraform/ssm.tf
@@ -76,6 +76,32 @@ resource "aws_ssm_parameter" "caddy_tls_key" {
   }
 }
 
+# The password for Dozzle's one login. Generated like every other secret here,
+# and read back the same way when you need it:
+#
+#   aws ssm get-parameter --name <ssm_secret_prefix>/dozzle_password \
+#     --with-decryption --query Parameter.Value --output text
+#
+# Only the password lives here, not the user list Dozzle actually reads. That
+# file holds a bcrypt hash, and bcrypt is salted — hashing it here would produce
+# a different value on every plan and rewrite the parameter on every apply. The
+# box hashes this into the file instead, once per deploy, so rotating the
+# password is just changing it here.
+resource "random_password" "dozzle_password" {
+  length  = 32
+  special = false
+}
+
+resource "aws_ssm_parameter" "dozzle_password" {
+  name  = "${var.ssm_secret_prefix}/dozzle_password"
+  type  = "SecureString"
+  value = random_password.dozzle_password.result
+
+  tags = {
+    Name = "${local.resource_name_prefix}-dozzle-password"
+  }
+}
+
 # Credentials of the api's own IAM user (iam_api.tf), not generated here.
 resource "aws_ssm_parameter" "api_s3_access_key_id" {
   name  = "${var.ssm_secret_prefix}/api_s3_access_key_id"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -42,6 +42,21 @@ variable "api_hostname" {
   }
 }
 
+# Named on the origin certificate alongside api_hostname — one certificate, both
+# names, so the proxy has a single pair to serve. Adding a name here means
+# reissuing that certificate, not adding a second one.
+variable "dozzle_hostname" {
+  type        = string
+  description = "Public hostname the container logs are served on. Point an A record at the elastic IP."
+
+  # An unset repository variable arrives empty, and Caddy reads an empty site
+  # address as a catch-all — which would put the logs on the api's hostname.
+  validation {
+    condition     = trimspace(var.dozzle_hostname) != ""
+    error_message = "dozzle_hostname must not be empty."
+  }
+}
+
 # The GitHub OAuth App users sign in with. Its callback URL is tied to
 # api_hostname, so an app is per-deployment — GitHub allows one callback URL per
 # OAuth App. Both halves are created by hand, so unlike every other credential

--- a/packages/internal-scripts/src/ssm-deploy.ts
+++ b/packages/internal-scripts/src/ssm-deploy.ts
@@ -17,6 +17,7 @@ const deployGroup = requiredEnv('DEPLOY_GROUP');
 const onBoxEnv: Record<string, string> = {
   API_IMAGE_URI: requiredEnv('API_IMAGE_URI'),
   API_HOSTNAME: requiredEnv('API_HOSTNAME'),
+  DOZZLE_HOSTNAME: requiredEnv('DOZZLE_HOSTNAME'),
   API_GITHUB_CLIENT_ID: requiredEnv('API_GITHUB_CLIENT_ID'),
   API_S3_BUCKET: requiredEnv('API_S3_BUCKET'),
   API_S3_ENDPOINT: requiredEnv('API_S3_ENDPOINT'),


### PR DESCRIPTION
Container logs for every service in the stack, local and prod, served on their
own hostname behind the existing Caddy edge.

Local reaches it over loopback with no login. Prod puts it on a public name, so
it authenticates: Terraform generates the password into SSM, and the box hashes
it into Dozzle's user list on every deploy — rotating it is a matter of
overwriting the parameter. The origin certificate carries both hostnames, so
there is one pair to serve and one `tls` snippet both sites import.

Needs a `DOZZLE_HOSTNAME` repository variable and a proxied A record before the
first deploy.