### PR TITLE
feat(infra): add the app host machine class

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -1,23 +1,21 @@
 # infra
 
-AWS, one stack, one box. `bootstrap/` is one-time CloudFormation, `terraform/`
-owns the resources, `pg-backup/` is the nightly dump sidecar, `caddy/` is the
-proxy's static config. `deploy/` holds only the two scripts that run *on* the
-box, which is why they are shell — the instance has no Bun. Everything CI runs
-lives in `@repo/internal-scripts`. The EC2 instance runs the compose stack — api, Postgres and Dozzle — behind an
-elastic IP, with a persistent EBS volume at `/data` and three S3 buckets:
-artifacts for user uploads, backups for Postgres dumps, deploy for runtime
-bundles. MinIO stands in for S3 locally only — `docker-compose.prod.yml` parks
-it on an inactive profile and points the api at the real bucket.
+AWS, one stack, two machine classes: the control plane runs the compose stack,
+app hosts run tenant microVMs. `bootstrap/` is one-time CloudFormation,
+`terraform/` owns the resources, `pg-backup/` is the nightly dump sidecar,
+`caddy/` is the proxy's static config. `deploy/` holds only the scripts that run
+*on* a box, which is why they are shell — an instance has no Bun. Everything CI
+runs lives in `@repo/internal-scripts`.
 
-Caddy terminates TLS on 443 and is the whole public surface; the api stays on
-loopback and on the compose network, which is the path fleet-host agents take
-later. Compute hosts and the CDN still come later.
+The Terraform explains itself; read it rather than a description of it here.
+
+MinIO stands in for S3 locally only — `docker-compose.prod.yml` parks it on an
+inactive profile and points the api at the real bucket.
 
 Config carries its component's prefix — `API_`, `POSTGRES_`, `PG_BACKUP_`,
-`CADDY_`, `DOZZLE_` — and keeps one name from the Terraform output through the
-SSM command to the `.env` the box writes. Nothing is aliased in transit, so
-nothing can drift.
+`CADDY_`, `DOZZLE_` — unless more than one component reads it, and keeps one
+name from the Terraform output through the SSM command to the `.env` the box
+writes. Nothing is aliased in transit, so nothing can drift.
 
 ## First run
 

