### PR TITLE
feat(api): place a first app on the fleet

### DIFF
--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -1,23 +1,90 @@
-import type { HostDesiredState, HostId, HostReportedState, SecretString } from '@repo/protocol';
+import {
+  type AppId,
+  DEFAULT_HEALTH_CHECK,
+  DEFAULT_INSTANCE_RESOURCES,
+  DEFAULT_RESTART_POLICY,
+  type DeploymentId,
+  type GuestPort,
+  type HostDesiredState,
+  type HostId,
+  type Hostname,
+  type HostReportedState,
+  type InstanceId,
+  type ObjectKey,
+  type SecretString,
+  type Sha256Digest,
+  type VolumeId,
+} from '@repo/protocol';
 import { Repository } from '#repositories/repository.ts';
 
-// Where the schema goes when there is one. Until then a host is told to run
-// nothing, which is a true answer rather than a placeholder: no app has been
-// created, so an empty desired state is exactly what the fleet should converge
-// to, and converging to it exercises every step converging to an app would.
-// Generation 1, not 0: an agent that has never polled reports knowing generation
-// 0, so state published at 0 answers `unchanged` and the host is never told
-// anything at all. Zero means "nothing has been published to this host yet" and
-// belongs to no real state.
-const FIRST_GENERATION = 1;
+// Where the schema goes when there is one. Until then one app, written out here,
+// which is what a control plane with no database can honestly offer: the shape is
+// exactly what a query will return, so replacing this is replacing the body of
+// `desiredState` and nothing above it.
+//
+// PocketBase rather than something of ours, deliberately — it is a released
+// third-party binary that needs a subcommand, writes to a directory it is told
+// about, and binds a port it is told about. A tenant we did not build is the only
+// kind that tests the contract instead of agreeing with it.
+const APP_ID = 'app-pocketbase' as AppId;
 
-const NOTHING_TO_RUN = {
-  generation: FIRST_GENERATION,
-  volumes: [],
-  instances: [],
+// Every volume on a host repeats the one prefix that host's ZeroFS serves, and the
+// agent refuses a prefix it does not serve. The host composes its own from IMDS, so
+// this value is the instance id of the machine as it stands and does not survive a
+// replacement — see the note in the pull request. A host reporting the prefixes it
+// serves is what removes the need to know this here.
+const STORAGE_PREFIX =
+  's3://nibrun-filesystems-eu-central-1/hosts/i-04d1d0f91bd5e41e5' as ObjectKey;
+
+const VOLUME_SIZE_BYTES = 8_589_934_592;
+
+const POCKETBASE_PORT = 8090 as GuestPort;
+
+const DESIRED_APP = {
+  generation: 2,
+  volumes: [
+    {
+      volumeId: 'vol-pocketbase' as VolumeId,
+      appId: APP_ID,
+      sizeBytes: VOLUME_SIZE_BYTES,
+      storagePrefix: STORAGE_PREFIX,
+      desiredState: 'present',
+    },
+  ],
+  instances: [
+    {
+      instanceId: 'inst-pocketbase-1' as InstanceId,
+      appId: APP_ID,
+      deploymentId: 'dep-pocketbase-1' as DeploymentId,
+      volumeId: 'vol-pocketbase' as VolumeId,
+      desiredState: 'running',
+      artifact: {
+        // Uploaded by hand; the agent hashes the stream as it downloads and refuses
+        // on either mismatch, so both values below are load-bearing.
+        objectKey: 'artifacts/app-pocketbase/pb-0-39-10' as ObjectKey,
+        digest: 'f119018534e7a9e0db837c2811dda589d03bbdb78a03decc0664aac864e53814' as Sha256Digest,
+        sizeBytes: 32_096_418,
+      },
+      config: {
+        guestPort: POCKETBASE_PORT,
+        // `serve` because the binary is a multi-command tool; 0.0.0.0 because the
+        // host forwards into the guest and loopback would not be reachable; --dir
+        // because PocketBase writes beside its working directory by default, which
+        // is the tmpfs at /app rather than the volume that survives a restart.
+        args: ['serve', `--http=0.0.0.0:${POCKETBASE_PORT}`, '--dir=/app/data/pb_data'],
+        environment: {},
+        resources: DEFAULT_INSTANCE_RESOURCES,
+        healthCheck: DEFAULT_HEALTH_CHECK,
+        restartPolicy: DEFAULT_RESTART_POLICY,
+      },
+      hostnames: [
+        { hostname: 'pocketbase.canister.site' as Hostname, kind: 'platform', isDefault: true },
+      ],
+    },
+  ],
   checkpoints: [],
   exports: [],
-} as const satisfies Omit<HostDesiredState, 'hostId'>;
+} satisfies Omit<HostDesiredState, 'hostId'>;
 
 export class AgentRepository extends Repository {
   // In this process rather than in Postgres, which is the one thing here that is
@@ -42,7 +109,7 @@ export class AgentRepository extends Repository {
   }
 
   desiredState({ hostId }: { hostId: HostId }): Promise<HostDesiredState> {
-    return Promise.resolve({ hostId, ...NOTHING_TO_RUN });
+    return Promise.resolve({ hostId, ...DESIRED_APP });
   }
 
   // Reported state is the fleet's view of itself and belongs beside the desired


### PR DESCRIPTION
The stub told every host to run nothing. It now tells one to run PocketBase.

**Uploaded by hand**, as intended: `s3://nibrun-artifacts-eu-central-1/artifacts/app-pocketbase/pb-0-39-10`. v0.39.10 `linux_amd64`, verified against PocketBase's own `checksums.txt` before extraction, and the object re-downloaded from S3 afterwards to confirm it round-trips byte-identically to the digest pinned here. `ELF 64-bit x86-64, statically linked` — no `INTERP`, so the glibc rootfs is irrelevant to it.

PocketBase rather than something of ours, deliberately. It needs a subcommand, writes to a directory it is told about, and binds a port it is told about — a tenant we did not build is the only kind that tests the contract instead of agreeing with it. It is what turned up the missing `args` in the first place.

```
guestPort: 8090
args: ['serve', '--http=0.0.0.0:8090', '--dir=/app/data/pb_data']
```

`0.0.0.0` because the host forwards into the guest and a loopback bind would be unreachable; `--dir` because PocketBase writes beside its working directory by default, which is the tmpfs at `/app` rather than the volume that survives a restart.

**Generation goes to 2.** A host that already converged at generation 1 is told `unchanged` and would never fetch this — the generation is what makes a change reach a fleet at all.

I verified the rendered state parses under the protocol's own `HostDesiredStateSchema`, which is the same check the agent runs on receipt.

## One value here cannot survive a host replacement

`storagePrefix` has to name a prefix the host's ZeroFS actually serves, and the agent refuses one it does not. The host composes its own on the box from IMDS — `s3://<filesystems-bucket>/hosts/<instance-id>` — so the control plane cannot derive it, and nothing on the wire carries it: `HostReportedState` reports volumes but never the prefixes the host serves.

So it is pinned to the instance as it stands today, and the next replacement invalidates it.

That is a genuine gap this first app surfaced rather than something to paper over here. The fix is for a host to report the prefixes it serves, and for the control plane to place a volume only on a prefix it has been told about — which is a protocol change, and its own PR. Worth doing before anything places apps for real, because today it is silently per-instance.