### PR TITLE
docs: cut the AGENTS.md files back to what the code cannot say

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -1,235 +1,43 @@
 # agent
 
 The nibrun host agent. One compiled binary per app host: it opens a session with the control
-plane, long-polls for desired state, converges the host onto it, and reports what it observes.
-It is never sent a command.
+plane, long-polls for desired state, converges the host onto it, and reports what it observes. It
+is never sent a command. Every decision behind that is commented at the definition it applies to —
+read `reconcile/`, `volumes/topology.ts` and `network/allocator.ts` first.
 
-Compiles against `@repo/protocol` and nothing else. No third-party dependencies — Bun's
-built-ins cover HTTP, S3, hashing, process spawning and file I/O, and that is what keeps the
-binary small and its supply chain trivial. Everything the host does that Bun cannot do is a
-subprocess: `systemctl`, `ip`, `nft`, `nbd-client`, `mkfs.ext4`, `mksquashfs`, `zerofs`.
+**No third-party dependencies, deliberately.** Bun's built-ins cover HTTP, S3, hashing, process
+spawning and file I/O, and `@repo/protocol` is the only import. That is what keeps the binary small
+and its supply chain trivial, and it is why everything the host does that Bun cannot do is a
+subprocess (`systemctl`, `ip`, `nft`, `nbd-client`, `mkfs.ext4`, `mksquashfs`, `zerofs`) rather
+than a library. Adding a dependency needs a reason that survives that trade.
 
-## Modules, in dependency order
+## What the host must provide, and does not yet
 
-| Module | What it owns |
-|---|---|
-| `lib/` | exec, atomic JSON files, backoff, structured logging, the one-shape HTTP client |
-| `control/` | the session, and the long-poll client that validates every message it receives |
-| `reconcile/plan.ts` | the pure diff: desired vs observed → a plan. No I/O |
-| `reconcile/reconciler.ts` | applies the plan, holds the bookkeeping, drives the health sweep |
-| `volumes/` | which ZeroFS serves which prefix, device files, NBD attach/detach, the one-time `mkfs`, checkpoints |
-| `vm/` | artifact cache, `instance.env`, the Firecracker config, the systemd template units |
-| `network/` | the slot allocator, tap devices, the whole nftables ruleset |
-| `health/` | the probe, and the reducer that decides `starting` vs `running` vs `failed` |
-| `report/` | instance records, capacity, versions, the report, and the route projection |
-| `proxy/` | the local Caddy site file, rendered from those routes, and the reload that swaps it in |
-| `aws/` | IMDSv2 credentials, because Bun's S3 client resolves static ones only |
+Owned by `infra/app-host/`, not fixable here.
 
-## The decisions worth knowing before reading the code
+- **A mount of the ZeroFS filesystem.** `[servers.ninep]` is configured and nothing mounts it, so
+  volume provisioning fails at its first step. The admin RPC cannot create files, so there is no
+  way to do this over the socket the agent already uses.
+- **`iproute2`, `nftables`, `nbd-client`, `e2fsprogs`, `squashfs-tools`.** Each is a subprocess the
+  agent shells out to, and nothing installs any of them.
+- **`net.ipv4.ip_forward=1`**, and a base `FORWARD` policy of `ACCEPT`. The agent owns
+  `table ip nibrun` and expresses isolation as `drop` rules, which are final wherever they appear;
+  its `accept` rules only end its own chain, so it composes with a coexisting ruleset but cannot
+  open one that is closed.
 
-**The agent does not own the VMs.** Each microVM is a systemd template instance,
-`nibrun-vm@<instance-id>.service`, so Firecracker is a child of init. The agent is the
-component that updates most often; if the VMs were its children, every agent restart would kill
-every tenant app on the host. Restarting the agent is a non-event, and an operator inspects one
-app with `systemctl status` and `journalctl -u nibrun-vm@<id>`.
+## What is not tested
 
-**The agent writes the routing config, and there is no other copy of it.** The local proxy's
-site blocks are rendered from the same records the boot path writes, filtered to instances whose
-tenant has answered a probe — a booted but dead VM is not routable. Rendered whole and compared
-before writing, like the nftables ruleset, so a reconcile that changes nothing reloads nothing;
-and reloaded rather than restarted, so one app's route appearing cannot interrupt another's
-traffic. A health transition is what makes an app routable, so the render happens on the status
-sweep as well as on reconcile.
+Everything that needs a hypervisor, a Linux kernel or AWS — this was written on macOS with no AWS
+credentials, and the gap is wider than the test count suggests.
 
