### PR TITLE
feat(infra): serve user apps from a proxy on the app host

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,10 +96,13 @@ jobs:
           TF_VAR_region: ${{ env.AWS_REGION }}
           TF_VAR_api_hostname: ${{ vars.API_HOSTNAME }}
           TF_VAR_dozzle_hostname: ${{ vars.DOZZLE_HOSTNAME }}
+          TF_VAR_app_domain: ${{ vars.APP_DOMAIN }}
           TF_VAR_api_github_client_id: ${{ vars.API_GITHUB_CLIENT_ID }}
           TF_VAR_api_github_client_secret: ${{ secrets.API_GITHUB_CLIENT_SECRET }}
           TF_VAR_caddy_tls_cert: ${{ vars.CADDY_TLS_CERT }}
           TF_VAR_caddy_tls_key: ${{ secrets.CADDY_TLS_KEY }}
+          TF_VAR_app_host_caddy_tls_cert: ${{ vars.APP_HOST_CADDY_TLS_CERT }}
+          TF_VAR_app_host_caddy_tls_key: ${{ secrets.APP_HOST_CADDY_TLS_KEY }}
           ALLOW_DESTROY: ${{ inputs.allow_destroy }}
         run: bun run --filter @repo/internal-scripts terraform-apply
 
@@ -150,6 +153,7 @@ jobs:
       FILESYSTEMS_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).filesystems_bucket }}
       ARTIFACTS_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).artifacts_bucket }}
       API_HOSTNAME: ${{ fromJSON(needs.terraform.outputs.values).api_hostname }}
