### PR TITLE
fix(infra): let the ZeroFS mount lose its first race

### DIFF
--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -323,7 +323,18 @@ fi
 
 # Where the agent creates a tenant's disk. Bound to ZeroFS above, so a restart of
 # the server takes it with it and this brings both back in order.
-systemctl restart nibrun-zerofs-mount.service
+#
+# ZeroFS is Type=exec, so systemd calls it started once the process execs — well
+# before it is answering on the 9P socket. Ordering after it therefore buys
+# nothing, and the first mount attempt loses the race and exits. The unit retries
+# and wins within seconds, so what the deploy asserts is that it converged, not
+# that it started first time.
+systemctl restart nibrun-zerofs-mount.service || true
+if ! timeout 60 bash -c 'until systemctl is-active --quiet nibrun-zerofs-mount.service; do sleep 1; done'; then
+  log "The ZeroFS mount never came up; the agent would have nowhere to put a disk"
+  systemctl status nibrun-zerofs-mount.service --no-pager || true
+  exit 1
+fi
 
 # A restart drops every connection this host is serving, so it happens only when
 # the binary or the unit's environment moved. Everything else — a new Caddyfile,

--- a/infra/app-host/systemd/nibrun-zerofs-mount.service
+++ b/infra/app-host/systemd/nibrun-zerofs-mount.service
@@ -31,7 +31,7 @@ ExecStartPost=/bin/sh -c 'for _ in $(seq 100); do mountpoint -q /mnt/zerofs && e
 ExecStopPost=-/usr/bin/fusermount3 -u /mnt/zerofs
 
 Restart=always
-RestartSec=5s
+RestartSec=2s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The mount unit from #32 works — it is mounted and active on the host right now. What failed is the deploy reading the wrong signal.

From the journal:

```
15:34:15  zerofs[29663]: ✗ Error: connecting to 9P server(s) unix:/run/zerofs/9p.sock: 9P connection lost
15:34:26  nibrun-zerofs-mount.service: Failed with result 'exit-code'.
15:34:31  Scheduled restart job, restart counter is at 1.
15:34:31  ZeroFS mounted at /mnt/zerofs (9P: unix:/run/zerofs/9p.sock, cache: writethrough)
```

`nibrun-zerofs.service` is `Type=exec`, so systemd calls it started the moment the process execs — well before it is answering on the socket. `After=` therefore guarantees almost nothing, and the first mount attempt loses the race. `Restart=always` wins it 16 seconds later, which is the unit behaving correctly; the deploy had already taken the first attempt's exit code as the answer and stopped.

So the deploy now asserts what it actually needs — that the mount converged — rather than that it started first time, and says plainly what is broken if it never does. `RestartSec` drops to 2s, because every second there is a second the agent cannot provision a volume.

Not fixed by ordering, deliberately: the only thing that would make the first attempt succeed is ZeroFS reporting readiness, and its binary carries no `NOTIFY_SOCKET`, so `Type=notify` would hang rather than help.