-**Restart policy lives in two layers and they do not overlap.** The *tenant process* is
-restarted by the guest's init, with the budget in `RestartPolicy`; when it exhausts that budget
-the guest powers itself off. The agent then sees the VM exit unasked, reports the instance
-`failed`, and **does not boot it again** — deciding whether to try elsewhere is the reconciler's
-call, and a host that retries forever hides a broken deploy. What the agent *does* retry is its
-own staging failures (an S3 hiccup, a `mkfs` that failed), with exponential backoff read from
-the same `RestartPolicy` numbers, up to `maxRestarts`. A new `deploymentId` resets the budget,
-because that is the reconciler acting.
-
-**A slot is one number per app.** Host port, tap device, guest /30 and NBD minor are all
-derived from it, so there is exactly one thing to persist (`slots.json`) and no way for three of
-the four to survive a restart while the fourth does not. The port is stable for the lifetime of
-the app, which is what makes a redeploy invisible to the routing layer. A slot is released only
-on an explicit volume `absent` — an instance merely missing from desired state is a stop, and
-reusing its port would route one tenant's traffic into another tenant's VM.
-
-**Instances are authoritative, volumes are not.** A microVM the control plane does not mention
-is stopped and forgotten. A volume it does not mention is left exactly as it is; removal is only
-ever an explicit `absent`, because a truncated response must not be able to delete a filesystem.
-A volume marked `absent` while an instance still holds it is reported blocked and torn down on a
-later pass, never mid-flight.
-
-**The last desired state is cached on disk** (`desired-state.json`) and reconciled against
-before the agent has even reached the control plane, so an agent restart during a control-plane
-outage still converges.
-
-**`cache_type: "Writeback"` on the data drive is mandatory.** Firecracker defaults a drive to
-`Unsafe`, which discards flush requests: the guest's `fsync` returns success, ZeroFS is never
-asked to flush, and the loss window stops being the flush interval and becomes unbounded.
-Nothing observable goes wrong until a host dies.
-
-**The host formats the tenant filesystem and never mounts it.** `mkfs.ext4` runs once at
-provisioning; the only other thing the agent reads from the block device is two magic bytes to
-tell a blank device from a provisioned one. Writing a filesystem is not parsing one, and the
-export design depends on the kernel never parsing a tenant-controlled filesystem.
-
-**One ZeroFS per host, and `storagePrefix` is checked rather than assumed.** A device file lives
-*inside* a ZeroFS filesystem, and a ZeroFS filesystem is one `[storage] url` prefix — so how many
-ZeroFS instances a host runs is a topology decision, not a deployment detail. v1 runs one, which
-buys one process, one local cache and one S3 client per host and is the only shape whose cost
-does not scale with tenant count. What it costs: the validated restore property — destroy a host,
-point a new ZeroFS at the same prefix, get the data back byte-identically — is per *host* rather
-than per *app*, and moving one app elsewhere is copying a device file between two filesystems
-rather than repointing at a prefix.
-
-The protocol already accommodates either shape because `storagePrefix` is on the volume; a
-per-host prefix just means every volume on the host repeats it. Nothing in `volumes/` assumes one
-filesystem — the mount path, the NBD socket and the admin RPC are all resolved *per volume* from
-the prefix it names, so one ZeroFS per app is a second factory in `volumes/topology.ts` plus a
-supervisor for the extra processes. A volume naming a prefix this host does not serve is reported
-`failed`, never created here: writing it into the wrong filesystem would put a tenant's data
-under a prefix nothing will ever look for it under, and no later reconcile undoes that.
-
-**Exactly one read-write `zerofs run` per storage prefix, fleet-wide.** ZeroFS does not reject a
-second writer — SlateDB's epoch fences the older one, which then dies on its next durable write,
-after a window in which it has been acknowledging writes that will be silently discarded. A
-duplicate is an outage, not an error message. The agent therefore never starts ZeroFS; systemd's
-own single-instance guarantee is the lock.
-
-**ZeroFS's lifecycle is not the agent's.** Restarting it tears down every NBD connection on the
-host mid-request; the agent only ever calls its admin RPC (`flush`, checkpoints), and flushes
-before every stop and detach because `ignore_fsync` makes the guest's own flushes a no-op. Worst
-case loss is `flush_interval_secs` **plus** the seal and upload — budget 5–15 s at a 5 s interval,
-not exactly 5. `CreateCheckpoint` takes the barrier itself, so no separate flush precedes it.
-
-**The `zerofs` CLI is how the agent drives it**, over `[servers.rpc]` — `flush`, `checkpoint
-create|list|delete`. The npm `zerofs-client` uses koffi native FFI and is unverified on Bun; it is
-deliberately not used. Creating and sizing a device file has no RPC at all and is a plain
-filesystem operation against the host's own mount of ZeroFS. That mount is **not** the tenant's
-ext4: the host writes a sparse *file* into ZeroFS's filesystem and never asks its kernel to
-interpret what that file contains, so the rule that the kernel never parses tenant-controlled
-filesystem metadata is intact. It looks like a violation and is not — `volumes/topology.ts` says
-so at the field it applies to.
-
-**`PORT` in `instance.env` comes from the declared guest port**, and a tenant value for it is
-dropped — it is the number the host forwards to. A value containing a newline has no
-representation in a format with no quoting, so it fails the instance rather than silently
-truncating configuration into the next line.
-
-**Log shipping is not built and must not reuse the control channel.** A log burst must never be
-able to delay a stop.
-
-## What this component needs from `infra/app-host/`
-
-Not owned here. Written down so the change that owns it can implement exactly this.
-
-### `nibrun-vm@.service` — already written, and it matches
-
-- `%i` is the `InstanceId` verbatim. Instance ids are `[0-9A-Za-z][0-9A-Za-z_-]{0,62}`, none of
-  which systemd escapes, so the unit name round-trips.
-- The unit reads **only** `/var/lib/nibrun/vm/%i/firecracker.json`. The agent writes that file,
-  the per-instance `config.squashfs` beside it, and the tap device, before calling
-  `systemctl start`. Nothing is passed on the command line and no environment is required.
-- The agent reaches it with `systemctl start|stop|show|list-units|reset-failed`, and needs
-  `Restart=no` to stay: if systemd restarted the VM, the agent could never report `failed` and
-  an app broken at boot would loop forever unobserved.
-- Firecracker's stdout is the guest console, so `journalctl -u nibrun-vm@<id>` is the tenant's
-  own output, for free.
-- If the jailer is adopted later, every path in `firecracker.json` becomes jail-relative and the
-  agent must stage into `<chroot>/root/`. That is a change to that unit *and* to `vm/manager.ts`
-  — it is not a drop-in.
-
-**One disagreement to settle.** The unit carries `BindsTo=nibrun-zerofs.service`, which stops
-every tenant VM on the host whenever ZeroFS restarts. The measured behaviour is milder than that
-implies: `nbd-client -persist` reconnects on its own, and with `-timeout 600` a ZeroFS restart is
-a *stall* in the guest, not an I/O error — the guest's ext4 only remounts read-only if the
-restart outlasts the timeout. `BindsTo` converts a recoverable stall into a fleet-wide outage,
-and kills VMs mid-write rather than at a durability point. The agent behaves correctly either
-way; this is a blast-radius decision that belongs to whoever owns the unit.
-
-### Still missing: a mount of the ZeroFS filesystem
-
-`[servers.ninep]` is configured but nothing mounts it, and an app's disk is a sparse file the
-agent creates at `<mount>/.nbd/<volume-id>`. Volume provisioning fails at the first step without
-one. Needed: a unit that mounts the 9P socket (`zerofs mount`, FUSE) at `AGENT_ZEROFS_MOUNT`,
-ordered after `nibrun-zerofs.service` and before `nibrun-agent.service`. The RPC admin service
-cannot create files, so there is no way to do this over the socket the agent already uses.
-
-### Filesystem
-
-| Path | Owner | Contents |
-|---|---|---|
-| `/var/lib/nibrun/` | agent, mode 0700 | `host-id`, `slots.json`, `instances.json`, `desired-state.json`, `artifacts/<digest>/`, `vm/<instance-id>/` |
-| `/var/lib/nibrun/bootstrap-token` | provisioning, mode 0600 | the bootstrap credential, delivered via instance user-data |
-| `/run/nibrun/vm-<instance-id>.sock` | the unit | Firecracker API socket. The agent does not use it — the VM is configured entirely by `--config-file` |
-| `/opt/nibrun/bin/guest-image/` | deploy | `vmlinux`, `rootfs.ext4` |
-| `/opt/nibrun/bin/firecracker/` | deploy | `firecracker` |
-| `/etc/nibrun/agent.env` | deploy, mode 0600 | the agent unit's `EnvironmentFile` |
-| `/etc/caddy/rendered/apps.caddy` | agent, mode 0644 | the site blocks, glob-imported by the deploy's Caddyfile and read by `nibrun-caddy.service` as its own user |
-| `/opt/nibrun/bundle/versions.json` | CI | `{ agent, guestImage, zerofs, firecracker }`, four version **strings** — validated against `HostVersionsSchema`; a missing or differently-shaped file is a hard startup failure. `infra/app-host/versions.json` is a richer object (urls, digests) and is **not** this file |
-| `/mnt/zerofs/` | a ZeroFS FUSE or NFS mount unit | the agent creates `.nbd/<volume-id>` in here |
-| `/run/zerofs/nbd.sock` | zerofs.service | NBD |
-| `/etc/zerofs/config.toml` | deploy | passed to every `zerofs` admin call |
-
-### Host packages and kernel state — none of this is provisioned yet
-
-`iproute2`, `nftables`, `nbd-client`, `e2fsprogs` (`mkfs.ext4`), `squashfs-tools` (`mksquashfs`).
-Nothing in `infra/` installs them today, and each one is a subprocess the agent shells out to.
-
-```
-modprobe nbd nbds_max=256        # the default of 16 caps the host at 16 apps
-sysctl net.ipv4.ip_forward=1
-```
-
-The base `FORWARD` policy must be `ACCEPT`. The agent owns `table ip nibrun` and expresses
-isolation as `drop` rules, which are final wherever they appear; its `accept` rules only end its
-own chain, so it composes with a coexisting ruleset but cannot open one that is closed.
-
-### Agent environment
-
-Required: `AGENT_CONTROL_PLANE_URL`, `AGENT_ARTIFACT_BUCKET`, `AGENT_AWS_REGION`,
-`AGENT_ZEROFS_STORAGE_PREFIX` — the `[storage] url` prefix this host's ZeroFS is pointed at, and
-the value the control plane must put on every volume it places here. It has to match what
-`/etc/zerofs/config.toml` names, or every volume is refused.
-
-Optional, with the defaults in `src/config.ts`: `AGENT_STATE_DIR`, `AGENT_RUNTIME_DIR`,
-`AGENT_BOOTSTRAP_TOKEN_FILE`, `AGENT_VERSIONS_FILE`, `AGENT_GUEST_IMAGE_DIR`,
-`AGENT_FIRECRACKER_DIR`, `AGENT_ZEROFS_MOUNT`, `AGENT_ZEROFS_CONFIG_FILE`,
-`AGENT_ZEROFS_NBD_SOCKET`, `AGENT_CADDY_SITES_FILE`, `AGENT_LOG_LEVEL`,
-`AGENT_CONTROL_PLANE_CIDRS`, `AGENT_GUEST_DNS_SERVERS`.
-
-The agent's own unit needs `CAP_NET_ADMIN` (tap devices, nftables) and root or equivalent for
-`nbd-client` and `mkfs.ext4`. It must **not** be `Restart=no`: an agent that dies should come
-back, and coming back is safe by construction. It reaches the proxy with
-`systemctl reload nibrun-caddy.service` and nothing else — it never starts, stops or configures
-that unit.
-
-### One thing `apps/runtime` should know
-
-Guests are denied every RFC1918, CGNAT and link-local destination, so the **VPC resolver is not
-reachable** from a guest under the default ruleset. Either `/init` writes a public resolver into
-`/run/resolv.conf`, or the operator names the VPC resolver in `AGENT_GUEST_DNS_SERVERS`, which
-renders an explicit accept for it ahead of the blanket drop.
-
-## What is not tested, and what it would take
-
-Everything that needs a hypervisor, a Linux kernel or AWS is untested — this was written on
-macOS with no AWS credentials. Specifically:
-
-- **The nftables ruleset is rendered and asserted as text, never loaded.** `nft -c -f -` on a
-  Linux host would check the syntax; proving the isolation rules needs a booted guest trying to
-  reach `169.254.169.254`, its neighbour and the control plane.
+- **The nftables ruleset is rendered and asserted as text, never loaded.** Proving the isolation
+  rules needs a booted guest trying to reach `169.254.169.254`, its neighbour and the control
+  plane.
 - **The Firecracker config is asserted as a structure, never booted.** Firecracker validates it
   with `deny_unknown_fields`, so a typo is a hard error at boot and nowhere earlier.
