### PR TITLE
fix(infra): install what the agent shells out to

### DIFF
--- a/infra/terraform/app_host_user_data.sh.tftpl
+++ b/infra/terraform/app_host_user_data.sh.tftpl
@@ -10,11 +10,20 @@ dnf install -y "kernel-modules-extra-$(uname -r)" || true
 
 dnf update -y
 
-# Only what the deploy itself needs to run, plus fuse3: ZeroFS exposes the
-# host's view of the filesystem over 9P and the agent reaches it through a FUSE
-# client, which needs the userspace helper. No Docker: everything this host runs
-# is a versioned binary the deploy fetches from S3 and starts under systemd.
-dnf install -y unzip fuse3
+# What the deploy needs to run, and what the agent shells out to once it does.
+# No Docker: everything this host runs is a versioned binary the deploy fetches
+# from S3 and starts under systemd.
+#
+#   unzip           the deploy installs the AWS CLI with it
+#   fuse3           ZeroFS serves the host's own view over 9P through a FUSE client
+#   nftables        guest isolation and the forward to a tenant's port
+#   nbd             attaches a tenant's disk, which ZeroFS serves over NBD
+#   squashfs-tools  builds the read-only config drive handed to a microVM
+#
+# The agent runs none of these until it has work, so a missing one surfaces when
+# an app is placed here rather than at boot — hence installing them together, up
+# front, rather than discovering them one replaced instance at a time.
+dnf install -y unzip fuse3 nftables nbd squashfs-tools
 
 # Not guaranteed on minimal AL2023, and the deploy script needs it.
 if ! command -v aws >/dev/null 2>&1; then


### PR DESCRIPTION
The agent registered and converged for the first time on the deployed host — session opened, desired state at generation 1, state persisted, no errors since. What it cannot yet do is place an app, because three of the binaries it shells out to are not on a minimal AL2023:

```
nft            MISSING    nftables         guest isolation and the forward to a tenant's port
nbd-client     MISSING    nbd              attaches a tenant's disk, which ZeroFS serves over NBD
mksquashfs     MISSING    squashfs-tools   builds the read-only config drive handed to a microVM
```

Only the first announced itself, as `firewall apply failed: Executable not found in $PATH: "nft"`. The other two would have waited until an app was actually placed, because the agent does not reach for them until it has work — so I audited every external command in `apps/agent/src` against the box rather than fixing the one that had spoken up. `ip`, `sysctl`, `mkfs.ext4`, `truncate`, `systemctl`, `mountpoint` and `fusermount3` are all present.

All three are in the `amazonlinux` repo (`nbd-3.25-1.amzn2023` provides `/usr/sbin/nbd-client`), so no EPEL and no extra repo.

**This replaces the app host**, as any bootstrap change now does. Cheap here — S3 is the source of truth and the host runs nothing — and much cheaper than learning about `nbd-client` on the next replacement and `mksquashfs` on the one after.