### PR TITLE
feat(agent): add the host agent

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -1,0 +1,223 @@
+# agent
+
+The nibrun host agent. One compiled binary per app host: it opens a session with the control
+plane, long-polls for desired state, converges the host onto it, and reports what it observes.
+It is never sent a command.
+
+Compiles against `@repo/protocol` and nothing else. No third-party dependencies — Bun's
+built-ins cover HTTP, S3, hashing, process spawning and file I/O, and that is what keeps the
+binary small and its supply chain trivial. Everything the host does that Bun cannot do is a
+subprocess: `systemctl`, `ip`, `nft`, `nbd-client`, `mkfs.ext4`, `mksquashfs`, `zerofs`.
+
+## Modules, in dependency order
+
+| Module | What it owns |
+|---|---|
+| `lib/` | exec, atomic JSON files, backoff, structured logging, the one-shape HTTP client |
+| `control/` | the session, and the long-poll client that validates every message it receives |
+| `reconcile/plan.ts` | the pure diff: desired vs observed → a plan. No I/O |
+| `reconcile/reconciler.ts` | applies the plan, holds the bookkeeping, drives the health sweep |
+| `volumes/` | which ZeroFS serves which prefix, device files, NBD attach/detach, the one-time `mkfs`, checkpoints |
+| `vm/` | artifact cache, `instance.env`, the Firecracker config, the systemd template units |
+| `network/` | the slot allocator, tap devices, the whole nftables ruleset |
+| `health/` | the probe, and the reducer that decides `starting` vs `running` vs `failed` |
+| `report/` | instance records, capacity, versions, the report, and the route projection |
+| `aws/` | IMDSv2 credentials, because Bun's S3 client resolves static ones only |
+
+## The decisions worth knowing before reading the code
+
+**The agent does not own the VMs.** Each microVM is a systemd template instance,
+`nibrun-vm@<instance-id>.service`, so Firecracker is a child of init. The agent is the
+component that updates most often; if the VMs were its children, every agent restart would kill
+every tenant app on the host. Restarting the agent is a non-event, and an operator inspects one
+app with `systemctl status` and `journalctl -u nibrun-vm@<id>`.
+
+**Restart policy lives in two layers and they do not overlap.** The *tenant process* is
+restarted by the guest's init, with the budget in `RestartPolicy`; when it exhausts that budget
+the guest powers itself off. The agent then sees the VM exit unasked, reports the instance
+`failed`, and **does not boot it again** — deciding whether to try elsewhere is the reconciler's
+call, and a host that retries forever hides a broken deploy. What the agent *does* retry is its
+own staging failures (an S3 hiccup, a `mkfs` that failed), with exponential backoff read from
+the same `RestartPolicy` numbers, up to `maxRestarts`. A new `deploymentId` resets the budget,
+because that is the reconciler acting.
+
+**A slot is one number per app.** Host port, tap device, guest /30 and NBD minor are all
+derived from it, so there is exactly one thing to persist (`slots.json`) and no way for three of
+the four to survive a restart while the fourth does not. The port is stable for the lifetime of
+the app, which is what makes a redeploy invisible to the routing layer. A slot is released only
+on an explicit volume `absent` — an instance merely missing from desired state is a stop, and
+reusing its port would route one tenant's traffic into another tenant's VM.
+
+**Instances are authoritative, volumes are not.** A microVM the control plane does not mention
+is stopped and forgotten. A volume it does not mention is left exactly as it is; removal is only
+ever an explicit `absent`, because a truncated response must not be able to delete a filesystem.
+A volume marked `absent` while an instance still holds it is reported blocked and torn down on a
+later pass, never mid-flight.
+
+**The last desired state is cached on disk** (`desired-state.json`) and reconciled against
+before the agent has even reached the control plane, so an agent restart during a control-plane
+outage still converges.
+
+**`cache_type: "Writeback"` on the data drive is mandatory.** Firecracker defaults a drive to
+`Unsafe`, which discards flush requests: the guest's `fsync` returns success, ZeroFS is never
+asked to flush, and the loss window stops being the flush interval and becomes unbounded.
+Nothing observable goes wrong until a host dies.
+
+**The host formats the tenant filesystem and never mounts it.** `mkfs.ext4` runs once at
+provisioning; the only other thing the agent reads from the block device is two magic bytes to
+tell a blank device from a provisioned one. Writing a filesystem is not parsing one, and the
+export design depends on the kernel never parsing a tenant-controlled filesystem.
+
+**One ZeroFS per host, and `storagePrefix` is checked rather than assumed.** A device file lives
+*inside* a ZeroFS filesystem, and a ZeroFS filesystem is one `[storage] url` prefix — so how many
+ZeroFS instances a host runs is a topology decision, not a deployment detail. v1 runs one, which
+buys one process, one local cache and one S3 client per host and is the only shape whose cost
+does not scale with tenant count. What it costs: the validated restore property — destroy a host,
+point a new ZeroFS at the same prefix, get the data back byte-identically — is per *host* rather
+than per *app*, and moving one app elsewhere is copying a device file between two filesystems
+rather than repointing at a prefix.
+
+The protocol already accommodates either shape because `storagePrefix` is on the volume; a
+per-host prefix just means every volume on the host repeats it. Nothing in `volumes/` assumes one
+filesystem — the mount path, the NBD socket and the admin RPC are all resolved *per volume* from
+the prefix it names, so one ZeroFS per app is a second factory in `volumes/topology.ts` plus a
+supervisor for the extra processes. A volume naming a prefix this host does not serve is reported
+`failed`, never created here: writing it into the wrong filesystem would put a tenant's data
+under a prefix nothing will ever look for it under, and no later reconcile undoes that.
+
+**Exactly one read-write `zerofs run` per storage prefix, fleet-wide.** ZeroFS does not reject a
+second writer — SlateDB's epoch fences the older one, which then dies on its next durable write,
+after a window in which it has been acknowledging writes that will be silently discarded. A
+duplicate is an outage, not an error message. The agent therefore never starts ZeroFS; systemd's
+own single-instance guarantee is the lock.
+
+**ZeroFS's lifecycle is not the agent's.** Restarting it tears down every NBD connection on the
+host mid-request; the agent only ever calls its admin RPC (`flush`, checkpoints), and flushes
+before every stop and detach because `ignore_fsync` makes the guest's own flushes a no-op. Worst
+case loss is `flush_interval_secs` **plus** the seal and upload — budget 5–15 s at a 5 s interval,
+not exactly 5. `CreateCheckpoint` takes the barrier itself, so no separate flush precedes it.
+
+**The `zerofs` CLI is how the agent drives it**, over `[servers.rpc]` — `flush`, `checkpoint
+create|list|delete`. The npm `zerofs-client` uses koffi native FFI and is unverified on Bun; it is
+deliberately not used. Creating and sizing a device file has no RPC at all and is a plain
+filesystem operation against the host's own mount of ZeroFS. That mount is **not** the tenant's
+ext4: the host writes a sparse *file* into ZeroFS's filesystem and never asks its kernel to
+interpret what that file contains, so the rule that the kernel never parses tenant-controlled
+filesystem metadata is intact. It looks like a violation and is not — `volumes/topology.ts` says
+so at the field it applies to.
+
+**`PORT` in `instance.env` comes from the declared guest port**, and a tenant value for it is
+dropped — it is the number the host forwards to. A value containing a newline has no
+representation in a format with no quoting, so it fails the instance rather than silently
+truncating configuration into the next line.
+
+**Log shipping is not built and must not reuse the control channel.** A log burst must never be
+able to delay a stop.
+
+## What this component needs from `infra/app-host/`
+
+Not owned here. Written down so the change that owns it can implement exactly this.
+
+### `nibrun-vm@.service` — already written, and it matches
+
+- `%i` is the `InstanceId` verbatim. Instance ids are `[0-9A-Za-z][0-9A-Za-z_-]{0,62}`, none of
+  which systemd escapes, so the unit name round-trips.
+- The unit reads **only** `/var/lib/nibrun/vm/%i/firecracker.json`. The agent writes that file,
+  the per-instance `config.squashfs` beside it, and the tap device, before calling
+  `systemctl start`. Nothing is passed on the command line and no environment is required.
+- The agent reaches it with `systemctl start|stop|show|list-units|reset-failed`, and needs
+  `Restart=no` to stay: if systemd restarted the VM, the agent could never report `failed` and
+  an app broken at boot would loop forever unobserved.
+- Firecracker's stdout is the guest console, so `journalctl -u nibrun-vm@<id>` is the tenant's
+  own output, for free.
+- If the jailer is adopted later, every path in `firecracker.json` becomes jail-relative and the
+  agent must stage into `<chroot>/root/`. That is a change to that unit *and* to `vm/manager.ts`
+  — it is not a drop-in.
+
+**One disagreement to settle.** The unit carries `BindsTo=nibrun-zerofs.service`, which stops
+every tenant VM on the host whenever ZeroFS restarts. The measured behaviour is milder than that
+implies: `nbd-client -persist` reconnects on its own, and with `-timeout 600` a ZeroFS restart is
+a *stall* in the guest, not an I/O error — the guest's ext4 only remounts read-only if the
+restart outlasts the timeout. `BindsTo` converts a recoverable stall into a fleet-wide outage,
+and kills VMs mid-write rather than at a durability point. The agent behaves correctly either
+way; this is a blast-radius decision that belongs to whoever owns the unit.
+
+### Still missing: a mount of the ZeroFS filesystem
+
+`[servers.ninep]` is configured but nothing mounts it, and an app's disk is a sparse file the
+agent creates at `<mount>/.nbd/<volume-id>`. Volume provisioning fails at the first step without
+one. Needed: a unit that mounts the 9P socket (`zerofs mount`, FUSE) at `AGENT_ZEROFS_MOUNT`,
+ordered after `nibrun-zerofs.service` and before `nibrun-agent.service`. The RPC admin service
+cannot create files, so there is no way to do this over the socket the agent already uses.
+
+### Filesystem
+
+| Path | Owner | Contents |
+|---|---|---|
+| `/var/lib/nibrun/` | agent, mode 0700 | `host-id`, `slots.json`, `instances.json`, `desired-state.json`, `artifacts/<digest>/`, `vm/<instance-id>/` |
+| `/var/lib/nibrun/bootstrap-token` | provisioning, mode 0600 | the bootstrap credential, delivered via instance user-data |
+| `/run/nibrun/vm-<instance-id>.sock` | the unit | Firecracker API socket. The agent does not use it — the VM is configured entirely by `--config-file` |
+| `/opt/nibrun/bin/guest-image/` | deploy | `vmlinux`, `rootfs.ext4` |
+| `/opt/nibrun/bin/firecracker/` | deploy | `firecracker` |
+| `/etc/nibrun/agent.env` | deploy, mode 0600 | the agent unit's `EnvironmentFile` |
+| `/opt/nibrun/bundle/versions.json` | CI | `{ agent, guestImage, zerofs, firecracker }`, four version **strings** — validated against `HostVersionsSchema`; a missing or differently-shaped file is a hard startup failure. `infra/app-host/versions.json` is a richer object (urls, digests) and is **not** this file |
+| `/mnt/zerofs/` | a ZeroFS FUSE or NFS mount unit | the agent creates `.nbd/<volume-id>` in here |
+| `/run/zerofs/nbd.sock` | zerofs.service | NBD |
+| `/etc/zerofs/config.toml` | deploy | passed to every `zerofs` admin call |
+
+### Host packages and kernel state — none of this is provisioned yet
+
+`iproute2`, `nftables`, `nbd-client`, `e2fsprogs` (`mkfs.ext4`), `squashfs-tools` (`mksquashfs`).
+Nothing in `infra/` installs them today, and each one is a subprocess the agent shells out to.
+
+```
+modprobe nbd nbds_max=256        # the default of 16 caps the host at 16 apps
+sysctl net.ipv4.ip_forward=1
+```
+
+The base `FORWARD` policy must be `ACCEPT`. The agent owns `table ip nibrun` and expresses
+isolation as `drop` rules, which are final wherever they appear; its `accept` rules only end its
+own chain, so it composes with a coexisting ruleset but cannot open one that is closed.
+
+### Agent environment
+
+Required: `AGENT_CONTROL_PLANE_URL`, `AGENT_ARTIFACT_BUCKET`, `AGENT_AWS_REGION`,
+`AGENT_ZEROFS_STORAGE_PREFIX` — the `[storage] url` prefix this host's ZeroFS is pointed at, and
+the value the control plane must put on every volume it places here. It has to match what
+`/etc/zerofs/config.toml` names, or every volume is refused.
+
+Optional, with the defaults in `src/config.ts`: `AGENT_STATE_DIR`, `AGENT_RUNTIME_DIR`,
+`AGENT_BOOTSTRAP_TOKEN_FILE`, `AGENT_VERSIONS_FILE`, `AGENT_GUEST_IMAGE_DIR`,
+`AGENT_FIRECRACKER_DIR`, `AGENT_ZEROFS_MOUNT`, `AGENT_ZEROFS_CONFIG_FILE`,
+`AGENT_ZEROFS_NBD_SOCKET`, `AGENT_LOG_LEVEL`, `AGENT_CONTROL_PLANE_CIDRS`,
+`AGENT_GUEST_DNS_SERVERS`.
+
+The agent's own unit needs `CAP_NET_ADMIN` (tap devices, nftables) and root or equivalent for
+`nbd-client` and `mkfs.ext4`. It must **not** be `Restart=no`: an agent that dies should come
+back, and coming back is safe by construction.
+
+### One thing `apps/runtime` should know
+
+Guests are denied every RFC1918, CGNAT and link-local destination, so the **VPC resolver is not
+reachable** from a guest under the default ruleset. Either `/init` writes a public resolver into
+`/run/resolv.conf`, or the operator names the VPC resolver in `AGENT_GUEST_DNS_SERVERS`, which
+renders an explicit accept for it ahead of the blanket drop.
+
+## What is not tested, and what it would take
+
+Everything that needs a hypervisor, a Linux kernel or AWS is untested — this was written on
+macOS with no AWS credentials. Specifically:
+
+- **The nftables ruleset is rendered and asserted as text, never loaded.** `nft -c -f -` on a
+  Linux host would check the syntax; proving the isolation rules needs a booted guest trying to
+  reach `169.254.169.254`, its neighbour and the control plane.
+- **The Firecracker config is asserted as a structure, never booted.** Firecracker validates it
+  with `deny_unknown_fields`, so a typo is a hard error at boot and nowhere earlier.
+- **NBD attach, `mkfs.ext4`, `mksquashfs`, `systemctl` and `zerofs` are all subprocesses whose
+  invocations are asserted nowhere.** In particular nothing has confirmed that a `truncate` onto
+  a `zerofs mount` produces a device file ZeroFS then exports, which is the single step the whole
+  volume path rests on. The parsers for their *output* are tested against captured
+  formats; the argument lists are not.
+- **S3 and IMDS.** The credential provider is tested against a stub; nothing has spoken to AWS.
+- The Firecracker drive-on-`/dev/nbdN` path is upstream-undocumented — mechanically sound, never
+  run here.

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@repo/agent",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "scripts": {
+    "build": "bun run scripts/build.ts",
+    "test": "bun test",
+    "check:types": "bun run --bun tsc"
+  },
+  "dependencies": {
+    "@repo/protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/agent/scripts/build.ts
+++ b/apps/agent/scripts/build.ts
@@ -1,0 +1,36 @@
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const AGENT_DIR = join(import.meta.dir, '..');
+const AGENT_DIST_DIR = join(AGENT_DIR, 'dist');
+const AGENT_BINARY_FILE = join(AGENT_DIST_DIR, 'nibrun-agent');
+const AGENT_ENTRYPOINT = 'src/index.ts';
+
+// App hosts are x86_64 Linux, and the target names a *released* Bun rather than whichever one
+// runs the build: a canary has no published Linux download, so an unpinned target turns "the
+// developer is on a canary" into a broken deploy instead of a build error. The version tracks
+// `.bun-version`, and the type does not describe the versioned form the CLI accepts.
+const AGENT_COMPILE_TARGET = 'bun-v1.3.14-linux-x64' as unknown as Bun.Build.CompileTarget;
+
+const FAILURE_EXIT_CODE = 1;
+
+console.log('🧹 Cleaning dist dir...');
+await rm(AGENT_DIST_DIR, { recursive: true, force: true });
+
+console.log('🔨 Compiling binary...');
+const buildResult = await Bun.build({
+  entrypoints: [AGENT_ENTRYPOINT],
+  compile: {
+    outfile: AGENT_BINARY_FILE,
+    target: AGENT_COMPILE_TARGET,
+  },
+  minify: { whitespace: true, syntax: true },
+  target: 'bun',
+});
+
+if (!buildResult.success) {
+  console.error('❌ Build failed:', JSON.stringify(buildResult, null, 2));
+  process.exit(FAILURE_EXIT_CODE);
+}
+
+console.log('✅ Done');

--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -1,0 +1,314 @@
+import { join } from 'node:path';
+import {
+  type AgentSession,
+  DEFAULT_AGENT_POLL_SETTINGS,
+  type HostDesiredState,
+  HostDesiredStateSchema,
+  type HostState,
+  type HostVersions,
+  type ObjectKey,
+  ProtocolValidationError,
+  parseMessage,
+  type SecretString,
+} from '@repo/protocol';
+import { InstanceCredentialProvider } from '#aws/instance-credentials.ts';
+import { type AgentConfig, loadAgentConfig } from '#config.ts';
+import { ControlPlaneClient, ControlPlaneError } from '#control/client.ts';
+import { HostIdentity, isSessionExpiring, openSession } from '#control/session.ts';
+import { backoffDelayMs } from '#lib/backoff.ts';
+import { nowTimestamp } from '#lib/clock.ts';
+import { runCommand } from '#lib/exec.ts';
+import { readJsonFile, readTextFile, writeJsonFile } from '#lib/json-store.ts';
+import { describeError, logger } from '#lib/logger.ts';
+import { readSlotRecords, SlotAllocator } from '#network/allocator.ts';
+import { Reconciler } from '#reconcile/reconciler.ts';
+import { buildReportedState } from '#report/build-report.ts';
+import {
+  allocatableCapacity,
+  readAvailableCacheBytes,
+  readHostCapacity,
+} from '#report/capacity.ts';
+import { readHostVersions } from '#report/versions.ts';
+import { s3ArtifactBytes } from '#vm/artifacts.ts';
+import { VmManager } from '#vm/manager.ts';
+import { SystemdVmUnits } from '#vm/systemd.ts';
+import { VolumeManager } from '#volumes/manager.ts';
+import { ZerofsTopology } from '#volumes/topology.ts';
+
+const STATUS_TICK_MS = 1_000;
+const FIRST_GENERATION = 0;
+
+const CONTROL_PLANE_BACKOFF = {
+  initialBackoffMs: 1_000,
+  maxBackoffMs: 60_000,
+  backoffFactor: 2,
+};
+const FIRST_FAILURE = 1;
+const NO_FAILURES = 0;
+
+const DESIRED_STATE_FILENAME = 'desired-state.json';
+
+export class MissingBootstrapTokenError extends Error {
+  constructor(path: string) {
+    super(`${path} is missing: the bootstrap credential arrives with the instance's user-data`);
+    this.name = 'MissingBootstrapTokenError';
+  }
+}
+
+export class Agent {
+  readonly #config: AgentConfig;
+  readonly #client: ControlPlaneClient;
+  readonly #identity: HostIdentity;
+  readonly #reconciler: Reconciler;
+  readonly #versions: HostVersions;
+  #session: AgentSession | undefined;
+  #knownGeneration = FIRST_GENERATION;
+  #running = true;
+
+  private constructor({
+    config,
+    versions,
+    reconciler,
+  }: {
+    config: AgentConfig;
+    versions: HostVersions;
+    reconciler: Reconciler;
+  }) {
+    this.#config = config;
+    this.#versions = versions;
+    this.#reconciler = reconciler;
+    this.#client = new ControlPlaneClient({ baseUrl: config.controlPlaneUrl });
+    this.#identity = new HostIdentity({ path: config.hostIdFile });
+  }
+
+  static async create({ config = loadAgentConfig() }: { config?: AgentConfig } = {}) {
+    const runner = runCommand;
+    const versions = await readHostVersions({ path: config.versionsFile });
+    // v1 runs one ZeroFS per host, so every volume placed here shares one storage prefix. The
+    // reasoning and what it costs are in `volumes/topology.ts`; everything downstream resolves
+    // per volume, so a per-app shape is a second factory rather than a rewrite.
+    const topology = ZerofsTopology.sharedHostFilesystem({
+      runner,
+      storagePrefix: config.zerofsStoragePrefix as ObjectKey,
+      mountPath: config.zerofsMount,
+      nbdSocketPath: config.zerofsNbdSocket,
+      configFile: config.zerofsConfigFile,
+    });
+    const units = new SystemdVmUnits({ runner });
+    // One allocator, shared: the host port, the tap, the guest address and the NBD minor are
+    // four views of the same slot, and two owners of it would eventually disagree.
+    const allocator = SlotAllocator.fromRecords(
+      readSlotRecords(await readJsonFile({ path: config.slotsFile })),
+    );
+    const reconciler = new Reconciler({
+      config,
+      runner,
+      units,
+      topology,
+      allocator,
+      vms: new VmManager({
+        runner,
+        units,
+        artifacts: s3ArtifactBytes({
+          bucket: config.artifactBucket,
+          region: config.awsRegion,
+          credentials: new InstanceCredentialProvider(),
+        }),
+        artifactCacheDir: config.artifactCacheDir,
+        guestImageDir: config.guestImageDir,
+        vmDir: config.vmDir,
+      }),
+      volumes: new VolumeManager({ runner, topology, allocator }),
+    });
+    return new Agent({ config, versions, reconciler });
+  }
+
+  stop() {
+    this.#running = false;
+  }
+
+  /**
+   * Converges against the last desired state this host was given before it has even reached
+   * the control plane, then joins the poll.
+   *
+   * The cached copy is what makes an agent restart during a control-plane outage a non-event:
+   * the host still knows what it is supposed to be running, and the poll that follows only
+   * ever corrects it.
+   */
+  async run(): Promise<void> {
+    await this.#reconciler.load();
+    const cached = await this.#readCachedDesiredState();
+    if (cached) {
+      this.#knownGeneration = cached.generation;
+      await this.#reconcileSafely(cached);
+    }
+
+    await this.#ensureSession();
+    const statusLoop = this.#runStatusLoop();
+    const reportLoop = this.#runReportLoop();
+    await this.#runPollLoop();
+    await Promise.all([statusLoop, reportLoop]);
+  }
+
+  async #runPollLoop(): Promise<void> {
+    let failures = NO_FAILURES;
+    while (this.#running) {
+      try {
+        const session = await this.#ensureSession();
+        const response = await this.#client.fetchDesiredState({
+          sessionToken: session.sessionToken,
+          request: {
+            knownGeneration: this.#knownGeneration,
+            waitSeconds: session.poll.maxWaitSeconds,
+          },
+        });
+        failures = NO_FAILURES;
+        if (response.result === 'changed') {
+          await writeJsonFile({ path: this.#desiredStatePath(), value: response.state });
+          this.#knownGeneration = response.state.generation;
+          await this.#reconcileSafely(response.state);
+        }
+        await Bun.sleep(session.poll.minIntervalMs);
+      } catch (error) {
+        failures += FIRST_FAILURE;
+        this.#handlePollError(error);
+        await Bun.sleep(backoffDelayMs({ attempt: failures, policy: CONTROL_PLANE_BACKOFF }));
+      }
+    }
+  }
+
+  #handlePollError(error: unknown): void {
+    if (error instanceof ControlPlaneError && error.isSessionExpired) {
+      this.#session = undefined;
+    }
+    if (error instanceof ProtocolValidationError) {
+      logger.error({ message: 'desired state rejected by validation', issues: error.issues });
+      return;
+    }
+    logger.warn({ message: 'desired state poll failed', ...describeError(error) });
+  }
+
+  async #runStatusLoop(): Promise<void> {
+    while (this.#running) {
+      try {
+        await this.#reconciler.refreshStates();
+      } catch (error) {
+        logger.warn({ message: 'status refresh failed', ...describeError(error) });
+      }
+      await Bun.sleep(STATUS_TICK_MS);
+    }
+  }
+
+  async #runReportLoop(): Promise<void> {
+    while (this.#running) {
+      const interval =
+        this.#session?.poll.reportIntervalMs ?? DEFAULT_AGENT_POLL_SETTINGS.reportIntervalMs;
+      try {
+        await this.#report();
+      } catch (error) {
+        logger.warn({ message: 'report failed', ...describeError(error) });
+      }
+      await Bun.sleep(interval);
+    }
+  }
+
+  async #report(): Promise<void> {
+    const session = await this.#ensureSession();
+    const records = this.#reconciler.records();
+    const capacity = await readHostCapacity({ cacheDir: this.#config.stateDir });
+    const report = buildReportedState({
+      hostId: session.hostId,
+      observedGeneration: this.#reconciler.observedGeneration,
+      reportedAt: nowTimestamp(),
+      state: this.#hostState(),
+      capacity,
+      allocatable: allocatableCapacity({
+        capacity,
+        committed: records
+          .filter((record) => record.state !== 'stopped' && record.state !== 'failed')
+          .map((record) => record.resources),
+        availableCacheBytes: await readAvailableCacheBytes({ cacheDir: this.#config.stateDir }),
+      }),
+      versions: this.#versions,
+      records,
+      volumes: this.#reconciler.volumeReports(),
+      checkpoints: this.#reconciler.checkpointReports(),
+    });
+    const response = await this.#client.sendReportedState({
+      sessionToken: session.sessionToken,
+      report,
+    });
+    if (response.generation !== this.#knownGeneration) {
+      logger.debug({
+        message: 'control plane has newer desired state',
+        generation: response.generation,
+      });
+    }
+  }
+
+  #hostState(): HostState {
+    return this.#reconciler.converged ? 'ready' : 'registering';
+  }
+
+  async #ensureSession(): Promise<AgentSession> {
+    if (this.#session && !isSessionExpiring({ session: this.#session, nowMs: Date.now() })) {
+      return this.#session;
+    }
+    const capacity = await readHostCapacity({ cacheDir: this.#config.stateDir });
+    this.#session = await openSession({
+      client: this.#client,
+      identity: this.#identity,
+      inputs: {
+        bootstrapToken: await this.#readBootstrapToken(),
+        versions: this.#versions,
+        capacity,
+      },
+    });
+    logger.info({
+      message: 'session opened',
+      hostId: this.#session.hostId,
+      expiresAt: this.#session.expiresAt,
+    });
+    return this.#session;
+  }
+
+  // The credential identifies the machine, not a user, and buys exactly one thing: a session.
+  // It is read from disk on every renewal rather than held in memory, so rotating the file is
+  // enough to rotate the credential.
+  async #readBootstrapToken(): Promise<SecretString> {
+    const token = await readTextFile({ path: this.#config.bootstrapTokenFile });
+    if (!token) {
+      throw new MissingBootstrapTokenError(this.#config.bootstrapTokenFile);
+    }
+    return token as SecretString;
+  }
+
+  #desiredStatePath() {
+    return join(this.#config.stateDir, DESIRED_STATE_FILENAME);
+  }
+
+  async #readCachedDesiredState(): Promise<HostDesiredState | undefined> {
+    const value = await readJsonFile({ path: this.#desiredStatePath() });
+    if (value === undefined) {
+      return undefined;
+    }
+    try {
+      return parseMessage({ schema: HostDesiredStateSchema, value });
+    } catch (error) {
+      logger.warn({ message: 'cached desired state discarded', ...describeError(error) });
+      return undefined;
+    }
+  }
+
+  async #reconcileSafely(desired: HostDesiredState): Promise<void> {
+    try {
+      await this.#reconciler.reconcile({ desired });
+    } catch (error) {
+      logger.error({
+        message: 'reconcile failed',
+        generation: desired.generation,
+        ...describeError(error),
+      });
+    }
+  }
+}

--- a/apps/agent/src/aws/instance-credentials.test.ts
+++ b/apps/agent/src/aws/instance-credentials.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  credentialsFromEnvironment,
+  fetchInstanceCredentials,
+  InstanceCredentialsError,
+  needsRefresh,
+  parseCredentialsDocument,
+} from '#aws/instance-credentials.ts';
+import type { HttpClient, HttpRequest } from '#lib/http.ts';
+
+const NOW_MS = 1_700_000_000_000;
+const ONE_MINUTE_MS = 60_000;
+const TEN_MINUTES_MS = 600_000;
+const ONE_HOUR_MS = 3_600_000;
+const HTTP_OK = 200;
+const HTTP_FORBIDDEN = 403;
+
+const ROLE = 'nibrun-app-host';
+const DOCUMENT = {
+  AccessKeyId: 'AKIAEXAMPLE',
+  SecretAccessKey: 'secret',
+  Token: 'session',
+  Expiration: new Date(NOW_MS + ONE_HOUR_MS).toISOString(),
+};
+
+const imds = ({ status = HTTP_OK }: { status?: number } = {}) => {
+  const requests: HttpRequest[] = [];
+  const http: HttpClient = (request) => {
+    requests.push(request);
+    if (status !== HTTP_OK) {
+      return Promise.resolve(new Response('denied', { status }));
+    }
+    if (request.url.endsWith('/api/token')) {
+      return Promise.resolve(new Response('token-value'));
+    }
+    if (request.url.endsWith('security-credentials/')) {
+      return Promise.resolve(new Response(`${ROLE}\n`));
+    }
+    return Promise.resolve(new Response(JSON.stringify(DOCUMENT)));
+  };
+  return { requests, http };
+};
+
+describe('static credentials win when they are present', () => {
+  test('a full pair is used', () => {
+    expect(
+      credentialsFromEnvironment({
+        AWS_ACCESS_KEY_ID: 'key',
+        AWS_SECRET_ACCESS_KEY: 'secret',
+        AWS_SESSION_TOKEN: 'token',
+      }),
+    ).toEqual({ accessKeyId: 'key', secretAccessKey: 'secret', sessionToken: 'token' });
+  });
+
+  test('half a pair is not credentials', () => {
+    expect(credentialsFromEnvironment({ AWS_ACCESS_KEY_ID: 'key' })).toBeUndefined();
+    expect(credentialsFromEnvironment({})).toBeUndefined();
+  });
+});
+
+describe('refresh happens before the credential can expire mid-transfer', () => {
+  test('nothing cached always refreshes', () => {
+    expect(needsRefresh({ credentials: undefined, nowMs: NOW_MS })).toBe(true);
+  });
+
+  test('a credential with no expiry never refreshes', () => {
+    expect(
+      needsRefresh({
+        credentials: { accessKeyId: 'k', secretAccessKey: 's' },
+        nowMs: NOW_MS,
+      }),
+    ).toBe(false);
+  });
+
+  test('the margin refreshes early rather than at the last moment', () => {
+    const credentials = {
+      accessKeyId: 'k',
+      secretAccessKey: 's',
+      expiresAtMs: NOW_MS + ONE_MINUTE_MS,
+    };
+    expect(needsRefresh({ credentials, nowMs: NOW_MS, marginMs: TEN_MINUTES_MS })).toBe(true);
+    expect(needsRefresh({ credentials, nowMs: NOW_MS, marginMs: 0 })).toBe(false);
+  });
+});
+
+describe('IMDSv2', () => {
+  test('the session token is fetched first and presented on every later request', async () => {
+    const { requests, http } = imds();
+    const credentials = await fetchInstanceCredentials({ http });
+    expect(credentials.accessKeyId).toBe(DOCUMENT.AccessKeyId);
+    expect(credentials.sessionToken).toBe(DOCUMENT.Token);
+    expect(requests[0]?.method).toBe('PUT');
+    expect(requests[1]?.headers?.['x-aws-ec2-metadata-token']).toBe('token-value');
+    expect(requests[2]?.url).toEndWith(ROLE);
+  });
+
+  test('a refused metadata request is an error, not empty credentials', async () => {
+    const { http } = imds({ status: HTTP_FORBIDDEN });
+    await expect(fetchInstanceCredentials({ http })).rejects.toThrow(InstanceCredentialsError);
+  });
+});
+
+describe('parsing the credential document', () => {
+  test('a well-formed document carries its expiry through as epoch milliseconds', () => {
+    expect(parseCredentialsDocument(DOCUMENT).expiresAtMs).toBe(NOW_MS + ONE_HOUR_MS);
+  });
+
+  test('a document with no key pair is refused', () => {
+    expect(() => parseCredentialsDocument({ Code: 'Failure' })).toThrow(InstanceCredentialsError);
+    expect(() => parseCredentialsDocument(null)).toThrow(InstanceCredentialsError);
+  });
+
+  test('an unparsable expiry is dropped rather than becoming NaN', () => {
+    const parsed = parseCredentialsDocument({ ...DOCUMENT, Expiration: 'soon' });
+    expect('expiresAtMs' in parsed).toBe(false);
+  });
+});