-- **NBD attach, `mkfs.ext4`, `mksquashfs`, `systemctl` and `zerofs` are all subprocesses whose
-  invocations are asserted nowhere.** In particular nothing has confirmed that a `truncate` onto
-  a `zerofs mount` produces a device file ZeroFS then exports, which is the single step the whole
-  volume path rests on. The parsers for their *output* are tested against captured
-  formats; the argument lists are not.
-- **S3 and IMDS.** The credential provider is tested against a stub; nothing has spoken to AWS.
+- **Every subprocess argument list is unasserted** — only the parsers for their *output* are
+  tested. In particular nothing has confirmed that a `truncate` onto a `zerofs` mount produces a
+  device file ZeroFS then exports, which is the one step the whole volume path rests on.
+- **S3 and IMDS** are tested against stubs; nothing has spoken to AWS.
 - The Firecracker drive-on-`/dev/nbdN` path is upstream-undocumented — mechanically sound, never
   run here.

--- a/apps/runtime/AGENTS.md
+++ b/apps/runtime/AGENTS.md
@@ -1,81 +1,28 @@
 # runtime
 
-The guest's PID 1. `/init` mounts what the guest needs, reads the instance config off
-its own drive, gives the tenant its volume at `data/`, drops privileges, and
-supervises the process until it is asked to stop or runs out of restarts. It and the
-tenant binary are the only two things that ever execute in the VM.
+The guest's PID 1. It boots and supervises the tenant binary inside one microVM, and is the only
+other thing that ever executes there. `src/init.c` is the sequence in order, `src/paths.h` is the
+boot contract shared with the host agent, and `src/config.h` is the `/instance.env` format.
 
