### PR TITLE
fix(infra): make an app host deploy reach a running agent and a second boot

### DIFF
--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -208,9 +208,26 @@ EOF
 chmod 0600 /etc/zerofs/zerofs.env.new
 changed_file /etc/zerofs/zerofs.env && NEEDS_RESTART+=(zerofs) || true
 
-cp versions.json "$NIBRUN_DIR/bundle/versions.json"
+# What the agent reports this host as running, validated against the protocol's
+# HostVersions — four version strings, and nothing like the pin file CI resolved
+# them from. A host with no adopted guest image is a legitimate state, but the
+# schema has no way to say so, so it says `none` rather than omitting the field.
+cat > "$NIBRUN_DIR/bundle/versions.json.new" <<EOF
+{
+  "agent": "${AGENT_VERSION}",
+  "guestImage": "${GUEST_IMAGE_VERSION:-none}",
+  "zerofs": "${ZEROFS_VERSION}",
+  "firecracker": "${FIRECRACKER_VERSION}"
+}
+EOF
+chmod 0644 "$NIBRUN_DIR/bundle/versions.json.new"
+changed_file "$NIBRUN_DIR/bundle/versions.json" && NEEDS_RESTART+=(agent) || true
 
 cp zerofs/config.toml /etc/zerofs/config.toml.new
+# Read by ZeroFS itself, which runs as its own user, so it cannot inherit the
+# 0600 the umask above gives the secrets around it. It holds no secret: every
+# value that is one arrives through zerofs.env.
+chmod 0644 /etc/zerofs/config.toml.new
 changed_file /etc/zerofs/config.toml && NEEDS_RESTART+=(zerofs) || true
 
 secret agent_bootstrap_token > /var/lib/nibrun/bootstrap-token.new
@@ -222,6 +239,10 @@ AGENT_CONTROL_PLANE_URL=https://${API_HOSTNAME}
 AGENT_BOOTSTRAP_TOKEN_FILE=/var/lib/nibrun/bootstrap-token
 AGENT_ARTIFACT_BUCKET=${ARTIFACTS_BUCKET}
 AGENT_AWS_REGION=${AWS_REGION}
+# The same prefix ZeroFS is pointed at, from the one variable both are rendered
+# from: a volume naming a prefix this host does not serve is refused, so the two
+# drifting apart would fail every volume placed here.
+AGENT_ZEROFS_STORAGE_PREFIX=${NIBRUN_FILESYSTEMS_URL}
 AWS_REGION=${AWS_REGION}
 EOF
 chmod 0600 /etc/nibrun/agent.env.new

--- a/infra/app-host/systemd/nibrun-agent.service
+++ b/infra/app-host/systemd/nibrun-agent.service
@@ -12,6 +12,11 @@ Wants=network-online.target
 Type=exec
 ExecStart=/opt/nibrun/bin/agent/nibrun-agent
 EnvironmentFile=/etc/nibrun/agent.env
+# The agent drives `zerofs flush` and the checkpoint subcommands against ZeroFS's
+# own config file, and ZeroFS expands that file's ${VAR} references from whatever
+# environment it is handed. Without these the flush before every VM stop fails,
+# which under ignore_fsync is the one step that makes the stop a durability point.
+EnvironmentFile=/etc/zerofs/zerofs.env
 
 Restart=always
 RestartSec=5s

--- a/infra/app-host/systemd/nibrun-vm@.service
+++ b/infra/app-host/systemd/nibrun-vm@.service
@@ -11,6 +11,11 @@ After=nibrun-zerofs.service
 [Service]
 Type=exec
 WorkingDirectory=/var/lib/nibrun/vm/%i
+# Firecracker refuses to bind a socket path that already exists, and it does not
+# clean its own up on exit — so without this the second boot of any instance dies
+# with FailedToBindSocket and never runs again. systemd guarantees one instance of
+# a unit at a time, so nothing can be listening on it when this runs.
+ExecStartPre=-/bin/rm -f /run/nibrun/vm-%i.sock
 ExecStart=/opt/nibrun/bin/firecracker/firecracker \
   --api-sock /run/nibrun/vm-%i.sock \
   --config-file /var/lib/nibrun/vm/%i/firecracker.json

--- a/packages/internal-scripts/src/publish-app-host-bundle.ts
+++ b/packages/internal-scripts/src/publish-app-host-bundle.ts
@@ -19,10 +19,6 @@ const BUNDLE_DIRECTORIES = ['systemd', 'zerofs', 'caddy'];
 // everything relative to itself.
 const ON_BOX_SCRIPTS = ['on_box_deploy.sh'];
 
-// The agent reads this to report what the host is running, so it ships with the
-// config rather than only being resolved by CI.
-const BUNDLE_FILES = ['versions.json'];
-
 // Shared with the control plane's bundle — both machine classes have a data
 // volume, and what they keep on it arrives as arguments.
 const SHARED_ON_BOX_SCRIPTS = ['ensure_data_volume.sh'];
@@ -37,7 +33,7 @@ const revision = requiredEnv('GITHUB_SHA');
 const appHostDir = join(repoRoot, 'infra/app-host');
 const bundlePath = join(tmpdir(), 'nibrun-app-host-bundle.tar.gz');
 
-await $`tar czf ${bundlePath} -C ${appHostDir} ${BUNDLE_DIRECTORIES} ${BUNDLE_FILES} -C ${join(appHostDir, 'deploy')} ${ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/deploy')} ${SHARED_ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/caddy')} ${SHARED_CADDY_FILES}`;
+await $`tar czf ${bundlePath} -C ${appHostDir} ${BUNDLE_DIRECTORIES} -C ${join(appHostDir, 'deploy')} ${ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/deploy')} ${SHARED_ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/caddy')} ${SHARED_CADDY_FILES}`;
 
 const bundleBytes = Bun.file(bundlePath).size;
 const url = `s3://${deployBucket}/app-host-bundles/${revision}.tar.gz`;


### PR DESCRIPTION
Found by running the deploy and the agent end to end on a real x86_64 host with `/dev/kvm`, against a stub control plane. Each of the five was blocking on its own.

- `cp versions.json "$NIBRUN_DIR/bundle/versions.json"` is a same-file copy — the script's cwd *is* `/opt/nibrun/bundle` — so `set -e` aborted the deploy there. It was also the wrong file for that path: the agent validates it against `HostVersions`. Now rendered from the values CI already exports, and the pin file no longer ships in the bundle.
- `agent.env` was missing `AGENT_ZEROFS_STORAGE_PREFIX`, which `loadAgentConfig` requires — `MissingConfigurationError` at startup, crash-loop.
- `/etc/zerofs/config.toml` inherited `0600 root:root` from the `umask 077` above it; the unit runs `User=zerofs`, so ZeroFS could not read its own config and crash-looped.
- The agent's unit did not carry ZeroFS's environment, so every `zerofs flush` failed on `${NIBRUN_FILESYSTEMS_PASSWORD}` expansion. That flush is the one step that makes a VM stop a durability point under `ignore_fsync`.
- Firecracker refuses to bind an existing API socket path and does not remove its own, so every instance failed its second boot with `FailedToBindSocket`.

Verified on the box: deploy completes, ZeroFS serves NBD, the agent registers, a microVM boots, stops and boots again, and the data survives destroying the entire local ZeroFS cache and restoring from S3.