### PR TITLE
chore(api): redeploy PocketBase onto the adopted guest image

### DIFF
--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -41,7 +41,7 @@ const VOLUME_SIZE_BYTES = 8_589_934_592;
 const POCKETBASE_PORT = 8090 as GuestPort;
 
 const DESIRED_APP = {
-  generation: 2,
+  generation: 3,
   volumes: [
     {
       volumeId: 'vol-pocketbase' as VolumeId,
@@ -55,7 +55,7 @@ const DESIRED_APP = {
     {
       instanceId: 'inst-pocketbase-1' as InstanceId,
       appId: APP_ID,
-      deploymentId: 'dep-pocketbase-1' as DeploymentId,
+      deploymentId: 'dep-pocketbase-2' as DeploymentId,
       volumeId: 'vol-pocketbase' as VolumeId,
       desiredState: 'running',
       artifact: {


### PR DESCRIPTION
#41 put the args-capable image on the host — `/opt/nibrun/bin/guest-image` now points at `6.1.180-ba5084da9128` — but nothing started, and both reasons are deliberate.

**A guest image bump restarts nothing.** Running VMs keep the kernel they booted with; a new image reaches an existing app when that app is next redeployed. That is what the deploy was designed to do, and it did it.

**An instance whose VM exited is left alone.** `planReconcile` answers `none` for an exited instance rather than `start`: the guest owns restarting the tenant within its own budget, and once the machine is gone the agent reports the failure instead of restarting forever. The record also carries an attempt window that is already spent.

So neither the image bump nor another poll will start it. What clears both is a **new deployment id** — `replace` stops the instance, discards it, deletes the record, and starts fresh, which is exactly what a redeploy means.

`dep-pocketbase-1` → `dep-pocketbase-2`, generation 2 → 3. The generation is what makes the change reach the host at all; the deployment id is what makes the host treat it as a redeploy rather than a no-op.

Nothing else changes: same artifact, same digest, same volume — which keeps its data, since a redeploy replaces the instance and not the filesystem.