--- a/apps/agent/src/aws/instance-credentials.ts
+++ b/apps/agent/src/aws/instance-credentials.ts
@@ -1,0 +1,150 @@
+import { type HttpClient, httpFetch } from '#lib/http.ts';
+
+const IMDS_BASE_URL = 'http://169.254.169.254';
+const TOKEN_PATH = '/latest/api/token';
+const ROLE_PATH = '/latest/meta-data/iam/security-credentials/';
+const TOKEN_TTL_HEADER = 'x-aws-ec2-metadata-token-ttl-seconds';
+const TOKEN_HEADER = 'x-aws-ec2-metadata-token';
+const TOKEN_TTL_SECONDS = 21_600;
+const REQUEST_TIMEOUT_MS = 5_000;
+// Refreshed well before expiry: the credential has to outlive the S3 transfer it is handed to,
+// and a large artifact takes longer than the margin a just-in-time refresh would leave.
+const REFRESH_MARGIN_MS = 300_000;
+
+export type AwsCredentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  expiresAtMs?: number;
+};
+
+export class InstanceCredentialsError extends Error {
+  constructor(detail: string) {
+    super(`Could not read instance role credentials: ${detail}`);
+    this.name = 'InstanceCredentialsError';
+  }
+}
+
+export function credentialsFromEnvironment(
+  env: Record<string, string | undefined>,
+): AwsCredentials | undefined {
+  const accessKeyId = env.AWS_ACCESS_KEY_ID?.trim();
+  const secretAccessKey = env.AWS_SECRET_ACCESS_KEY?.trim();
+  if (!accessKeyId || !secretAccessKey) {
+    return undefined;
+  }
+  const sessionToken = env.AWS_SESSION_TOKEN?.trim();
+  return { accessKeyId, secretAccessKey, ...(sessionToken ? { sessionToken } : {}) };
+}
+
+export function needsRefresh({
+  credentials,
+  nowMs,
+  marginMs = REFRESH_MARGIN_MS,
+}: {
+  credentials: AwsCredentials | undefined;
+  nowMs: number;
+  marginMs?: number;
+}): boolean {
+  if (!credentials) {
+    return true;
+  }
+  if (credentials.expiresAtMs === undefined) {
+    return false;
+  }
+  return credentials.expiresAtMs - marginMs <= nowMs;
+}
+
+export function parseCredentialsDocument(value: unknown): AwsCredentials {
+  const document = value as Record<string, unknown> | null;
+  const accessKeyId = document?.AccessKeyId;
+  const secretAccessKey = document?.SecretAccessKey;
+  const sessionToken = document?.Token;
+  if (typeof accessKeyId !== 'string' || typeof secretAccessKey !== 'string') {
+    throw new InstanceCredentialsError('response carried no key pair');
+  }
+  const expiration = document?.Expiration;
+  const expiresAtMs = typeof expiration === 'string' ? Date.parse(expiration) : Number.NaN;
+  return {
+    accessKeyId,
+    secretAccessKey,
+    ...(typeof sessionToken === 'string' ? { sessionToken } : {}),
+    ...(Number.isFinite(expiresAtMs) ? { expiresAtMs } : {}),
+  };
+}
+
+/**
+ * IMDSv2 by hand.
+ *
+ * Bun's S3 client resolves static credentials only, and this agent carries no third-party
+ * dependencies, so the instance role is read here and handed over explicitly. IMDSv2 rather
+ * than v1 because the session-token handshake is what makes a request forgeable only by
+ * something already running on the host.
+ */
+export async function fetchInstanceCredentials(
+  options: { http?: HttpClient; baseUrl?: string } = {},
+): Promise<AwsCredentials> {
+  const http: HttpClient = options.http ?? httpFetch;
+  const baseUrl = options.baseUrl ?? IMDS_BASE_URL;
+  const tokenResponse = await http({
+    url: `${baseUrl}${TOKEN_PATH}`,
+    method: 'PUT',
+    headers: { [TOKEN_TTL_HEADER]: String(TOKEN_TTL_SECONDS) },
+    timeoutMs: REQUEST_TIMEOUT_MS,
+  });
+  if (!tokenResponse.ok) {
+    throw new InstanceCredentialsError(`token request answered ${tokenResponse.status}`);
+  }
+  const headers = { [TOKEN_HEADER]: await tokenResponse.text() };
+
+  const roleResponse = await http({
+    url: `${baseUrl}${ROLE_PATH}`,
+    headers,
+    timeoutMs: REQUEST_TIMEOUT_MS,
+  });
+  if (!roleResponse.ok) {
+    throw new InstanceCredentialsError(`role listing answered ${roleResponse.status}`);
+  }
+  const roleName = (await roleResponse.text()).trim().split('\n')[0]?.trim();
+  if (!roleName) {
+    throw new InstanceCredentialsError('no role is attached to this instance');
+  }
+
+  const credentialsResponse = await http({
+    url: `${baseUrl}${ROLE_PATH}${roleName}`,
+    headers,
+    timeoutMs: REQUEST_TIMEOUT_MS,
+  });
+  if (!credentialsResponse.ok) {
+    throw new InstanceCredentialsError(`credential request answered ${credentialsResponse.status}`);
+  }
+  return parseCredentialsDocument(await credentialsResponse.json());
+}
+
+export class InstanceCredentialProvider {
+  #cached: AwsCredentials | undefined;
+  readonly #env: Record<string, string | undefined>;
+  readonly #http: HttpClient;
+
+  constructor({
+    env = Bun.env,
+    http = httpFetch,
+  }: { env?: Record<string, string | undefined>; http?: HttpClient } = {}) {
+    this.#env = env;
+    this.#http = http;
+  }
+
+  async resolve(): Promise<AwsCredentials> {
+    const fromEnvironment = credentialsFromEnvironment(this.#env);
+    if (fromEnvironment) {
+      return fromEnvironment;
+    }
+    if (needsRefresh({ credentials: this.#cached, nowMs: Date.now() })) {
+      this.#cached = await fetchInstanceCredentials({ http: this.#http });
+    }
+    if (!this.#cached) {
+      throw new InstanceCredentialsError('no credentials available');
+    }
+    return this.#cached;
+  }
+}

--- a/apps/agent/src/config.ts
+++ b/apps/agent/src/config.ts
@@ -1,0 +1,128 @@
+import { join } from 'node:path';
+
+const DEFAULT_STATE_DIR = '/var/lib/nibrun';
+const DEFAULT_RUNTIME_DIR = '/run/nibrun';
+const DEFAULT_ZEROFS_MOUNT = '/mnt/zerofs';
+const DEFAULT_ZEROFS_CONFIG = '/etc/zerofs/config.toml';
+const DEFAULT_ZEROFS_NBD_SOCKET = '/run/zerofs/nbd.sock';
+const DEFAULT_GUEST_IMAGE_DIR = '/opt/nibrun/bin/guest-image';
+const DEFAULT_FIRECRACKER_DIR = '/opt/nibrun/bin/firecracker';
+const DEFAULT_VERSIONS_FILE = '/opt/nibrun/bundle/versions.json';
+
+export const NBD_CONNECTIONS = 4;
+export const NBD_BLOCK_SIZE_BYTES = 4096;
+// S3 round trips under load are slow enough that a short NBD timeout turns a stall into an
+// EIO the guest's ext4 answers by remounting read-only.
+export const NBD_TIMEOUT_SECONDS = 600;
+
+export type AgentConfig = {
+  controlPlaneUrl: string;
+  bootstrapTokenFile: string;
+  stateDir: string;
+  runtimeDir: string;
+  hostIdFile: string;
+  slotsFile: string;
+  instancesFile: string;
+  artifactCacheDir: string;
+  vmDir: string;
+  versionsFile: string;
+  guestImageDir: string;
+  firecrackerDir: string;
+  zerofsMount: string;
+  zerofsConfigFile: string;
+  zerofsNbdSocket: string;
+  // The `[storage] url` prefix this host's ZeroFS is pointed at. A volume naming a different
+  // one is refused rather than created here, because a device file written into the wrong
+  // filesystem puts a tenant's data somewhere nothing will look for it.
+  zerofsStoragePrefix: string;
+  artifactBucket: string;
+  awsRegion: string;
+  // Guests are denied every private destination by default, so this is only needed when the
+  // control plane answers on a public address the blanket rule would not cover.
+  controlPlaneCidrs: string[];
+  // Empty by default, which leaves guests reaching a public resolver over the ordinary egress
+  // path. The VPC resolver sits inside RFC1918 and is therefore blocked with everything else,
+  // so naming it here is the only way to allow it without weakening the blanket rule.
+  guestDnsServers: string[];
+};
+
+class MissingConfigurationError extends Error {
+  constructor(name: string) {
+    super(`${name} is required`);
+    this.name = 'MissingConfigurationError';
+  }
+}
+
+const required = ({ env, name }: { env: Record<string, string | undefined>; name: string }) => {
+  const value = env[name]?.trim();
+  if (!value) {
+    throw new MissingConfigurationError(name);
+  }
+  return value;
+};
+
+const optional = ({
+  env,
+  name,
+  fallback,
+}: {
+  env: Record<string, string | undefined>;
+  name: string;
+  fallback: string;
+}) => env[name]?.trim() || fallback;
+
+const list = ({ env, name }: { env: Record<string, string | undefined>; name: string }) =>
+  (env[name] ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+export function loadAgentConfig({
+  env = Bun.env,
+}: {
+  env?: Record<string, string | undefined>;
+} = {}): AgentConfig {
+  const stateDir = optional({ env, name: 'AGENT_STATE_DIR', fallback: DEFAULT_STATE_DIR });
+  return {
+    controlPlaneUrl: required({ env, name: 'AGENT_CONTROL_PLANE_URL' }),
+    bootstrapTokenFile: optional({
+      env,
+      name: 'AGENT_BOOTSTRAP_TOKEN_FILE',
+      fallback: join(stateDir, 'bootstrap-token'),
+    }),
+    stateDir,
+    runtimeDir: optional({ env, name: 'AGENT_RUNTIME_DIR', fallback: DEFAULT_RUNTIME_DIR }),
+    hostIdFile: join(stateDir, 'host-id'),
+    slotsFile: join(stateDir, 'slots.json'),
+    instancesFile: join(stateDir, 'instances.json'),
+    artifactCacheDir: join(stateDir, 'artifacts'),
+    vmDir: join(stateDir, 'vm'),
+    versionsFile: optional({ env, name: 'AGENT_VERSIONS_FILE', fallback: DEFAULT_VERSIONS_FILE }),
+    guestImageDir: optional({
+      env,
+      name: 'AGENT_GUEST_IMAGE_DIR',
+      fallback: DEFAULT_GUEST_IMAGE_DIR,
+    }),
+    firecrackerDir: optional({
+      env,
+      name: 'AGENT_FIRECRACKER_DIR',
+      fallback: DEFAULT_FIRECRACKER_DIR,
+    }),
+    zerofsMount: optional({ env, name: 'AGENT_ZEROFS_MOUNT', fallback: DEFAULT_ZEROFS_MOUNT }),
+    zerofsConfigFile: optional({
+      env,
+      name: 'AGENT_ZEROFS_CONFIG_FILE',
+      fallback: DEFAULT_ZEROFS_CONFIG,
+    }),
+    zerofsNbdSocket: optional({
+      env,
+      name: 'AGENT_ZEROFS_NBD_SOCKET',
+      fallback: DEFAULT_ZEROFS_NBD_SOCKET,
+    }),
+    zerofsStoragePrefix: required({ env, name: 'AGENT_ZEROFS_STORAGE_PREFIX' }),
+    artifactBucket: required({ env, name: 'AGENT_ARTIFACT_BUCKET' }),
+    awsRegion: required({ env, name: 'AGENT_AWS_REGION' }),
+    controlPlaneCidrs: list({ env, name: 'AGENT_CONTROL_PLANE_CIDRS' }),
+    guestDnsServers: list({ env, name: 'AGENT_GUEST_DNS_SERVERS' }),
+  };
+}

--- a/apps/agent/src/control/client.test.ts
+++ b/apps/agent/src/control/client.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  AGENT_API_PREFIX,
+  AGENT_ROUTES,
+  type HostId,
+  PROTOCOL_VERSION,
+  PROTOCOL_VERSION_HEADER,
+  ProtocolValidationError,
+  type SecretString,
+} from '@repo/protocol';
+import { ControlPlaneClient, ControlPlaneError } from '#control/client.ts';
+
+const BASE_URL = 'https://control.example';
+const HTTP_OK = 200;
+const HTTP_UNAUTHORIZED = 401;
+const HTTP_UNAVAILABLE = 503;
+const SOME_GENERATION = 4;
+const SESSION_TOKEN = 'session-token' as SecretString;
+
+const VALID_SESSION = {
+  hostId: 'host-1',
+  sessionToken: 'granted',
+  expiresAt: '2026-08-03T11:00:00Z',
+  poll: { maxWaitSeconds: 30, minIntervalMs: 1_000, reportIntervalMs: 15_000 },
+};
+
+const respondWith = ({ body, status = HTTP_OK }: { body: unknown; status?: number }) => {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const fetchImpl = ((...args: [string, RequestInit]) => {
+    calls.push({ url: args[0], init: args[1] });
+    return Promise.resolve(new Response(JSON.stringify(body), { status }));
+  }) as unknown as typeof fetch;
+  return { calls, fetchImpl };
+};
+
+describe('every request identifies the protocol it speaks', () => {
+  test('the version header and the session are sent', async () => {
+    const { calls, fetchImpl } = respondWith({
+      body: { result: 'unchanged', generation: SOME_GENERATION },
+    });
+    const client = new ControlPlaneClient({ baseUrl: `${BASE_URL}/`, fetchImpl });
+    await client.fetchDesiredState({
+      sessionToken: SESSION_TOKEN,
+      request: { knownGeneration: SOME_GENERATION, waitSeconds: 1 },
+    });
+    const call = calls[0];
+    expect(call?.url).toBe(`${BASE_URL}${AGENT_API_PREFIX}${AGENT_ROUTES.desiredState}`);
+    expect(call?.init.method).toBe('POST');
+    const headers = call?.init.headers as Record<string, string>;
+    expect(headers[PROTOCOL_VERSION_HEADER]).toBe(String(PROTOCOL_VERSION));
+    expect(headers.authorization).toBe(`Bearer ${SESSION_TOKEN}`);
+  });
+
+  test('the session route is reached without a session', async () => {
+    const { calls, fetchImpl } = respondWith({ body: VALID_SESSION });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    const session = await client.openSession({
+      bootstrapToken: 'boot' as SecretString,
+      versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
+      capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
+    });
+    expect(session.hostId).toBe('host-1' as HostId);
+    const sessionHeaders = calls[0]?.init.headers as Record<string, string> | undefined;
+    expect(sessionHeaders?.authorization).toBeUndefined();
+  });
+});
+
+describe('validation at the boundary', () => {
+  test('a response missing a required field is rejected rather than believed', async () => {
+    const { fetchImpl } = respondWith({ body: { hostId: 'host-1', sessionToken: 'granted' } });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    await expect(
+      client.openSession({
+        bootstrapToken: 'boot' as SecretString,
+        versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
+        capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
+      }),
+    ).rejects.toThrow(ProtocolValidationError);
+  });
+
+  test('a mistyped field is rejected', async () => {
+    const { fetchImpl } = respondWith({ body: { result: 'unchanged', generation: 'four' } });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    await expect(
+      client.fetchDesiredState({
+        sessionToken: SESSION_TOKEN,
+        request: { knownGeneration: 0, waitSeconds: 0 },
+      }),
+    ).rejects.toThrow(ProtocolValidationError);
+  });
+
+  test('unknown fields are tolerated, because a rollout always produces them', async () => {
+    const { fetchImpl } = respondWith({
+      body: { ...VALID_SESSION, somethingTheNewerSideAdded: { nested: true } },
+    });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    const session = await client.openSession({
+      bootstrapToken: 'boot' as SecretString,
+      versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
+      capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
+    });
+    expect(session.expiresAt).toBe(VALID_SESSION.expiresAt as typeof session.expiresAt);
+  });
+
+  test('a timestamp with no offset is rejected: it is the silently wrong instant', async () => {
+    const { fetchImpl } = respondWith({
+      body: { ...VALID_SESSION, expiresAt: '2026-08-03T11:00:00' },
+    });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    await expect(
+      client.openSession({
+        bootstrapToken: 'boot' as SecretString,
+        versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
+        capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
+      }),
+    ).rejects.toThrow(ProtocolValidationError);
+  });
+});
+
+describe('errors', () => {
+  test('a 401 is recognisable as an expired session', async () => {
+    const { fetchImpl } = respondWith({ body: { error: 'expired' }, status: HTTP_UNAUTHORIZED });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    const error = await client
+      .fetchDesiredState({
+        sessionToken: SESSION_TOKEN,
+        request: { knownGeneration: 0, waitSeconds: 0 },
+      })
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(ControlPlaneError);
+    expect((error as ControlPlaneError).isSessionExpired).toBe(true);
+  });
+
+  test('another failure status is not mistaken for one', async () => {
+    const { fetchImpl } = respondWith({ body: { error: 'boom' }, status: HTTP_UNAVAILABLE });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    const error = await client
+      .fetchDesiredState({
+        sessionToken: SESSION_TOKEN,
+        request: { knownGeneration: 0, waitSeconds: 0 },
+      })
+      .catch((caught: unknown) => caught);
+    expect((error as ControlPlaneError).isSessionExpired).toBe(false);
+  });
+});

--- a/apps/agent/src/control/client.ts
+++ b/apps/agent/src/control/client.ts
@@ -1,0 +1,130 @@
+import {
+  AGENT_API_PREFIX,
+  AGENT_ROUTES,
+  type AgentSession,
+  type AgentSessionRequest,
+  AgentSessionSchema,
+  type DesiredStateRequest,
+  type DesiredStateResponse,
+  DesiredStateResponseSchema,
+  type HostReportedState,
+  PROTOCOL_VERSION,
+  PROTOCOL_VERSION_HEADER,
+  parseMessage,
+  type ReportedStateResponse,
+  ReportedStateResponseSchema,
+  type SecretString,
+} from '@repo/protocol';
+
+const POLL_TIMEOUT_MARGIN_MS = 10_000;
+const MS_PER_SECOND = 1_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const HTTP_UNAUTHORIZED = 401;
+
+export type FetchLike = typeof fetch;
+
+export class ControlPlaneError extends Error {
+  readonly status: number;
+
+  constructor({ status, route, body }: { status: number; route: string; body: string }) {
+    super(`${route} answered ${status}: ${body.slice(0, ControlPlaneError.MAX_BODY)}`);
+    this.name = 'ControlPlaneError';
+    this.status = status;
+  }
+
+  static readonly MAX_BODY = 256;
+
+  get isSessionExpired() {
+    return this.status === HTTP_UNAUTHORIZED;
+  }
+}
+
+/**
+ * Every call is an outbound POST carrying JSON, and every response is validated before it is
+ * believed. The two programs ship on different pipelines, so a response the agent cannot
+ * parse is the normal consequence of a rollout rather than an impossible state.
+ */
+export class ControlPlaneClient {
+  readonly #baseUrl: string;
+  readonly #fetch: FetchLike;
+
+  constructor({ baseUrl, fetchImpl = fetch }: { baseUrl: string; fetchImpl?: FetchLike }) {
+    this.#baseUrl = baseUrl.replace(/\/+$/, '');
+    this.#fetch = fetchImpl;
+  }
+
+  async openSession(request: AgentSessionRequest): Promise<AgentSession> {
+    const body = await this.#post({
+      route: AGENT_ROUTES.session,
+      body: request,
+      timeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+    return parseMessage({ schema: AgentSessionSchema, value: body });
+  }
+
+  async fetchDesiredState({
+    sessionToken,
+    request,
+  }: {
+    sessionToken: SecretString;
+    request: DesiredStateRequest;
+  }): Promise<DesiredStateResponse> {
+    const body = await this.#post({
+      route: AGENT_ROUTES.desiredState,
+      body: request,
+      sessionToken,
+      timeoutMs: request.waitSeconds * MS_PER_SECOND + POLL_TIMEOUT_MARGIN_MS,
+    });
+    return parseMessage({ schema: DesiredStateResponseSchema, value: body });
+  }
+
+  async sendReportedState({
+    sessionToken,
+    report,
+  }: {
+    sessionToken: SecretString;
+    report: HostReportedState;
+  }): Promise<ReportedStateResponse> {
+    const body = await this.#post({
+      route: AGENT_ROUTES.reportedState,
+      body: report,
+      sessionToken,
+      timeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+    return parseMessage({ schema: ReportedStateResponseSchema, value: body });
+  }
+
+  async #post({
+    route,
+    body,
+    sessionToken,
+    timeoutMs,
+  }: {
+    route: string;
+    body: unknown;
+    sessionToken?: SecretString;
+    timeoutMs: number;
+  }): Promise<unknown> {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      [PROTOCOL_VERSION_HEADER]: String(PROTOCOL_VERSION),
+    };
+    if (sessionToken) {
+      headers.authorization = `Bearer ${sessionToken}`;
+    }
+    const response = await this.#fetch(`${this.#baseUrl}${AGENT_API_PREFIX}${route}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      throw new ControlPlaneError({
+        status: response.status,
+        route,
+        body: await response.text(),
+      });
+    }
+    return response.json();
+  }
+}

