### PR TITLE
fix(agent): write the config drive the guest parses, and probe a socket that answers

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -117,6 +117,7 @@ export class Agent {
         artifactCacheDir: config.artifactCacheDir,
         guestImageDir: config.guestImageDir,
         vmDir: config.vmDir,
+        guestDnsServers: config.guestDnsServers,
       }),
       volumes: new VolumeManager({ runner, topology, allocator }),
     });

--- a/apps/agent/src/health/probe.test.ts
+++ b/apps/agent/src/health/probe.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_HEALTH_CHECK, type GuestPort, type Ipv4Address } from '@repo/protocol';
+import { probeInstance } from '#health/probe.ts';
+
+const LOOPBACK = '127.0.0.1' as Ipv4Address;
+// Nothing listens here, so a probe against it must fail rather than hang.
+const CLOSED_PORT = 1 as GuestPort;
+
+const withServer = async ({
+  run,
+  fetch = () => new Response('ok'),
+}: {
+  run: (port: GuestPort) => Promise<void>;
+  fetch?: () => Response;
+}) => {
+  const server = Bun.serve({ port: 0, hostname: LOOPBACK, fetch });
+  try {
+    await run(server.port as GuestPort);
+  } finally {
+    await server.stop(true);
+  }
+};
+
+// Against a real socket rather than a stub: what this asks of Bun's client is exactly the part
+// that cannot be checked by asserting a call shape.
+describe('the default probe asks only whether the tenant accepts a connection', () => {
+  test('a listening port is healthy', async () => {
+    await withServer({
+      run: async (guestPort) => {
+        expect(
+          await probeInstance({
+            guestIpv4: LOOPBACK,
+            guestPort,
+            healthCheck: DEFAULT_HEALTH_CHECK,
+          }),
+        ).toBe(true);
+      },
+    });
+  });
+
+  test('a port nothing listens on is not', async () => {
+    expect(
+      await probeInstance({
+        guestIpv4: LOOPBACK,
+        guestPort: CLOSED_PORT,
+        healthCheck: DEFAULT_HEALTH_CHECK,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('a declared path upgrades the probe to an HTTP GET', () => {
+  test('2xx is healthy', async () => {
+    await withServer({
+      run: async (guestPort) => {
+        expect(
+          await probeInstance({
+            guestIpv4: LOOPBACK,
+            guestPort,
+            healthCheck: { ...DEFAULT_HEALTH_CHECK, path: '/health' },
+          }),
+        ).toBe(true);
+      },
+    });
+  });
+
+  test('a listening tenant answering 500 is not', async () => {
+    await withServer({
+      fetch: () => new Response('down', { status: 500 }),
+      run: async (guestPort) => {
+        expect(
+          await probeInstance({
+            guestIpv4: LOOPBACK,
+            guestPort,
+            healthCheck: { ...DEFAULT_HEALTH_CHECK, path: '/health' },
+          }),
+        ).toBe(false);
+      },
+    });
+  });
+});

--- a/apps/agent/src/health/probe.ts
+++ b/apps/agent/src/health/probe.ts
@@ -27,7 +27,10 @@ async function probeTcp({ guestIpv4, guestPort, healthCheck }: ProbeTarget): Pro
   let socket: { end(): void } | undefined;
   try {
     const connection = await Promise.race([
-      Bun.connect({ hostname: guestIpv4, port: guestPort, socket: {} }),
+      // `Bun.connect` rejects handlers carrying neither `data` nor `drain`, and the rejection
+      // is indistinguishable here from a tenant that is down. The probe never reads what the
+      // tenant sends: that the connection opened at all is the whole question.
+      Bun.connect({ hostname: guestIpv4, port: guestPort, socket: { data: () => undefined } }),
       Bun.sleep(healthCheck.timeoutMs).then(() => undefined),
     ]);
     socket = connection;

--- a/apps/agent/src/vm/instance-env.test.ts
+++ b/apps/agent/src/vm/instance-env.test.ts
@@ -1,44 +1,70 @@
 import { describe, expect, test } from 'bun:test';
-import { DEFAULT_GUEST_PORT, type GuestPort, type SecretString } from '@repo/protocol';
+import {
+  DEFAULT_GUEST_PORT,
+  DEFAULT_RESTART_POLICY,
+  type GuestPort,
+  type SecretString,
+} from '@repo/protocol';
 import { renderInstanceEnv, UnrepresentableEnvironmentError } from '#vm/instance-env.ts';
 
 const secret = (value: string) => value as SecretString;
 
-describe('instance.env is line-oriented so the guest needs no parser', () => {
-  test('PORT is written from the declared guest port', () => {
-    expect(renderInstanceEnv({ guestPort: DEFAULT_GUEST_PORT, environment: {} })).toBe(
-      `PORT=${DEFAULT_GUEST_PORT}\n`,
+const render = (
+  overrides: Partial<Parameters<typeof renderInstanceEnv>[0]> = {},
+): ReturnType<typeof renderInstanceEnv> =>
+  renderInstanceEnv({
+    guestPort: DEFAULT_GUEST_PORT,
+    environment: {},
+    restartPolicy: DEFAULT_RESTART_POLICY,
+    dnsServers: [],
+    ...overrides,
+  });
+
+// apps/runtime/src/config.c accepts NIBRUN_ and ENV_ and rejects every other line, so these
+// assertions are the boot contract rather than a formatting preference.
+describe('what apps/runtime parses off the config drive', () => {
+  test('the runtime keys it requires are all present', () => {
+    expect(render().split('\n').filter(Boolean)).toEqual([
+      `NIBRUN_PORT=${DEFAULT_GUEST_PORT}`,
+      `NIBRUN_MAX_RESTARTS=${DEFAULT_RESTART_POLICY.maxRestarts}`,
+      `NIBRUN_INITIAL_BACKOFF_MS=${DEFAULT_RESTART_POLICY.initialBackoffMs}`,
+      `NIBRUN_MAX_BACKOFF_MS=${DEFAULT_RESTART_POLICY.maxBackoffMs}`,
+      `NIBRUN_BACKOFF_FACTOR=${DEFAULT_RESTART_POLICY.backoffFactor}`,
+      `NIBRUN_RESET_AFTER_MS=${DEFAULT_RESTART_POLICY.resetAfterMs}`,
+    ]);
+  });
+
+  test('tenant variables carry the tenant prefix, in a stable order', () => {
+    const rendered = render({ environment: { ZED: secret('1'), ALPHA: secret('2') } });
+    expect(rendered).toContain('\nENV_ALPHA=2\nENV_ZED=1\n');
+  });
+
+  // The prefix is what makes this impossible rather than merely handled: the runtime reads it
+  // as a tenant variable named NIBRUN_PORT, and its own PORT stays the one written above.
+  test('a tenant variable named after a runtime key stays the tenant’s', () => {
+    const rendered = render({ environment: { NIBRUN_PORT: secret('9999') } });
+    expect(rendered).toContain(`NIBRUN_PORT=${DEFAULT_GUEST_PORT}\n`);
+    expect(rendered).toContain('ENV_NIBRUN_PORT=9999\n');
+  });
+
+  test('nameservers are one comma-joined line, and absent when there are none', () => {
+    expect(render({ dnsServers: ['1.1.1.1', '8.8.8.8'] })).toContain(
+      'NIBRUN_DNS=1.1.1.1,8.8.8.8\n',
     );
-  });
-
-  test('a tenant PORT cannot override the port the host forwards to', () => {
-    const rendered = renderInstanceEnv({
-      guestPort: 8080 as GuestPort,
-      environment: { PORT: secret('9999') },
-    });
-    expect(rendered).toBe('PORT=8080\n');
-  });
-
-  test('variables are emitted in a stable order', () => {
-    const rendered = renderInstanceEnv({
-      guestPort: DEFAULT_GUEST_PORT,
-      environment: { ZED: secret('1'), ALPHA: secret('2') },
-    });
-    expect(rendered.split('\n')).toEqual([`PORT=${DEFAULT_GUEST_PORT}`, 'ALPHA=2', 'ZED=1', '']);
+    expect(render()).not.toContain('NIBRUN_DNS');
   });
 
   test('values are raw bytes, not quoted or escaped', () => {
-    const rendered = renderInstanceEnv({
-      guestPort: DEFAULT_GUEST_PORT,
-      environment: { DSN: secret('postgres://u:p@h/db?x=1 y=2') },
-    });
-    expect(rendered).toContain('DSN=postgres://u:p@h/db?x=1 y=2\n');
+    const rendered = render({ environment: { DSN: secret('postgres://u:p@h/db?x=1 y=2') } });
+    expect(rendered).toContain('ENV_DSN=postgres://u:p@h/db?x=1 y=2\n');
   });
 
   test('an empty value stays an empty value', () => {
-    expect(
-      renderInstanceEnv({ guestPort: DEFAULT_GUEST_PORT, environment: { EMPTY: secret('') } }),
-    ).toContain('EMPTY=\n');
+    expect(render({ environment: { EMPTY: secret('') } })).toContain('ENV_EMPTY=\n');
+  });
+
+  test('a non-default port is the one written', () => {
+    expect(render({ guestPort: 8080 as GuestPort })).toContain('NIBRUN_PORT=8080\n');
   });
 });
 
@@ -46,22 +72,16 @@ describe('what has no representation fails the instance', () => {
   test.each([['\n'], ['\r'], ['\0']])(
     'a value containing %j is refused rather than truncated',
     (character) => {
-      expect(() =>
-        renderInstanceEnv({
-          guestPort: DEFAULT_GUEST_PORT,
-          environment: { BAD: secret(`a${character}INJECTED=1`) },
-        }),
-      ).toThrow(UnrepresentableEnvironmentError);
+      expect(() => render({ environment: { BAD: secret(`a${character}INJECTED=1`) } })).toThrow(
+        UnrepresentableEnvironmentError,
+      );
     },
   );
 
   test('the error names the variable but never carries its value', () => {
     const error = (() => {
       try {
-        renderInstanceEnv({
-          guestPort: DEFAULT_GUEST_PORT,
-          environment: { API_KEY: secret('secret-value\nmore') },
-        });
+        render({ environment: { API_KEY: secret('secret-value\nmore') } });
       } catch (caught) {
         return caught as Error;
       }

--- a/apps/agent/src/vm/instance-env.ts
+++ b/apps/agent/src/vm/instance-env.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { GuestPort, TenantEnvironment } from '@repo/protocol';
+import type { GuestPort, RestartPolicy, TenantEnvironment } from '@repo/protocol';
 import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
 
 // Line-oriented `KEY=VALUE`, so the guest's init needs no parser. The file is generated and
@@ -13,7 +13,12 @@ export const INSTANCE_CONFIG_IMAGE = 'config.squashfs';
 const PRIVATE_MODE = 0o600;
 const PRIVATE_DIR_MODE = 0o700;
 
-const PORT_VARIABLE = 'PORT';
+// The two namespaces apps/runtime parses, and it accepts nothing outside them. They exist so
+// the two can never collide: a tenant variable actually called NIBRUN_PORT arrives as
+// ENV_NIBRUN_PORT and stays the tenant's.
+const RUNTIME_PREFIX = 'NIBRUN_';
+const TENANT_PREFIX = 'ENV_';
+
 const FORBIDDEN_VALUE_CHARACTERS = /[\n\r\0]/;
 
 export class UnrepresentableEnvironmentError extends Error {
@@ -27,32 +32,44 @@ export class UnrepresentableEnvironmentError extends Error {
 }
 
 /**
- * Renders the tenant's environment for the guest.
+ * Renders what the guest's init reads off its config drive.
  *
- * `PORT` is written from the port the app declared and a tenant value for it is dropped: that
- * number is what the host forwards to, so letting the tenant override it would produce a VM
- * nothing can reach and no error anywhere.
+ * The runtime carries no defaults for any `NIBRUN_` key and rejects a file missing one, so
+ * every value it needs is resolved here — the restart policy included, which is the guest's
+ * budget for the tenant process rather than anything this agent acts on.
  *
  * A value containing a newline has no representation in a format with no quoting, so it fails
- * the instance rather than silently truncating somebody's configuration into the next line.
+ * the instance rather than silently truncating somebody's configuration into the next line —
+ * and a second line could not carry a prefix, which is how the guest catches the same thing.
  */
 export function renderInstanceEnv({
   guestPort,
   environment,
+  restartPolicy,
+  dnsServers,
 }: {
   guestPort: GuestPort;
   environment: TenantEnvironment;
+  restartPolicy: RestartPolicy;
+  dnsServers: readonly string[];
 }): string {
-  const lines = [`${PORT_VARIABLE}=${guestPort}`];
+  const lines = [
+    `${RUNTIME_PREFIX}PORT=${guestPort}`,
+    `${RUNTIME_PREFIX}MAX_RESTARTS=${restartPolicy.maxRestarts}`,
+    `${RUNTIME_PREFIX}INITIAL_BACKOFF_MS=${restartPolicy.initialBackoffMs}`,
+    `${RUNTIME_PREFIX}MAX_BACKOFF_MS=${restartPolicy.maxBackoffMs}`,
+    `${RUNTIME_PREFIX}BACKOFF_FACTOR=${restartPolicy.backoffFactor}`,
+    `${RUNTIME_PREFIX}RESET_AFTER_MS=${restartPolicy.resetAfterMs}`,
+  ];
+  if (dnsServers.length > 0) {
+    lines.push(`${RUNTIME_PREFIX}DNS=${dnsServers.join(',')}`);
+  }
   for (const key of Object.keys(environment).sort()) {
-    if (key === PORT_VARIABLE) {
-      continue;
-    }
     const value = environment[key] ?? '';
     if (FORBIDDEN_VALUE_CHARACTERS.test(value)) {
       throw new UnrepresentableEnvironmentError(key);
     }
-    lines.push(`${key}=${value}`);
+    lines.push(`${TENANT_PREFIX}${key}=${value}`);
   }
   return `${lines.join('\n')}\n`;
 }
@@ -66,11 +83,15 @@ export async function buildInstanceConfigImage({
   workingDir,
   guestPort,
   environment,
+  restartPolicy,
+  dnsServers,
 }: {
   runner: CommandRunner;
   workingDir: string;
   guestPort: GuestPort;
   environment: TenantEnvironment;
+  restartPolicy: RestartPolicy;
+  dnsServers: readonly string[];
 }): Promise<string> {
   const stagingDir = join(workingDir, '.config-staging');
   const imagePath = join(workingDir, INSTANCE_CONFIG_IMAGE);
@@ -79,7 +100,7 @@ export async function buildInstanceConfigImage({
   try {
     await writeFile(
       join(stagingDir, INSTANCE_ENV_FILENAME),
-      renderInstanceEnv({ guestPort, environment }),
+      renderInstanceEnv({ guestPort, environment, restartPolicy, dnsServers }),
       {
         mode: PRIVATE_MODE,
       },

--- a/apps/agent/src/vm/manager.ts
+++ b/apps/agent/src/vm/manager.ts
@@ -23,6 +23,9 @@ export type VmManagerOptions = {
   artifactCacheDir: string;
   guestImageDir: string;
   vmDir: string;
+  // Written into the guest's config drive, which is the only way it gets a resolver: the root
+  // is read-only and there is no DHCP client to learn one from.
+  guestDnsServers: readonly string[];
 };
 
 export class VmManager {
@@ -75,6 +78,8 @@ export class VmManager {
       workingDir,
       guestPort: desired.config.guestPort,
       environment: desired.config.environment,
+      restartPolicy: desired.config.restartPolicy,
+      dnsServers: this.#options.guestDnsServers,
     });
 
     await writeJsonFile({


### PR DESCRIPTION
Found by booting a real `bun build --compile` binary in a Firecracker microVM. Both are blocking.

**The config drive.** `apps/runtime/src/config.c` accepts only `NIBRUN_` runtime keys and `ENV_` tenant variables, rejects every other line, and — as `config.h` says outright — carries no defaults for the restart policy it requires. `renderInstanceEnv` wrote bare `KEY=VALUE` and no policy, so every guest failed at line 1 and powered itself off:

```
[nibrun] instance.env line 1 starts with neither NIBRUN_ nor ENV_
```

The prefixes make a tenant variable structurally unable to collide with a runtime key, so the special case dropping the tenant's `PORT` is gone — `config_build_environment` owns that rule.

**The health probe.** `Bun.connect` rejects handlers carrying neither `data` nor `drain`; `probeTcp` passed `socket: {}`. The throw was caught and read as "tenant is down", so the default TCP probe could never succeed and no instance could ever leave `starting` — it went to `failed` after the grace period while the tenant was serving fine.

Verified after the fix: guest logs `instance configured: port 3000, 2 environment variables`, tenant runs as uid 65534, and the instance reports `starting` while the VM is up but not listening, flipping to `running` only once it accepts a connection.

`probe.test.ts` is new and goes against a real socket, which is the only thing that would have caught the second one.