### PR TITLE
fix(agent): call ZeroFS where the deploy put it

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -93,6 +93,7 @@ export class Agent {
       storagePrefix: config.zerofsStoragePrefix as ObjectKey,
       mountPath: config.zerofsMount,
       nbdSocketPath: config.zerofsNbdSocket,
+      binary: config.zerofsBinary,
       configFile: config.zerofsConfigFile,
     });
     const units = new SystemdVmUnits({ runner });

--- a/apps/agent/src/config.ts
+++ b/apps/agent/src/config.ts
@@ -2,6 +2,9 @@ import { join } from 'node:path';
 
 const DEFAULT_STATE_DIR = '/var/lib/nibrun';
 const DEFAULT_RUNTIME_DIR = '/run/nibrun';
+// Laid down by the deploy under a versioned path with a symlink to the active one, like
+// every other binary on this host. Not on PATH, so it is named in full.
+const DEFAULT_ZEROFS_BINARY = '/opt/nibrun/bin/zerofs/zerofs';
 const DEFAULT_ZEROFS_MOUNT = '/mnt/zerofs';
 const DEFAULT_ZEROFS_CONFIG = '/etc/zerofs/config.toml';
 const DEFAULT_ZEROFS_NBD_SOCKET = '/run/zerofs/nbd.sock';
@@ -31,6 +34,7 @@ export type AgentConfig = {
   guestImageDir: string;
   firecrackerDir: string;
   zerofsMount: string;
+  zerofsBinary: string;
   zerofsConfigFile: string;
   zerofsNbdSocket: string;
   caddySitesFile: string;
@@ -110,6 +114,11 @@ export function loadAgentConfig({
       env,
       name: 'AGENT_FIRECRACKER_DIR',
       fallback: DEFAULT_FIRECRACKER_DIR,
+    }),
+    zerofsBinary: optional({
+      env,
+      name: 'AGENT_ZEROFS_BINARY',
+      fallback: DEFAULT_ZEROFS_BINARY,
     }),
     zerofsMount: optional({ env, name: 'AGENT_ZEROFS_MOUNT', fallback: DEFAULT_ZEROFS_MOUNT }),
     zerofsConfigFile: optional({

--- a/apps/agent/src/volumes/topology.test.ts
+++ b/apps/agent/src/volumes/topology.test.ts
@@ -15,6 +15,7 @@ const topology = () =>
     storagePrefix: HOST_PREFIX,
     mountPath: '/mnt/zerofs',
     nbdSocketPath: '/run/zerofs/nbd.sock',
+    binary: '/opt/nibrun/bin/zerofs/zerofs',
     configFile: '/etc/zerofs/config.toml',
   });
 

--- a/apps/agent/src/volumes/topology.ts
+++ b/apps/agent/src/volumes/topology.ts
@@ -72,11 +72,13 @@ export class ZerofsTopology {
     storagePrefix,
     mountPath,
     nbdSocketPath,
+    binary,
     configFile,
   }: {
     runner: CommandRunner;
     storagePrefix: ObjectKey;
     mountPath: string;
+    binary: string;
     nbdSocketPath: string;
     configFile: string;
   }): ZerofsTopology {
@@ -86,7 +88,7 @@ export class ZerofsTopology {
         mountPath,
         nbdSocketPath,
         configFile,
-        admin: new ZerofsAdmin({ runner, configFile }),
+        admin: new ZerofsAdmin({ runner, binary, configFile }),
       },
     ]);
   }

--- a/apps/agent/src/volumes/zerofs.test.ts
+++ b/apps/agent/src/volumes/zerofs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import type { CheckpointId } from '@repo/protocol';
+import type { CommandRequest } from '#lib/exec.ts';
+import { ZerofsAdmin } from '#volumes/zerofs.ts';
+
+const NO_EXIT_CODE = 0;
+const BINARY = '/opt/nibrun/bin/zerofs/zerofs';
+
+function recordingAdmin() {
+  const commands: string[][] = [];
+  const runner = (request: CommandRequest) => {
+    commands.push([...request.command]);
+    return Promise.resolve({ code: NO_EXIT_CODE, stdout: '', stderr: '' });
+  };
+  return {
+    commands,
+    admin: new ZerofsAdmin({ runner, binary: BINARY, configFile: '/etc/z.toml' }),
+  };
+}
+
+// The deploy lays every binary down under a versioned path and puts none of them on PATH, so a
+// bare name resolves to nothing — and the flush that fails is the one that makes a stop a
+// durability point under ignore_fsync.
+describe('ZeroFS is invoked where the deploy put it', () => {
+  test('a flush names the binary in full', async () => {
+    const { commands, admin } = recordingAdmin();
+    await admin.flush();
+
+    expect(commands[0]?.[0]).toBe(BINARY);
+  });
+
+  test('so does every checkpoint command', async () => {
+    const { commands, admin } = recordingAdmin();
+    await admin.createCheckpoint({ checkpointId: 'cp-1' as CheckpointId });
+    await admin.deleteCheckpoint({ checkpointId: 'cp-1' as CheckpointId });
+    await admin.listCheckpoints();
+
+    expect(commands.every(([executable]) => executable === BINARY)).toBe(true);
+  });
+});