--- a/apps/agent/src/control/session.ts
+++ b/apps/agent/src/control/session.ts
@@ -1,0 +1,81 @@
+import {
+  type AgentSession,
+  type HostCapacity,
+  type HostId,
+  HostIdSchema,
+  type HostVersions,
+  isValidMessage,
+  type SecretString,
+} from '@repo/protocol';
+import type { ControlPlaneClient } from '#control/client.ts';
+import { toEpochMs } from '#lib/clock.ts';
+import { readTextFile, writeTextFile } from '#lib/json-store.ts';
+
+// Renewed well before it lapses: a session that expires mid-poll costs a round trip, and the
+// clock the control plane stamped it with is not the one the agent reads it against.
+const RENEWAL_SKEW_MS = 60_000;
+
+export function isSessionExpiring({
+  session,
+  nowMs,
+  skewMs = RENEWAL_SKEW_MS,
+}: {
+  session: AgentSession;
+  nowMs: number;
+  skewMs?: number;
+}): boolean {
+  return toEpochMs(session.expiresAt) - skewMs <= nowMs;
+}
+
+/**
+ * The host id the control plane assigned, kept on disk so a reinstalled agent rejoins as the
+ * same host rather than as a new one. A file that has been corrupted is discarded rather than
+ * sent, because registering twice is recoverable and claiming a malformed identity is not.
+ */
+export class HostIdentity {
+  readonly #path: string;
+
+  constructor({ path }: { path: string }) {
+    this.#path = path;
+  }
+
+  async read(): Promise<HostId | undefined> {
+    const value = await readTextFile({ path: this.#path });
+    if (value === undefined || !isValidMessage({ schema: HostIdSchema, value })) {
+      return undefined;
+    }
+    return value as HostId;
+  }
+
+  async write(hostId: HostId): Promise<void> {
+    await writeTextFile({ path: this.#path, value: `${hostId}\n` });
+  }
+}
+
+export type SessionInputs = {
+  bootstrapToken: SecretString;
+  versions: HostVersions;
+  capacity: HostCapacity;
+};
+
+export async function openSession({
+  client,
+  identity,
+  inputs,
+}: {
+  client: ControlPlaneClient;
+  identity: HostIdentity;
+  inputs: SessionInputs;
+}): Promise<AgentSession> {
+  const hostId = await identity.read();
+  const session = await client.openSession({
+    bootstrapToken: inputs.bootstrapToken,
+    ...(hostId ? { hostId } : {}),
+    versions: inputs.versions,
+    capacity: inputs.capacity,
+  });
+  if (session.hostId !== hostId) {
+    await identity.write(session.hostId);
+  }
+  return session;
+}

--- a/apps/agent/src/health/probe.ts
+++ b/apps/agent/src/health/probe.ts
@@ -1,0 +1,57 @@
+import type { GuestPort, HealthCheck, Ipv4Address } from '@repo/protocol';
+
+const HTTP_OK_MIN = 200;
+const HTTP_OK_MAX = 300;
+
+export type ProbeTarget = {
+  guestIpv4: Ipv4Address;
+  guestPort: GuestPort;
+  healthCheck: HealthCheck;
+};
+
+/**
+ * Asks the only question that matters: is the tenant's process accepting connections?
+ *
+ * The probe goes straight to the guest address rather than through the forwarded host port, so
+ * a failure means the tenant is down and never that a NAT rule is missing. A bare TCP connect
+ * is the default because it needs nothing of the tenant; a declared path upgrades it to an
+ * HTTP GET that has to answer 2xx.
+ */
+export function probeInstance(target: ProbeTarget): Promise<boolean> {
+  return target.healthCheck.path === undefined
+    ? probeTcp(target)
+    : probeHttp({ target, path: target.healthCheck.path });
+}
+
+async function probeTcp({ guestIpv4, guestPort, healthCheck }: ProbeTarget): Promise<boolean> {
+  let socket: { end(): void } | undefined;
+  try {
+    const connection = await Promise.race([
+      Bun.connect({ hostname: guestIpv4, port: guestPort, socket: {} }),
+      Bun.sleep(healthCheck.timeoutMs).then(() => undefined),
+    ]);
+    socket = connection;
+    return connection !== undefined;
+  } catch {
+    return false;
+  } finally {
+    socket?.end();
+  }
+}
+
+async function probeHttp({
+  target,
+  path,
+}: {
+  target: ProbeTarget;
+  path: string;
+}): Promise<boolean> {
+  try {
+    const response = await fetch(`http://${target.guestIpv4}:${target.guestPort}${path}`, {
+      signal: AbortSignal.timeout(target.healthCheck.timeoutMs),
+    });
+    return response.status >= HTTP_OK_MIN && response.status < HTTP_OK_MAX;
+  } catch {
+    return false;
+  }
+}

--- a/apps/agent/src/health/state.test.ts
+++ b/apps/agent/src/health/state.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_HEALTH_CHECK, type HealthCheck, type Timestamp } from '@repo/protocol';
+import { applyProbe, evaluateInstanceState, initialTracker } from '#health/state.ts';
+import type { UnitStatus } from '#vm/systemd.ts';
+
+const AT = '2026-08-03T10:00:00.000Z' as Timestamp;
+const STARTED_AT_MS = 1_000_000;
+const GRACE_MS = DEFAULT_HEALTH_CHECK.gracePeriodMs;
+const WITHIN_GRACE_MS = STARTED_AT_MS + GRACE_MS - 1;
+const PAST_GRACE_MS = STARTED_AT_MS + GRACE_MS + 1;
+
+const UNHEALTHY_RUN = DEFAULT_HEALTH_CHECK.unhealthyThreshold;
+const TWO_SUCCESSES = 2;
+
+const active: UnitStatus = { loaded: true, active: true, failed: false };
+const exited: UnitStatus = { loaded: true, active: false, failed: false, exitCode: 0 };
+const crashed: UnitStatus = { loaded: true, active: false, failed: true, exitCode: 1 };
+const absent: UnitStatus = { loaded: false, active: false, failed: false };
+
+const check = (overrides: Partial<HealthCheck> = {}): HealthCheck => ({
+  ...DEFAULT_HEALTH_CHECK,
+  ...overrides,
+});
+
+const HEALTHY_THRESHOLD = DEFAULT_HEALTH_CHECK.healthyThreshold;
+
+const probe = ({
+  tracker,
+  healthy,
+  healthyThreshold = HEALTHY_THRESHOLD,
+}: {
+  tracker: ReturnType<typeof initialTracker>;
+  healthy: boolean;
+  healthyThreshold?: number;
+}) => applyProbe({ tracker, healthy, at: AT, healthyThreshold });
+
+const failing = (count: number) => {
+  let tracker = initialTracker();
+  for (let index = 0; index < count; index += 1) {
+    tracker = probe({ tracker, healthy: false });
+  }
+  return tracker;
+};
+
+const healthyThen = (failures: number) => {
+  let tracker = probe({ tracker: initialTracker(), healthy: true });
+  for (let index = 0; index < failures; index += 1) {
+    tracker = probe({ tracker, healthy: false });
+  }
+  return tracker;
+};
+
+const evaluate = ({
+  unit,
+  tracker,
+  nowMs,
+  healthCheck = check(),
+  stopRequested = false,
+  desiredRunning = true,
+  startedAtMs = STARTED_AT_MS as number | undefined,
+}: {
+  unit: UnitStatus;
+  tracker: ReturnType<typeof initialTracker>;
+  nowMs: number;
+  healthCheck?: HealthCheck;
+  stopRequested?: boolean;
+  desiredRunning?: boolean;
+  startedAtMs?: number | undefined;
+}) =>
+  evaluateInstanceState({
+    unit,
+    tracker,
+    healthCheck,
+    desiredRunning,
+    stopRequested,
+    ...(startedAtMs === undefined ? {} : { startedAtMs }),
+    nowMs,
+  });
+
+describe('probe accounting', () => {
+  test('a success resets the failure run and records when it happened', () => {
+    const tracker = probe({ tracker: failing(2), healthy: true });
+    expect(tracker).toEqual({
+      consecutiveSuccesses: 1,
+      consecutiveFailures: 0,
+      everHealthy: true,
+      lastHealthyAt: AT,
+    });
+  });
+
+  test('a failure resets the success run but not the fact it was once healthy', () => {
+    const tracker = probe({
+      tracker: probe({ tracker: initialTracker(), healthy: true }),
+      healthy: false,
+    });
+    expect(tracker.consecutiveSuccesses).toBe(0);
+    expect(tracker.consecutiveFailures).toBe(1);
+    expect(tracker.everHealthy).toBe(true);
+  });
+});
+
+describe('a booted VM is not a running app', () => {
+  test('active with no successful probe is starting, not running', () => {
+    expect(evaluate({ unit: active, tracker: initialTracker(), nowMs: WITHIN_GRACE_MS })).toBe(
+      'starting',
+    );
+  });
+
+  test('running only once the tenant has accepted a connection', () => {
+    const tracker = probe({ tracker: initialTracker(), healthy: true });
+    expect(evaluate({ unit: active, tracker, nowMs: WITHIN_GRACE_MS })).toBe('running');
+  });
+
+  test('failures inside the grace period do not fail the instance', () => {
+    expect(evaluate({ unit: active, tracker: failing(10), nowMs: WITHIN_GRACE_MS })).toBe(
+      'starting',
+    );
+  });
+
+  test('never healthy past the grace period is failed', () => {
+    expect(evaluate({ unit: active, tracker: failing(UNHEALTHY_RUN), nowMs: PAST_GRACE_MS })).toBe(
+      'failed',
+    );
+  });
+
+  test('healthy once and then failing is unhealthy, not failed', () => {
+    expect(
+      evaluate({ unit: active, tracker: healthyThen(UNHEALTHY_RUN), nowMs: PAST_GRACE_MS }),
+    ).toBe('unhealthy');
+  });
+
+  test('a failure run below the threshold leaves a healthy instance running', () => {
+    expect(evaluate({ unit: active, tracker: healthyThen(1), nowMs: PAST_GRACE_MS })).toBe(
+      'running',
+    );
+  });
+});
+
+describe('what the VM itself is doing', () => {
+  test('a VM that exited unasked is failed and stays failed', () => {
+    expect(evaluate({ unit: exited, tracker: healthyThen(0), nowMs: PAST_GRACE_MS })).toBe(
+      'failed',
+    );
+  });
+
+  test('a crashed unit is failed regardless of the last probe', () => {
+    const tracker = probe({ tracker: initialTracker(), healthy: true });
+    expect(evaluate({ unit: crashed, tracker, nowMs: WITHIN_GRACE_MS })).toBe('failed');
+  });
+
+  test('a VM stopped on request is stopped, not failed', () => {
+    expect(
+      evaluate({
+        unit: exited,
+        tracker: initialTracker(),
+        nowMs: PAST_GRACE_MS,
+        stopRequested: true,
+      }),
+    ).toBe('stopped');
+  });
+
+  test('a stop in progress is reported as stopping while the unit is still up', () => {
+    expect(
+      evaluate({
+        unit: active,
+        tracker: probe({ tracker: initialTracker(), healthy: true }),
+        nowMs: PAST_GRACE_MS,
+        stopRequested: true,
+      }),
+    ).toBe('stopping');
+  });
+
+  test('an instance that was never started is pending', () => {
+    expect(
+      evaluateInstanceState({
+        unit: absent,
+        tracker: initialTracker(),
+        healthCheck: check(),
+        desiredRunning: true,
+        stopRequested: false,
+        nowMs: STARTED_AT_MS,
+      }),
+    ).toBe('pending');
+  });
+
+  test('an instance the control plane wants stopped reads as stopped once the unit is down', () => {
+    expect(
+      evaluate({
+        unit: absent,
+        tracker: initialTracker(),
+        nowMs: PAST_GRACE_MS,
+        desiredRunning: false,
+      }),
+    ).toBe('stopped');
+  });
+});
+
+describe('thresholds are honoured', () => {
+  test('healthyThreshold above one keeps a single success in starting', () => {
+    const tracker = probe({
+      tracker: initialTracker(),
+      healthy: true,
+      healthyThreshold: TWO_SUCCESSES,
+    });
+    expect(
+      evaluate({
+        unit: active,
+        tracker,
+        nowMs: WITHIN_GRACE_MS,
+        healthCheck: check({ healthyThreshold: TWO_SUCCESSES }),
+      }),
+    ).toBe('starting');
+  });
+
+  test('two successes reach running once the threshold is two', () => {
+    let tracker = probe({
+      tracker: initialTracker(),
+      healthy: true,
+      healthyThreshold: TWO_SUCCESSES,
+    });
+    tracker = probe({ tracker, healthy: true, healthyThreshold: TWO_SUCCESSES });
+    expect(
+      evaluate({
+        unit: active,
+        tracker,
+        nowMs: WITHIN_GRACE_MS,
+        healthCheck: check({ healthyThreshold: TWO_SUCCESSES }),
+      }),
+    ).toBe('running');
+  });
+});

--- a/apps/agent/src/health/state.ts
+++ b/apps/agent/src/health/state.ts
@@ -1,0 +1,105 @@
+import type { HealthCheck, InstanceState, Timestamp } from '@repo/protocol';
+import type { UnitStatus } from '#vm/systemd.ts';
+
+const NO_PROBES = 0;
+const ONE_PROBE = 1;
+
+export type HealthTracker = {
+  consecutiveSuccesses: number;
+  consecutiveFailures: number;
+  everHealthy: boolean;
+  lastHealthyAt?: Timestamp;
+};
+
+export const initialTracker = (): HealthTracker => ({
+  consecutiveSuccesses: NO_PROBES,
+  consecutiveFailures: NO_PROBES,
+  everHealthy: false,
+});
+
+/**
+ * `everHealthy` flips only once the success run reaches the threshold, not on the first
+ * accepted connection. The difference decides whether a later failure run reads as `unhealthy`
+ * — an app that was serving and stopped — or as `failed`, an app that never served at all.
+ */
+export function applyProbe({
+  tracker,
+  healthy,
+  at,
+  healthyThreshold,
+}: {
+  tracker: HealthTracker;
+  healthy: boolean;
+  at: Timestamp;
+  healthyThreshold: number;
+}): HealthTracker {
+  if (!healthy) {
+    return {
+      ...tracker,
+      consecutiveSuccesses: NO_PROBES,
+      consecutiveFailures: tracker.consecutiveFailures + ONE_PROBE,
+    };
+  }
+  const consecutiveSuccesses = tracker.consecutiveSuccesses + ONE_PROBE;
+  return {
+    ...tracker,
+    consecutiveSuccesses,
+    consecutiveFailures: NO_PROBES,
+    everHealthy: tracker.everHealthy || consecutiveSuccesses >= healthyThreshold,
+    lastHealthyAt: at,
+  };
+}
+
+export type LifecycleInputs = {
+  unit: UnitStatus;
+  tracker: HealthTracker;
+  healthCheck: HealthCheck;
+  desiredRunning: boolean;
+  stopRequested: boolean;
+  startedAtMs?: number;
+  nowMs: number;
+};
+
+/**
+ * Decides what an instance actually is, from what systemd says about the VM and what the probe
+ * says about the tenant.
+ *
+ * A booted microVM is not a running app. `starting` is a VM whose tenant process has not yet
+ * accepted a connection and `running` is one that has, and collapsing the two would let a
+ * deploy swap traffic onto a booted-but-dead VM — worse than a deploy that fails.
+ *
+ * A VM that exited without being asked to is `failed`, never restarted here: the guest owns
+ * the tenant process's restart budget, and when it exhausts it the guest powers itself off.
+ * Rebooting the VM at that point would hide a broken deploy behind a host that retries forever,
+ * and deciding whether to try elsewhere is the reconciler's call.
+ */
+export function evaluateInstanceState({
+  unit,
+  tracker,
+  healthCheck,
+  desiredRunning,
+  stopRequested,
+  startedAtMs,
+  nowMs,
+}: LifecycleInputs): InstanceState {
+  if (unit.failed) {
+    return 'failed';
+  }
+  if (!unit.active) {
+    if (stopRequested || !desiredRunning) {
+      return 'stopped';
+    }
+    return unit.loaded || startedAtMs !== undefined ? 'failed' : 'pending';
+  }
+  if (stopRequested) {
+    return 'stopping';
+  }
+  if (tracker.consecutiveSuccesses >= healthCheck.healthyThreshold) {
+    return 'running';
+  }
+  const withinGrace = startedAtMs === undefined || nowMs - startedAtMs < healthCheck.gracePeriodMs;
+  if (tracker.consecutiveFailures >= healthCheck.unhealthyThreshold && !withinGrace) {
+    return tracker.everHealthy ? 'unhealthy' : 'failed';
+  }
+  return tracker.everHealthy ? 'running' : 'starting';
+}

--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -1,0 +1,23 @@
+import { Agent } from '#agent.ts';
+import { describeError, logger } from '#lib/logger.ts';
+
+const FAILURE_EXIT_CODE = 1;
+
+const agent = await Agent.create();
+
+// The agent stopping must not stop anything it started. The VMs are systemd's children, so
+// exiting here leaves every tenant app running — which is the property that lets this
+// component be redeployed as often as it changes.
+for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+  process.on(signal, () => {
+    logger.info({ message: 'shutting down', signal });
+    agent.stop();
+  });
+}
+
+try {
+  await agent.run();
+} catch (error) {
+  logger.error({ message: 'agent exited', ...describeError(error) });
+  process.exit(FAILURE_EXIT_CODE);
+}

--- a/apps/agent/src/lib/backoff.test.ts
+++ b/apps/agent/src/lib/backoff.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_RESTART_POLICY } from '@repo/protocol';
+import { backoffDelayMs, isReadyToRetry, nextAttemptWindow } from '#lib/backoff.ts';
+
+const policy = DEFAULT_RESTART_POLICY;
+const TWO_GROWTHS = 2;
+const THIRD_ATTEMPT = 3;
+const FAR_PAST_THE_CAP = 100;
+const RESET_AFTER_MS = 60_000;
+const FLAT_BACKOFF = { initialBackoffMs: 250, maxBackoffMs: 1_000, backoffFactor: 1 };
+
+describe('backoffDelayMs', () => {
+  test('the first attempt does not wait', () => {
+    expect(backoffDelayMs({ attempt: 0, policy })).toBe(0);
+  });
+
+  test('it grows by the factor', () => {
+    expect(backoffDelayMs({ attempt: 1, policy })).toBe(policy.initialBackoffMs);
+    expect(backoffDelayMs({ attempt: 2, policy })).toBe(
+      policy.initialBackoffMs * policy.backoffFactor,
+    );
+    expect(backoffDelayMs({ attempt: 3, policy })).toBe(
+      policy.initialBackoffMs * policy.backoffFactor ** TWO_GROWTHS,
+    );
+  });
+
+  test('it is capped, so a long-broken app is retried at a fixed slow rate', () => {
+    expect(backoffDelayMs({ attempt: FAR_PAST_THE_CAP, policy })).toBe(policy.maxBackoffMs);
+  });
+
+  test('a factor of one degenerates to a constant delay rather than to zero', () => {
+    expect(backoffDelayMs({ attempt: THIRD_ATTEMPT, policy: FLAT_BACKOFF })).toBe(
+      FLAT_BACKOFF.initialBackoffMs,
+    );
+  });
+});
+
+describe('nextAttemptWindow', () => {
+  test('the first attempt counts as one', () => {
+    expect(
+      nextAttemptWindow({ window: { attempts: 0 }, nowMs: 0, resetAfterMs: RESET_AFTER_MS }),
+    ).toEqual({
+      attempts: 1,
+      lastAttemptAtMs: 0,
+    });
+  });
+
+  test('attempts accumulate inside the reset window', () => {
+    const first = nextAttemptWindow({
+      window: { attempts: 0 },
+      nowMs: 0,
+      resetAfterMs: RESET_AFTER_MS,
+    });
+    const second = nextAttemptWindow({ window: first, nowMs: 1_000, resetAfterMs: RESET_AFTER_MS });
+    expect(second.attempts).toBe(2);
+  });
+
+  test('a long gap resets the budget, so a monthly failure never exhausts it', () => {
+    const window = { attempts: policy.maxRestarts, lastAttemptAtMs: 0 };
+    expect(
+      nextAttemptWindow({
+        window,
+        nowMs: RESET_AFTER_MS * TWO_GROWTHS,
+        resetAfterMs: RESET_AFTER_MS,
+      }).attempts,
+    ).toBe(1);
+  });
+});
+
+describe('isReadyToRetry', () => {
+  test('a fresh window retries immediately', () => {
+    expect(isReadyToRetry({ window: { attempts: 0 }, nowMs: 0, policy })).toBe(true);
+  });
+
+  test('a retry inside the backoff is refused and allowed once it lapses', () => {
+    const window = { attempts: THIRD_ATTEMPT, lastAttemptAtMs: 0 };
+    const delay = backoffDelayMs({ attempt: THIRD_ATTEMPT, policy });
+    expect(isReadyToRetry({ window, nowMs: delay - 1, policy })).toBe(false);
+    expect(isReadyToRetry({ window, nowMs: delay, policy })).toBe(true);
+  });
+});

--- a/apps/agent/src/lib/backoff.ts
+++ b/apps/agent/src/lib/backoff.ts
@@ -1,0 +1,66 @@
+const FIRST_ATTEMPT = 0;
+
+export type BackoffPolicy = {
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+  backoffFactor: number;
+};
+
+/**
+ * Delay before attempt `attempt`, counted from zero — so the first attempt never waits.
+ *
+ * The shape is deliberately the same as the guest's restart policy and reads its numbers from
+ * the same object: the agent retrying a boot and the guest retrying a process are the same
+ * question asked one layer apart, and two sets of tuning constants for it would drift.
+ */
+export function backoffDelayMs({
+  attempt,
+  policy,
+}: {
+  attempt: number;
+  policy: BackoffPolicy;
+}): number {
+  if (attempt <= FIRST_ATTEMPT) {
+    return 0;
+  }
+  const grown = policy.initialBackoffMs * policy.backoffFactor ** (attempt - 1);
+  return Math.min(Math.round(grown), policy.maxBackoffMs);
+}
+
+export type AttemptWindow = {
+  attempts: number;
+  lastAttemptAtMs?: number;
+};
+
+/**
+ * A component that stayed up longer than `resetAfterMs` is treated as healthy and starts its
+ * budget over, so something that fails once a month never eventually exhausts a lifetime one.
+ */
+export function nextAttemptWindow({
+  window,
+  nowMs,
+  resetAfterMs,
+}: {
+  window: AttemptWindow;
+  nowMs: number;
+  resetAfterMs: number;
+}): AttemptWindow {
+  const elapsed = window.lastAttemptAtMs === undefined ? 0 : nowMs - window.lastAttemptAtMs;
+  const attempts = elapsed >= resetAfterMs ? 1 : window.attempts + 1;
+  return { attempts, lastAttemptAtMs: nowMs };
+}
+
+export function isReadyToRetry({
+  window,
+  nowMs,
+  policy,
+}: {
+  window: AttemptWindow;
+  nowMs: number;
+  policy: BackoffPolicy;
+}): boolean {
+  if (window.lastAttemptAtMs === undefined) {
+    return true;
+  }
+  return nowMs - window.lastAttemptAtMs >= backoffDelayMs({ attempt: window.attempts, policy });
+}

--- a/apps/agent/src/lib/clock.ts
+++ b/apps/agent/src/lib/clock.ts
@@ -1,0 +1,7 @@
+import type { Timestamp } from '@repo/protocol';
+
+export const nowTimestamp = (): Timestamp => new Date().toISOString() as Timestamp;
+
+export const toEpochMs = (value: Timestamp): number => Date.parse(value);
+
+export const fromEpochMs = (value: number): Timestamp => new Date(value).toISOString() as Timestamp;

--- a/apps/agent/src/lib/exec.ts
+++ b/apps/agent/src/lib/exec.ts
@@ -1,0 +1,58 @@
+const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
+
+export type CommandResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+export type CommandRequest = {
+  command: readonly string[];
+  stdin?: string;
+  timeoutMs?: number;
+};
+
+export type CommandRunner = (request: CommandRequest) => Promise<CommandResult>;
+
+export class CommandFailedError extends Error {
+  readonly command: readonly string[];
+  readonly result: CommandResult;
+
+  constructor({ command, result }: { command: readonly string[]; result: CommandResult }) {
+    const detail = result.stderr.trim() || result.stdout.trim();
+    super(`${command.join(' ')} exited ${result.code}${detail ? `: ${detail}` : ''}`);
+    this.name = 'CommandFailedError';
+    this.command = command;
+    this.result = result;
+  }
+}
+
+export const runCommand: CommandRunner = async ({ command, stdin, timeoutMs }) => {
+  const child = Bun.spawn({
+    cmd: [...command],
+    stdin: stdin === undefined ? 'ignore' : new TextEncoder().encode(stdin),
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return { code, stdout, stderr };
+};
+
+export async function runCommandOrThrow({
+  runner,
+  request,
+}: {
+  runner: CommandRunner;
+  request: CommandRequest;
+}): Promise<string> {
+  const result = await runner(request);
+  if (result.code !== 0) {
+    throw new CommandFailedError({ command: request.command, result });
+  }
+  return result.stdout;
+}

--- a/apps/agent/src/lib/http.ts
+++ b/apps/agent/src/lib/http.ts
@@ -1,0 +1,19 @@
+export type HttpRequest = {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+};
+
+// One narrow shape for every outbound call, so both callers can be handed a stub in a test
+// without either of them naming the platform's own fetch signature.
+export type HttpClient = (request: HttpRequest) => Promise<Response>;
+
+export const httpFetch: HttpClient = ({ url, method, headers, body, timeoutMs }) =>
+  fetch(url, {
+    ...(method ? { method } : {}),
+    ...(headers ? { headers } : {}),
+    ...(body === undefined ? {} : { body }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });

--- a/apps/agent/src/lib/json-store.ts
+++ b/apps/agent/src/lib/json-store.ts
@@ -1,0 +1,54 @@
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+const PRIVATE_FILE_MODE = 0o600;
+const PRIVATE_DIR_MODE = 0o700;
+const JSON_INDENT = 2;
+
+export async function readJsonFile({ path }: { path: string }): Promise<unknown> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    return undefined;
+  }
+  return file.json();
+}
+
+/**
+ * Writes through a sibling temporary file and renames, so a torn write can never leave the
+ * agent with a state file it cannot parse. Rename within a directory is atomic on ext4.
+ */
+export async function writeJsonFile({
+  path,
+  value,
+}: {
+  path: string;
+  value: unknown;
+}): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: PRIVATE_DIR_MODE });
+  const temporaryPath = `${path}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(value, null, JSON_INDENT)}\n`, {
+    mode: PRIVATE_FILE_MODE,
+  });
+  await rename(temporaryPath, path);
+}
+
+export async function readTextFile({ path }: { path: string }): Promise<string | undefined> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    return undefined;
+  }
+  return (await file.text()).trim();
+}
+
+export async function writeTextFile({
+  path,
+  value,
+}: {
+  path: string;
+  value: string;
+}): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: PRIVATE_DIR_MODE });
+  const temporaryPath = `${path}.tmp`;
+  await writeFile(temporaryPath, value, { mode: PRIVATE_FILE_MODE });
+  await rename(temporaryPath, path);
+}

--- a/apps/agent/src/lib/logger.ts
+++ b/apps/agent/src/lib/logger.ts
@@ -1,0 +1,44 @@
+import { nowTimestamp } from '#lib/clock.ts';
+
+const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
+
+type LogLevel = (typeof LOG_LEVELS)[number];
+
+const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+const isLogLevel = (value: string): value is LogLevel =>
+  (LOG_LEVELS as readonly string[]).includes(value);
+
+const configuredLevel = (): LogLevel => {
+  const value = Bun.env.AGENT_LOG_LEVEL?.toLowerCase() ?? '';
+  return isLogLevel(value) ? value : 'info';
+};
+
+let threshold = LEVEL_ORDER[configuredLevel()];
+
+export const setLogLevel = ({ level }: { level: LogLevel }) => {
+  threshold = LEVEL_ORDER[level];
+};
+
+export type LogEvent = { message: string } & Record<string, unknown>;
+
+// One JSON object per line on stderr. systemd captures it into the journal, where the fields
+// stay queryable — which is the only log transport this agent has until log shipping exists.
+const emit = ({ level, event }: { level: LogLevel; event: LogEvent }) => {
+  if (LEVEL_ORDER[level] < threshold) {
+    return;
+  }
+  process.stderr.write(`${JSON.stringify({ ts: nowTimestamp(), level, ...event })}\n`);
+};
+
+export const describeError = (error: unknown) =>
+  error instanceof Error
+    ? { error: error.message, errorName: error.name }
+    : { error: String(error) };
+
+export const logger = {
+  debug: (event: LogEvent) => emit({ level: 'debug', event }),
+  info: (event: LogEvent) => emit({ level: 'info', event }),
+  warn: (event: LogEvent) => emit({ level: 'warn', event }),
+  error: (event: LogEvent) => emit({ level: 'error', event }),
+};

