### PR TITLE
fix(infra): move the internal listener off Dozzle's port

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,6 +44,8 @@ services:
     ports:
       - "443:443"
       # Admitted from the app hosts' security group only; see infra/caddy/Caddyfile.
+      # On every interface like 443 above: the security group is the boundary, and
+      # AWS enforces it before a packet reaches the instance.
       - "${INTERNAL_PORT}:${INTERNAL_PORT}"
     healthcheck:
       test:

--- a/infra/deploy/on_box_deploy.sh
+++ b/infra/deploy/on_box_deploy.sh
@@ -11,7 +11,7 @@ log() { echo "=== [on_box_deploy $(date -u +%H:%M:%S)] $* ==="; }
 : "${API_IMAGE_URI:?}" "${API_HOSTNAME:?}" "${API_GITHUB_CLIENT_ID:?}" \
   "${ARTIFACTS_BUCKET:?}" "${API_S3_ENDPOINT:?}" "${PG_BACKUP_IMAGE_URI:?}" \
   "${PG_BACKUP_BUCKET:?}" "${SSM_SECRET_PREFIX:?}" "${AWS_REGION:?}" \
-  "${DATA_VOLUME_ID:?}" "${DOZZLE_HOSTNAME:?}"
+  "${DATA_VOLUME_ID:?}" "${DOZZLE_HOSTNAME:?}" "${INTERNAL_PORT:?}"
 
 # Per-deployment values no infrastructure resource feeds, still overridable from
 # the deploy so they never have to be edited here. The host port bindings are
@@ -92,9 +92,25 @@ PG_BACKUP_BUCKET=${PG_BACKUP_BUCKET}
 
 DOZZLE_HOSTNAME=${DOZZLE_HOSTNAME}
 DOZZLE_PORT=${DOZZLE_PORT}
+
+INTERNAL_PORT=${INTERNAL_PORT}
 EOF
 
 compose="docker compose -f docker-compose.yml -f docker-compose.prod.yml"
+
+# `compose up` reports a taken port as a docker-proxy bind failure minutes in,
+# costing a CI round trip to learn what the box knew before it started. The edge
+# binds every interface, so any listener on the port collides whatever address it
+# holds — including a loopback-only one, which is how Dozzle's 8080 broke this.
+# The edge is the expected holder on a redeploy, since nothing recreates it.
+log "Checking port ${INTERNAL_PORT} is free"
+port_holder=$(ss -lntpH "sport = :${INTERNAL_PORT}")
+if [ -n "$port_holder" ] &&
+  [ "$(docker ps --filter "publish=${INTERNAL_PORT}" --format '{{.Names}}')" != caddy ]; then
+  log "INTERNAL_PORT ${INTERNAL_PORT} is already held:"
+  printf '%s\n' "$port_holder"
+  exit 1
+fi
 
 log "Pulling images"
 $compose pull

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -53,8 +53,15 @@ variable "export_retention_days" {
 
 variable "internal_port" {
   type        = number
-  default     = 8080
+  default     = 19080
   description = "Port the control plane serves /internal on, reachable from app hosts over the VPC and from nowhere else. Plain HTTP: the security group is the boundary, and an origin certificate names hostnames rather than the private address an agent dials."
+
+  # Not 8080, which Dozzle already publishes in the same compose stack — the
+  # edge could not bind it and the deploy died on `compose up`. Chosen against
+  # the collision recurring rather than for the number: unregistered in
+  # /etc/services, outside the 3000/8000/9000 band anything added to the stack
+  # reaches for by default, and below the 32768 ephemeral floor so no outbound
+  # socket can be holding it when the edge starts.
 }
 
 variable "vpc_cidr_block" {


### PR DESCRIPTION
**The control-plane edge is currently down.** `caddy` has been stuck in `Created` since #31 merged — it never started, nothing is listening on 443, and the public api and Dozzle hostnames are unserved. This PR is what restores them.

The cause: the edge could not bind 8080, because Dozzle already publishes it in the same compose stack, so every deploy since has died on `compose up`. Moves the agent channel to a port nothing else claims, and adds a pre-flight check on the box so a future collision fails in seconds naming the holder, instead of costing a CI round trip.