--- a/apps/agent/src/volumes/zerofs.ts
+++ b/apps/agent/src/volumes/zerofs.ts
@@ -1,8 +1,6 @@
 import type { CheckpointId } from '@repo/protocol';
 import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
 
-const ZEROFS_COMMAND = 'zerofs';
-
 /**
  * ZeroFS is a long-running service this agent does not own.
  *
@@ -14,10 +12,20 @@ const ZEROFS_COMMAND = 'zerofs';
  */
 export class ZerofsAdmin {
   readonly #runner: CommandRunner;
+  readonly #binary: string;
   readonly #configFile: string;
 
-  constructor({ runner, configFile }: { runner: CommandRunner; configFile: string }) {
+  constructor({
+    runner,
+    binary,
+    configFile,
+  }: {
+    runner: CommandRunner;
+    binary: string;
+    configFile: string;
+  }) {
     this.#runner = runner;
+    this.#binary = binary;
     this.#configFile = configFile;
   }
 
@@ -26,7 +34,7 @@ export class ZerofsAdmin {
   async flush(): Promise<void> {
     await runCommandOrThrow({
       runner: this.#runner,
-      request: { command: [ZEROFS_COMMAND, 'flush', '-c', this.#configFile] },
+      request: { command: [this.#binary, 'flush', '-c', this.#configFile] },
     });
   }
 
@@ -34,7 +42,7 @@ export class ZerofsAdmin {
     await runCommandOrThrow({
       runner: this.#runner,
       request: {
-        command: [ZEROFS_COMMAND, 'checkpoint', 'create', '-c', this.#configFile, checkpointId],
+        command: [this.#binary, 'checkpoint', 'create', '-c', this.#configFile, checkpointId],
       },
     });
   }
@@ -43,7 +51,7 @@ export class ZerofsAdmin {
     await runCommandOrThrow({
       runner: this.#runner,
       request: {
-        command: [ZEROFS_COMMAND, 'checkpoint', 'delete', '-c', this.#configFile, checkpointId],
+        command: [this.#binary, 'checkpoint', 'delete', '-c', this.#configFile, checkpointId],
       },
     });
   }
@@ -51,7 +59,7 @@ export class ZerofsAdmin {
   async listCheckpoints(): Promise<string[]> {
     const output = await runCommandOrThrow({
       runner: this.#runner,
-      request: { command: [ZEROFS_COMMAND, 'checkpoint', 'list', '-c', this.#configFile] },
+      request: { command: [this.#binary, 'checkpoint', 'list', '-c', this.#configFile] },
     });
     return parseCheckpointNames(output);
   }


### PR DESCRIPTION
Live on the host right now, every time an instance stops:

```
zerofs flush failed: Executable not found in $PATH: "zerofs"
```

`ZerofsAdmin` invoked `zerofs` by bare name. The deploy lays every binary down under a versioned path with a symlink to the active one and puts none of them on `PATH` — the real one is `/opt/nibrun/bin/zerofs/zerofs`, which is also what makes rollback a symlink swap.

What that costs is easy to miss, because nothing looks broken. The periodic flush inside ZeroFS keeps running, so data is still reaching S3 every five seconds. What was failing is the flush the agent makes **before a VM stops or a device detaches** — and with `ignore_fsync` the guest's own barriers are a no-op, so that call is the only thing that turns acknowledged writes into durable ones at a stop. A clean stop was silently discarding up to a flush interval of a tenant's writes. Checkpoints were failing the same way, which is what an export will eventually be built on.

The path is configuration like every other binary the agent runs, defaulting to where the deploy puts it, so a versioned layout change is one constant rather than a hunt.

Two tests, because the failure mode is a warning in a log nobody reads rather than anything that stops: a flush and every checkpoint command must name the binary in full. I also checked the rest of the agent for bare invocations — the remainder are `ip`, `sysctl`, `systemctl`, `nft`, `mkfs.ext4`, `mksquashfs`, `nbd-client` and `truncate`, all of which come from distribution packages and are genuinely on `PATH`.