--- a/apps/agent/src/network/allocator.test.ts
+++ b/apps/agent/src/network/allocator.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test';
+import type { AppId, HostPort, Ipv4Address } from '@repo/protocol';
+import {
+  describeSlot,
+  HOST_PORT_BASE,
+  readSlotRecords,
+  SlotAllocator,
+  SlotExhaustedError,
+} from '#network/allocator.ts';
+
+const app = (name: string | number) => `app-${name}` as AppId;
+
+const SLOT_COUNT = 200;
+const SUBNET_PREFIX_LENGTH = 30;
+const BOUNDARY_SLOT = 64;
+const SOME_SLOT = 3;
+const DISTINCT_APPS = ['alpha', 'beta', 'gamma'];
+const BEYOND_THE_LAST_SLOT = 1_000;
+
+describe('slot derivation', () => {
+  test('every per-app resource comes from the one number', () => {
+    expect(describeSlot({ slot: 0, appId: app(0) })).toEqual({
+      slot: 0,
+      appId: app(0),
+      hostPort: HOST_PORT_BASE,
+      hostIpv4: '10.201.0.1',
+      guestIpv4: '10.201.0.2',
+      guestMac: '02:00:0a:c9:00:02',
+      tapName: 'nbr0',
+      nbdDevicePath: '/dev/nbd0',
+      subnetPrefixLength: SUBNET_PREFIX_LENGTH,
+    } as ReturnType<typeof describeSlot>);
+  });
+
+  test('slots do not overlap', () => {
+    const first = describeSlot({ slot: 0, appId: app(0) });
+    const second = describeSlot({ slot: 1, appId: app(1) });
+    expect(second.hostIpv4).toBe('10.201.0.5' as Ipv4Address);
+    expect(second.guestIpv4).toBe('10.201.0.6' as Ipv4Address);
+    expect(second.hostPort).toBe((first.hostPort + 1) as HostPort);
+  });
+
+  test('addressing carries past an octet boundary', () => {
+    expect(describeSlot({ slot: BOUNDARY_SLOT, appId: app(BOUNDARY_SLOT) }).guestIpv4).toBe(
+      '10.201.1.2' as Ipv4Address,
+    );
+  });
+});
+
+describe('allocation is stable for the lifetime of an app', () => {
+  test('a second allocation for the same app returns the same slot', () => {
+    const allocator = new SlotAllocator();
+    const first = allocator.allocate(app(1));
+    const second = allocator.allocate(app(1));
+    expect(second).toEqual(first);
+  });
+
+  test('a redeploy keeps the host port, which is what makes it invisible to routing', () => {
+    const allocator = new SlotAllocator();
+    const before = allocator.allocate(app(1)).hostPort;
+    // A redeploy is a new instance of the same app; nothing about the app's slot changes.
+    expect(allocator.allocate(app(1)).hostPort).toBe(before);
+  });
+
+  test('distinct apps never share a slot', () => {
+    const allocator = new SlotAllocator();
+    const ports = new Set(DISTINCT_APPS.map((name) => allocator.allocate(app(name)).hostPort));
+    expect(ports.size).toBe(DISTINCT_APPS.length);
+  });
+});
+
+describe('allocation survives an agent restart', () => {
+  test('records round-trip through the persisted shape', () => {
+    const allocator = new SlotAllocator();
+    allocator.allocate(app(1));
+    allocator.allocate(app(2));
+    const revived = SlotAllocator.fromRecords(
+      readSlotRecords(JSON.parse(JSON.stringify(allocator.toRecords()))),
+    );
+    expect(revived.lookup(app(2))).toEqual(allocator.lookup(app(2)));
+  });
+
+  test('a revived allocator does not hand a live slot to a new app', () => {
+    const allocator = new SlotAllocator();
+    allocator.allocate(app(1));
+    const revived = SlotAllocator.fromRecords(allocator.toRecords());
+    expect(revived.allocate(app(BEYOND_THE_LAST_SLOT)).slot).not.toBe(revived.lookup(app(1))?.slot);
+  });
+
+  test('a corrupted record file degrades to an empty allocator rather than throwing', () => {
+    expect(readSlotRecords('nonsense')).toEqual({});
+    expect(readSlotRecords({ 'app-1': 'three', 'app-2': SOME_SLOT })).toEqual({
+      'app-2': SOME_SLOT,
+    });
+  });
+
+  test('duplicate slots in a persisted file are not both honoured', () => {
+    const revived = SlotAllocator.fromRecords({ 'app-1': SOME_SLOT, 'app-2': SOME_SLOT });
+    expect(revived.lookup(app(1))?.slot).toBe(SOME_SLOT);
+    expect(revived.lookup(app(2))).toBeUndefined();
+  });
+});
+
+describe('release', () => {
+  test('a released slot becomes available again', () => {
+    const allocator = new SlotAllocator();
+    const slot = allocator.allocate(app(1)).slot;
+    allocator.release(app(1));
+    expect(allocator.lookup(app(1))).toBeUndefined();
+    expect(allocator.allocate(app(2)).slot).toBe(slot);
+  });
+});
+
+describe('exhaustion', () => {
+  test('running out of slots is an error, not a silent reuse', () => {
+    const allocator = new SlotAllocator();
+    for (let index = 0; index < SLOT_COUNT; index += 1) {
+      allocator.allocate(app(index));
+    }
+    expect(() => allocator.allocate(app(BEYOND_THE_LAST_SLOT))).toThrow(SlotExhaustedError);
+  });
+});

--- a/apps/agent/src/network/allocator.ts
+++ b/apps/agent/src/network/allocator.ts
@@ -1,0 +1,160 @@
+import type { AppId, HostPort, Ipv4Address } from '@repo/protocol';
+
+// Every per-app resource is derived from one small integer. A host port, a tap device, a /30
+// and an NBD minor are four things that have to agree with each other for the lifetime of an
+// app; deriving them from a single allocated slot means there is exactly one number to
+// persist, and no way for three of the four to survive a restart while the fourth does not.
+const SLOT_COUNT = 200;
+const FIRST_SLOT = 0;
+
+export const HOST_PORT_BASE = 21_000;
+
+// A /30 per slot inside 10.201.0.0/16: .0 network, .1 host, .2 guest, .3 broadcast.
+export const GUEST_NETWORK_CIDR = '10.201.0.0/16';
+const GUEST_SUBNET_PREFIX_LENGTH = 30;
+const ADDRESSES_PER_SLOT = 4;
+const GUEST_NETWORK_FIRST_OCTET = 10;
+const GUEST_NETWORK_SECOND_OCTET = 201;
+const OCTET_SIZE = 256;
+const HOST_ADDRESS_OFFSET = 1;
+const GUEST_ADDRESS_OFFSET = 2;
+
+export const TAP_NAME_PREFIX = 'nbr';
+
+const HEX_RADIX = 16;
+const MAC_OCTET_WIDTH = 2;
+// Locally administered, unicast. The last four octets are the guest's address, so a MAC on the
+// wire names the VM it belongs to without a lookup.
+const MAC_PREFIX = '02:00';
+
+export type AppSlot = {
+  slot: number;
+  appId: AppId;
+  hostPort: HostPort;
+  hostIpv4: Ipv4Address;
+  guestIpv4: Ipv4Address;
+  guestMac: string;
+  tapName: string;
+  nbdDevicePath: string;
+  subnetPrefixLength: number;
+};
+
+export class SlotExhaustedError extends Error {
+  constructor() {
+    super(`No free slot: this host is limited to ${SLOT_COUNT} apps`);
+    this.name = 'SlotExhaustedError';
+  }
+}
+
+const addressAt = (index: number): Ipv4Address => {
+  const third = Math.floor(index / OCTET_SIZE);
+  const fourth = index % OCTET_SIZE;
+  return `${GUEST_NETWORK_FIRST_OCTET}.${GUEST_NETWORK_SECOND_OCTET}.${third}.${fourth}` as Ipv4Address;
+};
+
+const macFor = (address: Ipv4Address) =>
+  [
+    MAC_PREFIX,
+    ...address
+      .split('.')
+      .map((octet) => Number(octet).toString(HEX_RADIX).padStart(MAC_OCTET_WIDTH, '0')),
+  ].join(':');
+
+export function describeSlot({ slot, appId }: { slot: number; appId: AppId }): AppSlot {
+  const base = slot * ADDRESSES_PER_SLOT;
+  const hostIpv4 = addressAt(base + HOST_ADDRESS_OFFSET);
+  const guestIpv4 = addressAt(base + GUEST_ADDRESS_OFFSET);
+  return {
+    slot,
+    appId,
+    hostPort: (HOST_PORT_BASE + slot) as HostPort,
+    hostIpv4,
+    guestIpv4,
+    guestMac: macFor(guestIpv4),
+    tapName: `${TAP_NAME_PREFIX}${slot}`,
+    nbdDevicePath: `/dev/nbd${slot}`,
+    subnetPrefixLength: GUEST_SUBNET_PREFIX_LENGTH,
+  };
+}
+
+export type SlotRecords = Record<string, number>;
+
+/**
+ * Slots are allocated per app, never per instance, which is what makes a redeploy invisible to
+ * the routing layer: same host, same port, new process behind it.
+ *
+ * They are released only on an explicit volume `absent`. That is the one signal in the
+ * protocol that means an app is definitively gone; an instance merely missing from desired
+ * state is a stop, and reusing its port for someone else would silently route a tenant's
+ * traffic into another tenant's VM.
+ */
+export class SlotAllocator {
+  readonly #byApp = new Map<AppId, number>();
+  readonly #taken = new Set<number>();
+
+  static fromRecords(records: SlotRecords): SlotAllocator {
+    const allocator = new SlotAllocator();
+    for (const [appId, slot] of Object.entries(records)) {
+      if (!Number.isInteger(slot) || slot < FIRST_SLOT || slot >= SLOT_COUNT) {
+        continue;
+      }
+      if (allocator.#taken.has(slot)) {
+        continue;
+      }
+      allocator.#byApp.set(appId as AppId, slot);
+      allocator.#taken.add(slot);
+    }
+    return allocator;
+  }
+
+  allocate(appId: AppId): AppSlot {
+    const existing = this.#byApp.get(appId);
+    if (existing !== undefined) {
+      return describeSlot({ slot: existing, appId });
+    }
+    for (let slot = FIRST_SLOT; slot < SLOT_COUNT; slot += 1) {
+      if (this.#taken.has(slot)) {
+        continue;
+      }
+      this.#byApp.set(appId, slot);
+      this.#taken.add(slot);
+      return describeSlot({ slot, appId });
+    }
+    throw new SlotExhaustedError();
+  }
+
+  lookup(appId: AppId): AppSlot | undefined {
+    const slot = this.#byApp.get(appId);
+    return slot === undefined ? undefined : describeSlot({ slot, appId });
+  }
+
+  release(appId: AppId): void {
+    const slot = this.#byApp.get(appId);
+    if (slot === undefined) {
+      return;
+    }
+    this.#byApp.delete(appId);
+    this.#taken.delete(slot);
+  }
+
+  slots(): AppSlot[] {
+    return [...this.#byApp.entries()].map(([appId, slot]) => describeSlot({ slot, appId }));
+  }
+
+  toRecords(): SlotRecords {
+    return Object.fromEntries([...this.#byApp.entries()].map(([appId, slot]) => [appId, slot]));
+  }
+}
+
+export function readSlotRecords(value: unknown): SlotRecords {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  const records: SlotRecords = {};
+  for (const [appId, slot] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof slot === 'number' && Number.isInteger(slot)) {
+      records[appId] = slot;
+    }
+  }
+  return records;
+}

--- a/apps/agent/src/network/firewall.test.ts
+++ b/apps/agent/src/network/firewall.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+import type { GuestPort, HostPort, Ipv4Address } from '@repo/protocol';
+import {
+  type FirewallState,
+  INSTANCE_METADATA_ADDRESS,
+  NFTABLES_TABLE,
+  renderRuleset,
+} from '#network/firewall.ts';
+
+const instance = {
+  hostPort: 21_000 as HostPort,
+  guestPort: 3000 as GuestPort,
+  hostIpv4: '10.201.0.1' as Ipv4Address,
+  guestIpv4: '10.201.0.2' as Ipv4Address,
+};
+
+const state = (overrides: Partial<FirewallState> = {}): FirewallState => ({
+  instances: [],
+  controlPlaneCidrs: [],
+  guestDnsServers: [],
+  ...overrides,
+});
+
+const dropsFrom = (ruleset: string) =>
+  ruleset
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith('drop') || line.includes('drop comment'));
+
+describe('the three isolation rules are never optional', () => {
+  test('guests cannot reach the instance metadata endpoint, with no instances configured', () => {
+    const drops = dropsFrom(renderRuleset(state()));
+    expect(drops.some((line) => line.includes(INSTANCE_METADATA_ADDRESS))).toBe(true);
+  });
+
+  test('guests cannot reach each other', () => {
+    const drops = dropsFrom(renderRuleset(state({ instances: [instance] })));
+    expect(drops.some((line) => line.includes('guest to guest'))).toBe(true);
+    expect(drops.some((line) => line.includes('10.201.0.0/16'))).toBe(true);
+  });
+
+  test('guests cannot reach the control plane', () => {
+    const ruleset = renderRuleset(state({ controlPlaneCidrs: ['203.0.113.10/32'] }));
+    expect(dropsFrom(ruleset).some((line) => line.includes('203.0.113.10/32'))).toBe(true);
+  });
+
+  test('every private destination is denied, not only the ones enumerated', () => {
+    const drops = dropsFrom(renderRuleset(state())).join('\n');
+    for (const cidr of ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', '169.254.0.0/16']) {
+      expect(drops).toContain(cidr);
+    }
+  });
+
+  test('guests cannot reach services on the host itself', () => {
+    expect(dropsFrom(renderRuleset(state())).some((line) => line.includes('guest to host'))).toBe(
+      true,
+    );
+  });
+});
+
+describe('forwarding', () => {
+  test('a host port is forwarded to the guest port, not to itself', () => {
+    const ruleset = renderRuleset(state({ instances: [instance] }));
+    expect(ruleset).toContain('tcp dport 21000 dnat to 10.201.0.2:3000');
+  });
+
+  test('nothing is forwarded when nothing is running', () => {
+    expect(renderRuleset(state())).not.toContain('dnat to');
+  });
+
+  test('guest egress is masqueraded, but only when leaving the guest network', () => {
+    expect(renderRuleset(state())).toContain('ip saddr 10.201.0.0/16 oifname != "nbr*" masquerade');
+  });
+
+  test('host-local traffic to a forwarded port is re-sourced so the guest can reply', () => {
+    const ruleset = renderRuleset(state({ instances: [instance] }));
+    expect(ruleset).toContain('ip saddr 127.0.0.0/8 ip daddr 10.201.0.2 snat to 10.201.0.1');
+  });
+});
+
+describe('the ruleset is a function of state, not a history of edits', () => {
+  test('the table is deleted and rebuilt, so a rerun converges instead of accumulating', () => {
+    const ruleset = renderRuleset(state({ instances: [instance] }));
+    expect(
+      ruleset.startsWith(`table ip ${NFTABLES_TABLE}\ndelete table ip ${NFTABLES_TABLE}\n`),
+    ).toBe(true);
+  });
+
+  test('rendering twice from the same state is byte-identical', () => {
+    const input = state({ instances: [instance], controlPlaneCidrs: ['203.0.113.0/24'] });
+    expect(renderRuleset(input)).toBe(renderRuleset(input));
+  });
+
+  test('a named DNS resolver is allowed out before the blanket private drop', () => {
+    const ruleset = renderRuleset(state({ guestDnsServers: ['10.0.0.2'] }));
+    const lines = ruleset.split('\n').map((line) => line.trim());
+    const accept = lines.findIndex((line) => line.startsWith('iifname "nbr*" ip daddr 10.0.0.2'));
+    const drop = lines.findIndex((line) => line.includes('private destinations'));
+    expect(accept).toBeGreaterThan(-1);
+    expect(accept).toBeLessThan(drop);
+  });
+});

--- a/apps/agent/src/network/firewall.ts
+++ b/apps/agent/src/network/firewall.ts
@@ -1,0 +1,148 @@
+import type { GuestPort, HostPort, Ipv4Address } from '@repo/protocol';
+import { GUEST_NETWORK_CIDR, TAP_NAME_PREFIX } from '#network/allocator.ts';
+
+export const NFTABLES_TABLE = 'nibrun';
+const TAP_MATCH = `"${TAP_NAME_PREFIX}*"`;
+
+export const INSTANCE_METADATA_ADDRESS = '169.254.169.254';
+
+const DNS_PORT = 53;
+
+// The blanket rule that makes the three isolation guarantees hold even for a destination
+// nobody thought to enumerate. Every one of these is somewhere a tenant has no business
+// reaching from inside a microVM.
+const PRIVATE_DESTINATIONS = [
+  '10.0.0.0/8',
+  '172.16.0.0/12',
+  '192.168.0.0/16',
+  '169.254.0.0/16',
+  '127.0.0.0/8',
+  '100.64.0.0/10',
+] as const;
+
+const CHAIN_INDENT = '  ';
+const RULE_INDENT = '    ';
+
+export type ForwardedInstance = {
+  hostPort: HostPort;
+  guestPort: GuestPort;
+  hostIpv4: Ipv4Address;
+  guestIpv4: Ipv4Address;
+};
+
+export type FirewallState = {
+  instances: ForwardedInstance[];
+  controlPlaneCidrs: readonly string[];
+  guestDnsServers: readonly string[];
+};
+
+const set = (values: readonly string[]) => `{ ${values.join(', ')} }`;
+
+const chain = ({ header, rules }: { header: string; rules: readonly string[] }) => [
+  `${CHAIN_INDENT}chain ${header}`,
+  ...rules.map((rule) => `${RULE_INDENT}${rule}`),
+  `${CHAIN_INDENT}}`,
+];
+
+/**
+ * The whole ruleset, rendered as one file and applied with `nft -f`.
+ *
+ * Rendering everything and replacing the table in a single transaction is what keeps the rules
+ * a function of state rather than a history of edits: there is no incremental add or delete
+ * that can be missed, and a reconcile that runs twice produces the same kernel state.
+ *
+ * The metadata-endpoint rule is written explicitly even though the instance's IMDS hop limit
+ * of 1 already defeats routed guest traffic. A guarantee that holds only while nobody changes
+ * an instance attribute is not a guarantee, and the credentials it protects are the host's own
+ * role — the most valuable thing on the machine.
+ */
+export function renderRuleset(state: FirewallState): string {
+  const lines: string[] = [
+    `table ip ${NFTABLES_TABLE}`,
+    `delete table ip ${NFTABLES_TABLE}`,
+    '',
+    `table ip ${NFTABLES_TABLE} {`,
+    ...forwardChain(state),
+    '',
+    ...inputChain(state),
+    '',
+    ...natChains(state),
+    '}',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+function forwardChain({ controlPlaneCidrs, guestDnsServers }: FirewallState): string[] {
+  return chain({
+    header: 'forward {',
+    rules: [
+      'type filter hook forward priority filter; policy accept;',
+      'ct state established,related accept',
+      ...guestDnsServers.flatMap((server) => [
+        `iifname ${TAP_MATCH} ip daddr ${server} udp dport ${DNS_PORT} accept`,
+        `iifname ${TAP_MATCH} ip daddr ${server} tcp dport ${DNS_PORT} accept`,
+      ]),
+      `iifname ${TAP_MATCH} ip daddr ${INSTANCE_METADATA_ADDRESS} drop comment "instance metadata endpoint"`,
+      `iifname ${TAP_MATCH} oifname ${TAP_MATCH} drop comment "guest to guest"`,
+      `iifname ${TAP_MATCH} ip daddr ${GUEST_NETWORK_CIDR} drop comment "guest to guest"`,
+      ...controlPlaneCidrs.map(
+        (cidr) => `iifname ${TAP_MATCH} ip daddr ${cidr} drop comment "control plane"`,
+      ),
+      `iifname ${TAP_MATCH} ip daddr ${set(PRIVATE_DESTINATIONS)} drop comment "private destinations"`,
+    ],
+  });
+}
+
+// Traffic from a guest to the host's own tap address never reaches the forward hook, so the
+// three isolation rules would leave every service listening on the host exposed to tenants.
+function inputChain({ guestDnsServers }: FirewallState): string[] {
+  return chain({
+    header: 'input {',
+    rules: [
+      'type filter hook input priority filter; policy accept;',
+      `iifname ${TAP_MATCH} ct state established,related accept`,
+      ...guestDnsServers.map((server) => `iifname ${TAP_MATCH} ip daddr ${server} accept`),
+      `iifname ${TAP_MATCH} drop comment "guest to host"`,
+    ],
+  });
+}
+
+function natChains({ instances }: FirewallState): string[] {
+  return [
+    ...chain({
+      header: 'prerouting {',
+      rules: [
+        'type nat hook prerouting priority dstnat; policy accept;',
+        ...instances.map(
+          (instance) =>
+            `iifname != ${TAP_MATCH} tcp dport ${instance.hostPort} dnat to ${instance.guestIpv4}:${instance.guestPort}`,
+        ),
+      ],
+    }),
+    '',
+    ...chain({
+      header: 'output {',
+      rules: [
+        'type nat hook output priority dstnat; policy accept;',
+        ...instances.map(
+          (instance) =>
+            `ip daddr 127.0.0.1 tcp dport ${instance.hostPort} dnat to ${instance.guestIpv4}:${instance.guestPort}`,
+        ),
+      ],
+    }),
+    '',
+    ...chain({
+      header: 'postrouting {',
+      rules: [
+        'type nat hook postrouting priority srcnat; policy accept;',
+        // The host's own connections to a forwarded port leave with a loopback source address,
+        // which the guest cannot reply to. They are re-sourced onto the tap they leave by.
+        ...instances.map(
+          (instance) =>
+            `oifname ${TAP_MATCH} ip saddr 127.0.0.0/8 ip daddr ${instance.guestIpv4} snat to ${instance.hostIpv4}`,
+        ),
+        `ip saddr ${GUEST_NETWORK_CIDR} oifname != ${TAP_MATCH} masquerade`,
+      ],
+    }),
+  ];
+}

--- a/apps/agent/src/network/nftables.ts
+++ b/apps/agent/src/network/nftables.ts
@@ -1,0 +1,19 @@
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+import { type FirewallState, renderRuleset } from '#network/firewall.ts';
+
+const NFT_COMMAND = 'nft';
+
+export async function applyRuleset({
+  runner,
+  state,
+}: {
+  runner: CommandRunner;
+  state: FirewallState;
+}): Promise<string> {
+  const ruleset = renderRuleset(state);
+  await runCommandOrThrow({
+    runner,
+    request: { command: [NFT_COMMAND, '-f', '-'], stdin: ruleset },
+  });
+  return ruleset;
+}

--- a/apps/agent/src/network/tap.ts
+++ b/apps/agent/src/network/tap.ts
@@ -1,0 +1,77 @@
+import type { Ipv4Address } from '@repo/protocol';
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+import { TAP_NAME_PREFIX } from '#network/allocator.ts';
+
+const IP_COMMAND = 'ip';
+
+export function parseLinkNames(output: string): string[] {
+  const parsed: unknown = JSON.parse(output);
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed
+    .map((entry) => (entry as { ifname?: unknown }).ifname)
+    .filter((name): name is string => typeof name === 'string');
+}
+
+export const isTapName = (name: string) =>
+  name.startsWith(TAP_NAME_PREFIX) && /^\d+$/.test(name.slice(TAP_NAME_PREFIX.length));
+
+export async function listTapNames({ runner }: { runner: CommandRunner }): Promise<string[]> {
+  const output = await runCommandOrThrow({
+    runner,
+    request: { command: [IP_COMMAND, '-json', 'link', 'show'] },
+  });
+  return parseLinkNames(output).filter(isTapName);
+}
+
+export type TapInterface = {
+  tapName: string;
+  hostIpv4: Ipv4Address;
+  subnetPrefixLength: number;
+};
+
+export async function ensureTap({
+  runner,
+  tap,
+}: {
+  runner: CommandRunner;
+  tap: TapInterface;
+}): Promise<void> {
+  const existing = await listTapNames({ runner });
+  if (!existing.includes(tap.tapName)) {
+    await runCommandOrThrow({
+      runner,
+      request: { command: [IP_COMMAND, 'tuntap', 'add', 'dev', tap.tapName, 'mode', 'tap'] },
+    });
+  }
+  // Idempotent by outcome rather than by command: `addr replace` leaves a re-run of a
+  // converged host doing nothing, which is what lets reconcile call this unconditionally.
+  await runCommandOrThrow({
+    runner,
+    request: {
+      command: [
+        IP_COMMAND,
+        'addr',
+        'replace',
+        `${tap.hostIpv4}/${tap.subnetPrefixLength}`,
+        'dev',
+        tap.tapName,
+      ],
+    },
+  });
+  await runCommandOrThrow({
+    runner,
+    request: { command: [IP_COMMAND, 'link', 'set', 'dev', tap.tapName, 'up'] },
+  });
+}
+
+export async function removeTap({
+  runner,
+  tapName,
+}: {
+  runner: CommandRunner;
+  tapName: string;
+}): Promise<void> {
+  await runner({ command: [IP_COMMAND, 'link', 'del', 'dev', tapName] });
+}

--- a/apps/agent/src/reconcile/plan.test.ts
+++ b/apps/agent/src/reconcile/plan.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, test } from 'bun:test';
+import type {
+  AppId,
+  CheckpointId,
+  DeploymentId,
+  DesiredInstance,
+  DesiredVolume,
+  HostDesiredState,
+  HostId,
+  InstanceId,
+  ObjectKey,
+  Sha256Digest,
+  VolumeId,
+} from '@repo/protocol';
+import {
+  DEFAULT_GUEST_PORT,
+  DEFAULT_HEALTH_CHECK,
+  DEFAULT_INSTANCE_RESOURCES,
+  DEFAULT_RESTART_POLICY,
+} from '@repo/protocol';
+import { type ObservedState, planReconcile } from '#reconcile/plan.ts';
+
+const APP = 'app-1' as AppId;
+const VOLUME = 'vol-1' as VolumeId;
+const INSTANCE = 'inst-1' as InstanceId;
+const DEPLOYMENT = 'dep-1' as DeploymentId;
+const DIGEST_HEX_LENGTH = 64;
+const ARTIFACT_SIZE_BYTES = 1_024;
+const VOLUME_SIZE_BYTES = 4_096;
+const GROWN_VOLUME_SIZE_BYTES = 8_192;
+const DIGEST = 'a'.repeat(DIGEST_HEX_LENGTH) as Sha256Digest;
+
+const desiredInstance = (overrides: Partial<DesiredInstance> = {}): DesiredInstance => ({
+  instanceId: INSTANCE,
+  appId: APP,
+  deploymentId: DEPLOYMENT,
+  volumeId: VOLUME,
+  desiredState: 'running',
+  artifact: {
+    digest: DIGEST,
+    sizeBytes: ARTIFACT_SIZE_BYTES,
+    objectKey: 'artifacts/a' as ObjectKey,
+  },
+  config: {
+    guestPort: DEFAULT_GUEST_PORT,
+    environment: {},
+    resources: DEFAULT_INSTANCE_RESOURCES,
+    healthCheck: DEFAULT_HEALTH_CHECK,
+    restartPolicy: DEFAULT_RESTART_POLICY,
+  },
+  hostnames: [],
+  ...overrides,
+});
+
+const desiredVolume = (overrides: Partial<DesiredVolume> = {}): DesiredVolume => ({
+  volumeId: VOLUME,
+  appId: APP,
+  sizeBytes: VOLUME_SIZE_BYTES,
+  storagePrefix: 'apps/app-1' as ObjectKey,
+  desiredState: 'present',
+  ...overrides,
+});
+
+const desiredState = (overrides: Partial<HostDesiredState> = {}): HostDesiredState => ({
+  hostId: 'host-1' as HostId,
+  generation: 1,
+  volumes: [],
+  instances: [],
+  checkpoints: [],
+  exports: [],
+  ...overrides,
+});
+
+const observedState = (overrides: Partial<ObservedState> = {}): ObservedState => ({
+  instances: [],
+  volumes: [],
+  checkpoints: [],
+  ...overrides,
+});
+
+describe('instances are authoritative', () => {
+  test('a desired instance nothing is running is started', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [desiredInstance()] }),
+      observed: observedState(),
+    });
+    expect(plan.instances).toEqual([{ action: 'start', desired: desiredInstance() }]);
+  });
+
+  test('a running instance the control plane does not mention is stopped', () => {
+    const plan = planReconcile({
+      desired: desiredState(),
+      observed: observedState({
+        instances: [
+          {
+            instanceId: INSTANCE,
+            appId: APP,
+            volumeId: VOLUME,
+            deploymentId: DEPLOYMENT,
+            present: true,
+            running: true,
+            exited: false,
+          },
+        ],
+      }),
+    });
+    expect(plan.instances).toEqual([
+      { action: 'stop', instanceId: INSTANCE, reason: 'not-desired' },
+    ]);
+  });
+
+  test('a stopped instance the control plane does not mention is forgotten', () => {
+    const plan = planReconcile({
+      desired: desiredState(),
+      observed: observedState({
+        instances: [
+          {
+            instanceId: INSTANCE,
+            present: true,
+            running: false,
+            exited: true,
+          },
+        ],
+      }),
+    });
+    expect(plan.instances).toEqual([{ action: 'forget', instanceId: INSTANCE }]);
+  });
+
+  test('a deployment change replaces rather than restarts', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [desiredInstance()] }),
+      observed: observedState({
+        instances: [
+          {
+            instanceId: INSTANCE,
+            appId: APP,
+            volumeId: VOLUME,
+            deploymentId: 'dep-0' as DeploymentId,
+            present: true,
+            running: true,
+            exited: false,
+          },
+        ],
+      }),
+    });
+    expect(plan.instances[0]?.action).toBe('replace');
+  });
+
+  test('a unit with no record is treated as a mismatch, not as converged', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [desiredInstance()] }),
+      observed: observedState({
+        instances: [{ instanceId: INSTANCE, present: true, running: true, exited: false }],
+      }),
+    });
+    expect(plan.instances[0]?.action).toBe('replace');
+  });
+
+  test('a VM that exited on its own is not booted again', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [desiredInstance()] }),
+      observed: observedState({
+        instances: [
+          {
+            instanceId: INSTANCE,
+            appId: APP,
+            volumeId: VOLUME,
+            deploymentId: DEPLOYMENT,
+            present: true,
+            running: false,
+            exited: true,
+          },
+        ],
+      }),
+    });
+    expect(plan.instances).toEqual([{ action: 'none', instanceId: INSTANCE }]);
+  });
+
+  test('a staging failure that never reached systemd is retried', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [desiredInstance()] }),
+      observed: observedState({
+        instances: [
+          {
+            instanceId: INSTANCE,
+            appId: APP,
+            volumeId: VOLUME,
+            deploymentId: DEPLOYMENT,
+            present: true,
+            running: false,
+            exited: false,
+          },
+        ],
+      }),
+    });
+    expect(plan.instances[0]?.action).toBe('start');
+  });
+
+  test('desiredState stopped stops a running instance and leaves a stopped one alone', () => {
+    const stopped = desiredInstance({ desiredState: 'stopped' });
+    const running = planReconcile({
+      desired: desiredState({ instances: [stopped] }),
+      observed: observedState({
+        instances: [{ instanceId: INSTANCE, present: true, running: true, exited: false }],
+      }),
+    });
+    expect(running.instances[0]).toEqual({
+      action: 'stop',
+      instanceId: INSTANCE,
+      reason: 'desired-stopped',
+    });
+
+    const already = planReconcile({
+      desired: desiredState({ instances: [stopped] }),
+      observed: observedState(),
+    });
+    expect(already.instances).toEqual([{ action: 'none', instanceId: INSTANCE }]);
+  });
+});
+
+describe('volumes are not authoritative', () => {
+  test('a volume missing from desired state is left completely alone', () => {
+    const plan = planReconcile({
+      desired: desiredState(),
+      observed: observedState({
+        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+      }),
+    });
+    expect(plan.volumes).toEqual([]);
+  });
+
+  test('removal requires an explicit absent', () => {
+    const plan = planReconcile({
+      desired: desiredState({ volumes: [desiredVolume({ desiredState: 'absent' })] }),
+      observed: observedState({
+        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+      }),
+    });
+    expect(plan.volumes[0]?.action).toBe('teardown');
+  });
+
+  test('a volume still held by an instance is blocked rather than destroyed', () => {
+    const plan = planReconcile({
+      desired: desiredState({ volumes: [desiredVolume({ desiredState: 'absent' })] }),
+      observed: observedState({
+        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+        instances: [
+          {
+            instanceId: INSTANCE,
+            appId: APP,
+            volumeId: VOLUME,
+            deploymentId: DEPLOYMENT,
+            present: true,
+            running: false,
+            exited: true,
+          },
+        ],
+      }),
+    });
+    expect(plan.volumes[0]).toEqual({
+      action: 'blocked',
+      desired: desiredVolume({ desiredState: 'absent' }),
+      blockedBy: [INSTANCE],
+    });
+  });
+
+  test('an unattached volume is provisioned and a grown one re-provisioned', () => {
+    const missing = planReconcile({
+      desired: desiredState({ volumes: [desiredVolume()] }),
+      observed: observedState(),
+    });
+    expect(missing.volumes[0]?.action).toBe('provision');
+
+    const small = planReconcile({
+      desired: desiredState({ volumes: [desiredVolume({ sizeBytes: GROWN_VOLUME_SIZE_BYTES })] }),
+      observed: observedState({
+        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+      }),
+    });
+    expect(small.volumes[0]?.action).toBe('provision');
+
+    const converged = planReconcile({
+      desired: desiredState({ volumes: [desiredVolume()] }),
+      observed: observedState({
+        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+      }),
+    });
+    expect(converged.volumes).toEqual([{ action: 'none', volumeId: VOLUME }]);
+  });
+});
+
+describe('checkpoints', () => {
+  const checkpointId = 'chk-1' as CheckpointId;
+
+  test('present creates only what is missing, absent deletes only what exists', () => {
+    const create = planReconcile({
+      desired: desiredState({
+        checkpoints: [{ checkpointId, volumeId: VOLUME, desiredState: 'present' }],
+      }),
+      observed: observedState(),
+    });
+    expect(create.checkpoints[0]?.action).toBe('create');
+
+    const already = planReconcile({
+      desired: desiredState({
+        checkpoints: [{ checkpointId, volumeId: VOLUME, desiredState: 'present' }],
+      }),
+      observed: observedState({ checkpoints: [{ checkpointId, volumeId: VOLUME }] }),
+    });
+    expect(already.checkpoints[0]?.action).toBe('none');
+
+    const remove = planReconcile({
+      desired: desiredState({
+        checkpoints: [{ checkpointId, volumeId: VOLUME, desiredState: 'absent' }],
+      }),
+      observed: observedState({ checkpoints: [{ checkpointId, volumeId: VOLUME }] }),
+    });
+    expect(remove.checkpoints[0]?.action).toBe('delete');
+  });
+});