-C, static, musl — this is resident in every microVM, so its memory is multiplied by
-how many a host packs. Measured: **1.3 MiB RSS, 62 KiB on disk**. Only the tenant's
-binary needs glibc, which is why the rootfs carries it.
+C, static, musl, because this is resident in every microVM and its cost is multiplied by how many
+a host packs: measured **1.3 MiB RSS, 62 KiB on disk**. Only the tenant's binary needs glibc,
+which is why the rootfs carries it and this does not link against it.
 
-## The sequence
+## Building
 
-`/dev` (only if the kernel has not already — it has, `CONFIG_DEVTMPFS_MOUNT`), the
-console, `/proc` `/sys` `/run` `/tmp` `/dev/shm`, the config drive read and then
-unmounted, `/run/resolv.conf`, the artifact drive, a root-owned tmpfs at `/app` with
-the data device mounted at `/app/data` and given to the tenant, then the tenant.
-Any failure before that last step ends the machine with the reason on the console: a
-tenant started without its volume would look healthy and lose everything it wrote.
+`bun run build` produces `dist/init`, which `infra/guest-image` copies to `/init` and hashes into
+its own version — so the toolchain is pinned in `versions.env` and the binary is stripped and
+build-id-free, to keep a rebuild byte-identical. A change that is not reproducible turns every
+guest-image build into a new version.
 
