### PR TITLE
feat(runtime): let a tenant binary take arguments

### DIFF
--- a/apps/agent/src/reconcile/plan.test.ts
+++ b/apps/agent/src/reconcile/plan.test.ts
@@ -43,6 +43,7 @@ const desiredInstance = (overrides: Partial<DesiredInstance> = {}): DesiredInsta
   },
   config: {
     guestPort: DEFAULT_GUEST_PORT,
+    args: [],
     environment: {},
     resources: DEFAULT_INSTANCE_RESOURCES,
     healthCheck: DEFAULT_HEALTH_CHECK,

--- a/apps/agent/src/vm/instance-env.test.ts
+++ b/apps/agent/src/vm/instance-env.test.ts
@@ -14,6 +14,7 @@ const render = (
 ): ReturnType<typeof renderInstanceEnv> =>
   renderInstanceEnv({
     guestPort: DEFAULT_GUEST_PORT,
+    args: [],
     environment: {},
     restartPolicy: DEFAULT_RESTART_POLICY,
     dnsServers: [],
@@ -89,5 +90,23 @@ describe('what has no representation fails the instance', () => {
     })();
     expect(error?.message).toContain('API_KEY');
     expect(error?.message).not.toContain('secret-value');
+  });
+});
+
+describe('arguments reach the guest as the user wrote them', () => {
+  test('they are numbered from zero, in order', () => {
+    const rendered = render({ args: ['serve', '--http=0.0.0.0:8090'] });
+
+    expect(rendered).toContain('NIBRUN_ARG_0=serve');
+    // Splitting on the first `=` only is what lets a flag carry its own value.
+    expect(rendered).toContain('NIBRUN_ARG_1=--http=0.0.0.0:8090');
+  });
+
+  test('a binary that needs none is given none', () => {
+    expect(render({ args: [] })).not.toContain('NIBRUN_ARG_');
+  });
+
+  test('an argument with no representation fails the instance rather than truncating', () => {
+    expect(() => render({ args: ['--flag=one\ntwo'] })).toThrow(UnrepresentableEnvironmentError);
   });
 });

--- a/apps/agent/src/vm/instance-env.ts
+++ b/apps/agent/src/vm/instance-env.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { GuestPort, RestartPolicy, TenantEnvironment } from '@repo/protocol';
+import type { GuestPort, RestartPolicy, TenantArguments, TenantEnvironment } from '@repo/protocol';
 import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
 
 // Line-oriented `KEY=VALUE`, so the guest's init needs no parser. The file is generated and