--- a/apps/agent/src/reconcile/plan.ts
+++ b/apps/agent/src/reconcile/plan.ts
@@ -1,0 +1,220 @@
+import type {
+  AppId,
+  CheckpointId,
+  DeploymentId,
+  DesiredCheckpoint,
+  DesiredInstance,
+  DesiredVolume,
+  HostDesiredState,
+  InstanceId,
+  VolumeId,
+} from '@repo/protocol';
+
+export type ObservedInstance = {
+  instanceId: InstanceId;
+  // Absent for a unit systemd knows about that this agent has no record of — which is what a
+  // host looks like after its state file is lost. The identity is unrecoverable from the unit
+  // alone, and every path below then treats it as a mismatch, which is the safe reading.
+  appId?: AppId;
+  volumeId?: VolumeId;
+  deploymentId?: DeploymentId;
+  // A unit systemd still knows about, whether or not it is currently active.
+  present: boolean;
+  running: boolean;
+  // The VM stopped without this agent asking it to: the guest exhausted the tenant process's
+  // restart budget and powered itself off, or Firecracker died. Booting it again here would
+  // hide a broken deploy behind a host that retries forever, so it is left alone until the
+  // reconciler says something new.
+  exited: boolean;
+};
+
+export type ObservedVolume = {
+  volumeId: VolumeId;
+  attached: boolean;
+  sizeBytes: number;
+};
+
+export type ObservedCheckpoint = {
+  checkpointId: CheckpointId;
+  volumeId: VolumeId;
+};
+
+export type ObservedState = {
+  instances: ObservedInstance[];
+  volumes: ObservedVolume[];
+  checkpoints: ObservedCheckpoint[];
+};
+
+export const INSTANCE_STOP_REASONS = ['desired-stopped', 'not-desired', 'superseded'] as const;
+
+export type InstanceStopReason = (typeof INSTANCE_STOP_REASONS)[number];
+
+export type InstancePlan =
+  | { action: 'start'; desired: DesiredInstance }
+  | { action: 'replace'; desired: DesiredInstance }
+  | { action: 'stop'; instanceId: InstanceId; reason: InstanceStopReason }
+  | { action: 'forget'; instanceId: InstanceId }
+  | { action: 'none'; instanceId: InstanceId };
+
+export type VolumePlan =
+  | { action: 'provision'; desired: DesiredVolume }
+  | { action: 'teardown'; desired: DesiredVolume }
+  | { action: 'blocked'; desired: DesiredVolume; blockedBy: InstanceId[] }
+  | { action: 'none'; volumeId: VolumeId };
+
+export type CheckpointPlan =
+  | { action: 'create'; desired: DesiredCheckpoint }
+  | { action: 'delete'; desired: DesiredCheckpoint }
+  | { action: 'none'; checkpointId: CheckpointId };
+
+export type ReconcilePlan = {
+  instances: InstancePlan[];
+  volumes: VolumePlan[];
+  checkpoints: CheckpointPlan[];
+};
+
+const byId = <Item, Key extends string>({
+  items,
+  key,
+}: {
+  items: readonly Item[];
+  key: (item: Item) => Key;
+}) => new Map(items.map((item) => [key(item), item] as const));
+
+/**
+ * Diffs desired state against what the host is observed to be doing.
+ *
+ * The asymmetry between the two lists is the point. `instances` is authoritative, so a microVM
+ * the control plane does not mention is one this host stops — that is what makes an orphaned
+ * VM converge away without anybody sending a command. `volumes` is not: removal is only ever
+ * an explicit `absent`, because a truncated or partially-written response must not be able to
+ * destroy a tenant's filesystem. A volume missing from desired state is left exactly as it is.
+ */
+export function planReconcile({
+  desired,
+  observed,
+}: {
+  desired: HostDesiredState;
+  observed: ObservedState;
+}): ReconcilePlan {
+  return {
+    instances: planInstances({ desired, observed }),
+    volumes: planVolumes({ desired, observed }),
+    checkpoints: planCheckpoints({ desired, observed }),
+  };
+}
+
+function planInstances({
+  desired,
+  observed,
+}: {
+  desired: HostDesiredState;
+  observed: ObservedState;
+}): InstancePlan[] {
+  const observedById = byId({ items: observed.instances, key: (instance) => instance.instanceId });
+  const plans: InstancePlan[] = [];
+
+  for (const wanted of desired.instances) {
+    const current = observedById.get(wanted.instanceId);
+    if (wanted.desiredState === 'stopped') {
+      plans.push(
+        current?.running
+          ? { action: 'stop', instanceId: wanted.instanceId, reason: 'desired-stopped' }
+          : { action: 'none', instanceId: wanted.instanceId },
+      );
+      continue;
+    }
+    if (!current?.present) {
+      plans.push({ action: 'start', desired: wanted });
+      continue;
+    }
+    if (current.deploymentId !== wanted.deploymentId) {
+      plans.push({ action: 'replace', desired: wanted });
+      continue;
+    }
+    if (current.running) {
+      plans.push({ action: 'none', instanceId: wanted.instanceId });
+      continue;
+    }
+    plans.push(
+      current.exited
+        ? { action: 'none', instanceId: wanted.instanceId }
+        : { action: 'start', desired: wanted },
+    );
+  }
+
+  const desiredIds = new Set(desired.instances.map((instance) => instance.instanceId));
+  for (const current of observed.instances) {
+    if (desiredIds.has(current.instanceId)) {
+      continue;
+    }
+    plans.push(
+      current.running
+        ? { action: 'stop', instanceId: current.instanceId, reason: 'not-desired' }
+        : { action: 'forget', instanceId: current.instanceId },
+    );
+  }
+
+  return plans;
+}
+
+function planVolumes({
+  desired,
+  observed,
+}: {
+  desired: HostDesiredState;
+  observed: ObservedState;
+}): VolumePlan[] {
+  const observedById = byId({ items: observed.volumes, key: (volume) => volume.volumeId });
+  const usedBy = new Map<VolumeId, InstanceId[]>();
+  for (const instance of observed.instances) {
+    if (!instance.present || instance.volumeId === undefined) {
+      continue;
+    }
+    usedBy.set(instance.volumeId, [...(usedBy.get(instance.volumeId) ?? []), instance.instanceId]);
+  }
+  for (const instance of desired.instances) {
+    if (usedBy.has(instance.volumeId)) {
+      continue;
+    }
+    usedBy.set(instance.volumeId, []);
+  }
+
+  return desired.volumes.map((wanted): VolumePlan => {
+    const current = observedById.get(wanted.volumeId);
+    if (wanted.desiredState === 'absent') {
+      const holders = usedBy.get(wanted.volumeId) ?? [];
+      if (holders.length > 0) {
+        return { action: 'blocked', desired: wanted, blockedBy: holders };
+      }
+      return current
+        ? { action: 'teardown', desired: wanted }
+        : { action: 'none', volumeId: wanted.volumeId };
+    }
+    if (!current?.attached || current.sizeBytes < wanted.sizeBytes) {
+      return { action: 'provision', desired: wanted };
+    }
+    return { action: 'none', volumeId: wanted.volumeId };
+  });
+}
+
+function planCheckpoints({
+  desired,
+  observed,
+}: {
+  desired: HostDesiredState;
+  observed: ObservedState;
+}): CheckpointPlan[] {
+  const observedIds = new Set(observed.checkpoints.map((checkpoint) => checkpoint.checkpointId));
+  return desired.checkpoints.map((wanted): CheckpointPlan => {
+    const exists = observedIds.has(wanted.checkpointId);
+    if (wanted.desiredState === 'present') {
+      return exists
+        ? { action: 'none', checkpointId: wanted.checkpointId }
+        : { action: 'create', desired: wanted };
+    }
+    return exists
+      ? { action: 'delete', desired: wanted }
+      : { action: 'none', checkpointId: wanted.checkpointId };
+  });
+}

--- a/apps/agent/src/reconcile/reconciler.ts
+++ b/apps/agent/src/reconcile/reconciler.ts
@@ -1,0 +1,579 @@
+import type {
+  AppId,
+  DesiredInstance,
+  DesiredVolume,
+  HostDesiredState,
+  InstanceId,
+  ObjectKey,
+  ReportedCheckpoint,
+  ReportedVolume,
+  VolumeId,
+} from '@repo/protocol';
+import type { AgentConfig } from '#config.ts';
+import { probeInstance } from '#health/probe.ts';
+import { applyProbe, evaluateInstanceState, initialTracker } from '#health/state.ts';
+import { isReadyToRetry, nextAttemptWindow } from '#lib/backoff.ts';
+import { nowTimestamp } from '#lib/clock.ts';
+import type { CommandRunner } from '#lib/exec.ts';
+import { readJsonFile, writeJsonFile } from '#lib/json-store.ts';
+import { describeError, logger } from '#lib/logger.ts';
+import type { SlotAllocator } from '#network/allocator.ts';
+import type { ForwardedInstance } from '#network/firewall.ts';
+import { applyRuleset } from '#network/nftables.ts';
+import {
+  type CheckpointPlan,
+  type ObservedState,
+  planReconcile,
+  type ReconcilePlan,
+} from '#reconcile/plan.ts';
+import {
+  type InstanceRecord,
+  newInstanceRecord,
+  readInstanceRecords,
+} from '#report/instance-record.ts';
+import { type RouteTarget, renderableRoutes } from '#report/routes.ts';
+import type { VmManager } from '#vm/manager.ts';
+import type { SystemdVmUnits, UnitStatus } from '#vm/systemd.ts';
+import type { VolumeManager } from '#volumes/manager.ts';
+import type { ZerofsTopology } from '#volumes/topology.ts';
+import type { ZerofsAdmin } from '#volumes/zerofs.ts';
+
+const NO_GENERATION = 0;
+const ONE_RESTART = 1;
+const MAX_MESSAGE_LENGTH = 512;
+
+const UNKNOWN_UNIT: UnitStatus = { loaded: false, active: false, failed: false };
+
+// A checkpoint names a volume, and which ZeroFS serves it is decided by that volume's storage
+// prefix — which only desired state carries. A checkpoint for a volume the host has never been
+// told about is refused rather than guessed at.
+class UnknownVolumeError extends Error {
+  constructor(volumeId: VolumeId) {
+    super(`No storage prefix is known for volume ${volumeId}`);
+    this.name = 'UnknownVolumeError';
+  }
+}
+
+export type ReconcilerOptions = {
+  config: AgentConfig;
+  runner: CommandRunner;
+  units: SystemdVmUnits;
+  vms: VmManager;
+  volumes: VolumeManager;
+  topology: ZerofsTopology;
+  allocator: SlotAllocator;
+};
+
+/**
+ * Pull, converge, report.
+ *
+ * Nothing here is driven by a command. Desired state describes a world, this compares it with
+ * what the host is observed to be doing, and the difference is the work — which is why an
+ * agent restart, a control-plane restart and a missed message are all non-events.
+ */
+export class Reconciler {
+  readonly #options: ReconcilerOptions;
+  readonly #records = new Map<InstanceId, InstanceRecord>();
+  readonly #unitStatus = new Map<InstanceId, UnitStatus>();
+  readonly #nextProbeAtMs = new Map<InstanceId, number>();
+  readonly #storagePrefixByVolume = new Map<VolumeId, ObjectKey>();
+  readonly #allocator: SlotAllocator;
+  #volumeReports: ReportedVolume[] = [];
+  #checkpointReports: ReportedCheckpoint[] = [];
+  #observedGeneration = NO_GENERATION;
+  #converged = false;
+
+  constructor(options: ReconcilerOptions) {
+    this.#options = options;
+    this.#allocator = options.allocator;
+  }
+
+  get observedGeneration() {
+    return this.#observedGeneration;
+  }
+
+  get converged() {
+    return this.#converged;
+  }
+
+  records(): InstanceRecord[] {
+    return [...this.#records.values()];
+  }
+
+  volumeReports(): ReportedVolume[] {
+    return this.#volumeReports;
+  }
+
+  checkpointReports(): ReportedCheckpoint[] {
+    return this.#checkpointReports;
+  }
+
+  // What the local user-app proxy will render its config from when it exists. Nothing consumes
+  // it yet; it is here so that when something does, it reads the state that boots the VMs
+  // rather than a second copy of it.
+  routes(): RouteTarget[] {
+    return renderableRoutes(this.records());
+  }
+
+  async load(): Promise<void> {
+    for (const record of readInstanceRecords(
+      await readJsonFile({ path: this.#options.config.instancesFile }),
+    )) {
+      this.#records.set(record.instanceId, record);
+    }
+    logger.info({
+      message: 'agent state loaded',
+      instances: this.#records.size,
+      slots: this.#allocator.slots().length,
+    });
+  }
+
+  /**
+   * What is really running, asked of systemd rather than remembered.
+   *
+   * The union of the units systemd knows about and the instances this agent has notes on is
+   * deliberate: a unit with no note is an orphan to stop, and a note with no unit is an
+   * instance that is gone. Trusting only the notes is what would make a restarted agent
+   * confidently wrong.
+   */
+  async observe(): Promise<ObservedState> {
+    const unitIds = await this.#options.units.listInstanceIds();
+    const ids = [...new Set([...unitIds, ...this.#records.keys()])];
+    const statuses = await this.#options.units.statuses(ids);
+    this.#unitStatus.clear();
+    for (const [instanceId, status] of statuses) {
+      this.#unitStatus.set(instanceId, status);
+    }
+
+    const instances = ids.map((instanceId) => {
+      const status = statuses.get(instanceId) ?? UNKNOWN_UNIT;
+      const record = this.#records.get(instanceId);
+      return {
+        instanceId,
+        ...(record ? { appId: record.appId, volumeId: record.volumeId } : {}),
+        ...(record ? { deploymentId: record.deploymentId } : {}),
+        present: status.loaded || record !== undefined,
+        running: status.active,
+        exited: !status.active && record?.startedAt !== undefined && !record.stopRequested,
+      };
+    });
+
+    return {
+      instances,
+      volumes: await this.#options.volumes.observe({ appIdByVolume: this.#appIdByVolume() }),
+      // Listing checkpoints costs an RPC round trip on every reconcile, and almost every
+      // reconcile has none to converge. The list is read once, inside the branch that needs it.
+      checkpoints: [],
+    };
+  }
+
+  async reconcile({ desired }: { desired: HostDesiredState }): Promise<void> {
+    const observed = await this.observe();
+    const plan = planReconcile({ desired, observed });
+    this.#syncDesired(desired);
+
+    await this.#applyStops(plan);
+    await this.#applyVolumes(plan);
+    await this.#applyStarts(plan);
+    await this.#applyCheckpoints({ plan, desired });
+    await this.#applyTeardowns(plan);
+    await this.#applyNetwork();
+    await this.#persist();
+
+    this.#observedGeneration = desired.generation;
+    this.#converged = true;
+  }
+
+  /**
+   * Probes the tenants that are due, then re-reads what systemd says and settles every
+   * instance's state from the two together.
+   */
+  async refreshStates(): Promise<void> {
+    const ids = [...this.#records.keys()];
+    const statuses = await this.#options.units.statuses(ids);
+    const nowMs = Date.now();
+
+    for (const record of this.#records.values()) {
+      const status = statuses.get(record.instanceId) ?? UNKNOWN_UNIT;
+      this.#unitStatus.set(record.instanceId, status);
+      if (status.active && this.#isProbeDue({ instanceId: record.instanceId, nowMs })) {
+        const healthy = await probeInstance({
+          guestIpv4: record.guestIpv4,
+          guestPort: record.guestPort,
+          healthCheck: record.healthCheck,
+        });
+        record.health = applyProbe({
+          tracker: record.health,
+          healthy,
+          at: nowTimestamp(),
+          healthyThreshold: record.healthCheck.healthyThreshold,
+        });
+        this.#nextProbeAtMs.set(record.instanceId, nowMs + record.healthCheck.intervalMs);
+      }
+      const previous = record.state;
+      record.state = evaluateInstanceState({
+        unit: status,
+        tracker: record.health,
+        healthCheck: record.healthCheck,
+        desiredRunning: record.desiredRunning,
+        stopRequested: record.stopRequested,
+        ...(record.startedAt ? { startedAtMs: Date.parse(record.startedAt) } : {}),
+        nowMs,
+      });
+      if (record.state !== previous) {
+        logger.info({
+          message: 'instance state changed',
+          instanceId: record.instanceId,
+          from: previous,
+          to: record.state,
+        });
+        if (status.exitCode !== undefined && !status.active) {
+          record.lastExitCode = status.exitCode;
+        }
+      }
+    }
+    await this.#persist();
+  }
+
+  // Hostnames, the health check and whether the app should be up can all change without the
+  // artifact changing. Folding them into the record here is what keeps the route renderer and
+  // the probe reading current configuration rather than whatever was true at boot.
+  #syncDesired(desired: HostDesiredState): void {
+    for (const volume of desired.volumes) {
+      this.#storagePrefixByVolume.set(volume.volumeId, volume.storagePrefix);
+    }
+    for (const wanted of desired.instances) {
+      const record = this.#records.get(wanted.instanceId);
+      if (!record) {
+        continue;
+      }
+      record.hostnames = wanted.hostnames;
+      record.healthCheck = wanted.config.healthCheck;
+      record.resources = wanted.config.resources;
+      record.desiredRunning = wanted.desiredState === 'running';
+      record.guestPort = wanted.config.guestPort;
+    }
+  }
+
+  #isProbeDue({ instanceId, nowMs }: { instanceId: InstanceId; nowMs: number }) {
+    return nowMs >= (this.#nextProbeAtMs.get(instanceId) ?? 0);
+  }
+
+  #appIdByVolume(): Map<VolumeId, AppId> {
+    return new Map(
+      [...this.#records.values()].map((record) => [record.volumeId, record.appId] as const),
+    );
+  }
+
+  async #applyStops(plan: ReconcilePlan): Promise<void> {
+    for (const action of plan.instances) {
+      if (action.action === 'stop') {
+        await this.#stop({ instanceId: action.instanceId, reason: action.reason });
+      }
+      if (action.action === 'replace') {
+        await this.#stop({ instanceId: action.desired.instanceId, reason: 'superseded' });
+        await this.#options.vms.discard({ instanceId: action.desired.instanceId });
+        this.#records.delete(action.desired.instanceId);
+      }
+      if (action.action === 'forget') {
+        await this.#options.vms.discard({ instanceId: action.instanceId });
+        this.#records.delete(action.instanceId);
+      }
+    }
+  }
+
+  async #stop({ instanceId, reason }: { instanceId: InstanceId; reason: string }): Promise<void> {
+    const record = this.#records.get(instanceId);
+    if (record) {
+      record.stopRequested = true;
+      record.state = 'stopping';
+    }
+    // Under `ignore_fsync` the guest's own flushes are a no-op, so this is the only thing
+    // standing between a stop and the loss of everything since the last periodic flush. Worst
+    // case is the flush interval *plus* the seal and upload, not exactly the interval.
+    await this.#tryFlush({ volumeId: record?.volumeId });
+    try {
+      await this.#options.vms.stop({ instanceId });
+      logger.info({ message: 'instance stopped', instanceId, reason });
+    } catch (error) {
+      logger.error({
+        message: 'instance stop failed',
+        instanceId,
+        reason,
+        ...describeError(error),
+      });
+    }
+    if (record) {
+      record.state = 'stopped';
+    }
+  }
+
+  async #applyVolumes(plan: ReconcilePlan): Promise<void> {
+    const reports: ReportedVolume[] = [];
+    for (const action of plan.volumes) {
+      if (action.action === 'provision') {
+        reports.push(await this.#provision(action.desired));
+      }
+      if (action.action === 'blocked') {
+        logger.warn({
+          message: 'volume removal deferred: still attached',
+          volumeId: action.desired.volumeId,
+          blockedBy: action.blockedBy,
+        });
+      }
+    }
+    this.#volumeReports = mergeVolumeReports({ existing: this.#volumeReports, updates: reports });
+  }
+
+  async #provision(desired: DesiredVolume): Promise<ReportedVolume> {
+    try {
+      return await this.#options.volumes.provision({ desired });
+    } catch (error) {
+      logger.error({
+        message: 'volume provisioning failed',
+        volumeId: desired.volumeId,
+        ...describeError(error),
+      });
+      return {
+        volumeId: desired.volumeId,
+        state: 'failed',
+        sizeBytes: desired.sizeBytes,
+        message: truncate(describeError(error).error),
+      };
+    }
+  }
+
+  async #applyTeardowns(plan: ReconcilePlan): Promise<void> {
+    for (const action of plan.volumes) {
+      if (action.action !== 'teardown') {
+        continue;
+      }
+      try {
+        const report = await this.#options.volumes.teardown({ desired: action.desired });
+        this.#volumeReports = mergeVolumeReports({
+          existing: this.#volumeReports,
+          updates: [report],
+        });
+      } catch (error) {
+        logger.error({
+          message: 'volume teardown failed',
+          volumeId: action.desired.volumeId,
+          ...describeError(error),
+        });
+      }
+    }
+  }
+
+  async #applyStarts(plan: ReconcilePlan): Promise<void> {
+    for (const action of plan.instances) {
+      if (action.action !== 'start' && action.action !== 'replace') {
+        continue;
+      }
+      await this.#start({ desired: action.desired });
+    }
+  }
+
+  async #start({ desired }: { desired: DesiredInstance }): Promise<void> {
+    const nowMs = Date.now();
+    const existing = this.#records.get(desired.instanceId);
+    const policy = desired.config.restartPolicy;
+    if (existing && existing.startAttempts.attempts > policy.maxRestarts) {
+      return;
+    }
+    if (existing && !isReadyToRetry({ window: existing.startAttempts, nowMs, policy })) {
+      return;
+    }
+
+    const slot = this.#allocator.allocate(desired.appId);
+    const record =
+      existing ??
+      newInstanceRecord({
+        instanceId: desired.instanceId,
+        appId: desired.appId,
+        deploymentId: desired.deploymentId,
+        volumeId: desired.volumeId,
+        hostnames: desired.hostnames,
+        hostPort: slot.hostPort,
+        guestPort: desired.config.guestPort,
+        guestIpv4: slot.guestIpv4,
+        artifactDigest: desired.artifact.digest,
+        state: 'pending',
+        health: initialTracker(),
+        healthCheck: desired.config.healthCheck,
+        resources: desired.config.resources,
+        desiredRunning: true,
+      });
+    record.startAttempts = nextAttemptWindow({
+      window: record.startAttempts,
+      nowMs,
+      resetAfterMs: policy.resetAfterMs,
+    });
+    this.#records.set(desired.instanceId, record);
+
+    try {
+      await this.#options.vms.boot({
+        desired,
+        slot,
+        dataDevicePath: slot.nbdDevicePath,
+      });
+      record.startedAt = nowTimestamp();
+      record.state = 'starting';
+      record.stopRequested = false;
+      record.health = initialTracker();
+      record.restartCount += existing ? ONE_RESTART : 0;
+      delete record.message;
+      this.#nextProbeAtMs.delete(desired.instanceId);
+      logger.info({
+        message: 'instance started',
+        instanceId: desired.instanceId,
+        hostPort: record.hostPort,
+        guestIpv4: record.guestIpv4,
+      });
+    } catch (error) {
+      record.state = 'failed';
+      record.message = truncate(describeError(error).error);
+      logger.error({
+        message: 'instance start failed',
+        instanceId: desired.instanceId,
+        attempt: record.startAttempts.attempts,
+        ...describeError(error),
+      });
+    }
+  }
+
+  /**
+   * `CreateCheckpoint` takes the flush barrier itself before capturing the manifest, so there
+   * is no separate flush here — an extra one would be a redundant round trip against a
+   * guarantee the RPC already makes.
+   */
+  async #applyCheckpoints({
+    plan,
+    desired,
+  }: {
+    plan: ReconcilePlan;
+    desired: HostDesiredState;
+  }): Promise<void> {
+    if (desired.checkpoints.length === 0) {
+      this.#checkpointReports = [];
+      return;
+    }
+    const reports: ReportedCheckpoint[] = [];
+    for (const action of plan.checkpoints) {
+      if (action.action === 'none') {
+        continue;
+      }
+      reports.push(await this.#applyCheckpoint(action));
+    }
+    this.#checkpointReports = reports;
+  }
+
+  async #applyCheckpoint(
+    action: Extract<CheckpointPlan, { action: 'create' | 'delete' }>,
+  ): Promise<ReportedCheckpoint> {
+    const { checkpointId, volumeId } = action.desired;
+    try {
+      const admin = this.#adminFor({ volumeId });
+      const existing = new Set(await admin.listCheckpoints());
+      if (action.action === 'create' && !existing.has(checkpointId)) {
+        await admin.createCheckpoint({ checkpointId });
+      }
+      if (action.action === 'delete' && existing.has(checkpointId)) {
+        await admin.deleteCheckpoint({ checkpointId });
+      }
+      return action.action === 'create'
+        ? {
+            checkpointId,
+            volumeId,
+            state: 'ready',
+            reference: checkpointId,
+            readyAt: nowTimestamp(),
+          }
+        : { checkpointId, volumeId, state: 'pending' };
+    } catch (error) {
+      return {
+        checkpointId,
+        volumeId,
+        state: 'failed',
+        message: truncate(describeError(error).error),
+      };
+    }
+  }
+
+  #adminFor({ volumeId }: { volumeId: VolumeId }): ZerofsAdmin {
+    const storagePrefix = this.#storagePrefixByVolume.get(volumeId);
+    if (storagePrefix === undefined) {
+      throw new UnknownVolumeError(volumeId);
+    }
+    return this.#options.topology.resolve({ storagePrefix }).admin;
+  }
+
+  async #tryFlush({ volumeId }: { volumeId?: VolumeId }): Promise<void> {
+    const prefix = volumeId === undefined ? undefined : this.#storagePrefixByVolume.get(volumeId);
+    for (const filesystem of this.#options.topology.all()) {
+      if (prefix !== undefined && filesystem.storagePrefix !== prefix) {
+        continue;
+      }
+      try {
+        await filesystem.admin.flush();
+      } catch (error) {
+        logger.warn({
+          message: 'zerofs flush failed',
+          storagePrefix: filesystem.storagePrefix,
+          ...describeError(error),
+        });
+      }
+    }
+  }
+
+  async #applyNetwork(): Promise<void> {
+    const instances: ForwardedInstance[] = [];
+    for (const record of this.#records.values()) {
+      const slot = this.#allocator.lookup(record.appId);
+      if (!slot) {
+        continue;
+      }
+      instances.push({
+        hostPort: slot.hostPort,
+        guestPort: record.guestPort,
+        hostIpv4: slot.hostIpv4,
+        guestIpv4: slot.guestIpv4,
+      });
+    }
+    try {
+      await applyRuleset({
+        runner: this.#options.runner,
+        state: {
+          instances,
+          controlPlaneCidrs: this.#options.config.controlPlaneCidrs,
+          guestDnsServers: this.#options.config.guestDnsServers,
+        },
+      });
+    } catch (error) {
+      logger.error({ message: 'firewall apply failed', ...describeError(error) });
+    }
+  }
+
+  async #persist(): Promise<void> {
+    await writeJsonFile({
+      path: this.#options.config.slotsFile,
+      value: this.#allocator.toRecords(),
+    });
+    await writeJsonFile({ path: this.#options.config.instancesFile, value: this.records() });
+  }
+}
+
+export function mergeVolumeReports({
+  existing,
+  updates,
+}: {
+  existing: readonly ReportedVolume[];
+  updates: readonly ReportedVolume[];
+}): ReportedVolume[] {
+  const merged = new Map(existing.map((report) => [report.volumeId, report] as const));
+  for (const report of updates) {
+    merged.set(report.volumeId, report);
+  }
+  return [...merged.values()];
+}
+
+const truncate = (value: string) => value.slice(0, MAX_MESSAGE_LENGTH);