-## /instance.env — the contract with the agent
+## Testing
 
-Line-oriented `KEY=VALUE`, generated per boot. Two namespaces, and a line in neither
-is rejected: `NIBRUN_<KEY>` for the runtime, `ENV_<NAME>` for a tenant variable. The
-prefixes are what makes them impossible to confuse — a tenant variable called
-`NIBRUN_PORT` arrives as `ENV_NIBRUN_PORT` and stays the tenant's.
+`bun run test` runs three Docker suites: unit, mount (every mount against a real kernel, with loop
+devices for the drives) and boot (the real `/init` as PID 1, start to finish). Boot deliberately
+avoids `--privileged`, which would hand the container the host's own `/dev`, where `vdb` is a real
+disk.
 
-`NIBRUN_PORT` becomes `PORT`. `NIBRUN_MAX_RESTARTS`, `NIBRUN_INITIAL_BACKOFF_MS`,
-`NIBRUN_MAX_BACKOFF_MS`, `NIBRUN_BACKOFF_FACTOR` and `NIBRUN_RESET_AFTER_MS` are
-`RestartPolicy`. All six are required — **the runtime carries no defaults**, because
-`DEFAULT_RESTART_POLICY` in `packages/protocol` is the only place they exist and a
-missing key is a bug in the writer. `NIBRUN_DNS` takes up to three comma-separated
-resolvers and is the one optional key; the agent should always emit it, since without
-it the tenant resolves nothing.
-
-Rejected loudly, before the tenant starts: an unknown `NIBRUN_` key, a duplicate, a
-name that is not `[A-Za-z_][A-Za-z0-9_]*`, a line under neither prefix, a NUL, a CR.
-**A tenant value may not contain a newline** — unrepresentable here, so it fails the
-boot rather than reaching the tenant truncated; better rejected in the API.
-`ENV_PORT` is dropped: the platform owns the port it probes and routes to. The tenant
-also gets `HOME=/app` and `TMPDIR=/tmp` if it did not set them itself.
-
-## Restarting, stopping, and what is logged
-
-The guest restarts the tenant with backoff until the budget is spent, resetting the
-count for a process that stayed up past `resetAfterMs`. Then it **ends the machine**
-rather than trying again: the agent observes the exit and reports the instance
-failed, and what happens next is the reconciler's. A host that retried forever would
-hide a broken deploy. Any exit counts — a server that exited is not serving.
-
-`SendCtrlAltDel` reaches PID 1 as SIGINT only because `/init` calls
-`reboot(RB_DISABLE_CAD)` first; the default is to reset the machine on the spot with
-the tenant mid-write. Then SIGTERM to the tenant's group, **10 s** (the agent's wait
-for the VM to exit must exceed this), SIGKILL, unmount, `sync`, and
-`reboot(RB_AUTOBOOT)` — a guest *reset* is the only thing Firecracker turns into "the
-microVM exited"; a power-off leaves the VMM running with nobody inside it.
-
-Tenant output is the guest console, unwrapped and unbuffered, so `journalctl -u
-nibrun-vm@<id>` gives an operator the app's output for free. The runtime's own lines
-share it, prefixed `[nibrun] `, one `write(2)` each. Nothing from `/instance.env` is
-ever logged — not values, not even tenant variable names.
-
-## Building and testing
-
-`bun run build` produces `dist/init`, which `infra/guest-image` copies to `/init` and
-hashes into its version — hence the pinned toolchain in `versions.env` and the
-stripped, build-id-free binary, which rebuild byte-identically.
-
-`bun run test` runs three Docker suites: **unit** (parsing, environment, backoff,
-budget, shutdown forwarding, reaping, the privilege drop), **mount** (every mount
-against a real kernel with loop devices for the drives, including both halves of the
-`CONFIG_DEVTMPFS_MOUNT` case, which cost one boot on hardware to learn) and **boot**
-(the real `/init` as PID 1, start to finish). Boot avoids `--privileged`, which would
-hand the container the host's own `/dev`, where `vdb` is a real disk.
-
-A boot under Firecracker v1.16.1 confirmed the sequence, data persisting across
-boots, and a spent budget ending the VM with Firecracker exiting 0.
-**`SendCtrlAltDel` itself is still unverified**: the pinned kernel has `SERIO_I8042`,
-`KEYBOARD_ATKBD`, `ACPI_BUTTON` and `ACPI_TINY_POWER_BUTTON` off, so nothing in the
-guest can receive it, and Firecracker dropped `i8042.nopnp` from its own cmdline
-because it breaks that path on an ACPI guest. Both belong to `infra/guest-image`.
+Verified on Firecracker v1.16.1: the boot sequence, data persisting across boots, a spent restart
+budget ending the VM with Firecracker exiting 0, and a graceful stop over `SendCtrlAltDel` — which
+works only because the guest kernel enables the i8042 path, and that belongs to
+`infra/guest-image`.

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -1,24 +1,18 @@
 # infra
 
