### PR TITLE
refactor(protocol): let the host say where a volume went

### DIFF
--- a/apps/agent/src/reconcile/plan.test.ts
+++ b/apps/agent/src/reconcile/plan.test.ts
@@ -57,7 +57,6 @@ const desiredVolume = (overrides: Partial<DesiredVolume> = {}): DesiredVolume =>
   volumeId: VOLUME,
   appId: APP,
   sizeBytes: VOLUME_SIZE_BYTES,
-  storagePrefix: 'apps/app-1' as ObjectKey,
   desiredState: 'present',
   ...overrides,
 });

--- a/apps/agent/src/reconcile/reconciler.ts
+++ b/apps/agent/src/reconcile/reconciler.ts
@@ -45,16 +45,6 @@ const MAX_MESSAGE_LENGTH = 512;
 
 const UNKNOWN_UNIT: UnitStatus = { loaded: false, active: false, failed: false };
 
-// A checkpoint names a volume, and which ZeroFS serves it is decided by that volume's storage
-// prefix — which only desired state carries. A checkpoint for a volume the host has never been
-// told about is refused rather than guessed at.
-class UnknownVolumeError extends Error {
-  constructor(volumeId: VolumeId) {
-    super(`No storage prefix is known for volume ${volumeId}`);
-    this.name = 'UnknownVolumeError';
-  }
-}
-
 export type ReconcilerOptions = {
   config: AgentConfig;
   runner: CommandRunner;
@@ -78,7 +68,6 @@ export class Reconciler {
   readonly #records = new Map<InstanceId, InstanceRecord>();
   readonly #unitStatus = new Map<InstanceId, UnitStatus>();
   readonly #nextProbeAtMs = new Map<InstanceId, number>();
-  readonly #storagePrefixByVolume = new Map<VolumeId, ObjectKey>();
   readonly #allocator: SlotAllocator;
   #volumeReports: ReportedVolume[] = [];
   #checkpointReports: ReportedCheckpoint[] = [];
@@ -245,9 +234,6 @@ export class Reconciler {
   // artifact changing. Folding them into the record here is what keeps the route renderer and
   // the probe reading current configuration rather than whatever was true at boot.
   #syncDesired(desired: HostDesiredState): void {
-    for (const volume of desired.volumes) {
-      this.#storagePrefixByVolume.set(volume.volumeId, volume.storagePrefix);
-    }
     for (const wanted of desired.instances) {
       const record = this.#records.get(wanted.instanceId);
       if (!record) {
@@ -297,7 +283,7 @@ export class Reconciler {
     // Under `ignore_fsync` the guest's own flushes are a no-op, so this is the only thing
     // standing between a stop and the loss of everything since the last periodic flush. Worst
     // case is the flush interval *plus* the seal and upload, not exactly the interval.
-    await this.#tryFlush({ volumeId: record?.volumeId });
+    await this.#tryFlush();
     try {
       await this.#options.vms.stop({ instanceId });
       logger.info({ message: 'instance stopped', instanceId, reason });
@@ -478,7 +464,7 @@ export class Reconciler {
   ): Promise<ReportedCheckpoint> {
     const { checkpointId, volumeId } = action.desired;
     try {
-      const admin = this.#adminFor({ volumeId });
+      const admin = this.#adminFor();
       const existing = new Set(await admin.listCheckpoints());
       if (action.action === 'create' && !existing.has(checkpointId)) {
         await admin.createCheckpoint({ checkpointId });
@@ -505,20 +491,12 @@ export class Reconciler {
     }
   }
 
-  #adminFor({ volumeId }: { volumeId: VolumeId }): ZerofsAdmin {
-    const storagePrefix = this.#storagePrefixByVolume.get(volumeId);
-    if (storagePrefix === undefined) {
-      throw new UnknownVolumeError(volumeId);
-    }
-    return this.#options.topology.resolve({ storagePrefix }).admin;
+  #adminFor(): ZerofsAdmin {
+    return this.#options.topology.place().admin;
   }
 
-  async #tryFlush({ volumeId }: { volumeId?: VolumeId }): Promise<void> {
-    const prefix = volumeId === undefined ? undefined : this.#storagePrefixByVolume.get(volumeId);
+  async #tryFlush(): Promise<void> {
     for (const filesystem of this.#options.topology.all()) {
-      if (prefix !== undefined && filesystem.storagePrefix !== prefix) {
-        continue;
-      }
       try {
         await filesystem.admin.flush();
       } catch (error) {

--- a/apps/agent/src/volumes/manager.ts
+++ b/apps/agent/src/volumes/manager.ts
@@ -42,7 +42,7 @@ export class VolumeManager {
   }
 
   async provision({ desired }: { desired: DesiredVolume }): Promise<ReportedVolume> {
-    const filesystem = this.#options.topology.resolve({ storagePrefix: desired.storagePrefix });
+    const filesystem = this.#options.topology.place();
     const slot = this.#options.allocator.allocate(desired.appId);
     const path = devicePathFor({ mount: filesystem.mountPath, volumeId: desired.volumeId });
     const sizeBytes = await ensureDeviceFile({ path, sizeBytes: desired.sizeBytes });
@@ -73,6 +73,7 @@ export class VolumeManager {
       state: 'ready',
       sizeBytes,
       devicePath: slot.nbdDevicePath,
+      storagePrefix: filesystem.storagePrefix,
     };
   }
 
@@ -83,7 +84,7 @@ export class VolumeManager {
    * the guest's own barriers were never a durability point at all.
    */
   async teardown({ desired }: { desired: DesiredVolume }): Promise<ReportedVolume> {
-    const filesystem = this.#options.topology.resolve({ storagePrefix: desired.storagePrefix });
+    const filesystem = this.#options.topology.place();
     const slot = this.#options.allocator.lookup(desired.appId);
     await filesystem.admin.flush();
     if (slot) {

--- a/apps/agent/src/volumes/topology.test.ts
+++ b/apps/agent/src/volumes/topology.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import type { ObjectKey } from '@repo/protocol';
 import type { CommandRunner } from '#lib/exec.ts';
-import { UnservedStoragePrefixError, ZerofsTopology } from '#volumes/topology.ts';
+import { ZerofsTopology } from '#volumes/topology.ts';
 
 const NO_EXIT_CODE = 0;
 const HOST_PREFIX = 'filesystems/host-1' as ObjectKey;
-const OTHER_PREFIX = 'filesystems/host-2' as ObjectKey;
 
 const runner: CommandRunner = () => Promise.resolve({ code: NO_EXIT_CODE, stdout: '', stderr: '' });
 
@@ -18,12 +17,20 @@ const topology = () =>
     configFile: '/etc/zerofs/config.toml',
   });
 
-describe('one ZeroFS per host', () => {
-  test('every volume placed here resolves to the one filesystem', () => {
-    const filesystem = topology().resolve({ storagePrefix: HOST_PREFIX });
+describe('the host decides where a volume goes', () => {
+  test('a volume is placed in the filesystem this host serves', () => {
+    const filesystem = topology().place();
+
+    expect(filesystem.storagePrefix).toBe(HOST_PREFIX);
     expect(filesystem.mountPath).toBe('/mnt/zerofs');
     expect(filesystem.nbdSocketPath).toBe('/run/zerofs/nbd.sock');
     expect(filesystem.configFile).toBe('/etc/zerofs/config.toml');
+  });
+
+  test('placing twice lands in the same filesystem', () => {
+    const host = topology();
+
+    expect(host.place().storagePrefix).toBe(host.place().storagePrefix);
   });
 
   test('the whole set is enumerable, which is what a fleet-wide flush needs', () => {
@@ -32,26 +39,5 @@ describe('one ZeroFS per host', () => {
         .all()
         .map((filesystem) => filesystem.storagePrefix),
     ).toEqual([HOST_PREFIX]);
-  });
-});
-
-describe('a prefix this host does not serve', () => {
-  test('is refused, never written to the filesystem that happens to be here', () => {
-    expect(() => topology().resolve({ storagePrefix: OTHER_PREFIX })).toThrow(
-      UnservedStoragePrefixError,
-    );
-  });
-
-  test('the error names both what was asked for and what is served', () => {
-    const error = (() => {
-      try {
-        topology().resolve({ storagePrefix: OTHER_PREFIX });
-      } catch (caught) {
-        return caught as Error;
-      }
-      return undefined;
-    })();
-    expect(error?.message).toContain(OTHER_PREFIX);
-    expect(error?.message).toContain(HOST_PREFIX);
   });
 });

--- a/apps/agent/src/volumes/topology.ts
+++ b/apps/agent/src/volumes/topology.ts
@@ -23,15 +23,10 @@ export type ZerofsFilesystem = {
   admin: ZerofsAdmin;
 };
 
-export class UnservedStoragePrefixError extends Error {
-  readonly storagePrefix: ObjectKey;
-
-  constructor({ storagePrefix, served }: { storagePrefix: ObjectKey; served: readonly string[] }) {
-    super(
-      `No ZeroFS on this host serves ${storagePrefix}; it serves ${served.join(', ') || 'nothing'}`,
-    );
-    this.name = 'UnservedStoragePrefixError';
-    this.storagePrefix = storagePrefix;
+export class NoFilesystemError extends Error {
+  constructor() {
+    super('This host serves no ZeroFS filesystem, so it can hold no volume');
+    this.name = 'NoFilesystemError';
   }
 }
 
@@ -48,11 +43,11 @@ export class UnservedStoragePrefixError extends Error {
  * two filesystems, not repointing at a prefix. A ZeroFS restart is also a fleet-wide event on
  * this host rather than one tenant's.
  *
- * The protocol already accommodates either shape, because `storagePrefix` is on the volume: a
- * per-host prefix simply means every volume on the host repeats it. Nothing below assumes one
- * filesystem — the volume path, the NBD socket and the admin RPC are all resolved *per volume*
- * from the prefix it names, so moving to one ZeroFS per app is a second factory here plus a
- * supervisor for the extra processes, not a rewrite of the volume manager.
+ * The protocol accommodates either shape, because where a volume went is reported rather than
+ * instructed: a per-host filesystem simply means every volume on it reports the same prefix.
+ * Nothing below assumes one filesystem — the volume path, the NBD socket and the admin RPC are
+ * all resolved from the filesystem a volume was placed in, so moving to one ZeroFS per app is a
+ * second factory here plus a supervisor for the extra processes, not a rewrite of the manager.
  *
  * The invariant that holds under both: **exactly one read-write `zerofs run` per storage prefix,
  * fleet-wide.** ZeroFS does not reject a second writer — SlateDB's epoch fences the older one,
@@ -92,19 +87,13 @@ export class ZerofsTopology {
   }
 
   /**
-   * A volume naming a prefix this host does not serve is refused rather than written somewhere
-   * else. Silently creating the device file in the wrong filesystem would put a tenant's data
-   * under a prefix nothing will ever look for it under, which no later reconcile can undo.
+   * Which filesystem a volume belongs in. One per host in v1, so nothing is being chosen — but
+   * choosing here is what makes a second shape a policy rather than a protocol change.
    */
-  resolve({ storagePrefix }: { storagePrefix: ObjectKey }): ZerofsFilesystem {
-    const filesystem = this.#filesystems.find(
-      (candidate) => candidate.storagePrefix === storagePrefix,
-    );
+  place(): ZerofsFilesystem {
+    const [filesystem] = this.#filesystems;
     if (!filesystem) {
-      throw new UnservedStoragePrefixError({
-        storagePrefix,
-        served: this.#filesystems.map((candidate) => candidate.storagePrefix),
-      });
+      throw new NoFilesystemError();
     }
     return filesystem;
   }

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -28,14 +28,6 @@ import { Repository } from '#repositories/repository.ts';
 // kind that tests the contract instead of agreeing with it.
 const APP_ID = 'app-pocketbase' as AppId;
 
-// Every volume on a host repeats the one prefix that host's ZeroFS serves, and the
-// agent refuses a prefix it does not serve. The host composes its own from IMDS, so
-// this value is the instance id of the machine as it stands and does not survive a
-// replacement — see the note in the pull request. A host reporting the prefixes it
-// serves is what removes the need to know this here.
-const STORAGE_PREFIX =
-  's3://nibrun-filesystems-eu-central-1/hosts/i-04d1d0f91bd5e41e5' as ObjectKey;
-
 const VOLUME_SIZE_BYTES = 8_589_934_592;
 
 const POCKETBASE_PORT = 8090 as GuestPort;
@@ -47,7 +39,6 @@ const DESIRED_APP = {
       volumeId: 'vol-pocketbase' as VolumeId,
       appId: APP_ID,
       sizeBytes: VOLUME_SIZE_BYTES,
-      storagePrefix: STORAGE_PREFIX,
       desiredState: 'present',
     },
   ],

--- a/packages/protocol/src/control/desired-state.ts
+++ b/packages/protocol/src/control/desired-state.ts
@@ -57,7 +57,6 @@ export const DesiredVolumeSchema = Type.Object({
   volumeId: VolumeIdSchema,
   appId: AppIdSchema,
   sizeBytes: ByteSizeSchema,
-  storagePrefix: ObjectKeySchema,
   desiredState: DesiredPresenceSchema,
 });
 

--- a/packages/protocol/src/control/reported-state.ts
+++ b/packages/protocol/src/control/reported-state.ts
@@ -16,6 +16,7 @@ import {
   ByteSizeSchema,
   HostPortSchema,
   Ipv4AddressSchema,
+  ObjectKeySchema,
   Sha256DigestSchema,
   TimestampSchema,
 } from '#lib/wire.ts';
@@ -50,6 +51,8 @@ export const ReportedVolumeSchema = Type.Object({
   volumeId: VolumeIdSchema,
   state: VolumeStateSchema,
   sizeBytes: ByteSizeSchema,
+  // Which ZeroFS filesystem the host put it in.
+  storagePrefix: Type.Optional(ObjectKeySchema),
   devicePath: Type.Optional(Type.String({ maxLength: MAX_DEVICE_PATH_LENGTH })),
   message: Type.Optional(MessageSchema),
 });

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -46,7 +46,6 @@ const desiredState = (): HostDesiredState => ({
       volumeId: 'vol_1' as VolumeId,
       appId: 'app_1' as AppId,
       sizeBytes: 1024,
-      storagePrefix: 'filesystems/app_1' as ObjectKey,
       desiredState: 'present',
     },
   ],


### PR DESCRIPTION
`storagePrefix` moves from `DesiredVolume` to `ReportedVolume`. The control plane says a volume should exist and how big; the host decides which of the ZeroFS filesystems it runs will hold it, and reports where it went.

The old shape had the control plane naming a location it cannot reach, cannot verify and cannot name. Its IAM has **no access to the filesystems bucket at all** — deliberately, so an export can never corrupt a running app's data — and the bucket's name is not in its environment. Before this, the only occurrence of the string `filesystems` anywhere in `apps/api` was a constant hard-coded in the previous PR, holding the *instance id* of whichever host happened to exist that hour.

That is what made it impossible to fill in honestly, and it would have gone stale on the next host replacement — of which there were four yesterday.

## What changed

- `DesiredVolume` is now `volumeId`, `appId`, `sizeBytes`, `desiredState`. What the volume is, not where it is.
- `ReportedVolume` gains an optional `storagePrefix` — the host answering where it put it.
- `ZerofsTopology.resolve({ storagePrefix })` becomes `place()`. One filesystem per host in v1, so there is nothing to choose between; the point is that the choice is made here.
- `UnservedStoragePrefixError` and the reconciler's `UnknownVolumeError` are deleted with the map they guarded. Nothing can hand this host a prefix any more, so nothing can hand it a wrong one.

## What it does not close off

The per-app-ZeroFS option is more open, not less. That shape becomes a placement policy inside `place()` — by app, by size, by whatever — rather than a protocol change, precisely because what a host placed where is reported rather than instructed. The topology's own note said the protocol accommodated either shape *because* the prefix was on the volume; that reasoning was inverted, and the comment is corrected.

Volumes stay first-class objects. Their lifetime differs from an instance's, deletion has to be its own statement rather than a side effect of removing an instance, a volume must outlive a stopped app, and checkpoints and exports both key off `volumeId` rather than `instanceId` — you export a tenant's data whether or not their app is up.