### PR TITLE
chore(infra): adopt the guest image that can pass arguments

### DIFF
--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -16,5 +16,5 @@
     "url": "https://github.com/caddyserver/caddy/releases/download/v2.11.4/caddy_2.11.4_linux_amd64.tar.gz",
     "sha256": "527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9"
   },
-  "guestImage": "6.1.180-436861c7d163"
+  "guestImage": "6.1.180-ba5084da9128"
 }


### PR DESCRIPTION
PocketBase got all the way to `exec` and no further:

```
[    0.659463] Run /init as init process
[nibrun] guest runtime starting
[nibrun] instance.env line 7 sets NIBRUN_ARG_0, which this runtime does not know
[    0.667197] reboot: Restarting system
```

The pinned image is `6.1.180-436861c7d163`, published at 13:36 — before #37 taught the runtime about arguments. Its `/init` refuses a key it does not know, which is the behaviour that PR deliberately kept: the runtime carries no defaults and a config it cannot fully honour fails the boot rather than silently running the wrong command line.

CI published `6.1.180-ba5084da9128` at 16:53, minutes after #37 merged. Same kernel, different rootfs, because the image's version is a digest of its inputs and `/init` is one of them. Nothing adopted it, because publishing is not adopting — this commit is the adoption, which is the whole point of the split.

Verified rather than assumed: `version.sh` on current `main`, with the runtime built from source, computes `6.1.180-ba5084da9128`. So the image CI published is the one this tree produces, and its manifest reports `init_is_stub: false`.

Everything ahead of the exec already worked on the host: the volume was created at 8 GiB, attached at `/dev/nbd0` and formatted; the VM booted in 0.66s with an address from the host-local range; `/init` mounted the drives and read the config. Only the last step was missing.

Nothing restarts on a guest image bump — running VMs keep the kernel they booted with, and this one reaches the app when it is next started.