--- a/apps/agent/src/report/build-report.test.ts
+++ b/apps/agent/src/report/build-report.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type AppId,
+  DEFAULT_GUEST_PORT,
+  DEFAULT_HEALTH_CHECK,
+  DEFAULT_INSTANCE_RESOURCES,
+  type DeploymentId,
+  type GuestPort,
+  type HostId,
+  type Hostname,
+  type HostPort,
+  HostReportedStateSchema,
+  type InstanceId,
+  type InstanceState,
+  type Ipv4Address,
+  isValidMessage,
+  type Sha256Digest,
+  type Timestamp,
+  type VolumeId,
+} from '@repo/protocol';
+import { initialTracker } from '#health/state.ts';
+import { buildReportedState, toReportedInstance } from '#report/build-report.ts';
+import { allocatableCapacity } from '#report/capacity.ts';
+import type { InstanceRecord } from '#report/instance-record.ts';
+import { renderableRoutes } from '#report/routes.ts';
+
+const AT = '2026-08-03T10:00:00.000Z' as Timestamp;
+const DIGEST_HEX_LENGTH = 64;
+const FIRST_HOST_PORT = 21_000 as HostPort;
+const OBSERVED_GENERATION = 7;
+const HOST_VCPUS = 4;
+const HOST_MEMORY_MIB = 8_192;
+const HOST_CACHE_BYTES = 1_000;
+const FREE_CACHE_BYTES = 400;
+const VOLUME_SIZE_BYTES = 4_096;
+
+const record = (overrides: Partial<InstanceRecord> = {}): InstanceRecord => ({
+  instanceId: 'inst-1' as InstanceId,
+  appId: 'app-1' as AppId,
+  deploymentId: 'dep-1' as DeploymentId,
+  volumeId: 'vol-1' as VolumeId,
+  hostnames: [{ hostname: 'a.example.com' as Hostname, kind: 'platform', isDefault: true }],
+  hostPort: FIRST_HOST_PORT,
+  guestPort: DEFAULT_GUEST_PORT,
+  guestIpv4: '10.201.0.2' as Ipv4Address,
+  artifactDigest: 'a'.repeat(DIGEST_HEX_LENGTH) as Sha256Digest,
+  state: 'running' as InstanceState,
+  health: initialTracker(),
+  healthCheck: DEFAULT_HEALTH_CHECK,
+  resources: DEFAULT_INSTANCE_RESOURCES,
+  desiredRunning: true,
+  startAttempts: { attempts: 1 },
+  restartCount: 0,
+  stopRequested: false,
+  ...overrides,
+});
+
+describe('the report always names the host-side port', () => {
+  test('routing is local, but the control plane cannot debug a host without it', () => {
+    expect(toReportedInstance(record()).hostPort).toBe(FIRST_HOST_PORT);
+  });
+
+  test('absent means unknown: no field is ever sent null', () => {
+    const reported = toReportedInstance(record());
+    expect('startedAt' in reported).toBe(false);
+    expect('lastHealthyAt' in reported).toBe(false);
+    expect('lastExitCode' in reported).toBe(false);
+    expect('message' in reported).toBe(false);
+  });
+
+  test('an exit code of zero is reported rather than dropped as falsy', () => {
+    expect(toReportedInstance(record({ lastExitCode: 0 })).lastExitCode).toBe(0);
+  });
+});
+
+describe('the assembled report satisfies the protocol', () => {
+  test('a full report validates against the schema it will be sent as', () => {
+    const report = buildReportedState({
+      hostId: 'host-1' as HostId,
+      observedGeneration: OBSERVED_GENERATION,
+      reportedAt: AT,
+      state: 'ready',
+      capacity: { vcpuCount: HOST_VCPUS, memoryMib: HOST_MEMORY_MIB, cacheBytes: HOST_CACHE_BYTES },
+      allocatable: {
+        vcpuCount: HOST_VCPUS,
+        memoryMib: HOST_MEMORY_MIB,
+        cacheBytes: FREE_CACHE_BYTES,
+      },
+      versions: { agent: 'sha', guestImage: '6.1', zerofs: '2.2.1', firecracker: '1.16.1' },
+      records: [record({ startedAt: AT })],
+      volumes: [{ volumeId: 'vol-1' as VolumeId, state: 'ready', sizeBytes: VOLUME_SIZE_BYTES }],
+      checkpoints: [],
+    });
+    expect(isValidMessage({ schema: HostReportedStateSchema, value: report })).toBe(true);
+  });
+});
+
+describe('the same records render the routing layer', () => {
+  test('only instances whose tenant answered are routable', () => {
+    const records = [
+      record(),
+      record({ instanceId: 'inst-2' as InstanceId, state: 'starting' }),
+      record({ instanceId: 'inst-3' as InstanceId, state: 'unhealthy' }),
+    ];
+    expect(renderableRoutes(records)).toEqual([
+      {
+        appId: 'app-1' as AppId,
+        hostnames: records[0]?.hostnames ?? [],
+        hostPort: FIRST_HOST_PORT,
+      },
+    ]);
+  });
+
+  test('an app with no hostname yet is not routed', () => {
+    expect(renderableRoutes([record({ hostnames: [] })])).toEqual([]);
+  });
+});
+
+const HOST_CAPACITY = {
+  vcpuCount: HOST_VCPUS,
+  memoryMib: HOST_MEMORY_MIB,
+  cacheBytes: HOST_CACHE_BYTES,
+};
+const BOOTED = [DEFAULT_INSTANCE_RESOURCES, DEFAULT_INSTANCE_RESOURCES];
+const DEFAULT_INSTANCE_RESOURCES_AS_CAPACITY = {
+  ...DEFAULT_INSTANCE_RESOURCES,
+  cacheBytes: HOST_CACHE_BYTES,
+};
+
+describe('allocatable capacity', () => {
+  test('what is booted is subtracted from what the host has', () => {
+    expect(
+      allocatableCapacity({
+        capacity: HOST_CAPACITY,
+        committed: BOOTED,
+        availableCacheBytes: FREE_CACHE_BYTES,
+      }),
+    ).toEqual({
+      vcpuCount: HOST_VCPUS - DEFAULT_INSTANCE_RESOURCES.vcpuCount * BOOTED.length,
+      memoryMib: HOST_MEMORY_MIB - DEFAULT_INSTANCE_RESOURCES.memoryMib * BOOTED.length,
+      cacheBytes: FREE_CACHE_BYTES,
+    });
+  });
+
+  test('an oversubscribed host reports zero rather than a negative', () => {
+    expect(
+      allocatableCapacity({
+        capacity: DEFAULT_INSTANCE_RESOURCES_AS_CAPACITY,
+        committed: [HOST_CAPACITY],
+        availableCacheBytes: FREE_CACHE_BYTES,
+      }),
+    ).toEqual({ vcpuCount: 0, memoryMib: 0, cacheBytes: FREE_CACHE_BYTES });
+  });
+
+  test('guest ports are branded apart from host ports at the type level', () => {
+    const guestPort: GuestPort = DEFAULT_GUEST_PORT;
+    // @ts-expect-error a GuestPort is not a HostPort, which is what stops a routing bug type-checking
+    const hostPort: HostPort = guestPort;
+    expect(hostPort).toBe(guestPort as unknown as HostPort);
+  });
+});

--- a/apps/agent/src/report/build-report.ts
+++ b/apps/agent/src/report/build-report.ts
@@ -1,0 +1,72 @@
+import type {
+  HostCapacity,
+  HostId,
+  HostReportedState,
+  HostState,
+  HostVersions,
+  ReportedCheckpoint,
+  ReportedInstance,
+  ReportedVolume,
+  Timestamp,
+} from '@repo/protocol';
+import type { InstanceRecord } from '#report/instance-record.ts';
+
+/**
+ * Every optional field is omitted rather than sent empty. Absent means unknown or not
+ * applicable, and there is one convention for that so nothing downstream has to decide what
+ * the difference between absent and null would have meant.
+ */
+export function toReportedInstance(record: InstanceRecord): ReportedInstance {
+  return {
+    instanceId: record.instanceId,
+    deploymentId: record.deploymentId,
+    state: record.state,
+    hostPort: record.hostPort,
+    guestIpv4: record.guestIpv4,
+    artifactDigest: record.artifactDigest,
+    restartCount: record.restartCount,
+    ...(record.startedAt ? { startedAt: record.startedAt } : {}),
+    ...(record.health.lastHealthyAt ? { lastHealthyAt: record.health.lastHealthyAt } : {}),
+    ...(record.lastExitCode === undefined ? {} : { lastExitCode: record.lastExitCode }),
+    ...(record.message ? { message: record.message } : {}),
+  };
+}
+
+export function buildReportedState({
+  hostId,
+  observedGeneration,
+  reportedAt,
+  state,
+  capacity,
+  allocatable,
+  versions,
+  records,
+  volumes,
+  checkpoints,
+}: {
+  hostId: HostId;
+  observedGeneration: number;
+  reportedAt: Timestamp;
+  state: HostState;
+  capacity: HostCapacity;
+  allocatable: HostCapacity;
+  versions: HostVersions;
+  records: readonly InstanceRecord[];
+  volumes: readonly ReportedVolume[];
+  checkpoints: readonly ReportedCheckpoint[];
+}): HostReportedState {
+  return {
+    hostId,
+    observedGeneration,
+    reportedAt,
+    state,
+    capacity,
+    allocatable,
+    versions,
+    volumes: [...volumes],
+    instances: records.map(toReportedInstance),
+    checkpoints: [...checkpoints],
+    // Writing exports is not implemented yet, so this host has none to report.
+    exports: [],
+  };
+}

--- a/apps/agent/src/report/capacity.ts
+++ b/apps/agent/src/report/capacity.ts
@@ -1,0 +1,59 @@
+import { statfs } from 'node:fs/promises';
+import { availableParallelism, totalmem } from 'node:os';
+import type { HostCapacity, InstanceResources } from '@repo/protocol';
+
+const BYTES_PER_MIB = 1_048_576;
+const NONE = 0;
+
+export async function readHostCapacity({ cacheDir }: { cacheDir: string }): Promise<HostCapacity> {
+  return {
+    vcpuCount: availableParallelism(),
+    memoryMib: Math.floor(totalmem() / BYTES_PER_MIB),
+    cacheBytes: await readCacheBytes({ cacheDir }),
+  };
+}
+
+async function readCacheBytes({ cacheDir }: { cacheDir: string }): Promise<number> {
+  try {
+    const stats = await statfs(cacheDir);
+    return Number(stats.blocks) * Number(stats.bsize);
+  } catch {
+    return NONE;
+  }
+}
+
+export async function readAvailableCacheBytes({ cacheDir }: { cacheDir: string }): Promise<number> {
+  try {
+    const stats = await statfs(cacheDir);
+    return Number(stats.bavail) * Number(stats.bsize);
+  } catch {
+    return NONE;
+  }
+}
+
+/**
+ * What is left after everything currently booted, which is what a placement decision needs.
+ * Floored at zero rather than allowed to go negative: an oversubscribed host is a fact to
+ * report, not a number to do arithmetic with.
+ */
+export function allocatableCapacity({
+  capacity,
+  committed,
+  availableCacheBytes,
+}: {
+  capacity: HostCapacity;
+  committed: readonly InstanceResources[];
+  availableCacheBytes: number;
+}): HostCapacity {
+  let usedVcpu = NONE;
+  let usedMemory = NONE;
+  for (const entry of committed) {
+    usedVcpu += entry.vcpuCount;
+    usedMemory += entry.memoryMib;
+  }
+  return {
+    vcpuCount: Math.max(capacity.vcpuCount - usedVcpu, NONE),
+    memoryMib: Math.max(capacity.memoryMib - usedMemory, NONE),
+    cacheBytes: Math.max(Math.min(availableCacheBytes, capacity.cacheBytes), NONE),
+  };
+}

--- a/apps/agent/src/report/instance-record.ts
+++ b/apps/agent/src/report/instance-record.ts
@@ -1,0 +1,94 @@
+import type {
+  AppHostname,
+  AppId,
+  DeploymentId,
+  GuestPort,
+  HealthCheck,
+  HostPort,
+  InstanceId,
+  InstanceResources,
+  InstanceState,
+  Ipv4Address,
+  Sha256Digest,
+  Timestamp,
+  VolumeId,
+} from '@repo/protocol';
+import type { HealthTracker } from '#health/state.ts';
+import type { AttemptWindow } from '#lib/backoff.ts';
+
+const NO_RESTARTS = 0;
+const NO_ATTEMPTS = 0;
+
+/**
+ * What the agent knows about one instance, in the shape the routing layer will want to read.
+ *
+ * Hostname, host-side port and health sit at the top level rather than being reachable only by
+ * replaying the boot path, so the local proxy's config can be rendered straight from this when
+ * it is built. That is the whole reason there is no routing table in the control plane: the
+ * process that knows what is running is the process that writes the routing config.
+ *
+ * It is a cache, not an authority. Systemd is what is actually running, and a record that
+ * cannot be read back is discarded rather than trusted.
+ */
+export type InstanceRecord = {
+  instanceId: InstanceId;
+  appId: AppId;
+  deploymentId: DeploymentId;
+  volumeId: VolumeId;
+  hostnames: AppHostname[];
+  hostPort: HostPort;
+  guestPort: GuestPort;
+  guestIpv4: Ipv4Address;
+  artifactDigest: Sha256Digest;
+  state: InstanceState;
+  health: HealthTracker;
+  healthCheck: HealthCheck;
+  resources: InstanceResources;
+  desiredRunning: boolean;
+  startAttempts: AttemptWindow;
+  restartCount: number;
+  stopRequested: boolean;
+  startedAt?: Timestamp;
+  lastExitCode?: number;
+  message?: string;
+};
+
+export const newInstanceRecord = (
+  fields: Omit<InstanceRecord, 'restartCount' | 'startAttempts' | 'stopRequested'>,
+): InstanceRecord => ({
+  ...fields,
+  restartCount: NO_RESTARTS,
+  startAttempts: { attempts: NO_ATTEMPTS },
+  stopRequested: false,
+});
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const REQUIRED_STRING_FIELDS = [
+  'instanceId',
+  'appId',
+  'deploymentId',
+  'volumeId',
+  'guestIpv4',
+  'artifactDigest',
+  'state',
+] as const;
+
+const REQUIRED_NUMBER_FIELDS = ['hostPort', 'guestPort', 'restartCount'] as const;
+
+// Deliberately structural rather than schema-driven: these are the agent's own notes, not a
+// message from another program, and the recovery for an unreadable one is to re-derive it from
+// what systemd reports rather than to reject the file.
+export function isInstanceRecord(value: unknown): value is InstanceRecord {
+  if (!isObject(value)) {
+    return false;
+  }
+  const hasStrings = REQUIRED_STRING_FIELDS.every((field) => typeof value[field] === 'string');
+  const hasNumbers = REQUIRED_NUMBER_FIELDS.every((field) => typeof value[field] === 'number');
+  return hasStrings && hasNumbers && Array.isArray(value.hostnames) && isObject(value.health);
+}
+
+export function readInstanceRecords(value: unknown): InstanceRecord[] {
+  return Array.isArray(value) ? value.filter(isInstanceRecord) : [];
+}

--- a/apps/agent/src/report/routes.ts
+++ b/apps/agent/src/report/routes.ts
@@ -1,0 +1,29 @@
+import type { AppHostname, AppId, HostPort } from '@repo/protocol';
+import type { InstanceRecord } from '#report/instance-record.ts';
+
+export type RouteTarget = {
+  appId: AppId;
+  hostnames: AppHostname[];
+  hostPort: HostPort;
+};
+
+/**
+ * Everything the local user-app proxy would need, derived from the same records the boot path
+ * writes.
+ *
+ * The proxy is not being built now. This exists so that when it is, its config is a projection
+ * of what the host is running rather than a second copy of it — which is what leaves no room
+ * for the two to drift.
+ *
+ * Only instances whose tenant has actually answered are routable: sending traffic to a booted
+ * but dead VM is the failure the `starting`/`running` distinction exists to prevent.
+ */
+export function renderableRoutes(records: readonly InstanceRecord[]): RouteTarget[] {
+  return records
+    .filter((record) => record.state === 'running' && record.hostnames.length > 0)
+    .map((record) => ({
+      appId: record.appId,
+      hostnames: record.hostnames,
+      hostPort: record.hostPort,
+    }));
+}

--- a/apps/agent/src/report/versions.ts
+++ b/apps/agent/src/report/versions.ts
@@ -1,0 +1,25 @@
+import { type HostVersions, HostVersionsSchema, parseMessage } from '@repo/protocol';
+import { readJsonFile } from '#lib/json-store.ts';
+
+export class MissingVersionsError extends Error {
+  constructor(path: string) {
+    super(`${path} is missing: a host that cannot say what it is running has been misdeployed`);
+    this.name = 'MissingVersionsError';
+  }
+}
+
+/**
+ * The pins CI writes into the bundle, read rather than compiled in.
+ *
+ * The agent's own version is the git SHA of the commit that built it; the other three name the
+ * versions installed under `/opt/nibrun/bin`. Reading them from the same file the deploy
+ * script installs from is what keeps a report from claiming a version a symlink no longer
+ * points at.
+ */
+export async function readHostVersions({ path }: { path: string }): Promise<HostVersions> {
+  const value = await readJsonFile({ path });
+  if (value === undefined) {
+    throw new MissingVersionsError(path);
+  }
+  return parseMessage({ schema: HostVersionsSchema, value });
+}

