### PR TITLE
feat(infra): give app hosts addresses that outlive a replacement

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -28,7 +28,7 @@ DNS, every record **proxied** (orange cloud):
 - `*.<app_domain>` A → `app_host_public_ips`, plus AAAA → `app_host_public_ipv6s`. One pair covers
   the whole fleet, so there is nothing per app in DNS.
 
-Neither address is elastic, so a stop/start means re-pointing.
+Both addresses outlive a replacement, so the records are written once.
 
 Then, **in both zones**: SSL/TLS **Full (strict)**; an **Origin Certificate** (ECC — Cloudflare's
 edge is its only client), whose two halves are a proxy's TLS inputs; and **Authenticated Origin

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -25,10 +25,11 @@ DNS, every record **proxied** (orange cloud):
 
 - one A record per control-plane hostname (`api_hostname`, `dozzle_hostname`) → `terraform output
   public_ip`
-- `*.<app_domain>` A → `app_host_public_ips`, plus AAAA → `app_host_public_ipv6s`. One pair covers
-  the whole fleet, so there is nothing per app in DNS.
+- `*.<app_domain>` A → `app_host_public_ips`. One record covers the whole fleet, so there is
+  nothing per app in DNS, and no AAAA: Cloudflare is the origin's only client and serves
+  visitors over IPv6 from its own edge.
 
-Both addresses outlive a replacement, so the records are written once.
+The address outlives a replacement, so the record is written once.
 
 Then, **in both zones**: SSL/TLS **Full (strict)**; an **Origin Certificate** (ECC — Cloudflare's
 edge is its only client), whose two halves are a proxy's TLS inputs; and **Authenticated Origin

