### PR TITLE
feat(infra): deploy the app hosts from CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,6 +68,16 @@ jobs:
           PG_BACKUP_IMAGE_URI: ${{ steps.pg_backup_image.outputs.image-uri }}
         run: bun run --filter @repo/internal-scripts verify-public-images
 
+      # Both are plain compiled binaries rather than images: nothing on an app
+      # host is containerised. Built before any credential is assumed, because
+      # neither needs one — and the guest image's version is a digest of its
+      # inputs including the runtime binary, so that has to exist first.
+      - name: Build the guest runtime
+        run: bun run --filter @repo/runtime build
+
+      - name: Build the agent
+        run: bun run --filter @repo/agent build
+
       - name: Configure AWS credentials (Terraform apply role)
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
@@ -109,6 +119,28 @@ jobs:
           DEPLOY_BUCKET: ${{ steps.tf.outputs.deploy_bucket }}
         run: bun run --filter @repo/internal-scripts publish-runtime-bundle
 
+      - name: Publish the agent binary
+        id: agent_binary
+        env:
+          DEPLOY_BUCKET: ${{ steps.tf.outputs.deploy_bucket }}
+        run: bun run --filter @repo/internal-scripts publish-agent-binary
+
+      # Skipped entirely unless the image's inputs changed — its version is a
+      # digest of them, so "already published" and "unchanged" are one question.
+      # When it does build, it compiles a kernel, hence the timeout.
+      - name: Publish the guest image
+        id: guest_image
+        timeout-minutes: 45
+        env:
+          GUEST_IMAGES_BUCKET: ${{ steps.tf.outputs.guest_images_bucket }}
+        run: bun run --filter @repo/internal-scripts publish-guest-image
+
+      - name: Publish the app host bundle
+        id: app_host_bundle
+        env:
+          DEPLOY_BUCKET: ${{ steps.tf.outputs.deploy_bucket }}
+        run: bun run --filter @repo/internal-scripts publish-app-host-bundle
+
       - name: Deploy via SSM
         env:
           BUNDLE_URL: ${{ steps.bundle.outputs.url }}
@@ -124,3 +156,19 @@ jobs:
           PG_BACKUP_IMAGE_URI: ${{ steps.pg_backup_image.outputs.image-uri }}
           PG_BACKUP_BUCKET: ${{ steps.tf.outputs.pg_backup_bucket }}
         run: bun run --filter @repo/internal-scripts ssm-deploy
+
+      # Separate from the control plane's deploy: a different bundle, a different
+      # DeployGroup, and a different machine class. The versions it installs come
+      # from infra/app-host/versions.json — never from asking S3 what is newest.
+      - name: Deploy the app hosts via SSM
+        env:
+          BUNDLE_URL: ${{ steps.app_host_bundle.outputs.url }}
+          APP_HOST_DEPLOY_GROUP: ${{ steps.tf.outputs.app_host_deploy_group }}
+          APP_HOST_DATA_VOLUME_IDS: ${{ steps.tf.outputs.app_host_data_volume_ids }}
+          SSM_SECRET_PREFIX: ${{ steps.tf.outputs.ssm_secret_prefix }}
+          AGENT_URL: ${{ steps.agent_binary.outputs.url }}
+          GUEST_IMAGES_BUCKET: ${{ steps.tf.outputs.guest_images_bucket }}
+          FILESYSTEMS_BUCKET: ${{ steps.tf.outputs.filesystems_bucket }}
+          ARTIFACTS_BUCKET: ${{ steps.tf.outputs.artifacts_bucket }}
+          API_HOSTNAME: ${{ steps.tf.outputs.api_hostname }}
+        run: bun run --filter @repo/internal-scripts ssm-deploy-app-hosts