-AWS, one stack, two machine classes: the control plane runs the compose stack,
-app hosts run tenant microVMs. `bootstrap/` is one-time CloudFormation,
-`terraform/` owns the resources, `pg-backup/` is the nightly dump sidecar,
-`caddy/` is the control-plane proxy's static config, plus the origin-pull CA
-both proxies authenticate the edge against. `deploy/` holds only the scripts
-that run *on* a box, which is why they are shell — an instance has no Bun.
-Everything CI runs lives in `@repo/internal-scripts`.
+AWS, one stack, two machine classes: the control plane runs the compose stack, app hosts run
+tenant microVMs. `deploy/` is shell rather than TypeScript because those scripts run *on* a box and
+an instance has no Bun; everything CI runs lives in `@repo/internal-scripts`.
 
-The Terraform explains itself; read it rather than a description of it here.
+The Terraform explains itself — read it rather than a description of it here.
 
-MinIO stands in for S3 locally only — `docker-compose.prod.yml` parks it on an
-inactive profile and points the api at the real bucket.
-
-Config carries its component's prefix — `API_`, `POSTGRES_`, `PG_BACKUP_`,
-`CADDY_`, `DOZZLE_` — unless more than one component reads it, and keeps one
-name from the Terraform output through the SSM command to the `.env` the box
-writes. Nothing is aliased in transit, so nothing can drift.
+Config carries its component's prefix (`API_`, `POSTGRES_`, `PG_BACKUP_`, `CADDY_`, `DOZZLE_`)
+unless more than one component reads it, and keeps one name from the Terraform output through the
+SSM command to the `.env` the box writes. Nothing is aliased in transit, so nothing can drift.
 
 ## First run
+
+All of this is manual and none of it is in code.
 
 ```sh
 # Console → CloudFormation → upload bootstrap/github-oidc-bootstrap.yaml, once.
@@ -27,51 +21,31 @@ terraform init
 terraform apply # prompts for every variable without a default
 ```
 
-Then point an A record at `terraform output public_ip`, **proxied** (orange
-cloud) — one per hostname, `api_hostname` and `dozzle_hostname`.
+DNS, every record **proxied** (orange cloud):
 
-User apps live in a second zone, `app_domain`, on a **different registrable
-domain**: a tenant app under the dashboard's own domain could set a cookie the
-browser would then send to the api. Terraform refuses a value that shares one.
-One wildcard `*.<app_domain>` record, proxied, pointed at
-`terraform output app_host_public_ips` — and an AAAA at
-`app_host_public_ipv6s` — covers the whole fleet, so there is nothing per app in
-DNS. Neither address is elastic, so a stop/start means re-pointing both.
+- one A record per control-plane hostname (`api_hostname`, `dozzle_hostname`) → `terraform output
+  public_ip`
+- `*.<app_domain>` A → `app_host_public_ips`, plus AAAA → `app_host_public_ipv6s`. One pair covers
+  the whole fleet, so there is nothing per app in DNS.
+
+Neither address is elastic, so a stop/start means re-pointing.
+
+Then, **in both zones**: SSL/TLS **Full (strict)**; an **Origin Certificate** (ECC — Cloudflare's
+edge is its only client), whose two halves are a proxy's TLS inputs; and **Authenticated Origin
+Pulls → Global** on. Turn that last one on *before* the first deploy carrying a proxy — Caddy
+requires the client certificate it enables, and without it every visitor gets a `525`.
 
 Sign-in needs a GitHub OAuth App whose callback URL is
 `https://<api_hostname>/api/auth/callback/github`.
 
-Three zone settings, none of them in code, **in both zones**: SSL/TLS **Full
-(strict)**; an **Origin Certificate** (ECC — Cloudflare's edge is its only
-client), whose two halves are a proxy's TLS inputs; and **Authenticated Origin
-Pulls → Global** on. Enable that last one before the first deploy carrying a
-proxy — Caddy requires the client certificate it turns on, and without it every
-visitor gets a `525`.
-
-An origin certificate is issued per zone, which is why there are two:
-`caddy_tls_*` for the control plane and `app_host_caddy_tls_*` for the app
-hosts. The control plane's must name **every** hostname its proxy serves — both
-of them today. Caddy serves the one pair from every site block, so a hostname
-missing from it fails the handshake rather than falling back to anything; adding
-a hostname later means reissuing that certificate and updating both halves, not
-issuing a second one. The app hosts' is a wildcard for `*.<app_domain>`
-precisely so that creating an app is never a certificate operation.
-
 ## Deploying
 