+      APP_DOMAIN: ${{ fromJSON(needs.terraform.outputs.values).app_domain }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -67,10 +67,13 @@ jobs:
           TF_VAR_region: ${{ env.AWS_REGION }}
           TF_VAR_api_hostname: ${{ vars.API_HOSTNAME }}
           TF_VAR_dozzle_hostname: ${{ vars.DOZZLE_HOSTNAME }}
+          TF_VAR_app_domain: ${{ vars.APP_DOMAIN }}
           TF_VAR_api_github_client_id: ${{ vars.API_GITHUB_CLIENT_ID }}
           TF_VAR_api_github_client_secret: ${{ secrets.API_GITHUB_CLIENT_SECRET }}
           TF_VAR_caddy_tls_cert: ${{ vars.CADDY_TLS_CERT }}
           TF_VAR_caddy_tls_key: ${{ secrets.CADDY_TLS_KEY }}
+          TF_VAR_app_host_caddy_tls_cert: ${{ vars.APP_HOST_CADDY_TLS_CERT }}
+          TF_VAR_app_host_caddy_tls_key: ${{ secrets.APP_HOST_CADDY_TLS_KEY }}
         run: bun run --filter @repo/internal-scripts terraform-plan
 
   infra-passed:

--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -22,6 +22,7 @@ subprocess: `systemctl`, `ip`, `nft`, `nbd-client`, `mkfs.ext4`, `mksquashfs`, `
 | `network/` | the slot allocator, tap devices, the whole nftables ruleset |
 | `health/` | the probe, and the reducer that decides `starting` vs `running` vs `failed` |
 | `report/` | instance records, capacity, versions, the report, and the route projection |
+| `proxy/` | the local Caddy site file, rendered from those routes, and the reload that swaps it in |
 | `aws/` | IMDSv2 credentials, because Bun's S3 client resolves static ones only |
 
 ## The decisions worth knowing before reading the code
@@ -31,6 +32,14 @@ subprocess: `systemctl`, `ip`, `nft`, `nbd-client`, `mkfs.ext4`, `mksquashfs`, `
 component that updates most often; if the VMs were its children, every agent restart would kill
 every tenant app on the host. Restarting the agent is a non-event, and an operator inspects one
 app with `systemctl status` and `journalctl -u nibrun-vm@<id>`.
+
+**The agent writes the routing config, and there is no other copy of it.** The local proxy's
+site blocks are rendered from the same records the boot path writes, filtered to instances whose
+tenant has answered a probe — a booted but dead VM is not routable. Rendered whole and compared
+before writing, like the nftables ruleset, so a reconcile that changes nothing reloads nothing;
+and reloaded rather than restarted, so one app's route appearing cannot interrupt another's
+traffic. A health transition is what makes an app routable, so the render happens on the status
+sweep as well as on reconcile.
 
 **Restart policy lives in two layers and they do not overlap.** The *tenant process* is
 restarted by the guest's init, with the budget in `RestartPolicy`; when it exhausts that budget
@@ -160,6 +169,7 @@ cannot create files, so there is no way to do this over the socket the agent alr
 | `/opt/nibrun/bin/guest-image/` | deploy | `vmlinux`, `rootfs.ext4` |
 | `/opt/nibrun/bin/firecracker/` | deploy | `firecracker` |
 | `/etc/nibrun/agent.env` | deploy, mode 0600 | the agent unit's `EnvironmentFile` |
+| `/etc/caddy/rendered/apps.caddy` | agent, mode 0644 | the site blocks, glob-imported by the deploy's Caddyfile and read by `nibrun-caddy.service` as its own user |
 | `/opt/nibrun/bundle/versions.json` | CI | `{ agent, guestImage, zerofs, firecracker }`, four version **strings** — validated against `HostVersionsSchema`; a missing or differently-shaped file is a hard startup failure. `infra/app-host/versions.json` is a richer object (urls, digests) and is **not** this file |
 | `/mnt/zerofs/` | a ZeroFS FUSE or NFS mount unit | the agent creates `.nbd/<volume-id>` in here |
 | `/run/zerofs/nbd.sock` | zerofs.service | NBD |
@@ -189,12 +199,14 @@ the value the control plane must put on every volume it places here. It has to m
 Optional, with the defaults in `src/config.ts`: `AGENT_STATE_DIR`, `AGENT_RUNTIME_DIR`,
 `AGENT_BOOTSTRAP_TOKEN_FILE`, `AGENT_VERSIONS_FILE`, `AGENT_GUEST_IMAGE_DIR`,
 `AGENT_FIRECRACKER_DIR`, `AGENT_ZEROFS_MOUNT`, `AGENT_ZEROFS_CONFIG_FILE`,
-`AGENT_ZEROFS_NBD_SOCKET`, `AGENT_LOG_LEVEL`, `AGENT_CONTROL_PLANE_CIDRS`,
-`AGENT_GUEST_DNS_SERVERS`.
+`AGENT_ZEROFS_NBD_SOCKET`, `AGENT_CADDY_SITES_FILE`, `AGENT_LOG_LEVEL`,
+`AGENT_CONTROL_PLANE_CIDRS`, `AGENT_GUEST_DNS_SERVERS`.
 
 The agent's own unit needs `CAP_NET_ADMIN` (tap devices, nftables) and root or equivalent for
 `nbd-client` and `mkfs.ext4`. It must **not** be `Restart=no`: an agent that dies should come
-back, and coming back is safe by construction.
+back, and coming back is safe by construction. It reaches the proxy with
+`systemctl reload nibrun-caddy.service` and nothing else — it never starts, stops or configures
+that unit.
 
 ### One thing `apps/runtime` should know
 

--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -21,6 +21,7 @@ import { runCommand } from '#lib/exec.ts';
 import { readJsonFile, readTextFile, writeJsonFile } from '#lib/json-store.ts';
 import { describeError, logger } from '#lib/logger.ts';
 import { readSlotRecords, SlotAllocator } from '#network/allocator.ts';
+import { CaddyProxy } from '#proxy/caddy.ts';
 import { Reconciler } from '#reconcile/reconciler.ts';
 import { buildReportedState } from '#report/build-report.ts';
 import {
@@ -106,6 +107,7 @@ export class Agent {
       units,
       topology,
       allocator,
+      proxy: new CaddyProxy({ runner, sitesFile: config.caddySitesFile }),
       vms: new VmManager({
         runner,
         units,

--- a/apps/agent/src/config.ts
+++ b/apps/agent/src/config.ts
@@ -8,6 +8,8 @@ const DEFAULT_ZEROFS_NBD_SOCKET = '/run/zerofs/nbd.sock';
 const DEFAULT_GUEST_IMAGE_DIR = '/opt/nibrun/bin/guest-image';
 const DEFAULT_FIRECRACKER_DIR = '/opt/nibrun/bin/firecracker';
 const DEFAULT_VERSIONS_FILE = '/opt/nibrun/bundle/versions.json';
+// Glob-imported by the Caddyfile the deploy installs, into a directory the deploy owns.
+const DEFAULT_CADDY_SITES_FILE = '/etc/caddy/rendered/apps.caddy';
 
 export const NBD_CONNECTIONS = 4;
 export const NBD_BLOCK_SIZE_BYTES = 4096;
@@ -31,6 +33,7 @@ export type AgentConfig = {
   zerofsMount: string;
   zerofsConfigFile: string;
   zerofsNbdSocket: string;
+  caddySitesFile: string;
   // The `[storage] url` prefix this host's ZeroFS is pointed at. A volume naming a different
   // one is refused rather than created here, because a device file written into the wrong
   // filesystem puts a tenant's data somewhere nothing will look for it.
@@ -118,6 +121,11 @@ export function loadAgentConfig({
       env,
       name: 'AGENT_ZEROFS_NBD_SOCKET',
       fallback: DEFAULT_ZEROFS_NBD_SOCKET,
+    }),
+    caddySitesFile: optional({
+      env,
+      name: 'AGENT_CADDY_SITES_FILE',
+      fallback: DEFAULT_CADDY_SITES_FILE,
     }),
     zerofsStoragePrefix: required({ env, name: 'AGENT_ZEROFS_STORAGE_PREFIX' }),
     artifactBucket: required({ env, name: 'AGENT_ARTIFACT_BUCKET' }),

--- a/apps/agent/src/lib/json-store.ts
+++ b/apps/agent/src/lib/json-store.ts
@@ -43,12 +43,15 @@ export async function readTextFile({ path }: { path: string }): Promise<string |
 export async function writeTextFile({
   path,
   value,
+  mode = PRIVATE_FILE_MODE,
 }: {
   path: string;
   value: string;
+  // Private unless the file is meant for another process on the host to read.
+  mode?: number;
 }): Promise<void> {
   await mkdir(dirname(path), { recursive: true, mode: PRIVATE_DIR_MODE });
   const temporaryPath = `${path}.tmp`;
-  await writeFile(temporaryPath, value, { mode: PRIVATE_FILE_MODE });
+  await writeFile(temporaryPath, value, { mode });
   await rename(temporaryPath, path);
 }

--- a/apps/agent/src/proxy/caddy.ts
+++ b/apps/agent/src/proxy/caddy.ts
@@ -1,0 +1,47 @@
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+import { writeTextFile } from '#lib/json-store.ts';
+import { renderAppSites } from '#proxy/caddyfile.ts';
+import type { RouteTarget } from '#report/routes.ts';
+
+const SYSTEMCTL = 'systemctl';
+const CADDY_UNIT = 'nibrun-caddy.service';
+
+// The proxy reads this as its own unprivileged user, and there is nothing secret in it.
+const SITE_FILE_MODE = 0o644;
+
+/**
+ * The local proxy's config, projected from the instances this host is actually running.
+ *
+ * The process that knows what is running is the process that writes the routing config, which is
+ * why there is no routing table in the control plane and no way for the two to disagree.
+ */
+export class CaddyProxy {
+  readonly #runner: CommandRunner;
+  readonly #sitesFile: string;
+  #applied: string | undefined;
+
+  constructor({ runner, sitesFile }: { runner: CommandRunner; sitesFile: string }) {
+    this.#runner = runner;
+    this.#sitesFile = sitesFile;
+  }
+
+  /**
+   * Reloaded rather than restarted: a route appearing or disappearing for one app must not
+   * interrupt traffic to the others this host is serving.
+   *
+   * The first call always writes, because what is on disk was written by whichever agent ran
+   * before this one and the host may have changed since.
+   */
+  async apply({ routes }: { routes: readonly RouteTarget[] }): Promise<void> {
+    const sites = renderAppSites(routes);
+    if (sites === this.#applied) {
+      return;
+    }
+    await writeTextFile({ path: this.#sitesFile, value: sites, mode: SITE_FILE_MODE });
+    await runCommandOrThrow({
+      runner: this.#runner,
+      request: { command: [SYSTEMCTL, 'reload', CADDY_UNIT] },
+    });
+    this.#applied = sites;
+  }
+}

--- a/apps/agent/src/proxy/caddyfile.test.ts
+++ b/apps/agent/src/proxy/caddyfile.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import type { AppHostname, AppId, Hostname, HostPort } from '@repo/protocol';
+import { renderAppSites } from '#proxy/caddyfile.ts';
+import type { RouteTarget } from '#report/routes.ts';
+
+const platform = (hostname: string): AppHostname => ({
+  hostname: hostname as Hostname,
+  kind: 'platform',
+  isDefault: true,
+});
+
+const custom = (hostname: string): AppHostname => ({
+  hostname: hostname as Hostname,
+  kind: 'custom',
+  isDefault: false,
+});
+
+const route = (overrides: Partial<RouteTarget> = {}): RouteTarget => ({
+  appId: 'app-a' as AppId,
+  hostnames: [platform('a.apps.example.com')],
+  hostPort: 21_000 as HostPort,
+  ...overrides,
+});
+
+describe('the rendered config is a projection of what is running', () => {
+  test('an app is reached on the loopback port the host forwards into its guest', () => {
+    const sites = renderAppSites([route()]);
+    expect(sites).toContain('https://a.apps.example.com {');
+    expect(sites).toContain('reverse_proxy 127.0.0.1:21000');
+  });
+
+  test('every site authenticates the edge, so none can be reached from the origin address', () => {
+    const sites = renderAppSites([route(), route({ appId: 'app-b' as AppId })]);
+    const blocks = sites.split('{').length - 1;
+    expect(sites.split('import origin_tls').length - 1).toBe(blocks);
+  });
+
+  test('nothing is routable when nothing is running', () => {
+    expect(renderAppSites([])).not.toContain('reverse_proxy');
+  });
+
+  test('an app answers on every hostname it has, not only the default one', () => {
+    const sites = renderAppSites([
+      route({
+        hostnames: [platform('a.apps.example.com'), custom('brought.example.dev')],
+      }),
+    ]);
+    expect(sites).toContain('https://a.apps.example.com, https://brought.example.dev {');
+  });
+
+  test('rendering twice from the same routes is byte-identical, whatever order they arrive in', () => {
+    const first = route({ appId: 'app-b' as AppId, hostPort: 21_001 as HostPort });
+    const second = route({ appId: 'app-a' as AppId });
+    expect(renderAppSites([first, second])).toBe(renderAppSites([second, first]));
+  });
+});
+
+describe('a record the agent cannot use cannot wedge the whole host', () => {
+  test('an unusable hostname is dropped rather than written into the config', () => {
+    const sites = renderAppSites([
+      route({
+        hostnames: [platform('a.apps.example.com } respond 500 #'), platform('b.apps.example.com')],
+      }),
+    ]);
+    expect(sites).toContain('https://b.apps.example.com {');
+    expect(sites).not.toContain('respond 500');
+  });
+
+  test('an app left with no usable hostname is left out entirely', () => {
+    const sites = renderAppSites([route({ hostnames: [platform('not a hostname')] })]);
+    expect(sites).not.toContain('reverse_proxy');
+  });
+});

--- a/apps/agent/src/proxy/caddyfile.ts
+++ b/apps/agent/src/proxy/caddyfile.ts
@@ -1,0 +1,47 @@
+import { HostnameSchema, isValidMessage } from '@repo/protocol';
+import type { RouteTarget } from '#report/routes.ts';
+
+const LOOPBACK = '127.0.0.1';
+const GENERATED_HEADER = '# Rendered by the nibrun agent. Edits are lost on the next reconcile.';
+
+/**
+ * The site blocks for the apps this host is running, imported by the static Caddyfile the deploy
+ * installs.
+ *
+ * Rendered whole and replaced in one write, like the nftables ruleset: there is no incremental
+ * add or remove to miss, and rendering twice from the same records is byte-identical — which is
+ * what lets the caller reload the proxy only when something really moved.
+ *
+ * The upstream is the loopback port the host forwards into the guest. A slot is per app rather
+ * than per instance, so a redeploy is a new microVM behind an address that never changed.
+ */
+export function renderAppSites(routes: readonly RouteTarget[]): string {
+  const blocks = routes
+    .map(siteBlock)
+    .filter((block) => block !== undefined)
+    // Records arrive in whatever order the agent happens to hold them, and the caller decides
+    // whether to reload by comparing this text with what it wrote last.
+    .sort();
+  return [GENERATED_HEADER, '', ...blocks].join('\n');
+}
+
+function siteBlock(route: RouteTarget): string | undefined {
+  const addresses = route.hostnames
+    .map((entry) => entry.hostname)
+    // The records these come from are the agent's own cache, structurally checked rather than
+    // parsed. One unusable hostname would stop the whole file loading and take routing for
+    // every app on the host with it, so it is dropped instead.
+    .filter((hostname) => isValidMessage({ schema: HostnameSchema, value: hostname }))
+    .sort()
+    .map((hostname) => `https://${hostname}`);
+  if (addresses.length === 0) {
+    return undefined;
+  }
+  return [
+    `${addresses.join(', ')} {`,
+    '\timport origin_tls',
+    `\treverse_proxy ${LOOPBACK}:${route.hostPort}`,
+    '}',
+    '',
+  ].join('\n');
+}

--- a/apps/agent/src/reconcile/reconciler.ts
+++ b/apps/agent/src/reconcile/reconciler.ts
@@ -20,6 +20,7 @@ import { describeError, logger } from '#lib/logger.ts';
 import type { SlotAllocator } from '#network/allocator.ts';
 import type { ForwardedInstance } from '#network/firewall.ts';
 import { applyRuleset } from '#network/nftables.ts';
+import type { CaddyProxy } from '#proxy/caddy.ts';
 import {
   type CheckpointPlan,
   type ObservedState,
@@ -62,6 +63,7 @@ export type ReconcilerOptions = {
   volumes: VolumeManager;
   topology: ZerofsTopology;
   allocator: SlotAllocator;
+  proxy: CaddyProxy;
 };
 
 /**
@@ -108,9 +110,8 @@ export class Reconciler {
     return this.#checkpointReports;
   }
 
-  // What the local user-app proxy will render its config from when it exists. Nothing consumes
-  // it yet; it is here so that when something does, it reads the state that boots the VMs
-  // rather than a second copy of it.
+  // What the local user-app proxy renders its config from — the same records the boot path
+  // writes, rather than a second copy of them.
   routes(): RouteTarget[] {
     return renderableRoutes(this.records());
   }
@@ -178,6 +179,7 @@ export class Reconciler {
     await this.#applyCheckpoints({ plan, desired });
     await this.#applyTeardowns(plan);
     await this.#applyNetwork();
+    await this.#applyRoutes();
     await this.#persist();
 
     this.#observedGeneration = desired.generation;
@@ -232,6 +234,10 @@ export class Reconciler {
         }
       }
     }
+    // An instance becomes routable here rather than in reconcile: the probe is what tells a
+    // booted VM from one whose tenant has answered, and that is the whole distinction routing
+    // rests on.
+    await this.#applyRoutes();
     await this.#persist();
   }
 
@@ -550,6 +556,14 @@ export class Reconciler {
       });
     } catch (error) {
       logger.error({ message: 'firewall apply failed', ...describeError(error) });
+    }
+  }
+
+  async #applyRoutes(): Promise<void> {
+    try {
+      await this.#options.proxy.apply({ routes: this.routes() });
+    } catch (error) {
+      logger.error({ message: 'proxy reload failed', ...describeError(error) });
     }
   }
 

--- a/apps/agent/src/report/routes.ts
+++ b/apps/agent/src/report/routes.ts
@@ -8,12 +8,9 @@ export type RouteTarget = {
 };
 
 /**
- * Everything the local user-app proxy would need, derived from the same records the boot path
- * writes.
- *
- * The proxy is not being built now. This exists so that when it is, its config is a projection
- * of what the host is running rather than a second copy of it — which is what leaves no room
- * for the two to drift.
+ * Everything the local user-app proxy needs, derived from the same records the boot path writes,
+ * so its config is a projection of what the host is running rather than a second copy of it —
+ * which is what leaves no room for the two to drift.
  *
  * Only instances whose tenant has actually answered are routable: sending traffic to a booted
  * but dead VM is the failure the `starting`/`running` distinction exists to prevent.

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -3,9 +3,10 @@
 AWS, one stack, two machine classes: the control plane runs the compose stack,
 app hosts run tenant microVMs. `bootstrap/` is one-time CloudFormation,
 `terraform/` owns the resources, `pg-backup/` is the nightly dump sidecar,
-`caddy/` is the proxy's static config. `deploy/` holds only the scripts that run
-*on* a box, which is why they are shell — an instance has no Bun. Everything CI
-runs lives in `@repo/internal-scripts`.
+`caddy/` is the control-plane proxy's static config, plus the origin-pull CA
+both proxies authenticate the edge against. `deploy/` holds only the scripts
+that run *on* a box, which is why they are shell — an instance has no Bun.
+Everything CI runs lives in `@repo/internal-scripts`.
 
 The Terraform explains itself; read it rather than a description of it here.
 
@@ -29,21 +30,32 @@ terraform apply # prompts for every variable without a default
 Then point an A record at `terraform output public_ip`, **proxied** (orange
 cloud) — one per hostname, `api_hostname` and `dozzle_hostname`.
 
+User apps live in a second zone, `app_domain`, on a **different registrable
+domain**: a tenant app under the dashboard's own domain could set a cookie the
+browser would then send to the api. Terraform refuses a value that shares one.
+One wildcard `*.<app_domain>` record, proxied, pointed at
+`terraform output app_host_public_ips` — and an AAAA at
+`app_host_public_ipv6s` — covers the whole fleet, so there is nothing per app in
+DNS. Neither address is elastic, so a stop/start means re-pointing both.
+
 Sign-in needs a GitHub OAuth App whose callback URL is
 `https://<api_hostname>/api/auth/callback/github`.
 
-Three zone settings, none of them in code: SSL/TLS **Full (strict)**; an
-**Origin Certificate** (ECC — Cloudflare's edge is its only client), whose two
-halves are the proxy's TLS inputs; and **Authenticated Origin Pulls → Global**
-on. Enable that last one before the first deploy carrying a proxy — Caddy
-requires the client certificate it turns on, and without it every visitor gets a
-`525`.
+Three zone settings, none of them in code, **in both zones**: SSL/TLS **Full
+(strict)**; an **Origin Certificate** (ECC — Cloudflare's edge is its only
+client), whose two halves are a proxy's TLS inputs; and **Authenticated Origin
+Pulls → Global** on. Enable that last one before the first deploy carrying a
+proxy — Caddy requires the client certificate it turns on, and without it every
+visitor gets a `525`.
 
-The certificate must name **every** hostname the proxy serves — both of them
-today. Caddy serves the one pair from every site block, so a hostname missing
-from it fails the handshake rather than falling back to anything. Adding a
-hostname later means reissuing that certificate and updating both halves, not
-issuing a second one.
+An origin certificate is issued per zone, which is why there are two:
+`caddy_tls_*` for the control plane and `app_host_caddy_tls_*` for the app
+hosts. The control plane's must name **every** hostname its proxy serves — both
+of them today. Caddy serves the one pair from every site block, so a hostname
+missing from it fails the handshake rather than falling back to anything; adding
+a hostname later means reissuing that certificate and updating both halves, not
+issuing a second one. The app hosts' is a wildcard for `*.<app_domain>`
+precisely so that creating an app is never a certificate operation.
 
 ## Deploying
 

--- a/infra/app-host/AGENTS.md
+++ b/infra/app-host/AGENTS.md
@@ -3,6 +3,12 @@
 Everything an app host runs. The machine itself is `infra/terraform/app_host.tf`; this is what
 lands on it.
 
+The user-app proxy is co-located here rather than central on purpose: if it dies, every app it
+served was on this host anyway, where a shared proxy would be a second failure domain able to
+take down apps that are otherwise healthy. It is also why there is no routing table in the
+control plane — the agent renders the site blocks from the instances it booted, so the process
+that knows what is running is the one that writes the routing config.
+
 Nothing here is containerised and Docker is not installed — the agent manipulates host
 networking and spawns microVMs, so a container would hand back every privilege it removed.
 
@@ -12,6 +18,8 @@ networking and spawns microVMs, so a container would hand back every privilege i
   bin/<component> -> versions/…      the active one; what the units resolve
   bundle/                            what CI ships: units, versions.json, the ZeroFS config, the deploy script
 /var/lib/nibrun/                     agent state, artifact cache, per-VM directories
+/etc/caddy/                          the proxy's static config, its origin certificate, and
+                                     rendered/, which belongs to the agent
 /data/                               the EBS volume — ZeroFS's local cache, and nothing else
 ```
 
@@ -37,6 +45,13 @@ Only the units whose resolved version — or whose configuration — actually mo
   are systemd units in their own right, so it comes back and reconciles against what it finds.
 - **Guest image or Firecracker bumped**: nothing restarts. Running VMs keep what they booted
   with; the new one reaches an app when it is next redeployed.
+- **Caddy's config or certificate changed**: reloaded, never restarted, because a change meant
+  for one app must not interrupt traffic to the others. The same holds for the routing config
+  the agent renders. A config that fails to load fails the deploy with the running one still
+  serving.
+- **Caddy bumped** — a new binary cannot be reloaded into a running process, so this restarts
+  it and every connection the host is serving is reset. Brief, and the edge retries, but it is
+  still a deliberate bump rather than a side effect.
 - **ZeroFS bumped — disruptive.** It serves the NBD device behind every guest disk on the host,
   so restarting it stalls every app at once and an attached guest may remount read-only. Bump
   it in its own commit, deliberately, expecting impact — never riding along with a feature push.

--- a/infra/app-host/caddy/Caddyfile
+++ b/infra/app-host/caddy/Caddyfile
@@ -1,0 +1,47 @@
+# The user-app edge, and the only thing on an app host listening off-loopback.
+# It runs here rather than centrally on purpose: if it dies, every app it served
+# was on this host anyway, where a shared proxy would be a second failure domain
+# able to take down apps that are otherwise healthy.
+#
+# This half is static. The site blocks for the apps this host is running are
+# rendered by the agent from the instances it booted and imported at the bottom.
+{
+	# No ACME: the certificate is a Cloudflare Origin Certificate covering
+	# *.{$APP_DOMAIN}, which the deploy fetches from SSM and writes into tls/
+	# next to this file. Hostnames are handed out per app, so there is no moment
+	# at which issuing a certificate would be a step in creating one.
+	auto_https off
+}
+
+# Authenticated Origin Pulls. The origin IP is discoverable, so the edge has to
+# prove it is the edge: without a client certificate signed by Cloudflare's
+# origin-pull CA the handshake is refused before any request is read. Turning
+# this on also makes Caddy enforce SNI == Host, which closes Host-header
+# spoofing along with it.
+#
+# A snippet because every site needs it identically — including the ones the
+# agent renders, which import this by name.
+(origin_tls) {
+	tls /etc/caddy/tls/origin.crt /etc/caddy/tls/origin.key {
+		client_auth {
+			mode require_and_verify
+			trust_pool file /etc/caddy/cloudflare-origin-pull-ca.pem
+		}
+	}
+}
+
+# One file, replaced whole on every routing change, and a glob so a host with no
+# app on it — or one whose agent has not converged yet — still starts.
+import /etc/caddy/rendered/*.caddy
+
+# Everything else under the app domain: a hostname whose app is not running
+# here, or not running at all. Caddy orders site blocks most-specific first, so
+# the rendered ones above win and this is what is left.
+#
+# It exists so an unknown hostname is answered rather than handled by whatever
+# TLS policy Caddy falls back to — this way every connection the edge makes to
+# this host is one Authenticated Origin Pulls has already checked.
+https://{$APP_DOMAIN}, https://*.{$APP_DOMAIN} {
+	import origin_tls
+	respond 404
+}

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -18,8 +18,9 @@ log() { echo "=== [on_box_deploy $(date -u +%H:%M:%S)] $* ==="; }
   "${ZEROFS_VERSION:?}" "${ZEROFS_URL:?}" "${ZEROFS_SHA256:?}" "${ZEROFS_MEMBER:?}" \
   "${FIRECRACKER_VERSION:?}" "${FIRECRACKER_URL:?}" "${FIRECRACKER_SHA256:?}" \
   "${FIRECRACKER_DIRECTORY:?}" \
-  "${FILESYSTEMS_BUCKET:?}" "${API_HOSTNAME:?}" "${GUEST_IMAGES_BUCKET:?}" \
-  "${ARTIFACTS_BUCKET:?}"
+  "${CADDY_VERSION:?}" "${CADDY_URL:?}" "${CADDY_SHA256:?}" \
+  "${FILESYSTEMS_BUCKET:?}" "${API_HOSTNAME:?}" "${APP_DOMAIN:?}" \
+  "${GUEST_IMAGES_BUCKET:?}" "${ARTIFACTS_BUCKET:?}"
 
 # Empty until a guest image is adopted in infra/app-host/versions.json. A host
 # with none deploys fine; it simply has no image to boot microVMs from, which is
@@ -43,7 +44,10 @@ CURRENT_DIR="$NIBRUN_DIR/bin"
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT
 
-mkdir -p "$VERSIONS_DIR" "$CURRENT_DIR" "$NIBRUN_DIR/bundle" /var/lib/nibrun /etc/nibrun /etc/zerofs
+# /etc/caddy/rendered is the agent's to write and Caddy's to read, so it is
+# created here — the agent only replaces the file inside it.
+mkdir -p "$VERSIONS_DIR" "$CURRENT_DIR" "$NIBRUN_DIR/bundle" /var/lib/nibrun \
+  /etc/nibrun /etc/zerofs /etc/caddy/tls /etc/caddy/rendered
 
 secret() {
   aws ssm get-parameter --name "${SSM_SECRET_PREFIX}/$1" --with-decryption \
@@ -55,6 +59,13 @@ bash ensure_data_volume.sh zerofs
 
 id -u zerofs >/dev/null 2>&1 || useradd --system --no-create-home --shell /sbin/nologin zerofs
 chown -R zerofs:zerofs /data/zerofs
+
+# The public edge runs unprivileged; systemd grants it CAP_NET_BIND_SERVICE and
+# nothing else. Only the private key is its own, which is why tls/ is the one
+# directory here nobody else can traverse.
+id -u caddy >/dev/null 2>&1 || useradd --system --no-create-home --shell /sbin/nologin caddy
+chown caddy:caddy /etc/caddy/tls
+chmod 0700 /etc/caddy/tls
 
 # --- Fetching versions -------------------------------------------------------
 #
@@ -95,6 +106,16 @@ install_firecracker() {
   mark_installed firecracker "$FIRECRACKER_VERSION"
 }
 
+install_caddy() {
+  local dir="$VERSIONS_DIR/caddy/$CADDY_VERSION"
+  mkdir -p "$dir"
+  curl -fsSL "$CADDY_URL" -o "$WORK_DIR/caddy.tar.gz"
+  verify_sha256 "$WORK_DIR/caddy.tar.gz" "$CADDY_SHA256"
+  tar xzf "$WORK_DIR/caddy.tar.gz" -C "$WORK_DIR" caddy
+  install -m 0755 "$WORK_DIR/caddy" "$dir/caddy"
+  mark_installed caddy "$CADDY_VERSION"
+}
+
 install_agent() {
   local dir="$VERSIONS_DIR/agent/$AGENT_VERSION"
   mkdir -p "$dir"
@@ -128,6 +149,11 @@ activate() {
 }
 
 NEEDS_RESTART=()
+# Caddy is the one component whose configuration is swapped without stopping it,
+# because a change meant for one app must not interrupt traffic to the others on
+# the host. Its *binary* still cannot move under a running process, so a version
+# bump lands in NEEDS_RESTART like everything else.
+NEEDS_RELOAD=()
 
 ensure() {
   local component=$1 version=$2 installer=$3
@@ -147,6 +173,7 @@ ensure() {
 
 ensure zerofs "$ZEROFS_VERSION" install_zerofs
 ensure firecracker "$FIRECRACKER_VERSION" install_firecracker
+ensure caddy "$CADDY_VERSION" install_caddy
 ensure agent "$AGENT_VERSION" install_agent
 
 if [ -n "$GUEST_IMAGE_VERSION" ]; then
@@ -200,6 +227,40 @@ EOF
 chmod 0600 /etc/nibrun/agent.env.new
 changed_file /etc/nibrun/agent.env && NEEDS_RESTART+=(agent) || true
 
+# The origin certificate Caddy serves. Held base64-encoded in SSM because a PEM
+# is multi-line and `--output text` mangles that, with no jq here to read the
+# JSON form instead; Terraform does the encoding (ssm.tf).
+write_pem() {
+  secret "$1" | base64 -d > "$2"
+}
+
+log "Writing the origin TLS material"
+write_pem app_host_caddy_tls_cert /etc/caddy/tls/origin.crt.new
+write_pem app_host_caddy_tls_key /etc/caddy/tls/origin.key.new
+changed_file /etc/caddy/tls/origin.crt && NEEDS_RELOAD+=(caddy) || true
+changed_file /etc/caddy/tls/origin.key && NEEDS_RELOAD+=(caddy) || true
+chown caddy:caddy /etc/caddy/tls/origin.crt /etc/caddy/tls/origin.key
+
+cp caddy/Caddyfile /etc/caddy/Caddyfile.new
+changed_file /etc/caddy/Caddyfile && NEEDS_RELOAD+=(caddy) || true
+
+cp cloudflare-origin-pull-ca.pem /etc/caddy/cloudflare-origin-pull-ca.pem.new
+changed_file /etc/caddy/cloudflare-origin-pull-ca.pem && NEEDS_RELOAD+=(caddy) || true
+
+# `caddy reload` re-adapts the Caddyfile, and the substitutions in it are read
+# from the unit's environment — so this is a restart rather than a reload: only
+# a fresh ExecStart is guaranteed to re-read the file.
+cat > /etc/caddy/caddy.env.new <<EOF
+APP_DOMAIN=${APP_DOMAIN}
+EOF
+changed_file /etc/caddy/caddy.env && NEEDS_RESTART+=(caddy) || true
+
+# Modes are set rather than inherited: none of this is secret, all of it is read
+# by a user that is not the one writing it, and the umask this script runs under
+# is whatever RunCommand hands it.
+chmod 0644 /etc/caddy/Caddyfile /etc/caddy/cloudflare-origin-pull-ca.pem /etc/caddy/caddy.env
+chmod 0755 /etc/caddy /etc/caddy/rendered
+
 log "Installing systemd units"
 units_changed=0
 for unit in systemd/*.service; do
@@ -210,7 +271,7 @@ if [ "$units_changed" = "1" ]; then
   systemctl daemon-reload
 fi
 
-systemctl enable nibrun-zerofs.service nibrun-agent.service >/dev/null
+systemctl enable nibrun-zerofs.service nibrun-caddy.service nibrun-agent.service >/dev/null
 
 # --- Restarting --------------------------------------------------------------
 #
@@ -219,6 +280,8 @@ systemctl enable nibrun-zerofs.service nibrun-agent.service >/dev/null
 # the agent, so it comes back and reconciles against what it finds.
 
 needs_restart() { printf '%s\n' "${NEEDS_RESTART[@]+"${NEEDS_RESTART[@]}"}" | grep -qx "$1"; }
+
+needs_reload() { printf '%s\n' "${NEEDS_RELOAD[@]+"${NEEDS_RELOAD[@]}"}" | grep -qx "$1"; }
 
 if needs_restart zerofs; then
   # Disruptive: ZeroFS serves the NBD device behind every guest disk on this
@@ -229,6 +292,18 @@ if needs_restart zerofs; then
   systemctl restart nibrun-zerofs.service
 else
   systemctl start nibrun-zerofs.service
+fi
+
+# A restart drops every connection this host is serving, so it happens only when
+# the binary or the unit's environment moved. Everything else — a new Caddyfile,
+# a re-issued certificate — is swapped in place, and a config that fails to load
+# fails the deploy while the running one keeps serving.
+if needs_restart caddy || ! systemctl is-active --quiet nibrun-caddy.service; then
+  log "Starting the user-app proxy"
+  systemctl restart nibrun-caddy.service
+elif needs_reload caddy; then
+  log "Proxy configuration changed — reloading it, leaving connections up"
+  systemctl reload nibrun-caddy.service
 fi
 
 if needs_restart agent; then
@@ -242,7 +317,7 @@ fi
 # bump reaches an app when it is next redeployed and restarts nothing now.
 
 log "Waiting for the services to settle"
-for unit in nibrun-zerofs nibrun-agent; do
+for unit in nibrun-zerofs nibrun-caddy nibrun-agent; do
   for _ in $(seq 1 30); do
     state=$(systemctl is-active "$unit.service" || true)
     [ "$state" = "active" ] && break
@@ -257,7 +332,7 @@ for unit in nibrun-zerofs nibrun-agent; do
 done
 
 log "Active versions"
-for component in zerofs firecracker agent guest-image; do
+for component in zerofs firecracker caddy agent guest-image; do
   if [ -L "$CURRENT_DIR/$component" ]; then
     echo "  $component -> $(basename "$(readlink "$CURRENT_DIR/$component")")"
   fi

--- a/infra/app-host/systemd/nibrun-caddy.service
+++ b/infra/app-host/systemd/nibrun-caddy.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=nibrun user-app proxy
+Documentation=https://caddyserver.com/docs/
+After=network-online.target
+Wants=network-online.target
+
+# Deliberately unrelated to nibrun-agent.service. The agent renders this
+# proxy's site file and asks for a reload; it does not own the process, so an
+# agent restart is not an interruption to anything already being served.
+[Service]
+Type=notify
+User=caddy
+Group=caddy
+ExecStart=/opt/nibrun/bin/caddy/caddy run --config /etc/caddy/Caddyfile
+# A reload swaps the config in place with no dropped connections. A restart here
+# would interrupt every app on the host, so one app's route appearing must never
+# be able to do it — and a config that does not load leaves the running one
+# alone and fails loudly instead.
+ExecReload=/opt/nibrun/bin/caddy/caddy reload --config /etc/caddy/Caddyfile --force
+EnvironmentFile=/etc/caddy/caddy.env
+
+Restart=always
+RestartSec=5s
+
+# Binding 443 is the only privilege it needs, and this is the process on the
+# host most exposed to the internet.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+StateDirectory=caddy
+Environment=XDG_DATA_HOME=/var/lib
+
+LimitNOFILE=1048576
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -11,5 +11,10 @@
     "sha256": "382a02a869e4d6d5cb14c40577f9545e8458021ea8b0b2d3fc10ec14d9c242e6",
     "directory": "release-v1.16.1-x86_64"
   },
+  "caddy": {
+    "version": "v2.11.4",
+    "url": "https://github.com/caddyserver/caddy/releases/download/v2.11.4/caddy_2.11.4_linux_amd64.tar.gz",
+    "sha256": "527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9"
+  },
   "guestImage": null
 }

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -18,6 +18,11 @@ output "dozzle_hostname" {
   value = var.dozzle_hostname
 }
 
+output "app_domain" {
+  description = "User apps are served under this. One wildcard record covers the fleet, so there is nothing per-app in DNS."
+  value       = var.app_domain
+}
+
 output "api_github_client_id" {
   description = "Public half of the GitHub OAuth App credentials; the secret half is read from SSM on the box."
   value       = var.api_github_client_id

--- a/infra/terraform/security_group.tf
+++ b/infra/terraform/security_group.tf
@@ -38,27 +38,65 @@ resource "aws_security_group" "instance" {
   }
 }
 
-# No ingress at all, and that is the design rather than an omission: nothing
-# needs to reach an app host. The agent dials out for control, so the control
+# Cloudflare's published edge ranges, from https://www.cloudflare.com/ips-v4
+# and /ips-v6. Pinned in git rather than fetched by a data source: a plan that
+# asks the internet what to allow can widen the only inbound rule on the fleet
+# with nothing for a reviewer to look at. Refresh it deliberately, in its own
+# commit.
+locals {
+  cloudflare_ipv4_cidrs = [
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    "131.0.72.0/22",
+  ]
+
+  cloudflare_ipv6_cidrs = [
+    "2400:cb00::/32",
+    "2606:4700::/32",
+    "2803:f800::/32",
+    "2405:b500::/32",
+    "2405:8100::/32",
+    "2a06:98c0::/29",
+    "2c0f:f248::/32",
+  ]
+}
+
+# One inbound rule, and it is the whole list: the user-app proxy. Nothing else
+# needs to reach an app host — the agent dials out for control, so the control
 # channel is never inbound and the control plane never initiates a connection
 # here; export reads a tenant's data from S3 rather than from the host; and
 # shell access is SSM Session Manager, whose agent connects outbound too.
-#
-# Exactly one rule is ever added, when the user-app proxy lands: 443 from
-# Cloudflare's published ranges, with Authenticated Origin Pulls. Pinned to the
-# ranges rather than opened to the world as the control plane's 443 is, because
-# what answers there is a proxy in front of tenant applications — the cost of a
-# directly-reachable origin is somebody else's app, not ours, so it is worth
-# carrying a list that changes underneath us.
-#
-# Written as an explicit empty set rather than an omitted block so a rule added
-# out of band is a diff Terraform removes, not drift it adopts.
 resource "aws_security_group" "app_host" {
   name        = "${local.resource_name_prefix}-app-host"
   description = "nibrun app host"
   vpc_id      = aws_vpc.app.id
 
-  ingress = []
+  # Pinned to Cloudflare's ranges rather than opened to the world as the control
+  # plane's 443 is. Authenticated Origin Pulls is what actually refuses a
+  # connection that did not come through the edge, and it holds on its own; this
+  # sits in front of it because what answers here is a proxy for third-party
+  # code, so the cost of a reachable origin is somebody else's app rather than
+  # ours — worth carrying a list that changes underneath us.
+  ingress {
+    description      = "HTTPS from Cloudflare"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = local.cloudflare_ipv4_cidrs
+    ipv6_cidr_blocks = local.cloudflare_ipv6_cidrs
+  }
 
   egress {
     description      = "All outbound"

--- a/infra/terraform/ssm.tf
+++ b/infra/terraform/ssm.tf
@@ -104,6 +104,30 @@ resource "aws_ssm_parameter" "dozzle_password" {
 
 # --- App hosts ---
 
+# The user-app proxy's TLS material, carried exactly like the control plane
+# proxy's above — base64 for the same reason, and both halves through SSM so
+# neither reaches the deploy's own environment. A different certificate, because
+# it is issued for a different zone.
+resource "aws_ssm_parameter" "app_host_caddy_tls_cert" {
+  name  = "${var.ssm_secret_prefix}/app_host_caddy_tls_cert"
+  type  = "SecureString"
+  value = base64encode(var.app_host_caddy_tls_cert)
+
+  tags = {
+    Name = "${local.resource_name_prefix}-app-host-caddy-tls-cert"
+  }
+}
+
+resource "aws_ssm_parameter" "app_host_caddy_tls_key" {
+  name  = "${var.ssm_secret_prefix}/app_host_caddy_tls_key"
+  type  = "SecureString"
+  value = base64encode(var.app_host_caddy_tls_key)
+
+  tags = {
+    Name = "${local.resource_name_prefix}-app-host-caddy-tls-key"
+  }
+}
+
 # ZeroFS encrypts everything it writes to the filesystems bucket under this. It
 # is generated once and never rotated in place: changing it does not re-encrypt
 # anything, it makes every existing tenant filesystem unreadable. Treat it as

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -87,6 +87,29 @@ variable "dozzle_hostname" {
   }
 }
 
+# No default for the same reason api_hostname has none, and read the validation
+# below before choosing a value: user apps must not share a registrable domain
+# with the dashboard.
+variable "app_domain" {
+  type        = string
+  description = "Registrable domain user apps are served under, as <slug>.<app_domain>. Point a wildcard A record at an app host."
+
+  validation {
+    condition     = trimspace(var.app_domain) != ""
+    error_message = "app_domain must not be empty."
+  }
+
+  # A user app is somebody else's code on a hostname we hand out. On a subdomain
+  # of the dashboard's own domain it could set a cookie the browser then sends
+  # to the api, which is a session-fixation primitive handed to every tenant.
+  # A separate registrable domain is what puts them either side of the public
+  # suffix boundary, so this is a security bound rather than a preference.
+  validation {
+    condition     = var.api_hostname != var.app_domain && !endswith(var.api_hostname, ".${var.app_domain}")
+    error_message = "app_domain must be a different registrable domain from api_hostname."
+  }
+}
+
 # The GitHub OAuth App users sign in with. Its callback URL is tied to
 # api_hostname, so an app is per-deployment — GitHub allows one callback URL per
 # OAuth App. Both halves are created by hand, so unlike every other credential
@@ -142,6 +165,32 @@ variable "caddy_tls_key" {
   validation {
     condition     = strcontains(var.caddy_tls_key, "PRIVATE KEY")
     error_message = "caddy_tls_key must be a PEM private key."
+  }
+}
+
+# The app hosts' own pair, issued for app_domain. Separate from the control
+# plane's because a Cloudflare Origin Certificate is issued per zone and
+# app_domain is a different zone by design — the same split the two proxies
+# already are. It has to be a wildcard: hostnames are handed out per app, and
+# reissuing a certificate every time somebody creates one is not a deploy step.
+variable "app_host_caddy_tls_cert" {
+  type        = string
+  description = "PEM of the Cloudflare Origin Certificate for *.app_domain. CI passes the APP_HOST_CADDY_TLS_CERT repository variable through."
+
+  validation {
+    condition     = strcontains(var.app_host_caddy_tls_cert, "BEGIN CERTIFICATE")
+    error_message = "app_host_caddy_tls_cert must be a PEM certificate."
+  }
+}
+
+variable "app_host_caddy_tls_key" {
+  type        = string
+  sensitive   = true
+  description = "PEM of the private key for app_host_caddy_tls_cert. CI passes the APP_HOST_CADDY_TLS_KEY repository secret through."
+
+  validation {
+    condition     = strcontains(var.app_host_caddy_tls_key, "PRIVATE KEY")
+    error_message = "app_host_caddy_tls_key must be a PEM private key."
   }
 }
 

--- a/packages/internal-scripts/src/publish-app-host-bundle.ts
+++ b/packages/internal-scripts/src/publish-app-host-bundle.ts
@@ -12,7 +12,7 @@ import { repoRoot } from '#shared/paths.ts';
 // — which is what makes a repeat deploy nearly free and rollback a symlink swap.
 // Tarring hundreds of megabytes of unchanged binaries into this would work, and
 // would be wrong.
-const BUNDLE_DIRECTORIES = ['systemd', 'zerofs'];
+const BUNDLE_DIRECTORIES = ['systemd', 'zerofs', 'caddy'];
 
 // Shell, not TypeScript: these run on the box, which has no Bun. Flattened to the
 // bundle root next to the directories above, because the deploy script resolves
@@ -27,13 +27,17 @@ const BUNDLE_FILES = ['versions.json'];
 // volume, and what they keep on it arrives as arguments.
 const SHARED_ON_BOX_SCRIPTS = ['ensure_data_volume.sh'];
 
+// Also shared: Cloudflare's origin-pull CA is one certificate, and both proxies
+// authenticate the same edge against it.
+const SHARED_CADDY_FILES = ['cloudflare-origin-pull-ca.pem'];
+
 const deployBucket = requiredEnv('DEPLOY_BUCKET');
 const revision = requiredEnv('GITHUB_SHA');
 
 const appHostDir = join(repoRoot, 'infra/app-host');
 const bundlePath = join(tmpdir(), 'nibrun-app-host-bundle.tar.gz');
 
-await $`tar czf ${bundlePath} -C ${appHostDir} ${BUNDLE_DIRECTORIES} ${BUNDLE_FILES} -C ${join(appHostDir, 'deploy')} ${ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/deploy')} ${SHARED_ON_BOX_SCRIPTS}`;
+await $`tar czf ${bundlePath} -C ${appHostDir} ${BUNDLE_DIRECTORIES} ${BUNDLE_FILES} -C ${join(appHostDir, 'deploy')} ${ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/deploy')} ${SHARED_ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/caddy')} ${SHARED_CADDY_FILES}`;
 
 const bundleBytes = Bun.file(bundlePath).size;
 const url = `s3://${deployBucket}/app-host-bundles/${revision}.tar.gz`;

--- a/packages/internal-scripts/src/shared/app-host-versions.ts
+++ b/packages/internal-scripts/src/shared/app-host-versions.ts
@@ -9,6 +9,7 @@ import { repoRoot } from '#shared/paths.ts';
 export type AppHostVersions = {
   zerofs: { version: string; url: string; sha256: string; member: string };
   firecracker: { version: string; url: string; sha256: string; directory: string };
+  caddy: { version: string; url: string; sha256: string };
   // Null until a guest image is adopted. Publishing one and adopting it are
   // separate commits; the adopting commit is the reviewable artifact.
   guestImage: string | null;

--- a/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
+++ b/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
@@ -27,6 +27,7 @@ const sharedEnv: Record<string, string> = {
   AWS_REGION: requiredEnv('AWS_REGION'),
   SSM_SECRET_PREFIX: requiredEnv('SSM_SECRET_PREFIX'),
   API_HOSTNAME: requiredEnv('API_HOSTNAME'),
+  APP_DOMAIN: requiredEnv('APP_DOMAIN'),
   FILESYSTEMS_BUCKET: requiredEnv('FILESYSTEMS_BUCKET'),
   GUEST_IMAGES_BUCKET: requiredEnv('GUEST_IMAGES_BUCKET'),
   ARTIFACTS_BUCKET: requiredEnv('ARTIFACTS_BUCKET'),
@@ -40,6 +41,9 @@ const sharedEnv: Record<string, string> = {
   FIRECRACKER_URL: versions.firecracker.url,
   FIRECRACKER_SHA256: versions.firecracker.sha256,
   FIRECRACKER_DIRECTORY: versions.firecracker.directory,
+  CADDY_VERSION: versions.caddy.version,
+  CADDY_URL: versions.caddy.url,
+  CADDY_SHA256: versions.caddy.sha256,
   GUEST_IMAGE_VERSION: versions.guestImage ?? '',
 };
 


### PR DESCRIPTION
Serves tenant apps on `*.<app_domain>` from a Caddy pinned onto the app host itself, whose site blocks the agent renders from `renderableRoutes()` — the same records that boot the VMs, so there is no routing table to drift from.

**`terraform-plan` fails until three repository settings exist**, which is the `api_hostname` pattern working as intended rather than a bug: an unset variable arrives empty and fails the plan instead of deploying a broken value.

- variable `APP_DOMAIN` — a **different registrable domain** from `API_HOSTNAME` (`app.nibrun.com` today), so a tenant app cannot set a cookie that reaches the dashboard session. Terraform rejects one that shares it.
- variable `APP_HOST_CADDY_TLS_CERT` and secret `APP_HOST_CADDY_TLS_KEY` — a Cloudflare Origin Certificate for `*.<app_domain>`, issued in that zone. `infra/AGENTS.md` covers the zone settings and the wildcard DNS record.

Conflicts with #24 on `.github/workflows/cd.yml`: whoever merges second moves `TF_VAR_app_domain` and the two `TF_VAR_app_host_caddy_tls_*` lines into the `terraform` job, and `APP_DOMAIN` into the `app-hosts` job as `${{ fromJSON(needs.terraform.outputs.values).app_domain }}`. The `DEPLOY_OUTPUTS` entry here disappears with the allowlist.
