### PR TITLE
fix(ci): publish the dozzle_hostname terraform output

### DIFF
--- a/packages/internal-scripts/src/terraform-apply.ts
+++ b/packages/internal-scripts/src/terraform-apply.ts
@@ -7,6 +7,7 @@ const PLAN_FILE = 'tfplan';
 // Consumed by the deploy steps that follow, under these exact names.
 const DEPLOY_OUTPUTS = [
   'api_hostname',
+  'dozzle_hostname',
   'api_github_client_id',
   'api_s3_bucket',
   'api_s3_endpoint',


### PR DESCRIPTION
`DEPLOY_OUTPUTS` is the allowlist of terraform outputs that reach the workflow,
and `dozzle_hostname` was not on it — so the deploy step read an empty value and
`ssm-deploy` failed on its required-env check. Same fix as #8.

Terraform applied fine on the merged deploy; only the SSM step failed, so a
re-run after this lands should go green.