-`.github/workflows/cd.yml`, on every push to main: build both images, apply
-Terraform, upload a bundle to S3, then trigger `on_box_deploy.sh` over SSM
-RunCommand — no SSH, no key material in CI. Secrets are never passed through:
-Terraform generates them into `/nibrun/…` and the instance reads them with its
-own role. Terraform runs under the admin bootstrap role; everything after it
-drops to the scoped deploy role.
+`.github/workflows/cd.yml`, on every push to main. No SSH and no key material in CI: the last leg
+triggers `on_box_deploy.sh` over SSM RunCommand.
 
-What the deploy needs arrives as repository variables and secrets — `cd.yml`
-holds the current set. Public values are variables, the rest are secrets, and
-Terraform reads each into an SSM parameter the instance decrypts for itself, so
-no secret reaches the deploy's own environment — RunCommand keeps its parameters
-in command history, in the clear, for 30 days.
-Both GHCR packages must be public — the box pulls with no registry credentials.
+**No secret may pass through the workflow's own environment.** RunCommand keeps its parameters in
+command history, in the clear, for 30 days — so Terraform writes secrets into SSM parameters the
+instance decrypts with its own role. Both GHCR packages must be public for the same reason: the box
+pulls with no registry credentials.
 
-`workflow_dispatch` takes `allow_destroy` for the times a plan legitimately
-replaces something.
+`workflow_dispatch` takes `allow_destroy` for the times a plan legitimately replaces something.

--- a/infra/app-host/AGENTS.md
+++ b/infra/app-host/AGENTS.md
@@ -1,69 +1,32 @@
 # infra/app-host
 
-Everything an app host runs. The machine itself is `infra/terraform/app_host.tf`; this is what
-lands on it.
+What lands on an app host once `infra/terraform/app_host.tf` has built the machine. Nothing is
+containerised: the agent manipulates host networking and spawns microVMs, so a container would
+hand back every privilege it removed.
 
-The user-app proxy is co-located here rather than central on purpose: if it dies, every app it
-served was on this host anyway, where a shared proxy would be a second failure domain able to
-take down apps that are otherwise healthy. It is also why there is no routing table in the
-control plane — the agent renders the site blocks from the instances it booted, so the process
-that knows what is running is the one that writes the routing config.
+## Invariants a change here must keep
 
-Nothing here is containerised and Docker is not installed — the agent manipulates host
-networking and spawns microVMs, so a container would hand back every privilege it removed.
+- **Re-running a deploy on a healthy host changes nothing**, and a new host reaches a working
+  state with nobody connecting to it. Every restart is conditional on something having actually
+  moved, so a step that runs unconditionally breaks the first half.
+- **A version is chosen only in `versions.json`.** Nothing may ask S3 what the newest one is — see
+  `packages/internal-scripts/src/shared/app-host-versions.ts`.
+- **Exactly one read-write `zerofs run` per storage prefix, fleet-wide.** ZeroFS does not reject a
+  second one: SlateDB's writer epoch fences the older process, which then dies on its next durable
+  write, after a window in which it has been acknowledging writes that are silently discarded. A
+  duplicate is an outage rather than an error message, and systemd's single-instance guarantee is
+  the only lock there is.
 
-```
-/opt/nibrun/
-  versions/<component>/<version>/…   every version fetched, until pruned
-  bin/<component> -> versions/…      the active one; what the units resolve
-  bundle/                            what CI ships: units, versions.json, the ZeroFS config, the deploy script
-/var/lib/nibrun/                     agent state, artifact cache, per-VM directories
-/etc/caddy/                          the proxy's static config, its origin certificate, and
-                                     rendered/, which belongs to the agent
-/data/                               the EBS volume — ZeroFS's local cache, and nothing else
-```
+## Unsettled
 
-A version directory counts as present only once it holds a `.installed` marker, so an
-interrupted download is retried rather than adopted as finished.
+**`nibrun-vm@.service` carries `BindsTo=nibrun-zerofs.service`**, which stops every tenant VM on
+the host whenever ZeroFS restarts. Measured behaviour is milder than that implies: `nbd-client
+-persist` reconnects on its own, and with a long timeout a ZeroFS restart is a *stall* in the guest
+rather than an I/O error — the guest's ext4 only remounts read-only if the restart outlasts the
+timeout. So `BindsTo` converts a recoverable stall into a fleet-wide outage, and kills VMs
+mid-write rather than at a durability point. The agent behaves correctly either way; this is a
+blast-radius decision nobody has made.
 