--- a/infra/terraform/app_host.tf
+++ b/infra/terraform/app_host.tf
@@ -1,0 +1,104 @@
+locals {
+  # Its own group, because an app host runs none of the control plane's software
+  # and the deploy has to be able to target the two classes separately.
+  app_host_deploy_group = "${local.resource_name_prefix}-app-host"
+}
+
+# The second machine class: no compose stack, and no Docker at all. The agent
+# manipulates host networking and spawns microVMs, so containerising it would
+# hand back every privilege the container removes.
+#
+# Terraform does not provision these dynamically — the fleet size is
+# var.app_host_count and scaling is changing it. The api holds no EC2
+# permissions on purpose: ec2:RunInstances plus iam:PassRole on a public-facing
+# service is not an acceptable risk at this stage.
+resource "aws_instance" "app_host" {
+  count = var.app_host_count
+
+  ami                    = data.aws_ssm_parameter.al2023_ami.value
+  instance_type          = var.app_host_instance_type
+  subnet_id              = aws_subnet.app.id
+  vpc_security_group_ids = [aws_security_group.app_host.id]
+  iam_instance_profile   = aws_iam_instance_profile.app_host.name
+
+  # A public address with no inbound rule costs nothing in exposure and buys
+  # outbound reach through the internet gateway, so bootstrap installs packages
+  # and fetches binaries the ordinary way instead of everything being mirrored
+  # into S3 first. No NAT gateway: NAT is for tenant egress, and no tenant app
+  # runs in this phase.
+  associate_public_ip_address = true
+
+  depends_on = [aws_route_table_association.app]
+
+  user_data                   = templatefile("${path.module}/app_host_user_data.sh.tftpl", {})
+  user_data_replace_on_change = false
+
+  root_block_device {
+    volume_size = var.app_host_root_volume_size
+    volume_type = "gp3"
+    encrypted   = true
+
+    tags = merge(local.common_tags, {
+      Name = "${local.resource_name_prefix}-app-host-${count.index}-root"
+    })
+  }
+
+  metadata_options {
+    http_tokens   = "required" # IMDSv2 only
+    http_endpoint = "enabled"
+    # One hop, unlike the control plane. A tenant microVM sits behind a tap
+    # device, so its packets reach IMDS forwarded by the host kernel with the
+    # hop already spent — which is what stops a guest minting this role's
+    # credentials. Nothing here runs in a container, so no workload of ours
+    # needs the second hop.
+    http_put_response_hop_limit = 1
+  }
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
+
+  tags = {
+    Name        = "${local.resource_name_prefix}-app-host-${count.index}"
+    DeployGroup = local.app_host_deploy_group
+  }
+}
+
+# ZeroFS's local cache, mounted at /data. Not where tenant data lives — S3 is
+# the source of truth and a host can be rebuilt from it — so the snapshots this
+# picks up are about bringing a replacement host back warm rather than about
+# durability, and prevent_destroy is about a plan never pulling a disk out from
+# under running microVMs.
+#
+# prevent_destroy under count applies to every element, which makes scaling
+# *down* a two-step operation rather than a decrement: lowering
+# var.app_host_count makes Terraform plan a destroy of the highest-index volume,
+# and prevent_destroy turns that into a hard plan error rather than a warning.
+# Drain the host, remove its volume and attachment from state (and delete the
+# volume by hand), then lower the count.
+resource "aws_ebs_volume" "app_host_data" {
+  count = var.app_host_count
+
+  availability_zone = local.availability_zone
+  size              = var.app_host_data_volume_size
+  type              = "gp3"
+  encrypted         = true
+
+  tags = {
+    Name = "${local.resource_name_prefix}-app-host-${count.index}-data"
+    # The DLM snapshot policy targets volumes by this tag.
+    Backup = local.resource_name_prefix
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_volume_attachment" "app_host_data" {
+  count = var.app_host_count
+
+  device_name = "/dev/sdf"
+  volume_id   = aws_ebs_volume.app_host_data[count.index].id
+  instance_id = aws_instance.app_host[count.index].id
+}

--- a/infra/terraform/app_host_user_data.sh.tftpl
+++ b/infra/terraform/app_host_user_data.sh.tftpl
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euxo pipefail
+
+# nbd is not in the base kernel package on AL2023 and ZeroFS serves every app
+# disk over it. Pinned to the running kernel, because the update below can stage
+# a newer one that is not booted yet, and done before that update so the pair
+# moves forward together. Best-effort: on a kernel that already carries nbd this
+# package is redundant, and the modprobe further down is the real gate.
+dnf install -y "kernel-modules-extra-$(uname -r)" || true
+
+dnf update -y
+
+# Only what the deploy itself needs to run. No Docker: everything this host runs
+# is a versioned binary the deploy fetches from S3 and starts under systemd.
+dnf install -y unzip
+
+# Not guaranteed on minimal AL2023, and the deploy script needs it.
+if ! command -v aws >/dev/null 2>&1; then
+  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+  unzip -q /tmp/awscliv2.zip -d /tmp
+  /tmp/aws/install
+fi
+
+# nbds_max is read only when the module loads and caps how many app disks one
+# host can serve, so it is set before the modprobe rather than discovered later;
+# raising it means reloading the module. Nothing auto-loads nbd, because there
+# is no device present to trigger it — ZeroFS creates the devices afterwards.
+#
+# kvm_intel is loaded explicitly rather than left to the CPU-feature autoload so
+# that an instance type without nested virtualisation fails the bootstrap
+# outright: the marker below is never written, and the deploy times out waiting
+# for it instead of installing an agent onto a host that can never boot a
+# microVM.
+echo "options nbd nbds_max=64" > /etc/modprobe.d/nibrun.conf
+printf 'kvm_intel\nnbd\n' > /etc/modules-load.d/nibrun.conf
+modprobe kvm_intel
+modprobe nbd
+
+mkdir -p /opt/nibrun /var/lib/nibrun
+
+# Completion marker — the deploy workflow waits for this, so it never lands on a
+# host without the AWS CLI, KVM or nbd. Kept outside /opt/nibrun because the
+# deploy command writes into that directory, and named for this machine class
+# rather than sharing the control plane's: the two bootstrap differently, and a
+# deploy waiting on the wrong marker would be waiting on a promise nobody made.
+touch /opt/nibrun-app-host-bootstrap.done

--- a/infra/terraform/dlm.tf
+++ b/infra/terraform/dlm.tf
@@ -23,9 +23,10 @@ resource "aws_iam_role_policy_attachment" "dlm" {
 }
 
 # Block-level counterpart to pg-backup's nightly logical dump, and the only
-# backup anything on the volume other than Postgres has.
+# backup anything on the control plane's volume other than Postgres has. Tag-
+# driven, so an app host's cache volume opts in by carrying the same tag.
 resource "aws_dlm_lifecycle_policy" "data" {
-  description        = "Daily snapshots of the nibrun data volume"
+  description        = "Daily snapshots of the nibrun data volumes"
   execution_role_arn = aws_iam_role.dlm.arn
   state              = "ENABLED"
 

--- a/infra/terraform/iam_api.tf
+++ b/infra/terraform/iam_api.tf
@@ -16,7 +16,7 @@ resource "aws_iam_access_key" "api" {
 }
 
 data "aws_iam_policy_document" "api_s3" {
-  # Scoped to the artifacts bucket and nothing else — this credential lives in a
+  # Kept as tight as the api can function with — this credential lives in a
   # container serving public traffic.
   statement {
     sid       = "ArtifactsObjects"
@@ -28,6 +28,33 @@ data "aws_iam_policy_document" "api_s3" {
     sid       = "ArtifactsList"
     actions   = ["s3:ListBucket"]
     resources = [aws_s3_bucket.artifacts.arn]
+  }
+
+  # Read-only on tenant filesystems, for export: it runs in the control plane and
+  # pulls a copy of the app's data out of the disk image ZeroFS wrote.
+  #
+  # This is the tightest grant that works today, and today nothing reads it. It
+  # will not be enough when export is built: a ZeroFS reader registers and renews
+  # its own ephemeral checkpoint so the writer's GC cannot delete what it is
+  # reading, so a strictly read-only grant fails at startup. Do not widen this to
+  # a blanket write when that happens — either add an explicit Deny on the keys
+  # holding tenant data, which keeps the guarantee structural, or copy the prefix
+  # elsewhere and read the copy, which keeps this grant at nothing.
+  #
+  # On this user rather than on the instance role because export runs inside the
+  # api, and the api reaches S3 with these static keys — which is the whole
+  # reason the user exists. When the api falls back to the default credential
+  # chain and this file goes away, the grant moves to aws_iam_role.instance.
+  statement {
+    sid       = "FilesystemsObjects"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.filesystems.arn}/*"]
+  }
+
+  statement {
+    sid       = "FilesystemsList"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.filesystems.arn]
   }
 }
 

--- a/infra/terraform/iam_app_host.tf
+++ b/infra/terraform/iam_app_host.tf
@@ -1,0 +1,100 @@
+# The app host's own role, separate from the control plane's (iam_instance.tf)
+# because the two machine classes want opposite grants on the same buckets: this
+# one writes tenant filesystems and only reads artifacts, and the control plane
+# is the other way round.
+#
+# ZeroFS resolves AWS credentials through the default chain, so this role is all
+# it needs — no static keys are provisioned for it, unlike the api (iam_api.tf).
+resource "aws_iam_role" "app_host" {
+  name               = "${local.resource_name_prefix}-app-host"
+  assume_role_policy = data.aws_iam_policy_document.instance_assume.json
+
+  tags = {
+    Name = "${local.resource_name_prefix}-app-host"
+  }
+}
+
+# SSM Session Manager + SSM RunCommand agent connectivity. Both are outbound
+# from the host, which is why the security group needs no inbound rule for
+# shell access or for deploys.
+resource "aws_iam_role_policy_attachment" "app_host_ssm_core" {
+  role       = aws_iam_role.app_host.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+data "aws_iam_policy_document" "app_host" {
+  # ZeroFS's backing store, and the only bucket this role writes. Multipart is
+  # explicit because ZeroFS uploads segments that way and cannot clean up after
+  # a failed upload without the abort.
+  statement {
+    sid = "FilesystemsWrite"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:AbortMultipartUpload",
+    ]
+    resources = ["${aws_s3_bucket.filesystems.arn}/*"]
+  }
+
+  statement {
+    sid       = "FilesystemsList"
+    actions   = ["s3:ListBucket", "s3:ListBucketMultipartUploads"]
+    resources = [aws_s3_bucket.filesystems.arn]
+  }
+
+  # Tenant binaries, read-only: the host boots them, the api is what uploads
+  # them, so a compromised host cannot rewrite the artifact another host runs.
+  statement {
+    sid       = "ArtifactsRead"
+    actions   = ["s3:GetObject", "s3:ListBucket"]
+    resources = [aws_s3_bucket.artifacts.arn, "${aws_s3_bucket.artifacts.arn}/*"]
+  }
+
+  # The pinned guest image, and this host's own deploy bundle.
+  statement {
+    sid       = "GuestImagesRead"
+    actions   = ["s3:GetObject", "s3:ListBucket"]
+    resources = [aws_s3_bucket.guest_images.arn, "${aws_s3_bucket.guest_images.arn}/*"]
+  }
+
+  statement {
+    sid       = "DeployRead"
+    actions   = ["s3:GetObject", "s3:ListBucket"]
+    resources = [aws_s3_bucket.deploy.arn, "${aws_s3_bucket.deploy.arn}/*"]
+  }
+
+  # Read deployment secrets.
+  statement {
+    sid       = "SsmRead"
+    actions   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+    resources = ["${local.ssm_param_arn_prefix}/*"]
+  }
+
+  # Decrypt SecureString parameters (default aws/ssm KMS key) — scoped to SSM.
+  statement {
+    sid       = "KmsDecryptViaSsm"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${data.aws_region.current.name}.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "app_host" {
+  name   = "${local.resource_name_prefix}-app-host"
+  role   = aws_iam_role.app_host.id
+  policy = data.aws_iam_policy_document.app_host.json
+}
+
+resource "aws_iam_instance_profile" "app_host" {
+  name = "${local.resource_name_prefix}-app-host"
+  role = aws_iam_role.app_host.name
+
+  tags = {
+    Name = "${local.resource_name_prefix}-app-host"
+  }
+}

--- a/infra/terraform/iam_github.tf
+++ b/infra/terraform/iam_github.tf
@@ -57,7 +57,16 @@ data "aws_iam_policy_document" "github_deploy" {
     resources = [aws_s3_bucket.deploy.arn, "${aws_s3_bucket.deploy.arn}/*"]
   }
 
-  # Find the target instance behind the deploy tag.
+  # Publish the pinned guest image. The only other bucket CI writes, and
+  # deliberately not artifacts: the deploy role must never be able to overwrite
+  # a user's binary.
+  statement {
+    sid       = "GuestImageWrite"
+    actions   = ["s3:PutObject", "s3:GetObject", "s3:ListBucket"]
+    resources = [aws_s3_bucket.guest_images.arn, "${aws_s3_bucket.guest_images.arn}/*"]
+  }
+
+  # Find the target instances behind the deploy tag.
   statement {
     sid       = "Ec2Describe"
     actions   = ["ec2:DescribeInstances"]

--- a/infra/terraform/network.tf
+++ b/infra/terraform/network.tf
@@ -52,3 +52,22 @@ resource "aws_route_table_association" "app" {
   subnet_id      = aws_subnet.app.id
   route_table_id = aws_route_table.app.id
 }
+
+# Free, and it keeps the highest-volume traffic in the system — ZeroFS reading
+# and writing segments — off any metered path if egress ever stops going
+# straight out of the internet gateway. Nothing has to be reconfigured to use
+# it: the endpoint routes the region's S3 prefix list, so the existing endpoint
+# hostname keeps working and the control plane's S3 traffic moves onto it too.
+#
+# It adds a route to the table above, but a prefix-list one, which the route
+# table resource leaves alone rather than planning away on the next refresh.
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.app.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.app.id]
+
+  tags = {
+    Name = "${local.resource_name_prefix}-s3"
+  }
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -59,6 +59,33 @@ output "instance_id" {
   value = aws_instance.app.id
 }
 
+output "app_host_deploy_group" {
+  description = "SSM targeting tag for app hosts. Distinct from deploy_group so a deploy reaches one machine class without touching the other."
+  value       = local.app_host_deploy_group
+}
+
+output "app_host_instance_ids" {
+  value = aws_instance.app_host[*].id
+}
+
+# Not a single DATA_VOLUME_ID like the control plane's, because each host has
+# its own: a deploy fanning out looks the instance it is targeting up here and
+# exports that one value under the usual name.
+output "app_host_data_volume_ids" {
+  description = "Instance id to the id of the volume mounted at /data on it."
+  value       = { for index, host in aws_instance.app_host : host.id => aws_ebs_volume.app_host_data[index].id }
+}
+
+output "filesystems_bucket" {
+  description = "ZeroFS's backing store. Read-write from app hosts, read-only from the control plane."
+  value       = aws_s3_bucket.filesystems.bucket
+}
+
+output "guest_images_bucket" {
+  description = "Where CI publishes the pinned guest image and app hosts fetch it from."
+  value       = aws_s3_bucket.guest_images.bucket
+}
+
 output "github_deploy_role_arn" {
   description = "Assumed by the deploy steps, after Terraform has run."
   value       = var.enable_github_deploy ? aws_iam_role.github_deploy[0].arn : null

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -1,6 +1,7 @@
-# Three buckets rather than one with prefix-scoped rules: each has a different
-# lifecycle, and each feeds exactly one config value, so no name is ever
-# rewritten on the way to the box.
+# A bucket per lifecycle rather than one with prefix-scoped rules: each has its
+# own retention, its own access pattern and its own set of principals, and each
+# feeds exactly one config value, so no name is ever rewritten on the way to the
+# box.
 #
 # Region suffix because the S3 namespace is global while a bucket is not: AWS
 # holds a deleted name for up to hours, so an unqualified name collides with the
@@ -121,6 +122,88 @@ resource "aws_s3_bucket_versioning" "artifacts" {
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
   bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# --- Tenant filesystems ---
+#
+# ZeroFS's backing store: one prefix per app, holding the segments that make up
+# that app's disk. Deliberately not a prefix inside artifacts.
+#
+# Versioning is why it cannot share: artifacts has it enabled, and ZeroFS's GC
+# deletes dead segments continuously, so on a versioned bucket every delete
+# would become a delete marker with the object retained — storage growing
+# without bound while the GC reports reclaiming space. Never enable versioning
+# here. The access patterns are opposite too, and deleting an app means
+# bulk-deleting a prefix, which should happen nowhere near users' binaries.
+#
+# Never put a lifecycle expiry on this bucket either. It holds live data: the
+# host's local disk is the cache, and this is what it is a cache of.
+resource "aws_s3_bucket" "filesystems" {
+  bucket = "${local.resource_name_prefix}-filesystems-${var.region}"
+
+  tags = {
+    Name = "${local.resource_name_prefix}-filesystems"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "filesystems" {
+  bucket                  = aws_s3_bucket.filesystems.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "filesystems" {
+  bucket = aws_s3_bucket.filesystems.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# --- Guest images ---
+#
+# The kernel and rootfs app hosts boot microVMs from, pinned by version and
+# fetched once per host. Not the deploy bucket, which carries a 30-day expiry
+# and force_destroy — right for a bundle regenerated on every push, and actively
+# wrong for an image a fleet stays pinned to for months. Not a prefix inside
+# artifacts either: CI writes here, and CI must never hold write access to the
+# bucket holding users' binaries.
+resource "aws_s3_bucket" "guest_images" {
+  bucket = "${local.resource_name_prefix}-guest-images-${var.region}"
+
+  tags = {
+    Name = "${local.resource_name_prefix}-guest-images"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "guest_images" {
+  bucket                  = aws_s3_bucket.guest_images.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "guest_images" {
+  bucket = aws_s3_bucket.guest_images.id
 
   rule {
     apply_server_side_encryption_by_default {

--- a/infra/terraform/security_group.tf
+++ b/infra/terraform/security_group.tf
@@ -37,3 +37,39 @@ resource "aws_security_group" "instance" {
     Name = local.resource_name_prefix
   }
 }
+
+# No ingress at all, and that is the design rather than an omission: nothing
+# needs to reach an app host. The agent dials out for control, so the control
+# channel is never inbound and the control plane never initiates a connection
+# here; export reads a tenant's data from S3 rather than from the host; and
+# shell access is SSM Session Manager, whose agent connects outbound too.
+#
+# Exactly one rule is ever added, when the user-app proxy lands: 443 from
+# Cloudflare's published ranges, with Authenticated Origin Pulls. Pinned to the
+# ranges rather than opened to the world as the control plane's 443 is, because
+# what answers there is a proxy in front of tenant applications — the cost of a
+# directly-reachable origin is somebody else's app, not ours, so it is worth
+# carrying a list that changes underneath us.
+#
+# Written as an explicit empty set rather than an omitted block so a rule added
+# out of band is a diff Terraform removes, not drift it adopts.
+resource "aws_security_group" "app_host" {
+  name        = "${local.resource_name_prefix}-app-host"
+  description = "nibrun app host"
+  vpc_id      = aws_vpc.app.id
+
+  ingress = []
+
+  egress {
+    description      = "All outbound"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name = "${local.resource_name_prefix}-app-host"
+  }
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -21,6 +21,30 @@ variable "data_volume_size" {
   description = "Persistent data EBS volume size in GB. Backs Postgres. Survives instance replacement."
 }
 
+variable "app_host_instance_type" {
+  type        = string
+  default     = "m7i-flex.large"
+  description = "Runs Firecracker microVMs and ZeroFS. Nested virtualisation works on ordinary Intel instances — verified on this one — so this is not a metal type and does not need to be."
+}
+
+variable "app_host_count" {
+  type        = number
+  default     = 1
+  description = "Size of the app host fleet. Terraform does not provision hosts dynamically, so scaling is changing this — but scaling down is not a plain decrement, see app_host.tf."
+}
+
+variable "app_host_root_volume_size" {
+  type        = number
+  default     = 50
+  description = "Root EBS volume size in GB for an app host. Holds the OS, the versioned binaries under /opt/nibrun and the artifact cache under /var/lib/nibrun."
+}
+
+variable "app_host_data_volume_size" {
+  type        = number
+  default     = 100
+  description = "Per-host data EBS volume size in GB, mounted at /data. Sized for ZeroFS's working set, not for the fleet's data — S3 holds that."
+}
+
 variable "vpc_cidr_block" {
   type        = string
   default     = "10.43.0.0/16"


### PR DESCRIPTION
A second machine class for tenant microVMs, plus the storage and credentials it needs. Additive — nothing existing is replaced.

The security group has **no ingress rules at all**, which is the design rather than an omission: the agent dials out, export reads from S3 rather than from the host, and shell access is SSM.

Two new buckets. `filesystems` cannot be a prefix inside `artifacts` because `artifacts` is versioned and ZeroFS's GC deletes segments continuously — every delete would become a delete marker with the object retained. `guest-images` is separate from `deploy` because `deploy` carries a 30-day expiry, and separate from `artifacts` so the CI role never holds write access to the bucket containing tenant binaries.

Verified: `terraform fmt -check` and `terraform validate` both clean. Not verified — no credentials locally — that the plan is non-destructive; the one thing worth a second look is the S3 gateway endpoint against the inline-route `aws_route_table`, though the provider explicitly skips `vpce-` prefix-list routes when it reads them, so it should not churn.