--- a/infra/app-host/AGENTS.md
+++ b/infra/app-host/AGENTS.md
@@ -1,0 +1,54 @@
+# infra/app-host
+
+Everything an app host runs. The machine itself is `infra/terraform/app_host.tf`; this is what
+lands on it.
+
+Nothing here is containerised and Docker is not installed — the agent manipulates host
+networking and spawns microVMs, so a container would hand back every privilege it removed.
+
+```
+/opt/nibrun/
+  versions/<component>/<version>/…   every version fetched, until pruned
+  bin/<component> -> versions/…      the active one; what the units resolve
+  bundle/                            what CI ships: units, versions.json, the ZeroFS config, the deploy script
+/var/lib/nibrun/                     agent state, artifact cache, per-VM directories
+/data/                               the EBS volume — ZeroFS's local cache, and nothing else
+```
+
+A version directory counts as present only once it holds a `.installed` marker, so an
+interrupted download is retried rather than adopted as finished.
+
+## versions.json is the only place a version is chosen
+
+CI reads it and **never asks S3 what the newest version is** — that is what makes "what is this
+host running" answerable from git rather than from whichever job ran last. The agent is the one
+exception: its version is the git SHA, and every push ships a new one.
+
+A build **publishes** a version without adopting it. Adopting is a separate commit editing this
+file, and that commit is the reviewable artifact. `guestImage` is `null` until the first image
+is adopted; a host deploys fine without one and simply cannot boot microVMs, which is correct
+before any tenant app exists.
+
+## What a deploy restarts, and what it must not
+
+Only the units whose resolved version — or whose configuration — actually moved.
+
+- **Agent bumped**, the common case: restarts `nibrun-agent`. **No tenant VM restarts.** They
+  are systemd units in their own right, so it comes back and reconciles against what it finds.
+- **Guest image or Firecracker bumped**: nothing restarts. Running VMs keep what they booted
+  with; the new one reaches an app when it is next redeployed.
+- **ZeroFS bumped — disruptive.** It serves the NBD device behind every guest disk on the host,
+  so restarting it stalls every app at once and an attached guest may remount read-only. Bump
+  it in its own commit, deliberately, expecting impact — never riding along with a feature push.
+- **Nothing bumped**: nothing downloads, no symlink moves, nothing restarts.
+
+Re-running a deploy on a healthy host must change nothing, and a new host must reach a working
+state with nobody connecting to it.
+
+## Two that will bite
+
+Exactly one read-write `zerofs run` may exist per storage prefix, **fleet-wide**. ZeroFS does
+not reject a second one — the fence is SlateDB's writer epoch and the loser exits, so a
+duplicate is an outage rather than an error message.
+
+Guest kernel 6.1's minimum end of support is 2026-09-02. Plan the bump.

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+# Runs ON an app host, invoked by the deploy workflow via SSM. Non-secret config
+# arrives as environment variables exported by the SSM command; secrets are read
+# from SSM here, by the instance role, so they never pass through CI.
+#
+# The bundle this lives in is kilobytes: units, the ZeroFS config, this script.
+# The binaries are not in it. They are fetched by version into a versioned path
+# and skipped entirely if that version is already on disk, which is what makes a
+# repeat deploy nearly free and rollback a symlink swap.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+log() { echo "=== [on_box_deploy $(date -u +%H:%M:%S)] $* ==="; }
+
+: "${AWS_REGION:?}" "${SSM_SECRET_PREFIX:?}" "${DATA_VOLUME_ID:?}" \
+  "${AGENT_VERSION:?}" "${AGENT_URL:?}" \
+  "${ZEROFS_VERSION:?}" "${ZEROFS_URL:?}" "${ZEROFS_SHA256:?}" "${ZEROFS_MEMBER:?}" \
+  "${FIRECRACKER_VERSION:?}" "${FIRECRACKER_URL:?}" "${FIRECRACKER_SHA256:?}" \
+  "${FIRECRACKER_DIRECTORY:?}" \
+  "${FILESYSTEMS_BUCKET:?}" "${API_HOSTNAME:?}" "${GUEST_IMAGES_BUCKET:?}" \
+  "${ARTIFACTS_BUCKET:?}"
+
+# Empty until a guest image is adopted in infra/app-host/versions.json. A host
+# with none deploys fine; it simply has no image to boot microVMs from, which is
+# the correct state before any tenant app exists.
+GUEST_IMAGE_VERSION="${GUEST_IMAGE_VERSION:-}"
+
+# Composed here rather than in CI because the prefix is scoped to this host and
+# the instance id is only known on it. ZeroFS opens exactly one prefix read-write
+# fleet-wide, and this is what makes that true by construction.
+instance_id=$(
+  token=$(curl -fsS -X PUT http://169.254.169.254/latest/api/token \
+    -H 'X-aws-ec2-metadata-token-ttl-seconds: 60')
+  curl -fsS -H "X-aws-ec2-metadata-token: $token" \
+    http://169.254.169.254/latest/meta-data/instance-id
+)
+NIBRUN_FILESYSTEMS_URL="s3://${FILESYSTEMS_BUCKET}/hosts/${instance_id}"
+
+NIBRUN_DIR=/opt/nibrun
+VERSIONS_DIR="$NIBRUN_DIR/versions"
+CURRENT_DIR="$NIBRUN_DIR/bin"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+mkdir -p "$VERSIONS_DIR" "$CURRENT_DIR" "$NIBRUN_DIR/bundle" /var/lib/nibrun /etc/nibrun /etc/zerofs
+
+secret() {
+  aws ssm get-parameter --name "${SSM_SECRET_PREFIX}/$1" --with-decryption \
+    --query Parameter.Value --output text
+}
+
+log "Ensuring the data volume is mounted"
+bash ensure_data_volume.sh zerofs
+
+id -u zerofs >/dev/null 2>&1 || useradd --system --no-create-home --shell /sbin/nologin zerofs
+chown -R zerofs:zerofs /data/zerofs
+
+# --- Fetching versions -------------------------------------------------------
+#
+# A version directory is only considered present once its marker exists, so an
+# interrupted download is retried rather than adopted as if it had finished.
+
+is_installed() { [ -f "$VERSIONS_DIR/$1/$2/.installed" ]; }
+
+mark_installed() { touch "$VERSIONS_DIR/$1/$2/.installed"; }
+
+verify_sha256() {
+  echo "$2  $1" | sha256sum -c - >/dev/null
+}
+
+install_zerofs() {
+  local dir="$VERSIONS_DIR/zerofs/$ZEROFS_VERSION"
+  mkdir -p "$dir"
+  curl -fsSL "$ZEROFS_URL" -o "$WORK_DIR/zerofs.tar.gz"
+  verify_sha256 "$WORK_DIR/zerofs.tar.gz" "$ZEROFS_SHA256"
+  # One multiplatform tarball, flat, holding a binary per platform.
+  tar xzf "$WORK_DIR/zerofs.tar.gz" -C "$WORK_DIR" "$ZEROFS_MEMBER"
+  install -m 0755 "$WORK_DIR/$ZEROFS_MEMBER" "$dir/zerofs"
+  mark_installed zerofs "$ZEROFS_VERSION"
+}
+
+install_firecracker() {
+  local dir="$VERSIONS_DIR/firecracker/$FIRECRACKER_VERSION"
+  mkdir -p "$dir"
+  curl -fsSL "$FIRECRACKER_URL" -o "$WORK_DIR/firecracker.tgz"
+  verify_sha256 "$WORK_DIR/firecracker.tgz" "$FIRECRACKER_SHA256"
+  tar xzf "$WORK_DIR/firecracker.tgz" -C "$WORK_DIR"
+  # Both binaries ship in the one tarball, suffixed with the version and arch.
+  # The jailer is version-locked to its firecracker, so they move together.
+  install -m 0755 "$WORK_DIR/$FIRECRACKER_DIRECTORY/firecracker-${FIRECRACKER_VERSION}-x86_64" \
+    "$dir/firecracker"
+  install -m 0755 "$WORK_DIR/$FIRECRACKER_DIRECTORY/jailer-${FIRECRACKER_VERSION}-x86_64" \
+    "$dir/jailer"
+  mark_installed firecracker "$FIRECRACKER_VERSION"
+}
+
+install_agent() {
+  local dir="$VERSIONS_DIR/agent/$AGENT_VERSION"
+  mkdir -p "$dir"
+  aws s3 cp "$AGENT_URL" "$dir/nibrun-agent"
+  chmod 0755 "$dir/nibrun-agent"
+  mark_installed agent "$AGENT_VERSION"
+}
+
+install_guest_image() {
+  local dir="$VERSIONS_DIR/guest-image/$GUEST_IMAGE_VERSION"
+  mkdir -p "$dir"
+  aws s3 cp --recursive "s3://${GUEST_IMAGES_BUCKET}/${GUEST_IMAGE_VERSION}/" "$dir/"
+  # Written by the publish step from the manifest's own digests, because this box
+  # has no jq to read the manifest with.
+  ( cd "$dir" && sha256sum -c SHA256SUMS )
+  mark_installed guest-image "$GUEST_IMAGE_VERSION"
+}
+
+# Succeeds when the active symlink changed, fails when it was already correct.
+# That distinction is the whole point: it decides what restarts.
+activate() {
+  local component=$1 version=$2
+  local target="$VERSIONS_DIR/$component/$version"
+  local link="$CURRENT_DIR/$component"
+
+  if [ "$(readlink "$link" 2>/dev/null || true)" = "$target" ]; then
+    return 1
+  fi
+  ln -sfn "$target" "$link"
+  return 0
+}
+
+NEEDS_RESTART=()
+
+ensure() {
+  local component=$1 version=$2 installer=$3
+
+  if is_installed "$component" "$version"; then
+    log "$component $version already on disk"
+  else
+    log "Fetching $component $version"
+    "$installer"
+  fi
+
+  if activate "$component" "$version"; then
+    log "$component now $version"
+    NEEDS_RESTART+=("$component")
+  fi
+}
+
+ensure zerofs "$ZEROFS_VERSION" install_zerofs
+ensure firecracker "$FIRECRACKER_VERSION" install_firecracker
+ensure agent "$AGENT_VERSION" install_agent
+
+if [ -n "$GUEST_IMAGE_VERSION" ]; then
+  ensure guest-image "$GUEST_IMAGE_VERSION" install_guest_image
+else
+  log "No guest image adopted — see infra/app-host/versions.json"
+fi
+
+# --- Configuration -----------------------------------------------------------
+#
+# Rewritten every deploy and compared before restarting, so a changed secret or a
+# changed template reaches the process that reads it without a version having to
+# move.
+
+umask 077
+
+changed_file() {
+  local path=$1
+  if [ -f "$path" ] && cmp -s "$path" "$path.new"; then
+    rm -f "$path.new"
+    return 1
+  fi
+  mv "$path.new" "$path"
+  return 0
+}
+
+cat > /etc/zerofs/zerofs.env.new <<EOF
+NIBRUN_FILESYSTEMS_URL=${NIBRUN_FILESYSTEMS_URL}
+NIBRUN_FILESYSTEMS_PASSWORD=$(secret filesystems_encryption_password)
+AWS_REGION=${AWS_REGION}
+EOF
+chmod 0600 /etc/zerofs/zerofs.env.new
+changed_file /etc/zerofs/zerofs.env && NEEDS_RESTART+=(zerofs) || true
+
+cp versions.json "$NIBRUN_DIR/bundle/versions.json"
+
+cp zerofs/config.toml /etc/zerofs/config.toml.new
+changed_file /etc/zerofs/config.toml && NEEDS_RESTART+=(zerofs) || true
+
+secret agent_bootstrap_token > /var/lib/nibrun/bootstrap-token.new
+chmod 0600 /var/lib/nibrun/bootstrap-token.new
+changed_file /var/lib/nibrun/bootstrap-token && NEEDS_RESTART+=(agent) || true
+
+cat > /etc/nibrun/agent.env.new <<EOF
+AGENT_CONTROL_PLANE_URL=https://${API_HOSTNAME}
+AGENT_BOOTSTRAP_TOKEN_FILE=/var/lib/nibrun/bootstrap-token
+AGENT_ARTIFACT_BUCKET=${ARTIFACTS_BUCKET}
+AGENT_AWS_REGION=${AWS_REGION}
+AWS_REGION=${AWS_REGION}
+EOF
+chmod 0600 /etc/nibrun/agent.env.new
+changed_file /etc/nibrun/agent.env && NEEDS_RESTART+=(agent) || true
+
+log "Installing systemd units"
+units_changed=0
+for unit in systemd/*.service; do
+  cp "$unit" "/etc/systemd/system/$(basename "$unit").new"
+  changed_file "/etc/systemd/system/$(basename "$unit")" && units_changed=1 || true
+done
+if [ "$units_changed" = "1" ]; then
+  systemctl daemon-reload
+fi
+
+systemctl enable nibrun-zerofs.service nibrun-agent.service >/dev/null
+
+# --- Restarting --------------------------------------------------------------
+#
+# Only what actually moved. In particular no tenant microVM is restarted by an
+# agent bump: they are systemd units in their own right rather than children of
+# the agent, so it comes back and reconciles against what it finds.
+
+needs_restart() { printf '%s\n' "${NEEDS_RESTART[@]+"${NEEDS_RESTART[@]}"}" | grep -qx "$1"; }
+
+if needs_restart zerofs; then
+  # Disruptive: ZeroFS serves the NBD device behind every guest disk on this
+  # host, so this stalls I/O for every app on it and an attached guest can
+  # remount read-only rather than wait. It happens because someone deliberately
+  # edited the ZeroFS pin, never as a side effect of a feature push.
+  log "ZeroFS changed — restarting it, which interrupts every app on this host"
+  systemctl restart nibrun-zerofs.service
+else
+  systemctl start nibrun-zerofs.service
+fi
+
+if needs_restart agent; then
+  log "Agent changed — restarting it, leaving tenant microVMs running"
+  systemctl restart nibrun-agent.service
+else
+  systemctl start nibrun-agent.service
+fi
+
+# Firecracker and the guest image are read by the *next* boot of a microVM, so a
+# bump reaches an app when it is next redeployed and restarts nothing now.
+
+log "Waiting for the services to settle"
+for unit in nibrun-zerofs nibrun-agent; do
+  for _ in $(seq 1 30); do
+    state=$(systemctl is-active "$unit.service" || true)
+    [ "$state" = "active" ] && break
+    sleep 2
+  done
+  if [ "$(systemctl is-active "$unit.service" || true)" != "active" ]; then
+    log "$unit did not become active"
+    systemctl status "$unit.service" --no-pager --lines 50 || true
+    journalctl -u "$unit.service" --no-pager --lines 100 || true
+    exit 1
+  fi
+done
+
+log "Active versions"
+for component in zerofs firecracker agent guest-image; do
+  if [ -L "$CURRENT_DIR/$component" ]; then
+    echo "  $component -> $(basename "$(readlink "$CURRENT_DIR/$component")")"
+  fi
+done
+
+log "Deploy finished"

--- a/infra/app-host/systemd/nibrun-agent.service
+++ b/infra/app-host/systemd/nibrun-agent.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=nibrun host agent
+After=network-online.target nibrun-zerofs.service
+Wants=network-online.target
+
+# Deliberately not BindsTo or Requires: the agent must be restartable, and
+# stoppable, without that being an event for anything it manages. Tenant microVMs
+# are systemd units in their own right rather than children of this process, so
+# restarting the agent leaves every running app alone — it comes back and
+# reconciles against what it finds.
+[Service]
+Type=exec
+ExecStart=/opt/nibrun/bin/agent/nibrun-agent
+EnvironmentFile=/etc/nibrun/agent.env
+
+Restart=always
+RestartSec=5s
+
+StateDirectory=nibrun
+RuntimeDirectory=nibrun
+
+# It creates tap devices, writes firewall rules and starts microVM units, so it
+# runs as root. Containerising it would hand back every privilege the container
+# removed, which is why nothing on this host is containerised.
+NoNewPrivileges=false
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/app-host/systemd/nibrun-vm@.service
+++ b/infra/app-host/systemd/nibrun-vm@.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=nibrun microVM %i
+# Its disk is an NBD device ZeroFS serves, so it cannot meaningfully outlive it.
+BindsTo=nibrun-zerofs.service
+After=nibrun-zerofs.service
+
+# Deliberately unrelated to nibrun-agent.service. The agent stages this VM's
+# files and asks init to start the unit, then stops caring — it is the component
+# that updates most often, and if these were its children every agent restart
+# would kill every tenant app on the host.
+[Service]
+Type=exec
+WorkingDirectory=/var/lib/nibrun/vm/%i
+ExecStart=/opt/nibrun/bin/firecracker/firecracker \
+  --api-sock /run/nibrun/vm-%i.sock \
+  --config-file /var/lib/nibrun/vm/%i/firecracker.json
+
+# No restart here on purpose. The guest's own init supervises the tenant process
+# with backoff and powers the VM off once that budget is exhausted, and the agent
+# reconciles a VM that should be running and is not. Restarting here as well
+# would race that loop and hide a broken deploy behind an infinite retry.
+Restart=no
+
+# The tenant's own output arrives on the guest console, which Firecracker writes
+# to its stdout and systemd captures — so `journalctl -u nibrun-vm@<id>` is the
+# app's log with no shipping built for it.
+StandardOutput=journal
+StandardError=journal
+
+KillSignal=SIGTERM
+TimeoutStopSec=30
+
+# A stop is abrupt from the guest's point of view: nothing here asks it to shut
+# down cleanly first. That is survivable only because the agent flushes ZeroFS
+# before stopping a VM, which is the step that turns acknowledged writes durable
+# when `ignore_fsync` has made the guest's own fsync a no-op.

--- a/infra/app-host/systemd/nibrun-zerofs.service
+++ b/infra/app-host/systemd/nibrun-zerofs.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=ZeroFS, backing every tenant disk on this host
+Documentation=https://www.zerofs.net
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User=zerofs
+Group=zerofs
+ExecStart=/opt/nibrun/bin/zerofs/zerofs run --config /etc/zerofs/config.toml
+EnvironmentFile=/etc/zerofs/zerofs.env
+
+# Any failed write to the object store terminates the process by design, and a
+# process fenced by another writer exits cleanly — `always` covers both, where
+# `on-failure` would leave a fenced host quietly serving nothing.
+Restart=always
+RestartSec=5s
+
+# Shutdown seals and uploads the open segment and flushes metadata. A SIGKILL
+# part-way through that loses the unflushed tail, which is exactly the data
+# ignore_fsync already put at risk. Do not shorten this.
+TimeoutStopSec=120
+
+CacheDirectory=zerofs
+StateDirectory=zerofs
+RuntimeDirectory=zerofs
+# The agent and nbd-client reach the sockets in here.
+RuntimeDirectoryMode=0750
+
+LimitNOFILE=1048576
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+# ProtectSystem=strict makes everything else read-only, and the cache lives on
+# the data volume rather than under CacheDirectory.
+ReadWritePaths=/data/zerofs
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -1,0 +1,15 @@
+{
+  "zerofs": {
+    "version": "v2.2.1",
+    "url": "https://github.com/Barre/ZeroFS/releases/download/v2.2.1/zerofs-pgo-multiplatform.tar.gz",
+    "sha256": "d4ae4e4e9bc0a6f4cc4253b6a9fc6c9b57feda6dc0f0cb7443f9264b2eeec621",
+    "member": "zerofs-linux-amd64-pgo"
+  },
+  "firecracker": {
+    "version": "v1.16.1",
+    "url": "https://github.com/firecracker-microvm/firecracker/releases/download/v1.16.1/firecracker-v1.16.1-x86_64.tgz",
+    "sha256": "382a02a869e4d6d5cb14c40577f9545e8458021ea8b0b2d3fc10ec14d9c242e6",
+    "directory": "release-v1.16.1-x86_64"
+  },
+  "guestImage": null
+}

--- a/infra/app-host/zerofs/config.toml
+++ b/infra/app-host/zerofs/config.toml
@@ -1,0 +1,65 @@
+# ZeroFS on an app host. Read by `zerofs run --config`, which has no default path
+# and no search behaviour — the unit passes this one explicitly.
+#
+# Every ${VAR} is expanded by ZeroFS itself from the process environment, which
+# the unit loads from /etc/zerofs/zerofs.env. Numbers are literal because the
+# substitution is a string one.
+
+[cache]
+# The EBS data volume, and the only thing on it. Sized well under the volume so a
+# full cache cannot fill the disk out from under the segments being written.
+dir = "/data/zerofs"
+disk_size_gb = 70.0
+memory_size_gb = 2.0
+warm_metadata = "filters_index"
+
+[storage]
+url = "${NIBRUN_FILESYSTEMS_URL}"
+encryption_password = "${NIBRUN_FILESYSTEMS_PASSWORD}"
+
+# Region only. Credentials resolve through the default chain, so the instance
+# role suffices and no static keys exist for this host.
+[aws]
+region = "${AWS_REGION}"
+
+[filesystem]
+# The setting the whole design rests on. Honouring fsync costs ~244 ms a call —
+# about 1.3 SQLite commits a second — which is unusable. With this, ~1.24 ms and
+# ~619 commits/s, roughly 1.9x faster than local EBS.
+#
+# It makes the guest's fsync a no-op all the way down: NBD FLUSH and FUA stop
+# meaning anything, and [lsm] flush_interval_secs below becomes the entire
+# durability guarantee.
+ignore_fsync = true
+compression = "zstd-3"
+
+[lsm]
+# The accepted RPO. Worst-case loss is this interval *plus* the time the seal and
+# upload take, so it is 5-15 s in practice rather than exactly 5. Five is the
+# enforced minimum and a lower value is silently clamped rather than rejected.
+#
+# sync_writes is deliberately absent: with ignore_fsync it is a hard config error.
+flush_interval_secs = 5
+
+# Unix sockets rather than TCP: everything that talks to ZeroFS is on this host.
+# Under /run rather than /tmp because the unit sets PrivateTmp, which would put a
+# /tmp socket in a namespace the agent cannot see.
+[servers.nbd]
+unix_socket = "/run/zerofs/nbd.sock"
+
+# How the agent creates and sizes an app's disk: the device files live in a .nbd
+# directory inside the ZeroFS filesystem itself, so managing them is a filesystem
+# operation rather than an RPC one.
+[servers.ninep]
+unix_socket = "/run/zerofs/9p.sock"
+
+# The admin RPC the `zerofs` CLI drives — flush, checkpoints, stats. Without this
+# section every one of those subcommands exits with "RPC server not configured".
+[servers.rpc]
+unix_socket = "/run/zerofs/rpc.sock"
+
+[prometheus]
+addresses = ["127.0.0.1:9091"]
+
+[telemetry]
+enabled = false

--- a/infra/deploy/ensure_data_volume.sh
+++ b/infra/deploy/ensure_data_volume.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-# Runs ON the instance before the compose stack is touched. Mounts the
-# persistent EBS data volume at /data and prepares the directories the prod
-# compose file binds the data-bearing named volumes to, so that data survives
-# instance replacement. Docker's own state (images, containers, derived volumes)
-# stays on the root disk — every deploy rebuilds it.
+# Runs ON an instance, before anything that reads /data. Mounts the persistent
+# EBS data volume there and creates the directories named as arguments, relative
+# to /data, so their contents survive instance replacement.
+#
+# Shipped in both bundles because both machine classes have a data volume; what
+# they keep on it is the caller's business and arrives as those arguments.
 # Idempotent: a no-op once the volume is mounted and the directories exist.
 set -euo pipefail
 
@@ -36,8 +37,6 @@ mkdir -p /data
 grep -qF "$dev" /etc/fstab || echo "$dev /data xfs defaults,nofail 0 2" >> /etc/fstab
 mountpoint -q /data || mount /data
 
-# Docker does not create missing host directories for local volumes with
-# `o: bind` driver_opts (unlike container bind mounts) — volume creation fails.
-# Only Postgres: production talks to real S3, so MinIO does not run here and
-# has no volume to back.
-mkdir -p /data/volumes/postgres-data
+for directory in "$@"; do
+  mkdir -p "/data/${directory}"
+done

--- a/infra/deploy/on_box_deploy.sh
+++ b/infra/deploy/on_box_deploy.sh
@@ -26,8 +26,12 @@ API_S3_PORT="${API_S3_PORT:-9000}"
 API_S3_CONSOLE_PORT="${API_S3_CONSOLE_PORT:-9001}"
 DOZZLE_PORT="${DOZZLE_PORT:-8080}"
 
+# Docker does not create missing host directories for local volumes with
+# `o: bind` driver_opts (unlike container bind mounts) — volume creation fails.
+# Only Postgres: production talks to real S3, so MinIO does not run here and has
+# no volume to back.
 log "Ensuring the persistent data volume is mounted and holds the data-bearing volumes"
-bash ensure_data_volume.sh
+bash ensure_data_volume.sh volumes/postgres-data
 
 secret() {
   aws ssm get-parameter --name "${SSM_SECRET_PREFIX}/$1" --with-decryption \

--- a/infra/terraform/ssm.tf
+++ b/infra/terraform/ssm.tf
@@ -102,6 +102,53 @@ resource "aws_ssm_parameter" "dozzle_password" {
   }
 }
 
+# --- App hosts ---
+
+# ZeroFS encrypts everything it writes to the filesystems bucket under this. It
+# is generated once and never rotated in place: changing it does not re-encrypt
+# anything, it makes every existing tenant filesystem unreadable. Treat it as
+# permanent for the life of the bucket.
+resource "random_password" "filesystems_encryption_password" {
+  length  = 48
+  special = false
+}
+
+resource "aws_ssm_parameter" "filesystems_encryption_password" {
+  name  = "${var.ssm_secret_prefix}/filesystems_encryption_password"
+  type  = "SecureString"
+  value = random_password.filesystems_encryption_password.result
+
+  tags = {
+    Name = "${local.resource_name_prefix}-filesystems-encryption-password"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# What an agent presents once, to exchange for a session. It identifies the
+# machine class rather than a user, and buys nothing else — so revoking a host is
+# expiring its session rather than rotating this.
+#
+# Read by the instance with its own role rather than baked into user_data, which
+# is the repo's established path for every other secret and, unlike user_data,
+# can be rotated without replacing the instance.
+resource "random_password" "agent_bootstrap_token" {
+  length  = 48
+  special = false
+}
+
+resource "aws_ssm_parameter" "agent_bootstrap_token" {
+  name  = "${var.ssm_secret_prefix}/agent_bootstrap_token"
+  type  = "SecureString"
+  value = random_password.agent_bootstrap_token.result
+
+  tags = {
+    Name = "${local.resource_name_prefix}-agent-bootstrap-token"
+  }
+}
+
 # Credentials of the api's own IAM user (iam_api.tf), not generated here.
 resource "aws_ssm_parameter" "api_s3_access_key_id" {
   name  = "${var.ssm_secret_prefix}/api_s3_access_key_id"

--- a/packages/internal-scripts/package.json
+++ b/packages/internal-scripts/package.json
@@ -7,8 +7,12 @@
   },
   "scripts": {
     "build-and-push-image": "bun run src/build-and-push-image.ts",
+    "publish-agent-binary": "bun run src/publish-agent-binary.ts",
+    "publish-app-host-bundle": "bun run src/publish-app-host-bundle.ts",
+    "publish-guest-image": "bun run src/publish-guest-image.ts",
     "publish-runtime-bundle": "bun run src/publish-runtime-bundle.ts",
     "ssm-deploy": "bun run src/ssm-deploy.ts",
+    "ssm-deploy-app-hosts": "bun run src/ssm-deploy-app-hosts.ts",
     "terraform-apply": "bun run src/terraform-apply.ts",
     "terraform-check": "bun run src/terraform-check.ts",
     "terraform-plan": "bun run src/terraform-plan.ts",

--- a/packages/internal-scripts/src/publish-agent-binary.ts
+++ b/packages/internal-scripts/src/publish-agent-binary.ts
@@ -1,0 +1,26 @@
+import { join } from 'node:path';
+import * as core from '@actions/core';
+import { aws } from '#shared/aws.ts';
+import { requiredEnv } from '#shared/env.ts';
+import { repoRoot } from '#shared/paths.ts';
+
+// Published under its git SHA, because every push ships a new agent — that is the
+// point of it being the component that updates most often. It lands in the deploy
+// bucket rather than artifacts: it is a deploy artifact, and the deploy role must
+// never hold write access to the bucket holding tenant binaries.
+const binaryPath = join(repoRoot, 'apps/agent/dist/nibrun-agent');
+
+const deployBucket = requiredEnv('DEPLOY_BUCKET');
+const revision = requiredEnv('GITHUB_SHA');
+
+if (!(await Bun.file(binaryPath).exists())) {
+  core.setFailed(`Missing ${binaryPath} — run the agent build before publishing it.`);
+  process.exit(1);
+}
+
+const url = `s3://${deployBucket}/agent/${revision}/nibrun-agent`;
+await aws(['s3', 'cp', binaryPath, url]);
+
+core.setOutput('url', url);
+core.setOutput('version', revision);
+core.info(`${url} (${Bun.file(binaryPath).size} bytes)`);

--- a/packages/internal-scripts/src/publish-app-host-bundle.ts
+++ b/packages/internal-scripts/src/publish-app-host-bundle.ts
@@ -1,0 +1,43 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as core from '@actions/core';
+import { $ } from 'bun';
+import { aws } from '#shared/aws.ts';
+import { requiredEnv } from '#shared/env.ts';
+import { repoRoot } from '#shared/paths.ts';
+
+// Kilobytes, deliberately: the units, the ZeroFS config and the deploy scripts.
+// The binaries are not in here. They are fetched separately from S3 by version,
+// into a versioned path, and skipped entirely if that version is already on disk
+// — which is what makes a repeat deploy nearly free and rollback a symlink swap.
+// Tarring hundreds of megabytes of unchanged binaries into this would work, and
+// would be wrong.
+const BUNDLE_DIRECTORIES = ['systemd', 'zerofs'];
+
+// Shell, not TypeScript: these run on the box, which has no Bun. Flattened to the
+// bundle root next to the directories above, because the deploy script resolves
+// everything relative to itself.
+const ON_BOX_SCRIPTS = ['on_box_deploy.sh'];
+
+// The agent reads this to report what the host is running, so it ships with the
+// config rather than only being resolved by CI.
+const BUNDLE_FILES = ['versions.json'];
+
+// Shared with the control plane's bundle — both machine classes have a data
+// volume, and what they keep on it arrives as arguments.
+const SHARED_ON_BOX_SCRIPTS = ['ensure_data_volume.sh'];
+
+const deployBucket = requiredEnv('DEPLOY_BUCKET');
+const revision = requiredEnv('GITHUB_SHA');
+
+const appHostDir = join(repoRoot, 'infra/app-host');
+const bundlePath = join(tmpdir(), 'nibrun-app-host-bundle.tar.gz');
+
+await $`tar czf ${bundlePath} -C ${appHostDir} ${BUNDLE_DIRECTORIES} ${BUNDLE_FILES} -C ${join(appHostDir, 'deploy')} ${ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/deploy')} ${SHARED_ON_BOX_SCRIPTS}`;
+
+const bundleBytes = Bun.file(bundlePath).size;
+const url = `s3://${deployBucket}/app-host-bundles/${revision}.tar.gz`;
+await aws(['s3', 'cp', bundlePath, url]);
+
+core.setOutput('url', url);
+core.info(`${url} (${bundleBytes} bytes)`);

--- a/packages/internal-scripts/src/publish-guest-image.ts
+++ b/packages/internal-scripts/src/publish-guest-image.ts
@@ -1,0 +1,88 @@
+import { join } from 'node:path';
+import * as core from '@actions/core';
+import { $ } from 'bun';
+import { writeSummary } from '#shared/actions.ts';
+import { aws } from '#shared/aws.ts';
+import { requiredEnv } from '#shared/env.ts';
+import { repoRoot } from '#shared/paths.ts';
+
+// Publishing is not adopting. This uploads an image under its own version and
+// stops; a host only runs it once a separate, reviewable commit edits `guestImage`
+// in infra/app-host/versions.json. That split is what keeps the fleet's kernel a
+// deliberate input rather than whatever the last build produced.
+
+type Manifest = {
+  version: string;
+  artifacts: { name: string; bytes: number; sha256: string }[];
+  inputs: { init_is_stub: boolean };
+};
+
+const guestImageDir = join(repoRoot, 'infra/guest-image');
+const distDir = join(guestImageDir, 'dist');
+
+const bucket = requiredEnv('GUEST_IMAGES_BUCKET');
+
+// The version is a digest of every input the build reads, so "has this already
+// been published" and "have the inputs changed" are the same question — which is
+// what stops the image being rebuilt on every push.
+const version = (await $`bash ${join(guestImageDir, 'version.sh')}`.text()).trim();
+core.info(`Guest image version: ${version}`);
+core.setOutput('version', version);
+
+const published = await aws([
+  's3api',
+  'head-object',
+  '--bucket',
+  bucket,
+  '--key',
+  `${version}/manifest.json`,
+])
+  .nothrow()
+  .quiet();
+
+if (published.exitCode === 0) {
+  core.info('Already published — inputs unchanged, nothing to build.');
+  process.exit(0);
+}
+
+core.info('Not published yet — building.');
+await $`bash ${join(guestImageDir, 'build.sh')}`.cwd(guestImageDir);
+
+const manifest = (await Bun.file(join(distDir, 'manifest.json')).json()) as Manifest;
+
+if (manifest.inputs.init_is_stub) {
+  core.setFailed('Refusing to publish an image built with the stub /init.');
+  process.exit(1);
+}
+
+if (manifest.version !== version) {
+  core.setFailed(
+    `Built ${manifest.version} but expected ${version} — the build is not reproducible.`,
+  );
+  process.exit(1);
+}
+
+// The box verifies what it downloaded, and it has no jq — so the digests the
+// manifest already carries are also written in the format sha256sum reads.
+const checksums = manifest.artifacts
+  .map((artifact) => `${artifact.sha256}  ${artifact.name}`)
+  .join('\n');
+await Bun.write(join(distDir, 'SHA256SUMS'), `${checksums}\n`);
+
+await aws(['s3', 'cp', '--recursive', distDir, `s3://${bucket}/${version}/`]);
+
+core.info(`Published s3://${bucket}/${version}/`);
+
+// Publishing is not adopting, and adopting is a human editing a pin. That person
+// should not have to dig the version out of a build log to find what to paste.
+await writeSummary(
+  [
+    '## Guest image published',
+    '',
+    `\`${version}\``,
+    '',
+    'No host runs it yet. To adopt it, set `guestImage` to that value in',
+    '`infra/app-host/versions.json` and open a pull request — that commit is the',
+    'reviewable record of the fleet changing kernel.',
+  ].join('\n'),
+);

--- a/packages/internal-scripts/src/shared/app-host-versions.ts
+++ b/packages/internal-scripts/src/shared/app-host-versions.ts
@@ -1,0 +1,21 @@
+import { join } from 'node:path';
+import { repoRoot } from '#shared/paths.ts';
+
+// The committed pins, and the only place a version is chosen. CI reads this and
+// must never ask S3 what the newest version is — that is what makes "what is this
+// host running" answerable from git rather than from whichever job ran last.
+//
+// The agent is the one exception: its version is the git SHA.
+export type AppHostVersions = {
+  zerofs: { version: string; url: string; sha256: string; member: string };
+  firecracker: { version: string; url: string; sha256: string; directory: string };
+  // Null until a guest image is adopted. Publishing one and adopting it are
+  // separate commits; the adopting commit is the reviewable artifact.
+  guestImage: string | null;
+};
+
+export const versionsPath = join(repoRoot, 'infra/app-host/versions.json');
+
+export async function readAppHostVersions(): Promise<AppHostVersions> {
+  return (await Bun.file(versionsPath).json()) as AppHostVersions;
+}

--- a/packages/internal-scripts/src/shared/ssm.ts
+++ b/packages/internal-scripts/src/shared/ssm.ts
@@ -1,0 +1,141 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { aws } from '#shared/aws.ts';
+
+const SSM_REGISTRATION_ATTEMPTS = 60;
+const DEPLOY_ATTEMPTS = 90;
+const POLL_MS = 10_000;
+const TERMINAL_STATUSES = new Set(['Success', 'Failed', 'Cancelled', 'TimedOut']);
+
+export type SsmInvocation = {
+  Status: string;
+  StandardOutputContent: string;
+  StandardErrorContent: string;
+};
+
+// POSIX single quoting: the one form with no metacharacters inside it, so a
+// value can never break out of the export line it lands in.
+export const quote = (value: string) => `'${value.replaceAll("'", `'\\''`)}'`;
+
+export const exportLine = (env: Record<string, string>) =>
+  Object.entries(env)
+    .map(([name, value]) => `${name}=${quote(value)}`)
+    .join(' ');
+
+export async function findInstanceIds({ deployGroup }: { deployGroup: string }) {
+  const output = await aws([
+    'ec2',
+    'describe-instances',
+    '--filters',
+    `Name=tag:DeployGroup,Values=${deployGroup}`,
+    'Name=instance-state-name,Values=running',
+    '--query',
+    'Reservations[].Instances[].InstanceId',
+    '--output',
+    'text',
+  ]).text();
+
+  return output.split(/\s+/).filter((id) => id && id !== 'None');
+}
+
+// A freshly-created box isn't registered with SSM yet; wait so send-command lands.
+export async function waitForSsmRegistration({ instanceId }: { instanceId: string }) {
+  for (let attempt = 0; attempt < SSM_REGISTRATION_ATTEMPTS; attempt++) {
+    const ping = (
+      await aws([
+        'ssm',
+        'describe-instance-information',
+        '--filters',
+        `Key=InstanceIds,Values=${instanceId}`,
+        '--query',
+        'InstanceInformationList[0].PingStatus',
+        '--output',
+        'text',
+      ])
+        .nothrow()
+        .quiet()
+        .text()
+    ).trim();
+
+    if (ping === 'Online') {
+      return true;
+    }
+    console.log(`  ${instanceId} ssm ping: ${ping || 'none'}`);
+    await Bun.sleep(POLL_MS);
+  }
+  return false;
+}
+
+export async function sendCommand({
+  instanceIds,
+  script,
+  comment,
+}: {
+  instanceIds: string[];
+  script: string;
+  comment: string;
+}) {
+  const parametersPath = join(tmpdir(), `ssm-params-${instanceIds.join('-')}.json`);
+  await Bun.write(parametersPath, JSON.stringify({ commands: [script] }));
+
+  return (
+    await aws([
+      'ssm',
+      'send-command',
+      '--document-name',
+      'AWS-RunShellScript',
+      '--comment',
+      comment,
+      '--instance-ids',
+      ...instanceIds,
+      '--parameters',
+      `file://${parametersPath}`,
+      '--query',
+      'Command.CommandId',
+      '--output',
+      'text',
+    ]).text()
+  ).trim();
+}
+
+async function readInvocation({
+  commandId,
+  instanceId,
+}: {
+  commandId: string;
+  instanceId: string;
+}) {
+  const result = await aws([
+    'ssm',
+    'get-command-invocation',
+    '--command-id',
+    commandId,
+    '--instance-id',
+    instanceId,
+  ])
+    .nothrow()
+    .quiet();
+
+  return result.exitCode === 0 ? ((await result.json()) as SsmInvocation) : null;
+}
+
+// RunCommand is async, and a full deploy can run for several minutes — longer
+// than the built-in `ssm wait command-executed` allows (~100s) — so poll until
+// the invocation reaches a terminal state.
+export async function waitForInvocation({
+  commandId,
+  instanceId,
+}: {
+  commandId: string;
+  instanceId: string;
+}) {
+  let invocation = await readInvocation({ commandId, instanceId });
+  for (let attempt = 0; attempt < DEPLOY_ATTEMPTS; attempt++) {
+    if (invocation && TERMINAL_STATUSES.has(invocation.Status)) {
+      break;
+    }
+    await Bun.sleep(POLL_MS);
+    invocation = await readInvocation({ commandId, instanceId });
+  }
+  return invocation;
+}

--- a/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
+++ b/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
@@ -1,0 +1,116 @@
+import * as core from '@actions/core';
+import { readAppHostVersions } from '#shared/app-host-versions.ts';
+import { optionalEnv, requiredEnv } from '#shared/env.ts';
+import {
+  exportLine,
+  findInstanceIds,
+  quote,
+  sendCommand,
+  waitForInvocation,
+  waitForSsmRegistration,
+} from '#shared/ssm.ts';
+
+const bundleUrl = requiredEnv('BUNDLE_URL');
+const deployGroup = requiredEnv('APP_HOST_DEPLOY_GROUP');
+const revision = requiredEnv('GITHUB_SHA');
+
+// Each host mounts its own volume, so the one value that differs per host comes
+// from a map keyed by instance id rather than a single output.
+const dataVolumeIds = JSON.parse(requiredEnv('APP_HOST_DATA_VOLUME_IDS')) as Record<string, string>;
+
+const versions = await readAppHostVersions();
+
+// Every name here is the name the box reads, and every version is the one pinned
+// in infra/app-host/versions.json — nothing is rewritten in transit, and nothing
+// is discovered from S3. Secrets are absent; the box reads those from SSM itself.
+const sharedEnv: Record<string, string> = {
+  AWS_REGION: requiredEnv('AWS_REGION'),
+  SSM_SECRET_PREFIX: requiredEnv('SSM_SECRET_PREFIX'),
+  API_HOSTNAME: requiredEnv('API_HOSTNAME'),
+  FILESYSTEMS_BUCKET: requiredEnv('FILESYSTEMS_BUCKET'),
+  GUEST_IMAGES_BUCKET: requiredEnv('GUEST_IMAGES_BUCKET'),
+  ARTIFACTS_BUCKET: requiredEnv('ARTIFACTS_BUCKET'),
+  AGENT_VERSION: revision,
+  AGENT_URL: requiredEnv('AGENT_URL'),
+  ZEROFS_VERSION: versions.zerofs.version,
+  ZEROFS_URL: versions.zerofs.url,
+  ZEROFS_SHA256: versions.zerofs.sha256,
+  ZEROFS_MEMBER: versions.zerofs.member,
+  FIRECRACKER_VERSION: versions.firecracker.version,
+  FIRECRACKER_URL: versions.firecracker.url,
+  FIRECRACKER_SHA256: versions.firecracker.sha256,
+  FIRECRACKER_DIRECTORY: versions.firecracker.directory,
+  GUEST_IMAGE_VERSION: versions.guestImage ?? '',
+};
+
+const instanceIds = await findInstanceIds({ deployGroup });
+
+// Zero hosts is a failure, not a quiet success: an app host that should exist and
+// does not is exactly what this deploy is meant to surface.
+if (instanceIds.length === 0) {
+  core.setFailed(`No running EC2 instance found for DeployGroup=${deployGroup}`);
+  process.exit(1);
+}
+console.log(`Targeting ${instanceIds.length} app host(s): ${instanceIds.join(', ')}`);
+
+const remoteScript = ({ dataVolumeId }: { dataVolumeId: string }) => `
+set -euo pipefail
+timeout 900 bash -c 'until [ -f /opt/nibrun-app-host-bootstrap.done ]; do echo waiting for instance bootstrap; sleep 5; done'
+mkdir -p /opt/nibrun/bundle
+aws s3 cp ${quote(bundleUrl)} /tmp/app-host-bundle.tar.gz
+tar xzf /tmp/app-host-bundle.tar.gz --overwrite -C /opt/nibrun/bundle
+cd /opt/nibrun/bundle
+export ${exportLine({ ...sharedEnv, DATA_VOLUME_ID: dataVolumeId })}
+bash on_box_deploy.sh
+`;
+
+async function deployTo({ instanceId }: { instanceId: string }) {
+  const dataVolumeId = dataVolumeIds[instanceId];
+  if (!dataVolumeId) {
+    return { instanceId, status: 'NoDataVolume', stdout: '', stderr: '' };
+  }
+
+  console.log(`[${instanceId}] waiting for SSM registration...`);
+  if (!(await waitForSsmRegistration({ instanceId }))) {
+    return { instanceId, status: 'NotRegistered', stdout: '', stderr: '' };
+  }
+
+  const commandId = await sendCommand({
+    instanceIds: [instanceId],
+    script: remoteScript({ dataVolumeId }),
+    comment: `Deploy ${optionalEnv('GITHUB_SHA') ?? 'manual'}`,
+  });
+  console.log(`[${instanceId}] SSM command: ${commandId}`);
+
+  const invocation = await waitForInvocation({ commandId, instanceId });
+  return {
+    instanceId,
+    status: invocation?.Status ?? 'Unknown',
+    stdout: invocation?.StandardOutputContent ?? '',
+    stderr: invocation?.StandardErrorContent ?? '',
+  };
+}
+
+// Concurrently, but every result is collected before anything is decided: a
+// partial rollout has to fail the deploy rather than be reported as success.
+const results = await Promise.all(instanceIds.map((instanceId) => deployTo({ instanceId })));
+
+for (const result of results) {
+  console.log(`\n===== ${result.instanceId}: ${result.status} =====`);
+  console.log(result.stdout);
+  if (result.status !== 'Success') {
+    console.error(result.stderr);
+  }
+}
+
+const failed = results.filter((result) => result.status !== 'Success');
+if (failed.length > 0) {
+  core.setFailed(
+    `Deploy failed on ${failed.length}/${results.length} app host(s): ${failed
+      .map((result) => `${result.instanceId} (${result.status})`)
+      .join(', ')}`,
+  );
+  process.exit(1);
+}
+
+console.log(`\nDeployed to all ${results.length} app host(s).`);

--- a/packages/internal-scripts/src/ssm-deploy.ts
+++ b/packages/internal-scripts/src/ssm-deploy.ts
@@ -1,13 +1,13 @@
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import * as core from '@actions/core';
-import { aws } from '#shared/aws.ts';
 import { optionalEnv, requiredEnv } from '#shared/env.ts';
-
-const SSM_REGISTRATION_ATTEMPTS = 60;
-const DEPLOY_ATTEMPTS = 90;
-const POLL_MS = 10_000;
-const TERMINAL_STATUSES = new Set(['Success', 'Failed', 'Cancelled', 'TimedOut']);
+import {
+  exportLine,
+  findInstanceIds,
+  quote,
+  sendCommand,
+  waitForInvocation,
+  waitForSsmRegistration,
+} from '#shared/ssm.ts';
 
 const bundleUrl = requiredEnv('BUNDLE_URL');
 const deployGroup = requiredEnv('DEPLOY_GROUP');
@@ -28,67 +28,20 @@ const onBoxEnv: Record<string, string> = {
   AWS_REGION: requiredEnv('AWS_REGION'),
 };
 
-// POSIX single quoting: the one form with no metacharacters inside it, so a
-// value can never break out of the export line it lands in.
-const quote = (value: string) => `'${value.replaceAll("'", `'\\''`)}'`;
+const [instanceId] = await findInstanceIds({ deployGroup });
 
-const instanceId = (
-  await aws([
-    'ec2',
-    'describe-instances',
-    '--filters',
-    `Name=tag:DeployGroup,Values=${deployGroup}`,
-    'Name=instance-state-name,Values=running',
-    '--query',
-    'Reservations[0].Instances[0].InstanceId',
-    '--output',
-    'text',
-  ]).text()
-).trim();
-
-if (!instanceId || instanceId === 'None') {
+if (!instanceId) {
   core.setFailed(`No running EC2 instance found for DeployGroup=${deployGroup}`);
   process.exit(1);
 }
 console.log(`Target instance: ${instanceId}`);
 
-// A freshly-created box isn't registered with SSM yet; wait so send-command lands.
 console.log('Waiting for the instance to register with SSM...');
-let online = false;
-for (let attempt = 0; attempt < SSM_REGISTRATION_ATTEMPTS; attempt++) {
-  const ping = (
-    await aws([
-      'ssm',
-      'describe-instance-information',
-      '--filters',
-      `Key=InstanceIds,Values=${instanceId}`,
-      '--query',
-      'InstanceInformationList[0].PingStatus',
-      '--output',
-      'text',
-    ])
-      .nothrow()
-      .quiet()
-      .text()
-  ).trim();
-
-  if (ping === 'Online') {
-    console.log('SSM is Online.');
-    online = true;
-    break;
-  }
-  console.log(`  ssm ping: ${ping || 'none'}`);
-  await Bun.sleep(POLL_MS);
-}
-
-if (!online) {
+if (!(await waitForSsmRegistration({ instanceId }))) {
   core.setFailed(`Instance ${instanceId} did not register with SSM within 10 minutes`);
   process.exit(1);
 }
-
-const exportLine = Object.entries(onBoxEnv)
-  .map(([name, value]) => `${name}=${quote(value)}`)
-  .join(' ');
+console.log('SSM is Online.');
 
 // The bootstrap-marker wait ensures Docker/Compose/AWS CLI are installed
 // (user_data) before we deploy onto a brand-new box. Extract in place (no rm
@@ -101,67 +54,19 @@ mkdir -p /opt/nibrun
 aws s3 cp ${quote(bundleUrl)} /tmp/bundle.tar.gz
 tar xzf /tmp/bundle.tar.gz --overwrite -C /opt/nibrun
 cd /opt/nibrun
-export ${exportLine}
+export ${exportLine(onBoxEnv)}
 bash on_box_deploy.sh
 `;
 
-const parametersPath = join(tmpdir(), 'ssm-params.json');
-await Bun.write(parametersPath, JSON.stringify({ commands: [remoteScript] }));
-
-const commandId = (
-  await aws([
-    'ssm',
-    'send-command',
-    '--document-name',
-    'AWS-RunShellScript',
-    '--comment',
-    `Deploy ${optionalEnv('GITHUB_SHA') ?? 'manual'}`,
-    '--instance-ids',
-    instanceId,
-    '--parameters',
-    `file://${parametersPath}`,
-    '--query',
-    'Command.CommandId',
-    '--output',
-    'text',
-  ]).text()
-).trim();
+const commandId = await sendCommand({
+  instanceIds: [instanceId],
+  script: remoteScript,
+  comment: `Deploy ${optionalEnv('GITHUB_SHA') ?? 'manual'}`,
+});
 console.log(`SSM command: ${commandId}`);
 
-async function readInvocation() {
-  const result = await aws([
-    'ssm',
-    'get-command-invocation',
-    '--command-id',
-    commandId,
-    '--instance-id',
-    instanceId,
-  ])
-    .nothrow()
-    .quiet();
-
-  if (result.exitCode !== 0) {
-    return null;
-  }
-  return result.json() as {
-    Status: string;
-    StandardOutputContent: string;
-    StandardErrorContent: string;
-  };
-}
-
-// RunCommand is async, and a full deploy (image pulls + compose up) can run for
-// several minutes — longer than the built-in `ssm wait command-executed` allows
-// (~100s) — so poll until the invocation reaches a terminal state.
 console.log('Waiting for the deploy command to finish (up to ~15m)...');
-let invocation = await readInvocation();
-for (let attempt = 0; attempt < DEPLOY_ATTEMPTS; attempt++) {
-  if (invocation && TERMINAL_STATUSES.has(invocation.Status)) {
-    break;
-  }
-  await Bun.sleep(POLL_MS);
-  invocation = await readInvocation();
-}
+const invocation = await waitForInvocation({ commandId, instanceId });
 
 const status = invocation?.Status ?? 'Unknown';
 console.log(`Status: ${status}`);

--- a/packages/internal-scripts/src/terraform-apply.ts
+++ b/packages/internal-scripts/src/terraform-apply.ts
@@ -17,6 +17,10 @@ const DEPLOY_OUTPUTS = [
   'deploy_group',
   'ssm_secret_prefix',
   'github_deploy_role_arn',
+  'app_host_deploy_group',
+  'app_host_data_volume_ids',
+  'filesystems_bucket',
+  'guest_images_bucket',
 ];
 
 const inActions = optionalEnv('GITHUB_ACTIONS') === 'true';
@@ -69,10 +73,14 @@ await group({
   run: () => terraform(['apply', '-input=false', PLAN_FILE]),
 });
 
+// Not every output is a string — the per-host volume map is an object, and
+// setOutput serialises it as JSON for the step that parses it back.
 const outputs = (await terraform(['output', '-json']).quiet().json()) as Record<
   string,
-  { value: string }
+  { value: unknown }
 >;
+
+const render = (value: unknown) => (typeof value === 'string' ? value : JSON.stringify(value));
 
 console.log(green(bold('\n✓ applied')));
 
@@ -83,5 +91,5 @@ for (const name of DEPLOY_OUTPUTS) {
     process.exit(1);
   }
   core.setOutput(name, value);
-  console.log(`  ${name}=${value}`);
+  console.log(`  ${name}=${render(value)}`);
 }


### PR DESCRIPTION
Extends the existing pipeline rather than inventing a parallel one: same OIDC auth, same bundle-to-S3 shape, same SSM RunCommand delivery.

Publishes the agent binary under its git SHA, and the guest image **only when its inputs change**. Ships a 7 KB bundle carrying units, the ZeroFS config and the deploy script — **the binaries are not in it**; they are fetched by version into a versioned path and skipped if already on disk, which is what makes a repeat deploy nearly free and rollback a symlink swap.

Versions come from a committed pin file. CI never asks S3 what the newest one is, so "what is this host running" is answerable from git.

**What a deploy restarts, and what it must not** — the deploy compares each resolved version against what the symlink points at:

| | |
|---|---|
| Agent bumped (every push) | restarts `nibrun-agent`, **no tenant VM restarts** |
| Guest image / Firecracker bumped | nothing restarts; the next boot picks it up |
| ZeroFS bumped | **disruptive** — stalls every app on the host, so it must be a deliberate commit |
| Nothing bumped | no download, no symlink move, no restart |

`ssm-deploy` is generalised to a fleet and fails on partial rollout; zero hosts found is a failure, not a quiet success.

## Merge order

GitHub can only express one base, and this genuinely needs three things. It is stacked on #17 for the agent binary it deploys, but it **also requires #13** (the app host and its Terraform outputs) and **#20** (which renames `api_s3_bucket` to `artifacts_bucket` — this branch reads the renamed output and deliberately does not add its own, so the two merge cleanly in either order but only work once both are in).

Forcing those into one chain would make an infrastructure review wait on an agent review for nothing.

## Worth review attention

The agent's bootstrap credential is delivered through **SSM**, not instance user-data as originally sketched. It is the path every other secret here takes, it satisfies the rule that no component require a secret outside the OIDC/SSM path, and unlike user-data it rotates without replacing the instance.