--- a/infra/terraform/app_host.tf
+++ b/infra/terraform/app_host.tf
@@ -27,14 +27,12 @@ resource "aws_instance" "app_host" {
   # into S3 first. No NAT gateway: NAT is for tenant egress, and no tenant app
   # runs in this phase.
   #
-  # Both families, because the wildcard record the user-app proxy needs carries an
-  # A and an AAAA — and both have to survive a replacement, which happens whenever
-  # the bootstrap changes. A specific address rather than a count: an auto-assigned
-  # one is drawn fresh each time and would leave the AAAA pointing at a host that
-  # no longer exists. The elastic IP below does the same job for v4, which has no
-  # equivalent because an elastic address is IPv4-only.
+  # An address in each family, but only the elastic one below is ever published:
+  # Cloudflare is the origin's only client and serves visitors over IPv6 from its
+  # own edge, so nothing here needs a stable IPv6. This one is for egress, and it
+  # is drawn fresh on every launch, which is fine because nothing points at it.
   associate_public_ip_address = true
-  ipv6_addresses              = [cidrhost(aws_subnet.app.ipv6_cidr_block, count.index + 1)]
+  ipv6_address_count          = 1
 
   # Without this the CPU exposes no VMX, kvm_intel refuses to load, and the
   # bootstrap deliberately dies before writing its marker. It is a launch-time

--- a/infra/terraform/app_host.tf
+++ b/infra/terraform/app_host.tf
@@ -27,12 +27,14 @@ resource "aws_instance" "app_host" {
   # into S3 first. No NAT gateway: NAT is for tenant egress, and no tenant app
   # runs in this phase.
   #
-  # Both families, so the wildcard record the user-app proxy needs can carry an
-  # AAAA as well as an A. The subnet assigns an IPv6 on creation anyway; stating
-  # it here is what stops a change to that default silently taking the address
-  # away from a host whose DNS points at it.
+  # Both families, because the wildcard record the user-app proxy needs carries an
+  # A and an AAAA — and both have to survive a replacement, which happens whenever
+  # the bootstrap changes. A specific address rather than a count: an auto-assigned
+  # one is drawn fresh each time and would leave the AAAA pointing at a host that
+  # no longer exists. The elastic IP below does the same job for v4, which has no
+  # equivalent because an elastic address is IPv4-only.
   associate_public_ip_address = true
-  ipv6_address_count          = 1
+  ipv6_addresses              = [cidrhost(aws_subnet.app.ipv6_cidr_block, count.index + 1)]
 
   # Without this the CPU exposes no VMX, kvm_intel refuses to load, and the
   # bootstrap deliberately dies before writing its marker. It is a launch-time
@@ -80,6 +82,20 @@ resource "aws_instance" "app_host" {
   tags = {
     Name        = "${local.resource_name_prefix}-app-host-${count.index}"
     DeployGroup = local.app_host_deploy_group
+  }
+}
+
+# What the app domain's wildcard A record points at. Unlike the instance's own
+# public address it outlives a replacement, so the record is written once rather
+# than chased every time the bootstrap changes.
+resource "aws_eip" "app_host" {
+  count = var.app_host_count
+
+  instance = aws_instance.app_host[count.index].id
+  domain   = "vpc"
+
+  tags = {
+    Name = "${local.resource_name_prefix}-app-host-${count.index}-public-ip"
   }
 }
 

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -91,11 +91,9 @@ output "app_host_instance_ids" {
   value = aws_instance.app_host[*].id
 }
 
-# No elastic IP, unlike the control plane, so these move if a host is stopped
-# and started — point the wildcard records at them and re-point after a replace.
 output "app_host_public_ips" {
   description = "A record targets for the app domain's wildcard."
-  value       = aws_instance.app_host[*].public_ip
+  value       = aws_eip.app_host[*].public_ip
 }
 
 output "app_host_public_ipv6s" {

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -96,11 +96,6 @@ output "app_host_public_ips" {
   value       = aws_eip.app_host[*].public_ip
 }
 
-output "app_host_public_ipv6s" {
-  description = "AAAA record targets for the app domain's wildcard."
-  value       = [for host in aws_instance.app_host : one(host.ipv6_addresses)]
-}
-
 # Not a single DATA_VOLUME_ID like the control plane's, because each host has
 # its own: a deploy fanning out looks the instance it is targeting up here and
 # exports that one value under the usual name.


### PR DESCRIPTION
There is no reason the app host lacked a stable address — it is an omission, not a decision. `ec2.tf` gives the control plane one with the comment *"Stable public IP — point the hostname's A record at this."* The app host was designed when nothing pointed DNS at it: no ingress, no proxy, no hostname. #25 introduced exactly that requirement and nobody went back.

The cost showed up today as a **522** from Cloudflare. The origin was fine — Caddy listening on `*:443`, the security group admitting Cloudflare's ranges, the handshake correctly refused without a client certificate. The wildcard record simply pointed at a host that no longer existed, because changing the bootstrap replaces the instance and every replacement drew a new address.

`infra/AGENTS.md` said *"Neither address is elastic, so a stop/start means re-pointing"* — documenting the trap rather than removing it.

## Both families, two mechanisms

An **elastic IP** per host for v4, associated by `count` so it scales with the fleet. Free while attached.

An elastic address is IPv4-only, so v6 needs something else: `ipv6_address_count = 1` becomes an explicit `ipv6_addresses = [cidrhost(aws_subnet.app.ipv6_cidr_block, count.index + 1)]`. An auto-assigned address is drawn fresh on every launch; a specific one is the same address each time, derived from the subnet the host is already in.

`app_host_public_ips` now reports the elastic address rather than the instance's own, so the output means what its description says.

## One thing to read in the plan

I could not determine locally whether changing `ipv6_address_count` to `ipv6_addresses` forces a replacement — Terraform's provider schema JSON does not carry `ForceNew`, and I would rather not guess about something that has replaced this host four times today. `terraform-plan` on this PR will say.

If it does replace: that is a one-time cost that ends the churn, since it is the last change needed for the addresses to stop moving. Worth confirming before applying, and worth updating the Cloudflare records **after** it applies rather than before.