@@ -44,11 +44,13 @@ export class UnrepresentableEnvironmentError extends Error {
  */
 export function renderInstanceEnv({
   guestPort,
+  args,
   environment,
   restartPolicy,
   dnsServers,
 }: {
   guestPort: GuestPort;
+  args: TenantArguments;
   environment: TenantEnvironment;
   restartPolicy: RestartPolicy;
   dnsServers: readonly string[];
@@ -63,6 +65,15 @@ export function renderInstanceEnv({
   ];
   if (dnsServers.length > 0) {
     lines.push(`${RUNTIME_PREFIX}DNS=${dnsServers.join(',')}`);
+  }
+  // Numbered rather than delimited: a format with no quoting cannot carry a separator that an
+  // argument might itself contain, and the guest refuses a gap rather than shifting the rest
+  // down one and running a command line nobody wrote.
+  for (const [index, argument] of args.entries()) {
+    if (FORBIDDEN_VALUE_CHARACTERS.test(argument)) {
+      throw new UnrepresentableEnvironmentError(`${RUNTIME_PREFIX}ARG_${index}`);
+    }
+    lines.push(`${RUNTIME_PREFIX}ARG_${index}=${argument}`);
   }
   for (const key of Object.keys(environment).sort()) {
     const value = environment[key] ?? '';
@@ -82,6 +93,7 @@ export async function buildInstanceConfigImage({
   runner,
   workingDir,
   guestPort,
+  args,
   environment,
   restartPolicy,
   dnsServers,
@@ -89,6 +101,7 @@ export async function buildInstanceConfigImage({
   runner: CommandRunner;
   workingDir: string;
   guestPort: GuestPort;
+  args: TenantArguments;
   environment: TenantEnvironment;
   restartPolicy: RestartPolicy;
   dnsServers: readonly string[];
@@ -100,7 +113,7 @@ export async function buildInstanceConfigImage({
   try {
     await writeFile(
       join(stagingDir, INSTANCE_ENV_FILENAME),
-      renderInstanceEnv({ guestPort, environment, restartPolicy, dnsServers }),
+      renderInstanceEnv({ guestPort, args, environment, restartPolicy, dnsServers }),
       {
         mode: PRIVATE_MODE,
       },

--- a/apps/agent/src/vm/manager.ts
+++ b/apps/agent/src/vm/manager.ts
@@ -77,6 +77,7 @@ export class VmManager {
       runner: this.#options.runner,
       workingDir,
       guestPort: desired.config.guestPort,
+      args: desired.config.args,
       environment: desired.config.environment,
       restartPolicy: desired.config.restartPolicy,
       dnsServers: this.#options.guestDnsServers,

--- a/apps/runtime/src/config.c
+++ b/apps/runtime/src/config.c
@@ -13,6 +13,7 @@
 #include "paths.h"
 
 #define RUNTIME_PREFIX "NIBRUN_"
+#define ARGUMENT_KEY_PREFIX "ARG_"
 #define TENANT_PREFIX "ENV_"
 
 #define MIN_PORT 1
@@ -151,6 +152,34 @@ static bool assign(struct instance_config *config, const struct field *field, ch
   return false;
 }
 
+/* NIBRUN_ARG_<n>. Slotted by index rather than appended, so the writer's order is
+ * irrelevant and a gap is caught after the whole file is read rather than silently
+ * shifting every later argument down one. */
+static bool parse_argument(struct instance_config *config, const char *key, char *value, size_t line_number) {
+  const char *digits = key + strlen(ARGUMENT_KEY_PREFIX);
+  if (*digits == '\0') {
+    log_line("instance.env line %zu sets %s%s with no index", line_number, RUNTIME_PREFIX, key);
+    return false;
+  }
+
+  char *unparsed = NULL;
+  errno = 0;
+  unsigned long index = strtoul(digits, &unparsed, 10);
+  if (errno != 0 || *unparsed != '\0' || index >= CONFIG_MAX_ARGUMENTS) {
+    log_line("instance.env line %zu sets %s%s, which is not an index below %d", line_number, RUNTIME_PREFIX,
+             key, CONFIG_MAX_ARGUMENTS);
+    return false;
+  }
+  if (config->arguments[index] != NULL) {
+    log_line("instance.env sets %s%s twice (line %zu)", RUNTIME_PREFIX, key, line_number);
+    return false;
+  }
+
+  config->arguments[index] = value;
+  config->argument_count++;
+  return true;
+}
+
 static bool parse_runtime_key(struct instance_config *config, bool *seen, char *line, size_t line_number) {
   char *equals = strchr(line, '=');
   if (equals == NULL) {
@@ -159,6 +188,10 @@ static bool parse_runtime_key(struct instance_config *config, bool *seen, char *
   }
   *equals = '\0';
   const char *key = line + strlen(RUNTIME_PREFIX);
+
+  if (starts_with(key, ARGUMENT_KEY_PREFIX)) {
+    return parse_argument(config, key, equals + 1, line_number);
+  }
 
   for (size_t index = 0; index < FIELD_COUNT; index++) {
     if (strcmp(key, FIELDS[index].key) != 0) {
@@ -288,6 +321,16 @@ bool config_parse(struct instance_config *config, char *text, size_t length) {
       return false;
     }
   }
+
+  /* Every index below the count must be filled, or an argument the user wrote is
+   * missing and the tenant would be exec'd with a subtly different command line
+   * rather than not at all. */
+  for (size_t index = 0; index < config->argument_count; index++) {
+    if (config->arguments[index] == NULL) {
+      log_line("instance.env skips %sARG_%zu", RUNTIME_PREFIX, index);
+      return false;
+    }
+  }
   return true;
 }
 
@@ -303,6 +346,18 @@ static bool defines(char *const *entries, size_t count, const char *name) {
     }
   }
   return false;
+}
+
+char *const *config_build_argv(const struct instance_config *config, const char *executable) {
+  static char *argv[CONFIG_MAX_ARGUMENTS + 2];
+
+  size_t count = 0;
+  argv[count++] = (char *)executable;
+  for (size_t index = 0; index < config->argument_count; index++) {
+    argv[count++] = config->arguments[index];
+  }
+  argv[count] = NULL;
+  return argv;
 }
 
 char *const *config_build_environment(const struct instance_config *config) {

--- a/apps/runtime/src/config.h
+++ b/apps/runtime/src/config.h
@@ -21,6 +21,8 @@
 
 #define CONFIG_MAX_BYTES (128 * 1024)
 #define CONFIG_MAX_TENANT_VARIABLES 256
+/* Mirrors MAX_ARGUMENTS in packages/protocol, which refuses to write more. */
+#define CONFIG_MAX_ARGUMENTS 64
 /* glibc's resolver reads at most MAXNS entries and silently drops the rest. */
 #define CONFIG_MAX_NAMESERVERS 3
 
@@ -37,6 +39,11 @@ struct instance_config {
   struct restart_policy restart_policy;
   char *nameservers[CONFIG_MAX_NAMESERVERS];
   size_t nameserver_count;
+  /* argv[1..]; argv[0] is the binary itself, which the runtime owns. Arrives as
+   * NIBRUN_ARG_<n> from 0 upwards, numbered rather than delimited because a
+   * format with no quoting cannot carry a separator an argument might contain. */
+  char *arguments[CONFIG_MAX_ARGUMENTS];
+  size_t argument_count;
   /* "NAME=value" strings, ready for execve. */
   char *tenant_environment[CONFIG_MAX_TENANT_VARIABLES];
   size_t tenant_variable_count;
@@ -48,6 +55,9 @@ struct instance_config {
 bool config_parse(struct instance_config *config, char *text, size_t length);
 
 bool config_read_file(struct instance_config *config, const char *path, char *buffer, size_t buffer_size);
+
+/* argv for execve: the binary, then the parsed arguments, then NULL. */
+char *const *config_build_argv(const struct instance_config *config, const char *executable);
 
 /* The environment the tenant is exec'd with: PORT, which the platform owns because
  * it is the port the agent probes and routes to, then the tenant's own variables,

--- a/apps/runtime/src/init.c
+++ b/apps/runtime/src/init.c
@@ -163,6 +163,7 @@ int main(void) {
           {
               .executable = TENANT_BINARY,
               .working_directory = APP_DIR,
+              .argv = config_build_argv(&config, TENANT_BINARY),
               .environment = config_build_environment(&config),
               .uid = TENANT_UID,
               .gid = TENANT_GID,

--- a/apps/runtime/src/supervise.c
+++ b/apps/runtime/src/supervise.c
@@ -107,8 +107,7 @@ static _Noreturn void become_tenant(const struct tenant_process *tenant) {
   OR_GIVE_UP(setgid(tenant->gid), "drop to its gid");
   OR_GIVE_UP(setuid(tenant->uid), "drop to its uid");
 
-  char *const argv[] = {(char *)tenant->executable, NULL};
-  execve(tenant->executable, argv, tenant->environment);
+  execve(tenant->executable, tenant->argv, tenant->environment);
   log_errno("could not run %s", tenant->executable);
   _exit(TENANT_SPAWN_EXIT_CODE);
 }

--- a/apps/runtime/src/supervise.h
+++ b/apps/runtime/src/supervise.h
@@ -9,6 +9,8 @@
 struct tenant_process {
   const char *executable;
   const char *working_directory;
+  /* argv as execve wants it, the binary itself included. */
+  char *const *argv;
   char *const *environment;
   uid_t uid;
   gid_t gid;

--- a/apps/runtime/tests/test-config.c
+++ b/apps/runtime/tests/test-config.c
@@ -157,6 +157,58 @@ static void builds_the_tenant_environment(void) {
   EXPECT(count == 4); /* PORT, HOME, TOKEN, TMPDIR — the tenant's own PORT dropped */
 }
 
+/* A binary that needs a subcommand cannot be started without these, and an argv
+ * that is subtly wrong is worse than one that fails: it runs the wrong thing. */
+static void passes_arguments_through_in_order(void) {
+  struct instance_config config;
+  EXPECT(parse(&config, REQUIRED
+                "NIBRUN_ARG_0=serve\n"
+                "NIBRUN_ARG_1=--http=0.0.0.0:8090\n"
+                "NIBRUN_ARG_2=--dir=/app/data/pb_data\n"));
+
+  EXPECT(config.argument_count == 3);
+  char *const *argv = config_build_argv(&config, "/mnt/artifact/server");
+  EXPECT(strcmp(argv[0], "/mnt/artifact/server") == 0);
+  EXPECT(strcmp(argv[1], "serve") == 0);
+  /* An argument containing '=' survives: the line splits on the first one only. */
+  EXPECT(strcmp(argv[2], "--http=0.0.0.0:8090") == 0);
+  EXPECT(strcmp(argv[3], "--dir=/app/data/pb_data") == 0);
+  EXPECT(argv[4] == NULL);
+}
+
+static void accepts_arguments_in_any_order(void) {
+  struct instance_config config;
+  EXPECT(parse(&config, REQUIRED
+                "NIBRUN_ARG_1=second\n"
+                "NIBRUN_ARG_0=first\n"));
+
+  char *const *argv = config_build_argv(&config, "/bin/x");
+  EXPECT(strcmp(argv[1], "first") == 0);
+  EXPECT(strcmp(argv[2], "second") == 0);
+}
+
+static void a_binary_with_no_arguments_is_exec_d_bare(void) {
+  struct instance_config config;
+  EXPECT(parse(&config, REQUIRED));
+
+  EXPECT(config.argument_count == 0);
+  char *const *argv = config_build_argv(&config, "/mnt/artifact/server");
+  EXPECT(strcmp(argv[0], "/mnt/artifact/server") == 0);
+  EXPECT(argv[1] == NULL);
+}
+
+static void rejects_a_gap_in_the_arguments(void) {
+  /* Accepting this would shift every later argument down one and exec a command
+   * line nobody wrote. */
+  EXPECT(rejects(REQUIRED "NIBRUN_ARG_0=serve\n" "NIBRUN_ARG_2=--verbose\n"));
+}
+
+static void rejects_an_unusable_argument_index(void) {
+  EXPECT(rejects(REQUIRED "NIBRUN_ARG_=serve\n"));
+  EXPECT(rejects(REQUIRED "NIBRUN_ARG_x=serve\n"));
+  EXPECT(rejects(REQUIRED "NIBRUN_ARG_0=one\n" "NIBRUN_ARG_0=two\n"));
+}
+
 int main(void) {
   accepts_a_generated_file();
   accepts_a_file_without_a_trailing_newline();
@@ -168,5 +220,10 @@ int main(void) {
   rejects_a_nul_byte();
   rejects_too_many_tenant_variables();
   builds_the_tenant_environment();
+  passes_arguments_through_in_order();
+  accepts_arguments_in_any_order();
+  a_binary_with_no_arguments_is_exec_d_bare();
+  rejects_a_gap_in_the_arguments();
+  rejects_an_unusable_argument_index();
   return EXPECT_REPORT("config");
 }

--- a/packages/protocol/src/domain/app.ts
+++ b/packages/protocol/src/domain/app.ts
@@ -12,6 +12,10 @@ import { DnsLabelSchema, GuestPortSchema, HostnameSchema, TimestampSchema } from
 const ENVIRONMENT_NAME_PATTERN = '^[A-Za-z_][A-Za-z0-9_]*$';
 const MIN_HOSTNAMES = 1;
 
+// Mirrored by CONFIG_MAX_ARGUMENTS in apps/runtime, which refuses a file exceeding it.
+const MAX_ARGUMENTS = 64;
+const MAX_ARGUMENT_LENGTH = 4096;
+
 // `platform` is the subdomain nibrun issues; `custom` is a domain the user brought. Modelling
 // hostnames as a set from the start is what keeps custom domains a new entry rather than a
 // schema change and a rewrite of every routing path.
@@ -41,8 +45,21 @@ export type TenantEnvironment = typeof TenantEnvironmentSchema.static;
 
 // What the user configured, snapshotted into every deployment so a rollback replays exactly
 // what ran rather than whatever the app happens to be configured with now.
+// argv[1..] for the tenant binary; argv[0] is always the binary itself. Empty for anything
+// built to run bare, which is what `bun build --compile` produces — but a released binary is
+// usually a multi-command tool, and one that needs `serve` cannot be started without this.
+//
+// A list rather than one string: splitting a command line means quoting rules, and the value
+// the user typed reaching exec unchanged is worth more than the convenience.
+export const TenantArgumentsSchema = Type.Array(Type.String({ maxLength: MAX_ARGUMENT_LENGTH }), {
+  maxItems: MAX_ARGUMENTS,
+});
+
+export type TenantArguments = typeof TenantArgumentsSchema.static;
+
 export const AppConfigSchema = Type.Object({
   guestPort: GuestPortSchema,
+  args: TenantArgumentsSchema,
   environment: TenantEnvironmentSchema,
   resources: InstanceResourcesSchema,
   healthCheck: HealthCheckSchema,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -67,6 +67,8 @@ export {
   type AppState,
   AppStateSchema,
   defaultHostname,
+  type TenantArguments,
+  TenantArgumentsSchema,
   type TenantEnvironment,
   TenantEnvironmentSchema,
 } from '#domain/app.ts';

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -64,6 +64,7 @@ const desiredState = (): HostDesiredState => ({
       },
       config: {
         guestPort: DEFAULT_GUEST_PORT,
+        args: ['serve', '--http=0.0.0.0:8090'],
         environment: { DATABASE_URL: TENANT_SECRET },
         resources: DEFAULT_INSTANCE_RESOURCES,
         healthCheck: DEFAULT_HEALTH_CHECK,


### PR DESCRIPTION
`argv` was the binary and nothing else — `char *const argv[] = {tenant->executable, NULL}`. That suits what `bun build --compile` produces and excludes most released binaries: anything needing a subcommand could not be started at all, and there is no way to work around it, because the guest image carries no shell and the artifact drive holds exactly one file.

`AppConfigSchema` gains `args`, which reach `execve` unchanged.

## Numbered, not delimited

They arrive as `NIBRUN_ARG_0`, `NIBRUN_ARG_1`, … `instance.env` has no quoting — that is what lets the guest parse it without a parser — so any separator is one an argument might itself contain. Numbering sidesteps it, and splitting each line on its **first** `=` means `--http=0.0.0.0:8090` survives as one argument.

A list on the wire rather than one command string, for the same reason: splitting a command line means quoting rules, and the value the user typed reaching `exec` unchanged is worth more than the convenience.

## What it refuses

- **A gap.** `ARG_0` and `ARG_2` with no `ARG_1` is rejected after the whole file is read. Accepting it would shift every later argument down one and exec a command line nobody wrote — worse than not starting, because it starts the wrong thing.
- **A repeated or unusable index**, and an index at or above `CONFIG_MAX_ARGUMENTS` (64, mirrored by `MAX_ARGUMENTS` in the protocol).
- **An argument containing a newline**, on the agent side, for the reason the tenant environment already does: a format with no quoting cannot represent it, and a second line carrying no prefix is how the guest catches the same thing.

Order in the file is irrelevant — arguments are slotted by index, so the writer is free and a gap is still caught.

## Tests

`config` goes from 51 checks to 69: order preserved, out-of-order input, `=` inside a value, no arguments at all, gaps, duplicate and malformed indices. Three more on the agent covering what it renders and what it refuses. The real boot test still passes — tenant unprivileged in `/app`, data surviving, clean poweroff.

Compiles under the existing `-Wall -Wextra -Werror -Wshadow -Wvla`.

## What this unblocks

PocketBase, which is what turned it up: `server serve --http=0.0.0.0:8090 --dir=/app/data/pb_data`, with the app's guest port declared as 8090 so the probe and the forward target the port it really binds, and its data on the persistent volume rather than the tmpfs.