### PR TITLE
feat(infra): give app hosts an IPv6 address

### DIFF
--- a/infra/terraform/app_host.tf
+++ b/infra/terraform/app_host.tf
@@ -26,7 +26,13 @@ resource "aws_instance" "app_host" {
   # and fetches binaries the ordinary way instead of everything being mirrored
   # into S3 first. No NAT gateway: NAT is for tenant egress, and no tenant app
   # runs in this phase.
+  #
+  # Both families, so the wildcard record the user-app proxy needs can carry an
+  # AAAA as well as an A. The subnet assigns an IPv6 on creation anyway; stating
+  # it here is what stops a change to that default silently taking the address
+  # away from a host whose DNS points at it.
   associate_public_ip_address = true
+  ipv6_address_count          = 1
 
   depends_on = [aws_route_table_association.app]
 

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -68,6 +68,18 @@ output "app_host_instance_ids" {
   value = aws_instance.app_host[*].id
 }
 
+# No elastic IP, unlike the control plane, so these move if a host is stopped
+# and started — point the wildcard records at them and re-point after a replace.
+output "app_host_public_ips" {
+  description = "A record targets for the app domain's wildcard."
+  value       = aws_instance.app_host[*].public_ip
+}
+
+output "app_host_public_ipv6s" {
+  description = "AAAA record targets for the app domain's wildcard."
+  value       = [for host in aws_instance.app_host : one(host.ipv6_addresses)]
+}
+
 # Not a single DATA_VOLUME_ID like the control plane's, because each host has
 # its own: a deploy fanning out looks the instance it is targeting up here and
 # exports that one value under the usual name.


### PR DESCRIPTION
The control plane declares `ipv6_address_count`; the app host relied on the subnet's `assign_ipv6_address_on_creation` default. Stated explicitly so both machine classes read the same, and published as outputs so the app domain's wildcard can carry an AAAA alongside its A.