### PR TITLE
chore(infra): drop the control plane's unused IPv6 output

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -26,10 +26,11 @@ DNS, every record **proxied** (orange cloud):
 - one A record per control-plane hostname (`api_hostname`, `dozzle_hostname`) → `terraform output
   public_ip`
 - `*.<app_domain>` A → `app_host_public_ips`. One record covers the whole fleet, so there is
-  nothing per app in DNS, and no AAAA: Cloudflare is the origin's only client and serves
-  visitors over IPv6 from its own edge.
+  nothing per app in DNS.
 
-The address outlives a replacement, so the record is written once.
+A records only, for both. Cloudflare is the only client either origin has, and it serves
+visitors over IPv6 from its own edge — an AAAA here would publish an address nothing needs to
+reach. Both addresses outlive a replacement, so the records are written once.
 
 Then, **in both zones**: SSL/TLS **Full (strict)**; an **Origin Certificate** (ECC — Cloudflare's
 edge is its only client), whose two halves are a proxy's TLS inputs; and **Authenticated Origin

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -6,10 +6,6 @@ output "public_ip" {
   value       = aws_eip.app.public_ip
 }
 
-output "public_ipv6" {
-  value = one(aws_instance.app.ipv6_addresses)
-}
-
 output "api_hostname" {
   value = var.api_hostname
 }


### PR DESCRIPTION
`output "public_ipv6"` is declared and read by nothing — not a workflow, not a script, not a document, not another resource. #44 removed the app host's equivalent once it was clear an AAAA on the origin buys nothing; the control plane's was left behind.

The reasoning is the same and applies to both, so `infra/AGENTS.md` now states it once rather than leaving it implied by which outputs happen to exist: Cloudflare is the only client either origin has, and it serves visitors over IPv6 from its own edge, so an AAAA here would publish an address nothing needs to reach.

Both instances keep their IPv6 address. It costs nothing, the subnet assigns one on creation regardless, and it is there for egress — the point is only that neither is published.