### PR TITLE
fix(agent): apply the firewall, and stop losing a concurrent state write

### DIFF
--- a/apps/agent/src/lib/json-store.ts
+++ b/apps/agent/src/lib/json-store.ts
@@ -5,6 +5,10 @@ const PRIVATE_FILE_MODE = 0o600;
 const PRIVATE_DIR_MODE = 0o700;
 const JSON_INDENT = 2;
 
+function temporaryPathFor(path: string): string {
+  return `${path}.${crypto.randomUUID()}.tmp`;
+}
+
 export async function readJsonFile({ path }: { path: string }): Promise<unknown> {
   const file = Bun.file(path);
   if (!(await file.exists())) {
@@ -16,6 +20,11 @@ export async function readJsonFile({ path }: { path: string }): Promise<unknown>
 /**
  * Writes through a sibling temporary file and renames, so a torn write can never leave the
  * agent with a state file it cannot parse. Rename within a directory is atomic on ext4.
+ *
+ * The temporary name is unique per write rather than `<path>.tmp`: two writes of the same file
+ * in flight together — a reconcile and a status refresh both persisting slots — would otherwise
+ * share it, and whichever renamed second would find the first had already moved it away and
+ * fail with ENOENT.
  */
 export async function writeJsonFile({
   path,
@@ -25,7 +34,7 @@ export async function writeJsonFile({
   value: unknown;
 }): Promise<void> {
   await mkdir(dirname(path), { recursive: true, mode: PRIVATE_DIR_MODE });
-  const temporaryPath = `${path}.tmp`;
+  const temporaryPath = temporaryPathFor(path);
   await writeFile(temporaryPath, `${JSON.stringify(value, null, JSON_INDENT)}\n`, {
     mode: PRIVATE_FILE_MODE,
   });
@@ -51,7 +60,7 @@ export async function writeTextFile({
   mode?: number;
 }): Promise<void> {
   await mkdir(dirname(path), { recursive: true, mode: PRIVATE_DIR_MODE });
-  const temporaryPath = `${path}.tmp`;
+  const temporaryPath = temporaryPathFor(path);
   await writeFile(temporaryPath, value, { mode });
   await rename(temporaryPath, path);
 }

--- a/apps/agent/src/network/firewall.test.ts
+++ b/apps/agent/src/network/firewall.test.ts
@@ -85,6 +85,16 @@ describe('forwarding', () => {
     expect(renderRuleset(state())).toContain('ip saddr 10.201.0.0/16 oifname != "nbr*" masquerade');
   });
 
+  // nft accepts `dstnat` only on prerouting and rejects the whole ruleset otherwise, which
+  // leaves the host with no isolation rules at all rather than with one bad chain.
+  test('the output chain uses a priority nft accepts on that hook', () => {
+    const ruleset = renderRuleset(state({ instances: [instance] }));
+    const output = ruleset.split('\n').find((line) => line.includes('hook output'));
+
+    expect(output).toContain('priority -100');
+    expect(ruleset).not.toContain('hook output priority dstnat');
+  });
+
   test('host-local traffic to a forwarded port is re-sourced so the guest can reply', () => {
     const ruleset = renderRuleset(state({ instances: [instance] }));
     expect(ruleset).toContain('ip saddr 127.0.0.0/8 ip daddr 10.201.0.2 snat to 10.201.0.1');

--- a/apps/agent/src/network/firewall.ts
+++ b/apps/agent/src/network/firewall.ts
@@ -8,6 +8,9 @@ export const INSTANCE_METADATA_ADDRESS = '169.254.169.254';
 
 const DNS_PORT = 53;
 
+// NF_IP_PRI_NAT_DST — what `dstnat` resolves to where the name is allowed.
+const OUTPUT_NAT_PRIORITY = -100;
+
 // The blanket rule that makes the three isolation guarantees hold even for a destination
 // nobody thought to enumerate. Every one of these is somewhere a tenant has no business
 // reaching from inside a microVM.
@@ -123,7 +126,9 @@ function natChains({ instances }: FirewallState): string[] {
     ...chain({
       header: 'output {',
       rules: [
-        'type nat hook output priority dstnat; policy accept;',
+        // The numeric value of dstnat, because the name is only accepted on prerouting: nft
+        // rejects `priority dstnat` on the output hook outright, and the whole ruleset with it.
+        `type nat hook output priority ${OUTPUT_NAT_PRIORITY}; policy accept;`,
         ...instances.map(
           (instance) =>
             `ip daddr 127.0.0.1 tcp dport ${instance.hostPort} dnat to ${instance.guestIpv4}:${instance.guestPort}`,


### PR DESCRIPTION
Both of these are on the deployed host right now, and between them the agent cannot place an app.

```
firewall apply failed: nft -f - exited 1: /dev/stdin:26:26-40: Error: invalid priority
  expression value in this context.  type nat hook output priority dstnat;
reconcile failed: ENOENT: rename '/var/lib/nibrun/slots.json.tmp' -> '/var/lib/nibrun/slots.json'
```

## The ruleset was rejected whole

`dstnat` is accepted only on `prerouting`. Checked against real nftables on the host:

```
-100     VALID
filter   VALID
dstnat   REJECTED: invalid priority expression value in this context
srcnat   REJECTED
```

Now `-100`, which is what `dstnat` resolves to where the name is allowed. The consequence was worse than one broken chain: `nft -f` is transactional, so a host was left with **no isolation rules at all** — no metadata-endpoint drop, no guest-to-guest drop, and no forward to a tenant's port.

I validated the entire rendered ruleset — an instance, DNS servers, the control-plane CIDR — with `nft -c` on the box, which checks without applying. It passes.

The regression test asserts the output hook's priority rather than merely that some rule exists, because the failure mode is a ruleset nft parses as far as the last chain and then discards.

## A shared temporary filename

`writeJsonFile` and `writeTextFile` both wrote `<path>.tmp` and renamed. A reconcile and a status refresh persisting slots at the same time share that name: the first rename moves it away, and the second fails with ENOENT — taking the reconcile with it.

The temporary name is now unique per write. The atomicity the helper exists for is unchanged; it was only ever the *name* that was shared.

This is the error I saw once at startup earlier and called cosmetic. It was not — it was the same bug arriving before there was anything to lose.