### PR TITLE
feat(infra): write exports from the host that owns the volume

### DIFF
--- a/infra/terraform/iam_api.tf
+++ b/infra/terraform/iam_api.tf
@@ -30,31 +30,18 @@ data "aws_iam_policy_document" "api_s3" {
     resources = [aws_s3_bucket.artifacts.arn]
   }
 
-  # Read-only on tenant filesystems, for export: it runs in the control plane and
-  # pulls a copy of the app's data out of the disk image ZeroFS wrote.
+  # No access to tenant filesystems at all, deliberately. The host that owns a
+  # volume writes the export itself — it has the device attached already, so it
+  # reads one tenant's filesystem and no other, in userspace and without mounting
+  # it. Anything here would be access to tenant data that nothing needs.
   #
-  # This is the tightest grant that works today, and today nothing reads it. It
-  # will not be enough when export is built: a ZeroFS reader registers and renews
-  # its own ephemeral checkpoint so the writer's GC cannot delete what it is
-  # reading, so a strictly read-only grant fails at startup. Do not widen this to
-  # a blanket write when that happens — either add an explicit Deny on the keys
-  # holding tenant data, which keeps the guarantee structural, or copy the prefix
-  # elsewhere and read the copy, which keeps this grant at nothing.
-  #
-  # On this user rather than on the instance role because export runs inside the
-  # api, and the api reaches S3 with these static keys — which is the whole
-  # reason the user exists. When the api falls back to the default credential
-  # chain and this file goes away, the grant moves to aws_iam_role.instance.
+  # Read on the exports bucket is what lets the api sign a download URL: a
+  # presigned URL carries the signer's own permissions, so it cannot grant a read
+  # this policy does not.
   statement {
-    sid       = "FilesystemsObjects"
+    sid       = "ExportsRead"
     actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.filesystems.arn}/*"]
-  }
-
-  statement {
-    sid       = "FilesystemsList"
-    actions   = ["s3:ListBucket"]
-    resources = [aws_s3_bucket.filesystems.arn]
+    resources = ["${aws_s3_bucket.exports.arn}/*"]
   }
 }
 

--- a/infra/terraform/iam_app_host.tf
+++ b/infra/terraform/iam_app_host.tf
@@ -64,6 +64,15 @@ data "aws_iam_policy_document" "app_host" {
     resources = [aws_s3_bucket.deploy.arn, "${aws_s3_bucket.deploy.arn}/*"]
   }
 
+  # The host writes the export itself, because it is the only party with the
+  # tenant's device attached. Write-only: a host has no reason to read back a
+  # bundle it produced, and the api is what serves them.
+  statement {
+    sid       = "ExportsWrite"
+    actions   = ["s3:PutObject", "s3:AbortMultipartUpload"]
+    resources = ["${aws_s3_bucket.exports.arn}/*"]
+  }
+
   # Read deployment secrets.
   statement {
     sid       = "SsmRead"

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -76,6 +76,11 @@ output "app_host_data_volume_ids" {
   value       = { for index, host in aws_instance.app_host : host.id => aws_ebs_volume.app_host_data[index].id }
 }
 
+output "exports_bucket" {
+  description = "Downloadable app exports. Written by app hosts, read by the api only to sign a download URL."
+  value       = aws_s3_bucket.exports.bucket
+}
+
 output "filesystems_bucket" {
   description = "ZeroFS's backing store. Read-write from app hosts, read-only from the control plane."
   value       = aws_s3_bucket.filesystems.bucket

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -211,3 +211,61 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "guest_images" {
     }
   }
 }
+
+# --- Exports ---
+#
+# The downloadable copies of an app, written by the host that owns the volume and
+# read only through a presigned URL the api signs.
+#
+# The expiry is a security requirement rather than housekeeping: a bundle carries
+# the tenant's environment variables and their entire dataset, so it must stop
+# existing rather than sit here indefinitely. It is a bucket rule and not a
+# per-object one on purpose — a rule cannot be forgotten on the one object that
+# mattered.
+#
+# No versioning, for the same reason. A version of an expired export is an
+# expired export that still exists.
+resource "aws_s3_bucket" "exports" {
+  bucket = "${local.resource_name_prefix}-exports-${var.region}"
+
+  tags = {
+    Name = "${local.resource_name_prefix}-exports"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "exports" {
+  bucket                  = aws_s3_bucket.exports.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "exports" {
+  bucket = aws_s3_bucket.exports.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "exports" {
+  bucket = aws_s3_bucket.exports.id
+
+  rule {
+    id     = "expire-exports"
+    status = "Enabled"
+    filter {}
+    expiration {
+      days = var.export_retention_days
+    }
+
+    # A bundle abandoned part-way through still holds tenant data, and an
+    # incomplete upload is invisible to the expiry rule above.
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -45,6 +45,12 @@ variable "app_host_data_volume_size" {
   description = "Per-host data EBS volume size in GB, mounted at /data. Sized for ZeroFS's working set, not for the fleet's data — S3 holds that."
 }
 
+variable "export_retention_days" {
+  type        = number
+  default     = 1
+  description = "How long a downloadable export survives. A security bound rather than a retention policy: the bundle carries the tenant's environment variables and their whole dataset. S3 lifecycle expiry runs daily, so 1 is the smallest meaningful value."
+}
+
 variable "vpc_cidr_block" {
   type        = string
   default     = "10.43.0.0/16"


### PR DESCRIPTION
Moves export off the control plane and onto the host, and takes the control plane's access to tenant filesystems away entirely.

The host already has the tenant's device attached, so it reads that one filesystem and no other, in userspace and without mounting it. The alternative — a ZeroFS reader in the control plane — cannot be strictly read-only against S3 (a reader registers and renews its own ephemeral checkpoint so the writer's GC does not delete what it is reading), and under the per-host storage layout it would have to open the whole host filesystem, handling *every* tenant's data to serve one.

So the api now holds **nothing** on `filesystems`, which is stronger than the read-only grant originally planned, and there is no Deny policy to get subtly wrong.

The api keeps `s3:GetObject` on the new exports bucket, because a presigned URL carries the signer's own permissions — it cannot grant a read this policy does not. Hosts get write-only there: a host has no reason to read back a bundle it produced.

**Expiry is a bucket lifecycle rule, not a per-object one.** A bundle carries the tenant's environment variables and their whole dataset, so this is a security bound rather than a retention policy — and a rule cannot be forgotten on the one object that mattered. Default one day, via `var.export_retention_days`; S3 lifecycle expiry runs daily so that is the smallest meaningful value. Incomplete multipart uploads are aborted after a day too, since a half-written bundle still holds tenant data and is invisible to the expiry rule.

Pairs with the protocol change in #12, which makes an export expressible as desired state so a reconciler can ask a host for one.

Verified: `terraform fmt -check` and `validate` clean.