--- a/apps/agent/src/vm/artifacts.test.ts
+++ b/apps/agent/src/vm/artifacts.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DesiredArtifact, ObjectKey, Sha256Digest } from '@repo/protocol';
+import {
+  type ArtifactBytes,
+  ArtifactSizeError,
+  artifactImagePath,
+  DigestMismatchError,
+  digestOfFile,
+  downloadAndVerify,
+} from '#vm/artifacts.ts';
+
+const CONTENT = new TextEncoder().encode('#!/usr/bin/env fake-binary\n');
+const CONTENT_DIGEST = new Bun.CryptoHasher('sha256').update(CONTENT).digest('hex') as Sha256Digest;
+const DIGEST_HEX_LENGTH = 64;
+const WRONG_DIGEST = 'b'.repeat(DIGEST_HEX_LENGTH) as Sha256Digest;
+
+const bytesOf = (chunks: Uint8Array[]): ArtifactBytes => ({
+  open: () =>
+    Promise.resolve(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(chunk);
+          }
+          controller.close();
+        },
+      }),
+    ),
+});
+
+const artifact = (overrides: Partial<DesiredArtifact> = {}): DesiredArtifact => ({
+  digest: CONTENT_DIGEST,
+  sizeBytes: CONTENT.byteLength,
+  objectKey: 'artifacts/app-1/binary' as ObjectKey,
+  ...overrides,
+});
+
+let directory: string;
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'nibrun-artifacts-'));
+});
+
+afterEach(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe('the digest is verified before anything can execute', () => {
+  test('matching bytes are written and kept', async () => {
+    const destination = join(directory, 'server');
+    await downloadAndVerify({ source: bytesOf([CONTENT]), artifact: artifact(), destination });
+    expect(await digestOfFile({ path: destination })).toBe(CONTENT_DIGEST);
+  });
+
+  test('a mismatched digest throws and leaves nothing behind', async () => {
+    const destination = join(directory, 'server');
+    await expect(
+      downloadAndVerify({
+        source: bytesOf([CONTENT]),
+        artifact: artifact({ digest: WRONG_DIGEST }),
+        destination,
+      }),
+    ).rejects.toThrow(DigestMismatchError);
+    expect(await Bun.file(destination).exists()).toBe(false);
+  });
+
+  test('bytes tampered with mid-stream are caught, not just a wrong first chunk', async () => {
+    const destination = join(directory, 'server');
+    const tampered = new Uint8Array(CONTENT);
+    tampered[tampered.length - 1] = 0;
+    await expect(
+      downloadAndVerify({ source: bytesOf([tampered]), artifact: artifact(), destination }),
+    ).rejects.toThrow(DigestMismatchError);
+  });
+
+  test('a size that disagrees with the manifest is rejected even when the digest matches', async () => {
+    const destination = join(directory, 'server');
+    await expect(
+      downloadAndVerify({
+        source: bytesOf([CONTENT]),
+        artifact: artifact({ sizeBytes: CONTENT.byteLength + 1 }),
+        destination,
+      }),
+    ).rejects.toThrow(ArtifactSizeError);
+    expect(await Bun.file(destination).exists()).toBe(false);
+  });
+
+  test('a stream split across chunks hashes the same as one chunk', async () => {
+    const destination = join(directory, 'server');
+    const half = Math.floor(CONTENT.byteLength / 2);
+    await downloadAndVerify({
+      source: bytesOf([CONTENT.slice(0, half), CONTENT.slice(half)]),
+      artifact: artifact(),
+      destination,
+    });
+    expect(await digestOfFile({ path: destination })).toBe(CONTENT_DIGEST);
+  });
+});
+
+describe('the cache is content-addressed', () => {
+  test('the path depends only on the digest, so a redeploy of the same bytes is free', () => {
+    expect(
+      artifactImagePath({ cacheDir: '/var/lib/nibrun/artifacts', digest: CONTENT_DIGEST }),
+    ).toBe(`/var/lib/nibrun/artifacts/${CONTENT_DIGEST}/artifact.squashfs`);
+  });
+});

--- a/apps/agent/src/vm/artifacts.ts
+++ b/apps/agent/src/vm/artifacts.ts
@@ -1,0 +1,170 @@
+import { chmod, mkdir, rename, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { DesiredArtifact, Sha256Digest } from '@repo/protocol';
+import type { InstanceCredentialProvider } from '#aws/instance-credentials.ts';
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+
+const DIGEST_ALGORITHM = 'sha256';
+const HEX_ENCODING = 'hex';
+const SQUASHFS_FILENAME = 'artifact.squashfs';
+// The path the guest's init execs. Fixed by the boot contract, not configurable.
+const GUEST_BINARY_NAME = 'server';
+const BINARY_MODE = 0o755;
+const CACHE_DIR_MODE = 0o755;
+
+export class DigestMismatchError extends Error {
+  readonly expected: Sha256Digest;
+  readonly actual: string;
+
+  constructor({ expected, actual }: { expected: Sha256Digest; actual: string }) {
+    super(`Artifact digest mismatch: expected ${expected}, got ${actual}`);
+    this.name = 'DigestMismatchError';
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+export class ArtifactSizeError extends Error {
+  constructor({ expected, actual }: { expected: number; actual: number }) {
+    super(`Artifact is ${actual} bytes, expected ${expected}`);
+    this.name = 'ArtifactSizeError';
+  }
+}
+
+// Content-addressed, so a redeploy of an artifact this host has already seen costs nothing and
+// two apps on the same binary share one squashfs.
+export const artifactDirectory = ({
+  cacheDir,
+  digest,
+}: {
+  cacheDir: string;
+  digest: Sha256Digest;
+}) => join(cacheDir, digest);
+
+export const artifactImagePath = (options: { cacheDir: string; digest: Sha256Digest }) =>
+  join(artifactDirectory(options), SQUASHFS_FILENAME);
+
+export type ArtifactBytes = {
+  open(objectKey: string): Promise<ReadableStream<Uint8Array>>;
+};
+
+export function s3ArtifactBytes({
+  bucket,
+  region,
+  credentials,
+}: {
+  bucket: string;
+  region: string;
+  credentials: InstanceCredentialProvider;
+}): ArtifactBytes {
+  return {
+    async open(objectKey: string) {
+      const resolved = await credentials.resolve();
+      const client = new Bun.S3Client({
+        bucket,
+        region,
+        accessKeyId: resolved.accessKeyId,
+        secretAccessKey: resolved.secretAccessKey,
+        ...(resolved.sessionToken ? { sessionToken: resolved.sessionToken } : {}),
+      });
+      return client.file(objectKey).stream();
+    },
+  };
+}
+
+/**
+ * Streams the artifact to disk while hashing it, and verifies before anything can execute it.
+ *
+ * The digest is the artifact's identity as far as a host is concerned; the object key is only
+ * where the bytes happened to be. Hashing during the transfer rather than after it means the
+ * bytes are never read twice, and the file is only ever moved into the content-addressed cache
+ * once it has been proven to be what it claims.
+ */
+export async function downloadAndVerify({
+  source,
+  artifact,
+  destination,
+}: {
+  source: ArtifactBytes;
+  artifact: DesiredArtifact;
+  destination: string;
+}): Promise<void> {
+  const hasher = new Bun.CryptoHasher(DIGEST_ALGORITHM);
+  const writer = Bun.file(destination).writer();
+  let written = 0;
+  try {
+    for await (const chunk of await source.open(artifact.objectKey)) {
+      hasher.update(chunk);
+      writer.write(chunk);
+      written += chunk.byteLength;
+    }
+    await writer.end();
+  } catch (error) {
+    await writer.end();
+    await rm(destination, { force: true });
+    throw error;
+  }
+
+  const actual = hasher.digest(HEX_ENCODING);
+  if (actual !== artifact.digest) {
+    await rm(destination, { force: true });
+    throw new DigestMismatchError({ expected: artifact.digest, actual });
+  }
+  if (written !== artifact.sizeBytes) {
+    await rm(destination, { force: true });
+    throw new ArtifactSizeError({ expected: artifact.sizeBytes, actual: written });
+  }
+}
+
+export async function digestOfFile({ path }: { path: string }): Promise<string> {
+  const hasher = new Bun.CryptoHasher(DIGEST_ALGORITHM);
+  for await (const chunk of Bun.file(path).stream()) {
+    hasher.update(chunk);
+  }
+  return hasher.digest(HEX_ENCODING);
+}
+
+/**
+ * Returns the path of the read-only squashfs the guest attaches as `vdb`, building it if this
+ * host has not seen the digest before.
+ */
+export async function ensureArtifactImage({
+  source,
+  runner,
+  cacheDir,
+  artifact,
+}: {
+  source: ArtifactBytes;
+  runner: CommandRunner;
+  cacheDir: string;
+  artifact: DesiredArtifact;
+}): Promise<string> {
+  const imagePath = artifactImagePath({ cacheDir, digest: artifact.digest });
+  if (await Bun.file(imagePath).exists()) {
+    return imagePath;
+  }
+
+  const stagingDir = join(cacheDir, `.staging-${artifact.digest}`);
+  await rm(stagingDir, { recursive: true, force: true });
+  await mkdir(stagingDir, { recursive: true, mode: CACHE_DIR_MODE });
+  try {
+    const binaryPath = join(stagingDir, GUEST_BINARY_NAME);
+    await downloadAndVerify({ source, artifact, destination: binaryPath });
+    await chmod(binaryPath, BINARY_MODE);
+
+    const stagedImage = `${stagingDir}.squashfs`;
+    await rm(stagedImage, { force: true });
+    await runCommandOrThrow({
+      runner,
+      request: { command: ['mksquashfs', stagingDir, stagedImage, '-no-progress', '-noappend'] },
+    });
+    await mkdir(artifactDirectory({ cacheDir, digest: artifact.digest }), {
+      recursive: true,
+      mode: CACHE_DIR_MODE,
+    });
+    await rename(stagedImage, imagePath);
+    return imagePath;
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
+}

--- a/apps/agent/src/vm/firecracker-config.test.ts
+++ b/apps/agent/src/vm/firecracker-config.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_INSTANCE_RESOURCES, type Ipv4Address } from '@repo/protocol';
+import {
+  DRIVE_IDS,
+  netmaskFor,
+  renderFirecrackerConfig,
+  renderKernelArgs,
+} from '#vm/firecracker-config.ts';
+
+const SUBNET_PREFIX_LENGTH = 30;
+const SLASH_24 = 24;
+const SLASH_16 = 16;
+const SLASH_32 = 32;
+const SLASH_0 = 0;
+
+const network = {
+  tapName: 'nbr3',
+  guestMac: '02:00:0a:c9:00:0e',
+  guestIpv4: '10.201.0.14' as Ipv4Address,
+  hostIpv4: '10.201.0.13' as Ipv4Address,
+  subnetPrefixLength: SUBNET_PREFIX_LENGTH,
+};
+
+const paths = {
+  kernelPath: '/opt/nibrun/bin/guest-image/vmlinux',
+  rootfsPath: '/opt/nibrun/bin/guest-image/rootfs.ext4',
+  artifactImagePath: '/var/lib/nibrun/artifacts/abc/artifact.squashfs',
+  instanceConfigImagePath: '/var/lib/nibrun/vm/inst-1/config.squashfs',
+  dataDevicePath: '/dev/nbd3',
+};
+
+const config = () =>
+  renderFirecrackerConfig({ resources: DEFAULT_INSTANCE_RESOURCES, paths, network });
+
+describe('the drive order is the boot contract', () => {
+  test('vda vdb vdc vdd are rootfs, artifact, instance config, tenant data', () => {
+    expect(config().drives.map((drive) => drive.drive_id)).toEqual([...DRIVE_IDS]);
+    expect(config().drives.map((drive) => drive.path_on_host)).toEqual([
+      paths.rootfsPath,
+      paths.artifactImagePath,
+      paths.instanceConfigImagePath,
+      paths.dataDevicePath,
+    ]);
+  });
+
+  test('only the rootfs is the root device', () => {
+    expect(config().drives.filter((drive) => drive.is_root_device)).toHaveLength(1);
+    expect(config().drives[0]?.is_root_device).toBe(true);
+  });
+});
+
+describe('the setting that fails silently', () => {
+  test('the tenant data drive is Writeback, so a guest fsync reaches the host', () => {
+    const data = config().drives.at(-1);
+    expect(data?.cache_type).toBe('Writeback');
+    expect(data?.is_read_only).toBe(false);
+  });
+
+  test('the three read-only drives have nothing to flush', () => {
+    for (const drive of config().drives.slice(0, -1)) {
+      expect(drive.is_read_only).toBe(true);
+      expect(drive.cache_type).toBe('Unsafe');
+    }
+  });
+
+  test('every drive uses the sync io engine', () => {
+    for (const drive of config().drives) {
+      expect(drive.io_engine).toBe('Sync');
+    }
+  });
+});
+
+describe('the kernel command line', () => {
+  test('it carries the three i8042 flags that halve boot time', () => {
+    const args = renderKernelArgs(network);
+    for (const flag of ['i8042.noaux', 'i8042.nomux', 'i8042.dumbkbd']) {
+      expect(args).toContain(flag);
+    }
+  });
+
+  // The fourth flag breaks SendCtrlAltDel on an ACPI-enabled guest, and the failure is silent:
+  // the API answers 204 and the VMM reports success whether or not the guest can hear it, so a
+  // graceful stop degrades to killing the VMM with the tenant mid-write.
+  test('it does not carry i8042.nopnp, which would break a graceful stop', () => {
+    expect(renderKernelArgs(network)).not.toContain('i8042.nopnp');
+  });
+
+  test('the static ip form means the guest needs no DHCP client', () => {
+    expect(renderKernelArgs(network)).toContain(
+      'ip=10.201.0.14::10.201.0.13:255.255.255.252::eth0:off',
+    );
+  });
+
+  test('the root is the first drive, read-only, with the runtime as pid 1', () => {
+    const args = renderKernelArgs(network);
+    expect(args).toContain('root=/dev/vda ro init=/init');
+    expect(args).toContain('console=ttyS0');
+    expect(args).toContain('panic=1');
+  });
+});
+
+describe('netmaskFor', () => {
+  test('common prefixes render as dotted quads', () => {
+    expect(netmaskFor(SUBNET_PREFIX_LENGTH)).toBe('255.255.255.252');
+    expect(netmaskFor(SLASH_24)).toBe('255.255.255.0');
+    expect(netmaskFor(SLASH_16)).toBe('255.255.0.0');
+    expect(netmaskFor(SLASH_32)).toBe('255.255.255.255');
+    expect(netmaskFor(SLASH_0)).toBe('0.0.0.0');
+  });
+});
+
+describe('machine and network', () => {
+  test('resources come from the app config and the tap from the allocated slot', () => {
+    expect(config()['machine-config']).toEqual({
+      vcpu_count: DEFAULT_INSTANCE_RESOURCES.vcpuCount,
+      mem_size_mib: DEFAULT_INSTANCE_RESOURCES.memoryMib,
+      smt: false,
+    });
+    expect(config()['network-interfaces']).toEqual([
+      { iface_id: 'eth0', host_dev_name: 'nbr3', guest_mac: network.guestMac },
+    ]);
+  });
+});

--- a/apps/agent/src/vm/firecracker-config.ts
+++ b/apps/agent/src/vm/firecracker-config.ts
@@ -1,0 +1,138 @@
+import type { InstanceResources, Ipv4Address } from '@repo/protocol';
+
+// Firecracker assigns virtio-blk devices in the order this array declares them, so the order
+// is the boot contract: vda rootfs, vdb artifact, vdc instance config, vdd tenant data.
+export const DRIVE_IDS = ['rootfs', 'artifact', 'config', 'data'] as const;
+
+const OCTET_BITS = 8;
+const FULL_OCTET = 255;
+const OCTET_COUNT = 4;
+const NO_BITS = 0;
+
+// Three i8042 flags, and a measured 1.02 s to 0.60 s boot win. `i8042.nopnp` is deliberately
+// not among them: it breaks SendCtrlAltDel on an ACPI-enabled guest, which ours is, so a
+// graceful stop would silently become a kill — the API answers 204 either way. The static `ip=`
+// form is why the guest ships no DHCP client: the kernel configures eth0 before /init runs.
+const BASE_KERNEL_ARGS =
+  'console=ttyS0 reboot=k panic=1 pci=off i8042.noaux i8042.nomux i8042.dumbkbd root=/dev/vda ro init=/init';
+
+export function netmaskFor(prefixLength: number): string {
+  const octets: number[] = [];
+  for (let index = 0; index < OCTET_COUNT; index += 1) {
+    const bits = Math.min(Math.max(prefixLength - index * OCTET_BITS, NO_BITS), OCTET_BITS);
+    octets.push(FULL_OCTET & ~((1 << (OCTET_BITS - bits)) - 1));
+  }
+  return octets.join('.');
+}
+
+export function renderKernelArgs({
+  guestIpv4,
+  hostIpv4,
+  subnetPrefixLength,
+}: {
+  guestIpv4: Ipv4Address;
+  hostIpv4: Ipv4Address;
+  subnetPrefixLength: number;
+}): string {
+  const netmask = netmaskFor(subnetPrefixLength);
+  return `${BASE_KERNEL_ARGS} ip=${guestIpv4}::${hostIpv4}:${netmask}::eth0:off`;
+}
+
+export type FirecrackerDrive = {
+  drive_id: string;
+  path_on_host: string;
+  is_root_device: boolean;
+  is_read_only: boolean;
+  cache_type: 'Unsafe' | 'Writeback';
+  io_engine: 'Sync' | 'Async';
+};
+
+export type FirecrackerConfig = {
+  'boot-source': { kernel_image_path: string; boot_args: string };
+  drives: FirecrackerDrive[];
+  'machine-config': { vcpu_count: number; mem_size_mib: number; smt: boolean };
+  'network-interfaces': { iface_id: string; host_dev_name: string; guest_mac: string }[];
+};
+
+const READ_ONLY_DRIVE = {
+  is_root_device: false,
+  is_read_only: true,
+  // Meaningless on a read-only drive: there is nothing to flush.
+  cache_type: 'Unsafe',
+  // io_uring is still a developer preview upstream, adds device-creation latency to every cold
+  // start, and its workers escape the cgroup the VM is confined to.
+  io_engine: 'Sync',
+} as const satisfies Omit<FirecrackerDrive, 'drive_id' | 'path_on_host'>;
+
+export type VmPaths = {
+  kernelPath: string;
+  rootfsPath: string;
+  artifactImagePath: string;
+  instanceConfigImagePath: string;
+  dataDevicePath: string;
+};
+
+export type VmNetwork = {
+  tapName: string;
+  guestMac: string;
+  guestIpv4: Ipv4Address;
+  hostIpv4: Ipv4Address;
+  subnetPrefixLength: number;
+};
+
+const NETWORK_INTERFACE_ID = 'eth0';
+
+/**
+ * The whole VM, as one file Firecracker both configures and boots from.
+ *
+ * `cache_type` on the data drive is the one setting here that fails silently. Firecracker
+ * defaults a drive to `Unsafe`, which discards flush requests: the guest's fsync returns
+ * success, ZeroFS is never asked to flush, and the loss window stops being the flush interval
+ * and becomes unbounded. Nothing observable goes wrong until a host dies.
+ */
+export function renderFirecrackerConfig({
+  resources,
+  paths,
+  network,
+}: {
+  resources: InstanceResources;
+  paths: VmPaths;
+  network: VmNetwork;
+}): FirecrackerConfig {
+  return {
+    'boot-source': {
+      kernel_image_path: paths.kernelPath,
+      boot_args: renderKernelArgs(network),
+    },
+    drives: [
+      {
+        ...READ_ONLY_DRIVE,
+        drive_id: DRIVE_IDS[0],
+        path_on_host: paths.rootfsPath,
+        is_root_device: true,
+      },
+      { ...READ_ONLY_DRIVE, drive_id: DRIVE_IDS[1], path_on_host: paths.artifactImagePath },
+      { ...READ_ONLY_DRIVE, drive_id: DRIVE_IDS[2], path_on_host: paths.instanceConfigImagePath },
+      {
+        drive_id: DRIVE_IDS[3],
+        path_on_host: paths.dataDevicePath,
+        is_root_device: false,
+        is_read_only: false,
+        cache_type: 'Writeback',
+        io_engine: 'Sync',
+      },
+    ],
+    'machine-config': {
+      vcpu_count: resources.vcpuCount,
+      mem_size_mib: resources.memoryMib,
+      smt: false,
+    },
+    'network-interfaces': [
+      {
+        iface_id: NETWORK_INTERFACE_ID,
+        host_dev_name: network.tapName,
+        guest_mac: network.guestMac,
+      },
+    ],
+  };
+}

--- a/apps/agent/src/vm/instance-env.test.ts
+++ b/apps/agent/src/vm/instance-env.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_GUEST_PORT, type GuestPort, type SecretString } from '@repo/protocol';
+import { renderInstanceEnv, UnrepresentableEnvironmentError } from '#vm/instance-env.ts';
+
+const secret = (value: string) => value as SecretString;
+
+describe('instance.env is line-oriented so the guest needs no parser', () => {
+  test('PORT is written from the declared guest port', () => {
+    expect(renderInstanceEnv({ guestPort: DEFAULT_GUEST_PORT, environment: {} })).toBe(
+      `PORT=${DEFAULT_GUEST_PORT}\n`,
+    );
+  });
+
+  test('a tenant PORT cannot override the port the host forwards to', () => {
+    const rendered = renderInstanceEnv({
+      guestPort: 8080 as GuestPort,
+      environment: { PORT: secret('9999') },
+    });
+    expect(rendered).toBe('PORT=8080\n');
+  });
+
+  test('variables are emitted in a stable order', () => {
+    const rendered = renderInstanceEnv({
+      guestPort: DEFAULT_GUEST_PORT,
+      environment: { ZED: secret('1'), ALPHA: secret('2') },
+    });
+    expect(rendered.split('\n')).toEqual([`PORT=${DEFAULT_GUEST_PORT}`, 'ALPHA=2', 'ZED=1', '']);
+  });
+
+  test('values are raw bytes, not quoted or escaped', () => {
+    const rendered = renderInstanceEnv({
+      guestPort: DEFAULT_GUEST_PORT,
+      environment: { DSN: secret('postgres://u:p@h/db?x=1 y=2') },
+    });
+    expect(rendered).toContain('DSN=postgres://u:p@h/db?x=1 y=2\n');
+  });
+
+  test('an empty value stays an empty value', () => {
+    expect(
+      renderInstanceEnv({ guestPort: DEFAULT_GUEST_PORT, environment: { EMPTY: secret('') } }),
+    ).toContain('EMPTY=\n');
+  });
+});
+
+describe('what has no representation fails the instance', () => {
+  test.each([['\n'], ['\r'], ['\0']])(
+    'a value containing %j is refused rather than truncated',
+    (character) => {
+      expect(() =>
+        renderInstanceEnv({
+          guestPort: DEFAULT_GUEST_PORT,
+          environment: { BAD: secret(`a${character}INJECTED=1`) },
+        }),
+      ).toThrow(UnrepresentableEnvironmentError);
+    },
+  );
+
+  test('the error names the variable but never carries its value', () => {
+    const error = (() => {
+      try {
+        renderInstanceEnv({
+          guestPort: DEFAULT_GUEST_PORT,
+          environment: { API_KEY: secret('secret-value\nmore') },
+        });
+      } catch (caught) {
+        return caught as Error;
+      }
+      return undefined;
+    })();
+    expect(error?.message).toContain('API_KEY');
+    expect(error?.message).not.toContain('secret-value');
+  });
+});

--- a/apps/agent/src/vm/instance-env.ts
+++ b/apps/agent/src/vm/instance-env.ts
@@ -1,0 +1,99 @@
+import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { GuestPort, TenantEnvironment } from '@repo/protocol';
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+
+// Line-oriented `KEY=VALUE`, so the guest's init needs no parser. The file is generated and
+// never hand-edited, which is what lets the format be this thin.
+export const INSTANCE_ENV_FILENAME = 'instance.env';
+export const INSTANCE_CONFIG_IMAGE = 'config.squashfs';
+
+// Carries the tenant's environment variables, which are secrets. Readable only by the user the
+// agent and Firecracker run as.
+const PRIVATE_MODE = 0o600;
+const PRIVATE_DIR_MODE = 0o700;
+
+const PORT_VARIABLE = 'PORT';
+const FORBIDDEN_VALUE_CHARACTERS = /[\n\r\0]/;
+
+export class UnrepresentableEnvironmentError extends Error {
+  readonly name_: string;
+
+  constructor(variableName: string) {
+    super(`Environment variable ${variableName} cannot be represented in instance.env`);
+    this.name = 'UnrepresentableEnvironmentError';
+    this.name_ = variableName;
+  }
+}
+
+/**
+ * Renders the tenant's environment for the guest.
+ *
+ * `PORT` is written from the port the app declared and a tenant value for it is dropped: that
+ * number is what the host forwards to, so letting the tenant override it would produce a VM
+ * nothing can reach and no error anywhere.
+ *
+ * A value containing a newline has no representation in a format with no quoting, so it fails
+ * the instance rather than silently truncating somebody's configuration into the next line.
+ */
+export function renderInstanceEnv({
+  guestPort,
+  environment,
+}: {
+  guestPort: GuestPort;
+  environment: TenantEnvironment;
+}): string {
+  const lines = [`${PORT_VARIABLE}=${guestPort}`];
+  for (const key of Object.keys(environment).sort()) {
+    if (key === PORT_VARIABLE) {
+      continue;
+    }
+    const value = environment[key] ?? '';
+    if (FORBIDDEN_VALUE_CHARACTERS.test(value)) {
+      throw new UnrepresentableEnvironmentError(key);
+    }
+    lines.push(`${key}=${value}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Builds the read-only squashfs the guest attaches as `vdc`, rebuilt on every boot because the
+ * app's configuration can change without its artifact changing.
+ */
+export async function buildInstanceConfigImage({
+  runner,
+  workingDir,
+  guestPort,
+  environment,
+}: {
+  runner: CommandRunner;
+  workingDir: string;
+  guestPort: GuestPort;
+  environment: TenantEnvironment;
+}): Promise<string> {
+  const stagingDir = join(workingDir, '.config-staging');
+  const imagePath = join(workingDir, INSTANCE_CONFIG_IMAGE);
+  await rm(stagingDir, { recursive: true, force: true });
+  await mkdir(stagingDir, { recursive: true, mode: PRIVATE_DIR_MODE });
+  try {
+    await writeFile(
+      join(stagingDir, INSTANCE_ENV_FILENAME),
+      renderInstanceEnv({ guestPort, environment }),
+      {
+        mode: PRIVATE_MODE,
+      },
+    );
+    await rm(imagePath, { force: true });
+    await runCommandOrThrow({
+      runner,
+      request: {
+        command: ['mksquashfs', stagingDir, imagePath, '-no-progress', '-noappend', '-all-root'],
+      },
+    });
+    await chmod(imagePath, PRIVATE_MODE);
+    return imagePath;
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
+}

--- a/apps/agent/src/vm/manager.ts
+++ b/apps/agent/src/vm/manager.ts
@@ -1,0 +1,112 @@
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { DesiredInstance, InstanceId } from '@repo/protocol';
+import type { CommandRunner } from '#lib/exec.ts';
+import { writeJsonFile } from '#lib/json-store.ts';
+import type { AppSlot } from '#network/allocator.ts';
+import { ensureTap } from '#network/tap.ts';
+import { type ArtifactBytes, ensureArtifactImage } from '#vm/artifacts.ts';
+import { renderFirecrackerConfig } from '#vm/firecracker-config.ts';
+import { buildInstanceConfigImage } from '#vm/instance-env.ts';
+import type { SystemdVmUnits } from '#vm/systemd.ts';
+
+export const FIRECRACKER_CONFIG_FILENAME = 'firecracker.json';
+export const GUEST_KERNEL_FILENAME = 'vmlinux';
+export const GUEST_ROOTFS_FILENAME = 'rootfs.ext4';
+
+const VM_DIR_MODE = 0o700;
+
+export type VmManagerOptions = {
+  runner: CommandRunner;
+  units: SystemdVmUnits;
+  artifacts: ArtifactBytes;
+  artifactCacheDir: string;
+  guestImageDir: string;
+  vmDir: string;
+};
+
+export class VmManager {
+  readonly #options: VmManagerOptions;
+
+  constructor(options: VmManagerOptions) {
+    this.#options = options;
+  }
+
+  workingDir(instanceId: InstanceId): string {
+    return join(this.#options.vmDir, instanceId);
+  }
+
+  /**
+   * Stages everything the VM needs and hands the boot to systemd.
+   *
+   * The agent never becomes the VM's parent: it writes the files, asks init to start the unit,
+   * and stops caring. Everything staged here is either content-addressed and shared, or lives
+   * under this instance's own directory, so two boots of the same app never race on a path.
+   */
+  async boot({
+    desired,
+    slot,
+    dataDevicePath,
+  }: {
+    desired: DesiredInstance;
+    slot: AppSlot;
+    dataDevicePath: string;
+  }): Promise<void> {
+    const artifactImagePath = await ensureArtifactImage({
+      source: this.#options.artifacts,
+      runner: this.#options.runner,
+      cacheDir: this.#options.artifactCacheDir,
+      artifact: desired.artifact,
+    });
+
+    await ensureTap({
+      runner: this.#options.runner,
+      tap: {
+        tapName: slot.tapName,
+        hostIpv4: slot.hostIpv4,
+        subnetPrefixLength: slot.subnetPrefixLength,
+      },
+    });
+
+    const workingDir = this.workingDir(desired.instanceId);
+    await mkdir(workingDir, { recursive: true, mode: VM_DIR_MODE });
+    const instanceConfigImagePath = await buildInstanceConfigImage({
+      runner: this.#options.runner,
+      workingDir,
+      guestPort: desired.config.guestPort,
+      environment: desired.config.environment,
+    });
+
+    await writeJsonFile({
+      path: join(workingDir, FIRECRACKER_CONFIG_FILENAME),
+      value: renderFirecrackerConfig({
+        resources: desired.config.resources,
+        paths: {
+          kernelPath: join(this.#options.guestImageDir, GUEST_KERNEL_FILENAME),
+          rootfsPath: join(this.#options.guestImageDir, GUEST_ROOTFS_FILENAME),
+          artifactImagePath,
+          instanceConfigImagePath,
+          dataDevicePath,
+        },
+        network: {
+          tapName: slot.tapName,
+          guestMac: slot.guestMac,
+          guestIpv4: slot.guestIpv4,
+          hostIpv4: slot.hostIpv4,
+          subnetPrefixLength: slot.subnetPrefixLength,
+        },
+      }),
+    });
+
+    await this.#options.units.start(desired.instanceId);
+  }
+
+  async stop({ instanceId }: { instanceId: InstanceId }): Promise<void> {
+    await this.#options.units.stop(instanceId);
+  }
+
+  async discard({ instanceId }: { instanceId: InstanceId }): Promise<void> {
+    await this.#options.units.forget(instanceId);
+    await rm(this.workingDir(instanceId), { recursive: true, force: true });
+  }
+}

--- a/apps/agent/src/vm/systemd.test.ts
+++ b/apps/agent/src/vm/systemd.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import type { InstanceId } from '@repo/protocol';
+import {
+  instanceIdFromUnit,
+  parseProperties,
+  parsePropertyBlocks,
+  parseUnitNames,
+  unitStatusFrom,
+  vmUnitName,
+} from '#vm/systemd.ts';
+
+describe('unit naming round-trips', () => {
+  test('an instance id becomes a template instance and back', () => {
+    const instanceId = 'inst-A_1' as InstanceId;
+    expect(vmUnitName(instanceId)).toBe('nibrun-vm@inst-A_1.service');
+    expect(instanceIdFromUnit(vmUnitName(instanceId))).toBe(instanceId);
+  });
+
+  test('a unit that is not ours is ignored', () => {
+    expect(instanceIdFromUnit('sshd.service')).toBeUndefined();
+    expect(instanceIdFromUnit('nibrun-vm@inst-1.socket')).toBeUndefined();
+  });
+
+  test('an instance name that is not a valid identifier is refused', () => {
+    expect(instanceIdFromUnit('nibrun-vm@..\\x2fetc.service')).toBeUndefined();
+    expect(instanceIdFromUnit('nibrun-vm@.service')).toBeUndefined();
+  });
+});
+
+describe('list-units output', () => {
+  test('unit names are read past the status glyph systemd prefixes failures with', () => {
+    const output = [
+      'nibrun-vm@inst-1.service loaded active running nibrun microVM inst-1',
+      '● nibrun-vm@inst-2.service loaded failed failed nibrun microVM inst-2',
+      '',
+    ].join('\n');
+    expect(parseUnitNames(output)).toEqual([
+      'nibrun-vm@inst-1.service',
+      'nibrun-vm@inst-2.service',
+    ]);
+  });
+
+  test('an empty listing yields nothing rather than an empty name', () => {
+    expect(parseUnitNames('')).toEqual([]);
+  });
+});
+
+describe('show output', () => {
+  test('properties split on the first equals, so values may contain one', () => {
+    expect(parseProperties('LoadState=loaded\nExecStart=/bin/x --a=b')).toEqual({
+      LoadState: 'loaded',
+      ExecStart: '/bin/x --a=b',
+    });
+  });
+
+  test('several units come back in one call, in the order asked', () => {
+    const blocks = parsePropertyBlocks(
+      'LoadState=loaded\nActiveState=active\n\nLoadState=not-found\nActiveState=inactive\n',
+    );
+    expect(blocks).toHaveLength(2);
+    expect(blocks[1]?.LoadState).toBe('not-found');
+  });
+});
+
+describe('unit status', () => {
+  test('active and activating both count as up', () => {
+    expect(unitStatusFrom({ LoadState: 'loaded', ActiveState: 'active' }).active).toBe(true);
+    expect(unitStatusFrom({ LoadState: 'loaded', ActiveState: 'activating' }).active).toBe(true);
+  });
+
+  test('a failed unit is loaded, not active, and failed', () => {
+    expect(
+      unitStatusFrom({ LoadState: 'loaded', ActiveState: 'failed', ExecMainStatus: '1' }),
+    ).toEqual({ loaded: true, active: false, failed: true, exitCode: 1 });
+  });
+
+  test('a unit systemd has never heard of is neither loaded nor active', () => {
+    expect(unitStatusFrom({ LoadState: 'not-found', ActiveState: 'inactive' })).toEqual({
+      loaded: false,
+      active: false,
+      failed: false,
+    });
+  });
+
+  test('a missing exit code is absent rather than zero', () => {
+    expect(unitStatusFrom({ LoadState: 'loaded', ActiveState: 'active' }).exitCode).toBeUndefined();
+  });
+});

--- a/apps/agent/src/vm/systemd.ts
+++ b/apps/agent/src/vm/systemd.ts
@@ -1,0 +1,153 @@
+import { type InstanceId, InstanceIdSchema, isValidMessage } from '@repo/protocol';
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+
+const SYSTEMCTL = 'systemctl';
+
+/**
+ * One systemd template instance per microVM, so Firecracker is a child of init and not of this
+ * agent.
+ *
+ * The agent is the component that updates most often. If the VMs were its children, every
+ * agent restart would kill every tenant app on the host — which would make the one operation
+ * that has to be routine the most dangerous one. Parented to init, an agent restart is a
+ * non-event and an operator can inspect a single app with `systemctl status` and `journalctl`.
+ */
+export const VM_UNIT_TEMPLATE = 'nibrun-vm@';
+const UNIT_SUFFIX = '.service';
+const UNIT_PATTERN = `${VM_UNIT_TEMPLATE}*${UNIT_SUFFIX}`;
+
+export const vmUnitName = (instanceId: InstanceId) =>
+  `${VM_UNIT_TEMPLATE}${instanceId}${UNIT_SUFFIX}`;
+
+// Instance ids are alphanumerics, hyphens and underscores, none of which systemd escapes, so
+// the unit name carries the id verbatim in both directions.
+export function instanceIdFromUnit(unitName: string): InstanceId | undefined {
+  if (!unitName.startsWith(VM_UNIT_TEMPLATE) || !unitName.endsWith(UNIT_SUFFIX)) {
+    return undefined;
+  }
+  const value = unitName.slice(VM_UNIT_TEMPLATE.length, -UNIT_SUFFIX.length);
+  return isValidMessage({ schema: InstanceIdSchema, value }) ? (value as InstanceId) : undefined;
+}
+
+export function parseUnitNames(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim().replace(/^[^\w]*\s*/, ''))
+    .map((line) => line.split(/\s+/)[0] ?? '')
+    .filter((name) => name.endsWith(UNIT_SUFFIX));
+}
+
+export function parseProperties(output: string): Record<string, string> {
+  const properties: Record<string, string> = {};
+  for (const line of output.split('\n')) {
+    const separator = line.indexOf('=');
+    if (separator <= 0) {
+      continue;
+    }
+    properties[line.slice(0, separator)] = line.slice(separator + 1);
+  }
+  return properties;
+}
+
+// `systemctl show` answers for several units in one call, emitting one block per unit in the
+// order asked and separating them with a blank line. One subprocess per status sweep rather
+// than one per instance is the difference between a poll that scales to a full host and one
+// that does not.
+export function parsePropertyBlocks(output: string): Record<string, string>[] {
+  return output
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0)
+    .map(parseProperties);
+}
+
+export type UnitStatus = {
+  loaded: boolean;
+  active: boolean;
+  failed: boolean;
+  exitCode?: number;
+};
+
+const SHOWN_PROPERTIES = ['LoadState', 'ActiveState', 'SubState', 'Result', 'ExecMainStatus'];
+
+export function unitStatusFrom(properties: Record<string, string>): UnitStatus {
+  const loadState = properties.LoadState ?? 'not-found';
+  const activeState = properties.ActiveState ?? 'inactive';
+  const exitCode = Number.parseInt(properties.ExecMainStatus ?? '', 10);
+  return {
+    loaded: loadState === 'loaded',
+    active: activeState === 'active' || activeState === 'activating',
+    failed: activeState === 'failed',
+    ...(Number.isFinite(exitCode) ? { exitCode } : {}),
+  };
+}
+
+export class SystemdVmUnits {
+  readonly #runner: CommandRunner;
+
+  constructor({ runner }: { runner: CommandRunner }) {
+    this.#runner = runner;
+  }
+
+  async listInstanceIds(): Promise<InstanceId[]> {
+    const output = await runCommandOrThrow({
+      runner: this.#runner,
+      request: {
+        command: [
+          SYSTEMCTL,
+          'list-units',
+          '--type=service',
+          '--all',
+          '--plain',
+          '--no-legend',
+          '--no-pager',
+          UNIT_PATTERN,
+        ],
+      },
+    });
+    return parseUnitNames(output)
+      .map(instanceIdFromUnit)
+      .filter((id): id is InstanceId => id !== undefined);
+  }
+
+  async statuses(instanceIds: readonly InstanceId[]): Promise<Map<InstanceId, UnitStatus>> {
+    const statuses = new Map<InstanceId, UnitStatus>();
+    if (instanceIds.length === 0) {
+      return statuses;
+    }
+    const result = await this.#runner({
+      command: [
+        SYSTEMCTL,
+        'show',
+        ...instanceIds.map(vmUnitName),
+        `--property=${SHOWN_PROPERTIES.join(',')}`,
+      ],
+    });
+    const blocks = parsePropertyBlocks(result.stdout);
+    for (const [index, instanceId] of instanceIds.entries()) {
+      const block = blocks[index] ?? { LoadState: 'not-found', ActiveState: 'inactive' };
+      statuses.set(instanceId, unitStatusFrom(block));
+    }
+    return statuses;
+  }
+
+  async start(instanceId: InstanceId): Promise<void> {
+    await runCommandOrThrow({
+      runner: this.#runner,
+      request: { command: [SYSTEMCTL, 'start', vmUnitName(instanceId)] },
+    });
+  }
+
+  async stop(instanceId: InstanceId): Promise<void> {
+    await runCommandOrThrow({
+      runner: this.#runner,
+      request: { command: [SYSTEMCTL, 'stop', vmUnitName(instanceId)] },
+    });
+  }
+
+  // A template instance that exited stays loaded and `failed` until it is reset, which would
+  // otherwise make an instance the control plane has forgotten linger in every enumeration.
+  async forget(instanceId: InstanceId): Promise<void> {
+    await this.#runner({ command: [SYSTEMCTL, 'reset-failed', vmUnitName(instanceId)] });
+  }
+}

--- a/apps/agent/src/volumes/device-file.ts
+++ b/apps/agent/src/volumes/device-file.ts
@@ -1,0 +1,67 @@
+import { mkdir, open, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { VolumeId } from '@repo/protocol';
+
+// ZeroFS resolves every NBD export by looking this directory up on each negotiation, so a
+// device file appears the moment it is created — no restart, no registration step.
+export const NBD_DIRECTORY = '.nbd';
+
+// Firecracker sizes a block device with lseek and computes sectors as `size >> 9`. A size that
+// is not a multiple of 512 leaves the tail invisible to the guest, with a warning and no error.
+const SECTOR_SIZE_BYTES = 512;
+
+export const isSectorAligned = (sizeBytes: number) => sizeBytes % SECTOR_SIZE_BYTES === 0;
+
+export const alignToSector = (sizeBytes: number) =>
+  Math.ceil(sizeBytes / SECTOR_SIZE_BYTES) * SECTOR_SIZE_BYTES;
+
+export const devicePathFor = ({ mount, volumeId }: { mount: string; volumeId: VolumeId }) =>
+  join(mount, NBD_DIRECTORY, volumeId);
+
+export class VolumeShrinkError extends Error {
+  constructor({ current, requested }: { current: number; requested: number }) {
+    super(`Refusing to shrink a volume from ${current} to ${requested} bytes`);
+    this.name = 'VolumeShrinkError';
+  }
+}
+
+export async function readDeviceFileSize({ path }: { path: string }): Promise<number | undefined> {
+  try {
+    return (await stat(path)).size;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Creates or grows the sparse file ZeroFS exports as this volume's block device.
+ *
+ * Growing preserves the data; shrinking discards everything past the new size, which is why a
+ * smaller desired size is refused rather than obeyed. Desired state that has gone backwards is
+ * a control-plane bug, and truncating a tenant's filesystem is not a recoverable way to
+ * discover it.
+ */
+export async function ensureDeviceFile({
+  path,
+  sizeBytes,
+}: {
+  path: string;
+  sizeBytes: number;
+}): Promise<number> {
+  const target = alignToSector(sizeBytes);
+  const current = await readDeviceFileSize({ path });
+  if (current !== undefined && current > target) {
+    throw new VolumeShrinkError({ current, requested: target });
+  }
+  if (current === target) {
+    return target;
+  }
+  await mkdir(join(path, '..'), { recursive: true });
+  const handle = await open(path, 'a');
+  try {
+    await handle.truncate(target);
+  } finally {
+    await handle.close();
+  }
+  return target;
+}

--- a/apps/agent/src/volumes/ext4.ts
+++ b/apps/agent/src/volumes/ext4.ts
@@ -1,0 +1,63 @@
+import { open } from 'node:fs/promises';
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+
+const SUPERBLOCK_MAGIC_OFFSET = 1080;
+const MAGIC_BYTE_COUNT = 2;
+const EXT_MAGIC = 0xef53;
+const HIGH_BYTE_SHIFT = 8;
+const FIRST_BYTE = 0;
+const SECOND_BYTE = 1;
+
+export const FILESYSTEM_LABEL = 'nibrun-data';
+
+export function hasExtMagic(bytes: Uint8Array): boolean {
+  if (bytes.length < MAGIC_BYTE_COUNT) {
+    return false;
+  }
+  const low = bytes[FIRST_BYTE] ?? 0;
+  const high = bytes[SECOND_BYTE] ?? 0;
+  return (low | (high << HIGH_BYTE_SHIFT)) === EXT_MAGIC;
+}
+
+/**
+ * Reads the two magic bytes of the ext superblock.
+ *
+ * This is comparing a constant, not parsing a filesystem: the host must never let its kernel
+ * interpret tenant-controlled metadata, which is the rule the export design depends on, and
+ * the only thing that distinguishes a blank device from one already provisioned.
+ */
+export async function isFormatted({ devicePath }: { devicePath: string }): Promise<boolean> {
+  const handle = await open(devicePath, 'r');
+  try {
+    const buffer = new Uint8Array(MAGIC_BYTE_COUNT);
+    await handle.read(buffer, FIRST_BYTE, MAGIC_BYTE_COUNT, SUPERBLOCK_MAGIC_OFFSET);
+    return hasExtMagic(buffer);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Writes the filesystem exactly once, when the volume is provisioned.
+ *
+ * Writing a filesystem is not parsing one, so this stays on the host rather than in the guest,
+ * and it keeps the guest runtime to mounting a device that is already valid.
+ */
+export async function formatOnce({
+  runner,
+  devicePath,
+}: {
+  runner: CommandRunner;
+  devicePath: string;
+}): Promise<boolean> {
+  if (await isFormatted({ devicePath })) {
+    return false;
+  }
+  await runCommandOrThrow({
+    runner,
+    request: {
+      command: ['mkfs.ext4', '-q', '-L', FILESYSTEM_LABEL, devicePath],
+    },
+  });
+  return true;
+}

--- a/apps/agent/src/volumes/manager.ts
+++ b/apps/agent/src/volumes/manager.ts
@@ -1,0 +1,161 @@
+import { readdir, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { AppId, DesiredVolume, ReportedVolume, VolumeId } from '@repo/protocol';
+import type { CommandRunner } from '#lib/exec.ts';
+import { describeError, logger } from '#lib/logger.ts';
+import type { SlotAllocator } from '#network/allocator.ts';
+import type { ObservedVolume } from '#reconcile/plan.ts';
+import { devicePathFor, ensureDeviceFile, NBD_DIRECTORY } from '#volumes/device-file.ts';
+import { formatOnce } from '#volumes/ext4.ts';
+import { attach, detach, isAttached } from '#volumes/nbd.ts';
+import type { ZerofsFilesystem, ZerofsTopology } from '#volumes/topology.ts';
+
+const EMPTY_SIZE = 0;
+
+export type VolumeManagerOptions = {
+  runner: CommandRunner;
+  topology: ZerofsTopology;
+  allocator: SlotAllocator;
+};
+
+export class VolumeManager {
+  readonly #options: VolumeManagerOptions;
+
+  constructor(options: VolumeManagerOptions) {
+    this.#options = options;
+  }
+
+  /**
+   * Enumerates the device files ZeroFS is exporting, which is the truth a restarted agent
+   * converges against — not what it remembers having created.
+   */
+  async observe({
+    appIdByVolume,
+  }: {
+    appIdByVolume: ReadonlyMap<VolumeId, AppId>;
+  }): Promise<ObservedVolume[]> {
+    const observed: ObservedVolume[] = [];
+    for (const filesystem of this.#options.topology.all()) {
+      observed.push(...(await this.#observeFilesystem({ filesystem, appIdByVolume })));
+    }
+    return observed;
+  }
+
+  async provision({ desired }: { desired: DesiredVolume }): Promise<ReportedVolume> {
+    const filesystem = this.#options.topology.resolve({ storagePrefix: desired.storagePrefix });
+    const slot = this.#options.allocator.allocate(desired.appId);
+    const path = devicePathFor({ mount: filesystem.mountPath, volumeId: desired.volumeId });
+    const sizeBytes = await ensureDeviceFile({ path, sizeBytes: desired.sizeBytes });
+
+    if (!(await isAttached({ runner: this.#options.runner, devicePath: slot.nbdDevicePath }))) {
+      await attach({
+        runner: this.#options.runner,
+        socketPath: filesystem.nbdSocketPath,
+        devicePath: slot.nbdDevicePath,
+        volumeId: desired.volumeId,
+      });
+    }
+
+    const formatted = await formatOnce({
+      runner: this.#options.runner,
+      devicePath: slot.nbdDevicePath,
+    });
+    if (formatted) {
+      logger.info({
+        message: 'volume formatted',
+        volumeId: desired.volumeId,
+        device: slot.nbdDevicePath,
+      });
+    }
+
+    return {
+      volumeId: desired.volumeId,
+      state: 'ready',
+      sizeBytes,
+      devicePath: slot.nbdDevicePath,
+    };
+  }
+
+  /**
+   * The only path that destroys tenant data, and it runs only for a volume the control plane
+   * has explicitly marked `absent`. A flush first, so the detach happens at a durability point
+   * rather than dropping whatever the periodic flush had not yet uploaded — with `ignore_fsync`
+   * the guest's own barriers were never a durability point at all.
+   */
+  async teardown({ desired }: { desired: DesiredVolume }): Promise<ReportedVolume> {
+    const filesystem = this.#options.topology.resolve({ storagePrefix: desired.storagePrefix });
+    const slot = this.#options.allocator.lookup(desired.appId);
+    await filesystem.admin.flush();
+    if (slot) {
+      await detach({ runner: this.#options.runner, devicePath: slot.nbdDevicePath });
+    }
+    await rm(devicePathFor({ mount: filesystem.mountPath, volumeId: desired.volumeId }), {
+      force: true,
+    });
+    this.#options.allocator.release(desired.appId);
+    return { volumeId: desired.volumeId, state: 'deleting', sizeBytes: EMPTY_SIZE };
+  }
+
+  async #observeFilesystem({
+    filesystem,
+    appIdByVolume,
+  }: {
+    filesystem: ZerofsFilesystem;
+    appIdByVolume: ReadonlyMap<VolumeId, AppId>;
+  }): Promise<ObservedVolume[]> {
+    const directory = join(filesystem.mountPath, NBD_DIRECTORY);
+    let names: string[];
+    try {
+      names = await readdir(directory);
+    } catch (error) {
+      logger.warn({
+        message: 'zerofs nbd directory unreadable',
+        directory,
+        ...describeError(error),
+      });
+      return [];
+    }
+
+    const observed: ObservedVolume[] = [];
+    for (const name of names) {
+      const volumeId = name as VolumeId;
+      const sizeBytes = await this.#sizeOf(join(directory, name));
+      if (sizeBytes === undefined) {
+        continue;
+      }
+      observed.push({
+        volumeId,
+        sizeBytes,
+        attached: await this.#isAttachedFor({ volumeId, appIdByVolume }),
+      });
+    }
+    return observed;
+  }
+
+  async #sizeOf(path: string): Promise<number | undefined> {
+    try {
+      const entry = await stat(path);
+      return entry.isFile() ? entry.size : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async #isAttachedFor({
+    volumeId,
+    appIdByVolume,
+  }: {
+    volumeId: VolumeId;
+    appIdByVolume: ReadonlyMap<VolumeId, AppId>;
+  }): Promise<boolean> {
+    const appId = appIdByVolume.get(volumeId);
+    if (appId === undefined) {
+      return false;
+    }
+    const slot = this.#options.allocator.lookup(appId);
+    if (!slot) {
+      return false;
+    }
+    return await isAttached({ runner: this.#options.runner, devicePath: slot.nbdDevicePath });
+  }
+}

--- a/apps/agent/src/volumes/nbd.ts
+++ b/apps/agent/src/volumes/nbd.ts
@@ -1,0 +1,65 @@
+import type { VolumeId } from '@repo/protocol';
+import { NBD_BLOCK_SIZE_BYTES, NBD_CONNECTIONS, NBD_TIMEOUT_SECONDS } from '#config.ts';
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+
+const NBD_CLIENT = 'nbd-client';
+const CONNECTED_EXIT_CODE = 0;
+
+export async function isAttached({
+  runner,
+  devicePath,
+}: {
+  runner: CommandRunner;
+  devicePath: string;
+}): Promise<boolean> {
+  const result = await runner({ command: [NBD_CLIENT, '-check', devicePath] });
+  return result.code === CONNECTED_EXIT_CODE;
+}
+
+/**
+ * `-persist` reconnects on its own, and a long timeout is what keeps a ZeroFS restart a stall
+ * rather than an I/O error: the kernel returns EIO once the timeout lapses, and the guest's
+ * ext4 answers an EIO by remounting itself read-only.
+ */
+export async function attach({
+  runner,
+  socketPath,
+  devicePath,
+  volumeId,
+}: {
+  runner: CommandRunner;
+  socketPath: string;
+  devicePath: string;
+  volumeId: VolumeId;
+}): Promise<void> {
+  await runCommandOrThrow({
+    runner,
+    request: {
+      command: [
+        NBD_CLIENT,
+        '-unix',
+        socketPath,
+        devicePath,
+        '-N',
+        volumeId,
+        '-persist',
+        '-timeout',
+        String(NBD_TIMEOUT_SECONDS),
+        '-connections',
+        String(NBD_CONNECTIONS),
+        '-block-size',
+        String(NBD_BLOCK_SIZE_BYTES),
+      ],
+    },
+  });
+}
+
+export async function detach({
+  runner,
+  devicePath,
+}: {
+  runner: CommandRunner;
+  devicePath: string;
+}): Promise<void> {
+  await runner({ command: [NBD_CLIENT, '-d', devicePath] });
+}

--- a/apps/agent/src/volumes/topology.test.ts
+++ b/apps/agent/src/volumes/topology.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import type { ObjectKey } from '@repo/protocol';
+import type { CommandRunner } from '#lib/exec.ts';
+import { UnservedStoragePrefixError, ZerofsTopology } from '#volumes/topology.ts';
+
+const NO_EXIT_CODE = 0;
+const HOST_PREFIX = 'filesystems/host-1' as ObjectKey;
+const OTHER_PREFIX = 'filesystems/host-2' as ObjectKey;
+
+const runner: CommandRunner = () => Promise.resolve({ code: NO_EXIT_CODE, stdout: '', stderr: '' });
+
+const topology = () =>
+  ZerofsTopology.sharedHostFilesystem({
+    runner,
+    storagePrefix: HOST_PREFIX,
+    mountPath: '/mnt/zerofs',
+    nbdSocketPath: '/run/zerofs/nbd.sock',
+    configFile: '/etc/zerofs/config.toml',
+  });
+
+describe('one ZeroFS per host', () => {
+  test('every volume placed here resolves to the one filesystem', () => {
+    const filesystem = topology().resolve({ storagePrefix: HOST_PREFIX });
+    expect(filesystem.mountPath).toBe('/mnt/zerofs');
+    expect(filesystem.nbdSocketPath).toBe('/run/zerofs/nbd.sock');
+    expect(filesystem.configFile).toBe('/etc/zerofs/config.toml');
+  });
+
+  test('the whole set is enumerable, which is what a fleet-wide flush needs', () => {
+    expect(
+      topology()
+        .all()
+        .map((filesystem) => filesystem.storagePrefix),
+    ).toEqual([HOST_PREFIX]);
+  });
+});
+
+describe('a prefix this host does not serve', () => {
+  test('is refused, never written to the filesystem that happens to be here', () => {
+    expect(() => topology().resolve({ storagePrefix: OTHER_PREFIX })).toThrow(
+      UnservedStoragePrefixError,
+    );
+  });
+
+  test('the error names both what was asked for and what is served', () => {
+    const error = (() => {
+      try {
+        topology().resolve({ storagePrefix: OTHER_PREFIX });
+      } catch (caught) {
+        return caught as Error;
+      }
+      return undefined;
+    })();
+    expect(error?.message).toContain(OTHER_PREFIX);
+    expect(error?.message).toContain(HOST_PREFIX);
+  });
+});

--- a/apps/agent/src/volumes/topology.ts
+++ b/apps/agent/src/volumes/topology.ts
@@ -1,0 +1,115 @@
+import type { ObjectKey } from '@repo/protocol';
+import type { CommandRunner } from '#lib/exec.ts';
+import { ZerofsAdmin } from '#volumes/zerofs.ts';
+
+/**
+ * One ZeroFS filesystem, which is one `[storage] url` prefix.
+ *
+ * A device file lives *inside* a ZeroFS filesystem, so the prefix a volume names decides which
+ * ZeroFS serves it. That makes the number of ZeroFS instances per host a real topology choice
+ * rather than a deployment detail — see the note on {@link ZerofsTopology.sharedHostFilesystem}.
+ */
+export type ZerofsFilesystem = {
+  storagePrefix: ObjectKey;
+  // The host's own mount of ZeroFS's filesystem, where `.nbd/<volume-id>` is created and sized.
+  //
+  // This is not the tenant's ext4. The host mounts ZeroFS and writes a sparse *file* into it;
+  // what that file contains is a filesystem image the host never asks its kernel to interpret.
+  // The rule the export design depends on is that the kernel never parses tenant-controlled
+  // filesystem metadata, and it is intact — this looks like a violation and is not.
+  mountPath: string;
+  nbdSocketPath: string;
+  configFile: string;
+  admin: ZerofsAdmin;
+};
+
+export class UnservedStoragePrefixError extends Error {
+  readonly storagePrefix: ObjectKey;
+
+  constructor({ storagePrefix, served }: { storagePrefix: ObjectKey; served: readonly string[] }) {
+    super(
+      `No ZeroFS on this host serves ${storagePrefix}; it serves ${served.join(', ') || 'nothing'}`,
+    );
+    this.name = 'UnservedStoragePrefixError';
+    this.storagePrefix = storagePrefix;
+  }
+}
+
+/**
+ * Which ZeroFS instance serves which storage prefix.
+ *
+ * **v1 runs one ZeroFS per host**, so every volume placed here shares one prefix. That buys one
+ * process, one local cache and one S3 client for the whole host, and it is the only shape whose
+ * cost does not scale with tenant count.
+ *
+ * What it costs, stated plainly: the validated restore property — destroy a host, point a new
+ * ZeroFS at the same bucket prefix, get the data back byte-identically — becomes per *host*
+ * rather than per *app*. Moving one app to another host is then copying a device file between
+ * two filesystems, not repointing at a prefix. A ZeroFS restart is also a fleet-wide event on
+ * this host rather than one tenant's.
+ *
+ * The protocol already accommodates either shape, because `storagePrefix` is on the volume: a
+ * per-host prefix simply means every volume on the host repeats it. Nothing below assumes one
+ * filesystem — the volume path, the NBD socket and the admin RPC are all resolved *per volume*
+ * from the prefix it names, so moving to one ZeroFS per app is a second factory here plus a
+ * supervisor for the extra processes, not a rewrite of the volume manager.
+ *
+ * The invariant that holds under both: **exactly one read-write `zerofs run` per storage prefix,
+ * fleet-wide.** ZeroFS does not reject a second writer — SlateDB's epoch fences the older one,
+ * which then dies on its next durable write, after a window in which it has been acknowledging
+ * writes that will be silently discarded. A duplicate is an outage, not an error message. The
+ * agent therefore never starts ZeroFS; systemd's own single-instance guarantee is the lock.
+ */
+export class ZerofsTopology {
+  readonly #filesystems: ZerofsFilesystem[];
+
+  private constructor(filesystems: ZerofsFilesystem[]) {
+    this.#filesystems = filesystems;
+  }
+
+  static sharedHostFilesystem({
+    runner,
+    storagePrefix,
+    mountPath,
+    nbdSocketPath,
+    configFile,
+  }: {
+    runner: CommandRunner;
+    storagePrefix: ObjectKey;
+    mountPath: string;
+    nbdSocketPath: string;
+    configFile: string;
+  }): ZerofsTopology {
+    return new ZerofsTopology([
+      {
+        storagePrefix,
+        mountPath,
+        nbdSocketPath,
+        configFile,
+        admin: new ZerofsAdmin({ runner, configFile }),
+      },
+    ]);
+  }
+
+  /**
+   * A volume naming a prefix this host does not serve is refused rather than written somewhere
+   * else. Silently creating the device file in the wrong filesystem would put a tenant's data
+   * under a prefix nothing will ever look for it under, which no later reconcile can undo.
+   */
+  resolve({ storagePrefix }: { storagePrefix: ObjectKey }): ZerofsFilesystem {
+    const filesystem = this.#filesystems.find(
+      (candidate) => candidate.storagePrefix === storagePrefix,
+    );
+    if (!filesystem) {
+      throw new UnservedStoragePrefixError({
+        storagePrefix,
+        served: this.#filesystems.map((candidate) => candidate.storagePrefix),
+      });
+    }
+    return filesystem;
+  }
+
+  all(): readonly ZerofsFilesystem[] {
+    return this.#filesystems;
+  }
+}

--- a/apps/agent/src/volumes/zerofs.ts
+++ b/apps/agent/src/volumes/zerofs.ts
@@ -1,0 +1,69 @@
+import type { CheckpointId } from '@repo/protocol';
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+
+const ZEROFS_COMMAND = 'zerofs';
+
+/**
+ * ZeroFS is a long-running service this agent does not own.
+ *
+ * Restarting it tears down every NBD connection on the host mid-request, with no session state
+ * to resume and no reply to the requests already in flight — so every attached microVM stalls
+ * at once, and an unclean stop drops whatever had been acknowledged but not yet flushed. The
+ * agent therefore only ever talks to it over the admin RPC; starting and stopping it is an
+ * operator action with a fleet-wide blast radius, not a step in a reconcile.
+ */
+export class ZerofsAdmin {
+  readonly #runner: CommandRunner;
+  readonly #configFile: string;
+
+  constructor({ runner, configFile }: { runner: CommandRunner; configFile: string }) {
+    this.#runner = runner;
+    this.#configFile = configFile;
+  }
+
+  // Called before a VM stops or a device detaches: with `ignore_fsync` the guest's own flushes
+  // are a no-op, so this is the only thing that turns acknowledged writes into durable ones.
+  async flush(): Promise<void> {
+    await runCommandOrThrow({
+      runner: this.#runner,
+      request: { command: [ZEROFS_COMMAND, 'flush', '-c', this.#configFile] },
+    });
+  }
+
+  async createCheckpoint({ checkpointId }: { checkpointId: CheckpointId }): Promise<void> {
+    await runCommandOrThrow({
+      runner: this.#runner,
+      request: {
+        command: [ZEROFS_COMMAND, 'checkpoint', 'create', '-c', this.#configFile, checkpointId],
+      },
+    });
+  }
+
+  async deleteCheckpoint({ checkpointId }: { checkpointId: CheckpointId }): Promise<void> {
+    await runCommandOrThrow({
+      runner: this.#runner,
+      request: {
+        command: [ZEROFS_COMMAND, 'checkpoint', 'delete', '-c', this.#configFile, checkpointId],
+      },
+    });
+  }
+
+  async listCheckpoints(): Promise<string[]> {
+    const output = await runCommandOrThrow({
+      runner: this.#runner,
+      request: { command: [ZEROFS_COMMAND, 'checkpoint', 'list', '-c', this.#configFile] },
+    });
+    return parseCheckpointNames(output);
+  }
+}
+
+// `zerofs checkpoint list` prints one checkpoint per line; only named checkpoints are listed,
+// and every name this agent creates is a checkpoint id.
+export function parseCheckpointNames(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(/\s+/)[0] ?? '')
+    .filter((name) => name.length > 0);
+}

--- a/apps/agent/tsconfig.json
+++ b/apps/agent/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "scripts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,16 @@
         "typescript": "catalog:",
       },
     },
+    "apps/agent": {
+      "name": "@repo/agent",
+      "dependencies": {
+        "@repo/protocol": "workspace:*",
+      },
+      "devDependencies": {
+        "@repo/typescript-config": "workspace:*",
+        "typescript": "catalog:",
+      },
+    },
     "apps/api": {
       "name": "@repo/api",
       "dependencies": {
@@ -362,6 +372,8 @@
     "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.120.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ys+upfqNtSu58huAhJMBKl3XCkGzyVFBlMlGPzHeFKgpFF/OdgNs1MMf8oaJIbgMH8ZxgGF7qfue39eJohmKIg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
+
+    "@repo/agent": ["@repo/agent@workspace:apps/agent"],
 
     "@repo/api": ["@repo/api@workspace:apps/api"],
 


### PR DESCRIPTION
Runs on each app host as a systemd service. Registers, pulls desired state, converges locally against what is *actually* running, and reports what it observes — it never receives commands, so an agent restart, a control-plane restart and a missed message are all non-events.

**Tenant microVMs are systemd units in their own right, never children of this process.** The agent is the component that updates most often; if the VMs were its children, every agent restart would kill every tenant app on the host, making the one routine operation the most dangerous one.

Covers ZeroFS device provisioning, artifact pull with digest verification, VM lifecycle, tap networking with the three isolation rules, health probing the tenant's declared port, and reporting the stable host-side port. No third-party dependencies — `@repo/protocol` and Bun built-ins only.

129 tests over the parts where a bug would be silent: reconcile diffing, port allocation and its persistence, digest mismatch, backoff, boundary validation, and the state machine separating `starting` from `running` from `failed`.

Not verifiable here: no hypervisor and no AWS credentials on this machine, so nothing that boots a VM or talks to S3 has been executed.

Stacked on #16 for the lockfile; it depends on `packages/protocol` (#12), not on the guest image.