-## versions.json is the only place a version is chosen
-
-CI reads it and **never asks S3 what the newest version is** — that is what makes "what is this
-host running" answerable from git rather than from whichever job ran last. The agent is the one
-exception: its version is the git SHA, and every push ships a new one.
-
-A build **publishes** a version without adopting it. Adopting is a separate commit editing this
-file, and that commit is the reviewable artifact. `guestImage` is `null` until the first image
-is adopted; a host deploys fine without one and simply cannot boot microVMs, which is correct
-before any tenant app exists.
-
-## What a deploy restarts, and what it must not
-
-Only the units whose resolved version — or whose configuration — actually moved.
-
-- **Agent bumped**, the common case: restarts `nibrun-agent`. **No tenant VM restarts.** They
-  are systemd units in their own right, so it comes back and reconciles against what it finds.
-- **Guest image or Firecracker bumped**: nothing restarts. Running VMs keep what they booted
-  with; the new one reaches an app when it is next redeployed.
-- **Caddy's config or certificate changed**: reloaded, never restarted, because a change meant
-  for one app must not interrupt traffic to the others. The same holds for the routing config
-  the agent renders. A config that fails to load fails the deploy with the running one still
-  serving.
-- **Caddy bumped** — a new binary cannot be reloaded into a running process, so this restarts
-  it and every connection the host is serving is reset. Brief, and the edge retries, but it is
-  still a deliberate bump rather than a side effect.
-- **ZeroFS bumped — disruptive.** It serves the NBD device behind every guest disk on the host,
-  so restarting it stalls every app at once and an attached guest may remount read-only. Bump
-  it in its own commit, deliberately, expecting impact — never riding along with a feature push.
-- **Nothing bumped**: nothing downloads, no symlink moves, nothing restarts.
-
-Re-running a deploy on a healthy host must change nothing, and a new host must reach a working
-state with nobody connecting to it.
-
-## Two that will bite
-
-Exactly one read-write `zerofs run` may exist per storage prefix, **fleet-wide**. ZeroFS does
-not reject a second one — the fence is SlateDB's writer epoch and the loser exits, so a
-duplicate is an outage rather than an error message.
-
-Guest kernel 6.1's minimum end of support is 2026-09-02. Plan the bump.
+**Nothing mounts `[servers.ninep]`.** An app's disk is a sparse file the agent creates inside the
+ZeroFS filesystem, so volume provisioning cannot work until a unit mounts that socket where the
+agent looks for it, ordered after `nibrun-zerofs.service` and before `nibrun-agent.service`.

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -1,46 +1,17 @@
 # @repo/protocol
 
-The domain model and the contract between the control plane and the host agent. Two
-independently deployed programs compile against it, so a change here is a change to both.
+The contract between the control plane and the host agent. Two independently deployed programs
+compile against it, so a change here is a change to both — and the two are out of sync during
+every rollout, which is the case the schemas and `PROTOCOL_VERSION` are shaped around.
 
-Nothing in here talks to anything: no HTTP client, no side effects, no dependency but TypeBox.
-The agent binary imports this package and must not acquire a web framework by doing so — which
-is why schemas come from `@sinclair/typebox` directly and never from Elysia's `t`. They are the
-same library; importing it through Elysia would drag the framework into a binary with no HTTP
-server in it, for nothing.
+The model is desired state, never commands. Nothing here may be shaped like `start(x)`.
 
-Types derive from schemas (`typeof XSchema.static`) and state enums from one `const` array, so
-they cannot drift. Never hand-write a type a schema already describes.
+## Constraints on a change
 
-## Wire conventions
-
-JSON and only JSON. **Absent means unknown or not applicable — no field is ever `null`.**
-Timestamps carry a mandatory UTC offset, because a local time without one is what a lenient
-parser silently turns into a wrong instant.
-
-## Desired state, not commands
-
-The control plane describes what a host should be running; the host describes what it is
-running. Nothing is shaped like `start(x)`.
-
-That is what makes agent restart, control-plane restart and a missed message all non-events:
-the next poll re-reads the truth. A push model turns each of them into a delivery problem with
-replay, dedup and ordering to solve. The reconciler is being designed the same way.
-
-## Transport: long-polling HTTP, every route a POST
-
-Two constraints decide it. The connection is always outbound from the host, so control traffic
-never requires an inbound rule — a security requirement, not a preference. And the agent pulls
-and converges rather than receiving commands.
-
-Long polling meets both with the least machinery: nothing to reconnect, no channel liveness to
-maintain, and no persistent connection tempting a push model. Reads are POSTs because a long
-poll is not a cacheable GET, and one wire format means one validation path.
-
-**Log shipping, when it is built, gets its own path.** A log burst must never delay a stop.
-
-## Secrets
-
-Redact before logging any message. `redactSecrets` is driven by the schema, so a secret field
-added later is covered because it is *declared* secret — not because someone remembered to
-extend a list of field names.
+- **Schemas come from `@sinclair/typebox` directly, never from Elysia's `t`.** Same library, but
+  importing it through Elysia would drag a web framework into a binary with no HTTP server in it.
+  TypeBox is the only dependency, and this package must acquire no side effects and no client.
+- Types derive from schemas (`typeof XSchema.static`), state enums from one `const` array. Never
+  hand-write a type a schema already describes.
+- Absent means unknown or not applicable. **No field is ever `null`.**
+- **Log shipping, when it is built, gets its own path.** A log burst must never delay a stop.


### PR DESCRIPTION
The five files were mostly restating comments that already sit at the definition they describe. What is left is the measured numbers, the cross-component contracts, the unsettled decisions, and an honest account of what is untested or unbuilt.

Two claims were stale and are corrected: a graceful stop over `SendCtrlAltDel` is verified now that the guest kernel enables the i8042 path, and app hosts do provision `nbd` and `kvm_intel`. The gaps that are still real — no 9P mount, the uninstalled host packages, `ip_forward` — I re-verified and kept.