### PR TITLE
feat(agent): the host that owns the volume writes the export

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -156,6 +156,7 @@ jobs:
       GUEST_IMAGES_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).guest_images_bucket }}
       FILESYSTEMS_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).filesystems_bucket }}
       ARTIFACTS_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).artifacts_bucket }}
+      EXPORTS_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).exports_bucket }}
       API_HOSTNAME: ${{ fromJSON(needs.terraform.outputs.values).api_hostname }}
       APP_DOMAIN: ${{ fromJSON(needs.terraform.outputs.values).app_domain }}
       CONTROL_PLANE_INTERNAL_URL: ${{ fromJSON(needs.terraform.outputs.values).control_plane_internal_url }}

--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -15,6 +15,7 @@ import { InstanceCredentialProvider } from '#aws/instance-credentials.ts';
 import { type AgentConfig, loadAgentConfig } from '#config.ts';
 import { ControlPlaneClient, ControlPlaneError } from '#control/client.ts';
 import { HostIdentity, isSessionExpiring, openSession } from '#control/session.ts';
+import { ExportManager } from '#exports/manager.ts';
 import { backoffDelayMs } from '#lib/backoff.ts';
 import { nowTimestamp } from '#lib/clock.ts';
 import { runCommand } from '#lib/exec.ts';
@@ -97,6 +98,12 @@ export class Agent {
       configFile: config.zerofsConfigFile,
     });
     const units = new SystemdVmUnits({ runner });
+    const credentials = new InstanceCredentialProvider();
+    const artifacts = s3ArtifactBytes({
+      bucket: config.artifactBucket,
+      region: config.awsRegion,
+      credentials,
+    });
     // One allocator, shared: the host port, the tap, the guest address and the NBD minor are
     // four views of the same slot, and two owners of it would eventually disagree.
     const allocator = SlotAllocator.fromRecords(
@@ -109,14 +116,19 @@ export class Agent {
       topology,
       allocator,
       proxy: new CaddyProxy({ runner, sitesFile: config.caddySitesFile }),
+      exports: new ExportManager({
+        runner,
+        topology,
+        artifacts,
+        credentials,
+        bucket: config.exportBucket,
+        region: config.awsRegion,
+        stagingDir: config.exportStagingDir,
+      }),
       vms: new VmManager({
         runner,
         units,
-        artifacts: s3ArtifactBytes({
-          bucket: config.artifactBucket,
-          region: config.awsRegion,
-          credentials: new InstanceCredentialProvider(),
-        }),
+        artifacts,
         artifactCacheDir: config.artifactCacheDir,
         guestImageDir: config.guestImageDir,
         vmDir: config.vmDir,
@@ -237,6 +249,7 @@ export class Agent {
       records,
       volumes: this.#reconciler.volumeReports(),
       checkpoints: this.#reconciler.checkpointReports(),
+      exports: this.#reconciler.exportReports(),
     });
     const response = await this.#client.sendReportedState({
       sessionToken: session.sessionToken,

--- a/apps/agent/src/config.ts
+++ b/apps/agent/src/config.ts
@@ -28,6 +28,8 @@ export type AgentConfig = {
   hostIdFile: string;
   slotsFile: string;
   instancesFile: string;
+  exportsFile: string;
+  exportStagingDir: string;
   artifactCacheDir: string;
   vmDir: string;
   versionsFile: string;
@@ -43,6 +45,10 @@ export type AgentConfig = {
   // filesystem puts a tenant's data somewhere nothing will look for it.
   zerofsStoragePrefix: string;
   artifactBucket: string;
+  // Write-only for this host by IAM, so a bundle it has already produced is unreadable to it.
+  // What was written is therefore remembered in `exportsFile` rather than observed, which is the
+  // one place the agent cannot converge against reality.
+  exportBucket: string;
   awsRegion: string;
   // Guests are denied every private destination by default, so this is only needed when the
   // control plane answers on a public address the blanket rule would not cover.
@@ -102,6 +108,8 @@ export function loadAgentConfig({
     hostIdFile: join(stateDir, 'host-id'),
     slotsFile: join(stateDir, 'slots.json'),
     instancesFile: join(stateDir, 'instances.json'),
+    exportsFile: join(stateDir, 'exports.json'),
+    exportStagingDir: join(stateDir, 'exports'),
     artifactCacheDir: join(stateDir, 'artifacts'),
     vmDir: join(stateDir, 'vm'),
     versionsFile: optional({ env, name: 'AGENT_VERSIONS_FILE', fallback: DEFAULT_VERSIONS_FILE }),
@@ -138,6 +146,7 @@ export function loadAgentConfig({
     }),
     zerofsStoragePrefix: required({ env, name: 'AGENT_ZEROFS_STORAGE_PREFIX' }),
     artifactBucket: required({ env, name: 'AGENT_ARTIFACT_BUCKET' }),
+    exportBucket: required({ env, name: 'AGENT_EXPORT_BUCKET' }),
     awsRegion: required({ env, name: 'AGENT_AWS_REGION' }),
     controlPlaneCidrs: list({ env, name: 'AGENT_CONTROL_PLANE_CIDRS' }),
     guestDnsServers: list({ env, name: 'AGENT_GUEST_DNS_SERVERS' }),

--- a/apps/agent/src/exports/bundle.test.ts
+++ b/apps/agent/src/exports/bundle.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DesiredArtifact, ObjectKey, Sha256Digest } from '@repo/protocol';
+import { EmptyDumpError, writeBundle } from '#exports/bundle.ts';
+import type { CommandRequest, CommandResult } from '#lib/exec.ts';
+import type { ArtifactBytes } from '#vm/artifacts.ts';
+
+const DEVICE_PATH = '/dev/nbd7';
+const BINARY_BYTES = new TextEncoder().encode('binary');
+const OK: CommandResult = { code: 0, stdout: '', stderr: '' };
+
+const artifacts: ArtifactBytes = {
+  open: () =>
+    Promise.resolve(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(BINARY_BYTES);
+          controller.close();
+        },
+      }),
+    ),
+};
+
+const artifact = (): DesiredArtifact => ({
+  digest: new Bun.CryptoHasher('sha256').update(BINARY_BYTES).digest('hex') as Sha256Digest,
+  sizeBytes: BINARY_BYTES.byteLength,
+  objectKey: 'artifacts/app-1/server' as ObjectKey,
+});
+
+let stagingDir: string;
+
+beforeEach(async () => {
+  stagingDir = await mkdtemp(join(tmpdir(), 'bundle-test-'));
+});
+
+afterEach(async () => {
+  await rm(stagingDir, { recursive: true, force: true });
+});
+
+// The dump is what a real `debugfs` would leave behind, so the tar step downstream has
+// something to archive.
+const runnerWritingDump = (calls: CommandRequest[]) => async (request: CommandRequest) => {
+  calls.push(request);
+  const [command] = request.command;
+  if (command === 'debugfs') {
+    const destination = join(stagingDir, 'data');
+    await mkdir(join(destination, 'pb_data'), { recursive: true });
+    await writeFile(join(destination, 'pb_data', 'data.db'), 'tenant');
+  }
+  if (command === 'tar') {
+    await writeFile(join(stagingDir, 'bundle.tar.gz'), 'archive');
+  }
+  return OK;
+};
+
+test('reads the device with debugfs and never mounts it', async () => {
+  const calls: CommandRequest[] = [];
+  await writeBundle({
+    runner: runnerWritingDump(calls),
+    artifacts,
+    artifact: artifact(),
+    devicePath: DEVICE_PATH,
+    stagingDir,
+  });
+
+  const dump = calls.find((call) => call.command[0] === 'debugfs');
+  expect(dump?.command).toEqual([
+    'debugfs',
+    '-R',
+    `rdump / ${join(stagingDir, 'data')}`,
+    DEVICE_PATH,
+  ]);
+  expect(calls.some((call) => call.command[0] === 'mount')).toBe(false);
+  // No `-w`: a read-only open is what keeps the export off the tenant's write path.
+  expect(dump?.command).not.toContain('-w');
+});
+
+test('archives the data tree and the binary, and not the archive itself', async () => {
+  const calls: CommandRequest[] = [];
+  const bundle = await writeBundle({
+    runner: runnerWritingDump(calls),
+    artifacts,
+    artifact: artifact(),
+    devicePath: DEVICE_PATH,
+    stagingDir,
+  });
+
+  const tar = calls.find((call) => call.command[0] === 'tar');
+  expect(tar?.command).toEqual([
+    'tar',
+    'czf',
+    join(stagingDir, 'bundle.tar.gz'),
+    '-C',
+    stagingDir,
+    'data',
+    'server',
+  ]);
+  expect(tar?.command).not.toContain('.');
+  expect(bundle.sizeBytes).toBeGreaterThan(0);
+});
+
+test('a dump that produced nothing is an error rather than an empty bundle', () => {
+  const runner = async (request: CommandRequest) => {
+    if (request.command[0] === 'tar') {
+      await writeFile(join(stagingDir, 'bundle.tar.gz'), 'archive');
+    }
+    return OK;
+  };
+
+  expect(
+    writeBundle({
+      runner,
+      artifacts,
+      artifact: artifact(),
+      devicePath: DEVICE_PATH,
+      stagingDir,
+    }),
+  ).rejects.toThrow(EmptyDumpError);
+});

--- a/apps/agent/src/exports/bundle.ts
+++ b/apps/agent/src/exports/bundle.ts
@@ -1,0 +1,96 @@
+import { mkdir, readdir, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { DesiredArtifact } from '@repo/protocol';
+import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
+import { type ArtifactBytes, downloadAndVerify } from '#vm/artifacts.ts';
+
+const STAGING_MODE = 0o700;
+const DATA_DIRECTORY = 'data';
+const BINARY_NAME = 'server';
+const BUNDLE_NAME = 'bundle.tar.gz';
+// A tenant filesystem is unbounded where every other subprocess here is not, and the default
+// would abort a large export part-way with nothing to distinguish it from a broken device.
+const DUMP_TIMEOUT_MS = 3_600_000;
+
+export class EmptyDumpError extends Error {
+  constructor(devicePath: string) {
+    super(`debugfs produced nothing from ${devicePath}`);
+    this.name = 'EmptyDumpError';
+  }
+}
+
+/**
+ * Reads the tenant's filesystem with `debugfs`, which walks inodes in userspace.
+ *
+ * This is the rule from `volumes/ext4.ts` held at its sharpest: the bundle is built from a
+ * filesystem the host never asks its kernel to interpret, so a malformed or hostile image is a
+ * userspace failure rather than a host one. Mounting it — even read-only — would hand
+ * tenant-controlled metadata to the kernel and give up the property the design is built on.
+ *
+ * `debugfs` reports a failed `rdump` on stderr and still exits 0, so an empty destination is
+ * the only reliable signal that nothing came out.
+ */
+async function dumpFilesystem({
+  runner,
+  devicePath,
+  destination,
+}: {
+  runner: CommandRunner;
+  devicePath: string;
+  destination: string;
+}): Promise<void> {
+  await mkdir(destination, { recursive: true, mode: STAGING_MODE });
+  await runCommandOrThrow({
+    runner,
+    request: {
+      command: ['debugfs', '-R', `rdump / ${destination}`, devicePath],
+      timeoutMs: DUMP_TIMEOUT_MS,
+    },
+  });
+  if ((await readdir(destination)).length === 0) {
+    throw new EmptyDumpError(devicePath);
+  }
+}
+
+/**
+ * Builds the downloadable copy of one app: the binary it runs and the filesystem it wrote.
+ *
+ * The binary is fetched from the artifact bucket rather than lifted out of the local squashfs
+ * cache, because `downloadAndVerify` proves the digest on the way past and unpacking a squashfs
+ * would prove nothing about what is inside it.
+ */
+export async function writeBundle({
+  runner,
+  artifacts,
+  artifact,
+  devicePath,
+  stagingDir,
+}: {
+  runner: CommandRunner;
+  artifacts: ArtifactBytes;
+  artifact: DesiredArtifact;
+  devicePath: string;
+  stagingDir: string;
+}): Promise<{ path: string; sizeBytes: number }> {
+  await rm(stagingDir, { recursive: true, force: true });
+  await mkdir(stagingDir, { recursive: true, mode: STAGING_MODE });
+
+  await dumpFilesystem({ runner, devicePath, destination: join(stagingDir, DATA_DIRECTORY) });
+  await downloadAndVerify({
+    source: artifacts,
+    artifact,
+    destination: join(stagingDir, BINARY_NAME),
+  });
+
+  const bundlePath = join(stagingDir, BUNDLE_NAME);
+  await runCommandOrThrow({
+    runner,
+    request: {
+      // Named entries rather than `.`, which would sweep the archive into itself.
+      command: ['tar', 'czf', bundlePath, '-C', stagingDir, DATA_DIRECTORY, BINARY_NAME],
+      timeoutMs: DUMP_TIMEOUT_MS,
+    },
+  });
+
+  return { path: bundlePath, sizeBytes: (await stat(bundlePath)).size };
+}

--- a/apps/agent/src/exports/manager.ts
+++ b/apps/agent/src/exports/manager.ts
@@ -1,0 +1,119 @@
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { DesiredArtifact, DesiredExport, ReportedExport } from '@repo/protocol';
+import type { InstanceCredentialProvider } from '#aws/instance-credentials.ts';
+import { writeBundle } from '#exports/bundle.ts';
+import { nowTimestamp } from '#lib/clock.ts';
+import type { CommandRunner } from '#lib/exec.ts';
+import { logger } from '#lib/logger.ts';
+import type { ArtifactBytes } from '#vm/artifacts.ts';
+import type { ZerofsTopology } from '#volumes/topology.ts';
+
+const UPLOAD_PART_SIZE_BYTES = 8_388_608;
+const UPLOAD_QUEUE_SIZE = 4;
+const UPLOAD_RETRIES = 3;
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+// Structural rather than schema-driven, for the same reason as `readInstanceRecords`: this is
+// the agent's own note of what it wrote, not a message from another program. A record that
+// cannot be read back is dropped, which costs one re-written bundle rather than a failed start.
+const isReportedExport = (value: unknown): value is ReportedExport =>
+  isObject(value) && typeof value.exportId === 'string' && typeof value.state === 'string';
+
+export const readExportReports = (value: unknown): ReportedExport[] =>
+  Array.isArray(value) ? value.filter(isReportedExport) : [];
+
+export type ExportManagerOptions = {
+  runner: CommandRunner;
+  topology: ZerofsTopology;
+  artifacts: ArtifactBytes;
+  credentials: InstanceCredentialProvider;
+  bucket: string;
+  region: string;
+  stagingDir: string;
+};
+
+export class ExportManager {
+  readonly #options: ExportManagerOptions;
+
+  constructor(options: ExportManagerOptions) {
+    this.#options = options;
+  }
+
+  /**
+   * Writes one bundle and uploads it, then removes every local trace of it.
+   *
+   * The staging tree is a second copy of a tenant's entire dataset sitting in the clear on a
+   * shared host, so it is deleted whether or not the upload worked — a failed export must not
+   * leave one behind for the next one to trip over or for anything else on the box to read.
+   */
+  async write({
+    desired,
+    artifact,
+    devicePath,
+  }: {
+    desired: DesiredExport;
+    artifact: DesiredArtifact;
+    devicePath: string;
+  }): Promise<ReportedExport> {
+    const stagingDir = join(this.#options.stagingDir, desired.exportId);
+    try {
+      // Under `ignore_fsync` the guest's own barriers are not durability points, so this is what
+      // turns its acknowledged writes into bytes the device will actually hand back.
+      await this.#options.topology.place().admin.flush();
+
+      const bundle = await writeBundle({
+        runner: this.#options.runner,
+        artifacts: this.#options.artifacts,
+        artifact,
+        devicePath,
+        stagingDir,
+      });
+      await this.#upload({ path: bundle.path, objectKey: desired.objectKey });
+
+      logger.info({
+        message: 'export written',
+        exportId: desired.exportId,
+        objectKey: desired.objectKey,
+        sizeBytes: bundle.sizeBytes,
+      });
+      return {
+        exportId: desired.exportId,
+        state: 'ready',
+        sizeBytes: bundle.sizeBytes,
+        readyAt: nowTimestamp(),
+      };
+    } finally {
+      await rm(stagingDir, { recursive: true, force: true });
+    }
+  }
+
+  async #upload({ path, objectKey }: { path: string; objectKey: string }): Promise<void> {
+    const resolved = await this.#options.credentials.resolve();
+    const client = new Bun.S3Client({
+      bucket: this.#options.bucket,
+      region: this.#options.region,
+      accessKeyId: resolved.accessKeyId,
+      secretAccessKey: resolved.secretAccessKey,
+      ...(resolved.sessionToken ? { sessionToken: resolved.sessionToken } : {}),
+    });
+
+    // Streamed in parts rather than read into memory: a bundle is a tenant's whole dataset, and
+    // the host has no bound on it that this process could hold.
+    //
+    // A throw before `end()` leaves the multipart upload uncommitted rather than publishing a
+    // truncated bundle, and the bucket's `abort_incomplete_multipart_upload` rule reaps it —
+    // which is why writing exports needs no delete permission.
+    const writer = client.file(objectKey).writer({
+      partSize: UPLOAD_PART_SIZE_BYTES,
+      queueSize: UPLOAD_QUEUE_SIZE,
+      retry: UPLOAD_RETRIES,
+    });
+    for await (const chunk of Bun.file(path).stream()) {
+      writer.write(chunk);
+    }
+    await writer.end();
+  }
+}

--- a/apps/agent/src/reconcile/plan.test.ts
+++ b/apps/agent/src/reconcile/plan.test.ts
@@ -5,6 +5,7 @@ import type {
   DeploymentId,
   DesiredInstance,
   DesiredVolume,
+  ExportId,
   HostDesiredState,
   HostId,
   InstanceId,
@@ -75,6 +76,7 @@ const observedState = (overrides: Partial<ObservedState> = {}): ObservedState =>
   instances: [],
   volumes: [],
   checkpoints: [],
+  exports: [],
   ...overrides,
 });
 
@@ -339,5 +341,51 @@ describe('checkpoints', () => {
       observed: observedState({ checkpoints: [{ checkpointId, volumeId: VOLUME }] }),
     });
     expect(remove.checkpoints[0]?.action).toBe('delete');
+  });
+});
+
+describe('exports', () => {
+  const exportId = 'exp-1' as ExportId;
+  const desiredExport = (overrides = {}) => ({
+    exportId,
+    appId: APP,
+    volumeId: VOLUME,
+    objectKey: 'exports/app-1/exp-1.tar.gz' as ObjectKey,
+    desiredState: 'present' as const,
+    ...overrides,
+  });
+
+  test('a bundle this host has not written is written', () => {
+    const plan = planReconcile({
+      desired: desiredState({ exports: [desiredExport()] }),
+      observed: observedState(),
+    });
+    expect(plan.exports).toEqual([{ action: 'write', desired: desiredExport() }]);
+  });
+
+  test('a bundle already written is never written twice', () => {
+    const plan = planReconcile({
+      desired: desiredState({ exports: [desiredExport()] }),
+      observed: observedState({ exports: [{ exportId, written: true }] }),
+    });
+    expect(plan.exports[0]?.action).toBe('none');
+  });
+
+  // A failed export is remembered as a record but not as a bundle, so the next reconcile is
+  // what retries it — the one case where re-reading the whole filesystem is the right answer.
+  test('a bundle that failed is retried', () => {
+    const plan = planReconcile({
+      desired: desiredState({ exports: [desiredExport()] }),
+      observed: observedState({ exports: [{ exportId, written: false }] }),
+    });
+    expect(plan.exports[0]?.action).toBe('write');
+  });
+
+  test('absent forgets the record rather than deleting an object it cannot reach', () => {
+    const plan = planReconcile({
+      desired: desiredState({ exports: [desiredExport({ desiredState: 'absent' })] }),
+      observed: observedState({ exports: [{ exportId, written: true }] }),
+    });
+    expect(plan.exports).toEqual([{ action: 'forget', exportId }]);
   });
 });

--- a/apps/agent/src/reconcile/plan.ts
+++ b/apps/agent/src/reconcile/plan.ts
@@ -3,8 +3,10 @@ import type {
   CheckpointId,
   DeploymentId,
   DesiredCheckpoint,
+  DesiredExport,
   DesiredInstance,
   DesiredVolume,
+  ExportId,
   HostDesiredState,
   InstanceId,
   VolumeId,
@@ -39,10 +41,25 @@ export type ObservedCheckpoint = {
   volumeId: VolumeId;
 };
 
+/**
+ * An export this host has already written, as it remembers it.
+ *
+ * The one thing here that is remembered rather than observed. Every other observation is a
+ * question asked of the host — systemd, the ZeroFS mount, the admin RPC — but a host holds
+ * write-only credentials on the export bucket, so it cannot read back whether the object it
+ * produced is there. Re-writing on doubt is not the safe default it usually is: it would
+ * re-upload a tenant's entire dataset on every agent restart.
+ */
+export type ObservedExport = {
+  exportId: ExportId;
+  written: boolean;
+};
+
 export type ObservedState = {
   instances: ObservedInstance[];
   volumes: ObservedVolume[];
   checkpoints: ObservedCheckpoint[];
+  exports: ObservedExport[];
 };
 
 export const INSTANCE_STOP_REASONS = ['desired-stopped', 'not-desired', 'superseded'] as const;
@@ -67,10 +84,21 @@ export type CheckpointPlan =
   | { action: 'delete'; desired: DesiredCheckpoint }
   | { action: 'none'; checkpointId: CheckpointId };
 
+/**
+ * `forget` rather than `delete`: the host cannot remove an object it has no delete permission
+ * for, and does not need to. Expiry is the bucket's lifecycle rule, which is what makes it
+ * unforgettable — so `absent` here means this host stops carrying the record, nothing more.
+ */
+export type ExportPlan =
+  | { action: 'write'; desired: DesiredExport }
+  | { action: 'forget'; exportId: ExportId }
+  | { action: 'none'; exportId: ExportId };
+
 export type ReconcilePlan = {
   instances: InstancePlan[];
   volumes: VolumePlan[];
   checkpoints: CheckpointPlan[];
+  exports: ExportPlan[];
 };
 
 const byId = <Item, Key extends string>({
@@ -101,6 +129,7 @@ export function planReconcile({
     instances: planInstances({ desired, observed }),
     volumes: planVolumes({ desired, observed }),
     checkpoints: planCheckpoints({ desired, observed }),
+    exports: planExports({ desired, observed }),
   };
 }
 
@@ -195,6 +224,34 @@ function planVolumes({
       return { action: 'provision', desired: wanted };
     }
     return { action: 'none', volumeId: wanted.volumeId };
+  });
+}
+
+/**
+ * An export is written once and never rewritten.
+ *
+ * Unlike every other plan here this one is not a diff against reality, because the host cannot
+ * see the bucket it writes to. A bundle already written is left alone even if the object has
+ * since been deleted or expired underneath it — re-reading a tenant's whole filesystem on the
+ * strength of a guess is worse than an export the control plane has to ask for again.
+ */
+function planExports({
+  desired,
+  observed,
+}: {
+  desired: HostDesiredState;
+  observed: ObservedState;
+}): ExportPlan[] {
+  const writtenIds = new Set(
+    observed.exports.filter((current) => current.written).map((current) => current.exportId),
+  );
+  return desired.exports.map((wanted): ExportPlan => {
+    if (wanted.desiredState === 'absent') {
+      return { action: 'forget', exportId: wanted.exportId };
+    }
+    return writtenIds.has(wanted.exportId)
+      ? { action: 'none', exportId: wanted.exportId }
+      : { action: 'write', desired: wanted };
   });
 }
 

--- a/apps/agent/src/reconcile/reconciler.ts
+++ b/apps/agent/src/reconcile/reconciler.ts
@@ -2,14 +2,17 @@ import type {
   AppId,
   DesiredInstance,
   DesiredVolume,
+  ExportId,
   HostDesiredState,
   InstanceId,
   ObjectKey,
   ReportedCheckpoint,
+  ReportedExport,
   ReportedVolume,
   VolumeId,
 } from '@repo/protocol';
 import type { AgentConfig } from '#config.ts';
+import { type ExportManager, readExportReports } from '#exports/manager.ts';
 import { probeInstance } from '#health/probe.ts';
 import { applyProbe, evaluateInstanceState, initialTracker } from '#health/state.ts';
 import { isReadyToRetry, nextAttemptWindow } from '#lib/backoff.ts';
@@ -23,6 +26,7 @@ import { applyRuleset } from '#network/nftables.ts';
 import type { CaddyProxy } from '#proxy/caddy.ts';
 import {
   type CheckpointPlan,
+  type ExportPlan,
   type ObservedState,
   planReconcile,
   type ReconcilePlan,
@@ -56,6 +60,7 @@ export type ReconcilerOptions = {
   units: SystemdVmUnits;
   vms: VmManager;
   volumes: VolumeManager;
+  exports: ExportManager;
   topology: ZerofsTopology;
   allocator: SlotAllocator;
   proxy: CaddyProxy;
@@ -76,6 +81,7 @@ export class Reconciler {
   readonly #allocator: SlotAllocator;
   #volumeReports: ReportedVolume[] = [];
   #checkpointReports: ReportedCheckpoint[] = [];
+  readonly #exportReports = new Map<ExportId, ReportedExport>();
   #observedGeneration = NO_GENERATION;
   #converged = false;
 
@@ -104,6 +110,10 @@ export class Reconciler {
     return this.#checkpointReports;
   }
 
+  exportReports(): ReportedExport[] {
+    return [...this.#exportReports.values()];
+  }
+
   // What the local user-app proxy renders its config from — the same records the boot path
   // writes, rather than a second copy of them.
   routes(): RouteTarget[] {
@@ -116,10 +126,16 @@ export class Reconciler {
     )) {
       this.#records.set(record.instanceId, record);
     }
+    for (const report of readExportReports(
+      await readJsonFile({ path: this.#options.config.exportsFile }),
+    )) {
+      this.#exportReports.set(report.exportId, report);
+    }
     logger.info({
       message: 'agent state loaded',
       instances: this.#records.size,
       slots: this.#allocator.slots().length,
+      exports: this.#exportReports.size,
     });
   }
 
@@ -167,6 +183,10 @@ export class Reconciler {
       // Listing checkpoints costs an RPC round trip on every reconcile, and almost every
       // reconcile has none to converge. The list is read once, inside the branch that needs it.
       checkpoints: [],
+      exports: [...this.#exportReports.values()].map((report) => ({
+        exportId: report.exportId,
+        written: report.state === 'ready',
+      })),
     };
   }
 
@@ -179,6 +199,9 @@ export class Reconciler {
     await this.#applyVolumes(plan);
     await this.#applyStarts(plan);
     await this.#applyCheckpoints({ plan, desired });
+    // After starts, so an export never competes with a boot for the device it reads, and before
+    // teardowns, so a volume marked absent in the same generation is still there to read from.
+    await this.#applyExports({ plan, desired });
     await this.#applyTeardowns(plan);
     await this.#applyNetwork();
     await this.#applyRoutes();
@@ -504,6 +527,61 @@ export class Reconciler {
     }
   }
 
+  async #applyExports({
+    plan,
+    desired,
+  }: {
+    plan: ReconcilePlan;
+    desired: HostDesiredState;
+  }): Promise<void> {
+    for (const action of plan.exports) {
+      if (action.action === 'none') {
+        continue;
+      }
+      if (action.action === 'forget') {
+        this.#exportReports.delete(action.exportId);
+        continue;
+      }
+      this.#exportReports.set(
+        action.desired.exportId,
+        await this.#writeExport({ action, desired }),
+      );
+    }
+  }
+
+  /**
+   * The artifact is joined from the instance desired state rather than carried on the export,
+   * so a bundle can only ever pair a filesystem with the binary this host was told to run
+   * against it. An app with no instance here has no such pairing, and reporting that is more
+   * use than shipping half a bundle.
+   */
+  async #writeExport({
+    action,
+    desired,
+  }: {
+    action: Extract<ExportPlan, { action: 'write' }>;
+    desired: HostDesiredState;
+  }): Promise<ReportedExport> {
+    const { exportId, appId } = action.desired;
+    const artifact = desired.instances.find((instance) => instance.appId === appId)?.artifact;
+    const devicePath = this.#allocator.lookup(appId)?.nbdDevicePath;
+
+    if (!artifact || !devicePath) {
+      const reason = artifact
+        ? 'no device attached for this app'
+        : 'no instance to take a binary from';
+      logger.error({ message: 'export not writable here', exportId, appId, reason });
+      return { exportId, state: 'failed', message: truncate(reason) };
+    }
+
+    try {
+      return await this.#options.exports.write({ desired: action.desired, artifact, devicePath });
+    } catch (error) {
+      logger.error({ message: 'export failed', exportId, appId, ...describeError(error) });
+      return { exportId, state: 'failed', message: truncate(describeError(error).error) };
+    }
+  }
+
   #adminFor(): ZerofsAdmin {
     return this.#options.topology.place().admin;
   }
@@ -564,6 +642,7 @@ export class Reconciler {
       value: this.#allocator.toRecords(),
     });
     await writeJsonFile({ path: this.#options.config.instancesFile, value: this.records() });
+    await writeJsonFile({ path: this.#options.config.exportsFile, value: this.exportReports() });
   }
 }
 

--- a/apps/agent/src/report/build-report.test.ts
+++ b/apps/agent/src/report/build-report.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   type DeploymentId,
+  type ExportId,
   type GuestPort,
   type HostId,
   type Hostname,
@@ -28,6 +29,7 @@ const AT = '2026-08-03T10:00:00.000Z' as Timestamp;
 const DIGEST_HEX_LENGTH = 64;
 const FIRST_HOST_PORT = 21_000 as HostPort;
 const OBSERVED_GENERATION = 7;
+const BUNDLE_SIZE_BYTES = 1_782_579;
 const HOST_VCPUS = 4;
 const HOST_MEMORY_MIB = 8_192;
 const HOST_CACHE_BYTES = 1_000;
@@ -90,6 +92,14 @@ describe('the assembled report satisfies the protocol', () => {
       records: [record({ startedAt: AT })],
       volumes: [{ volumeId: 'vol-1' as VolumeId, state: 'ready', sizeBytes: VOLUME_SIZE_BYTES }],
       checkpoints: [],
+      exports: [
+        {
+          exportId: 'exp-1' as ExportId,
+          state: 'ready',
+          sizeBytes: BUNDLE_SIZE_BYTES,
+          readyAt: AT,
+        },
+      ],
     });
     expect(isValidMessage({ schema: HostReportedStateSchema, value: report })).toBe(true);
   });

--- a/apps/agent/src/report/build-report.ts
+++ b/apps/agent/src/report/build-report.ts
@@ -5,6 +5,7 @@ import type {
   HostState,
   HostVersions,
   ReportedCheckpoint,
+  ReportedExport,
   ReportedInstance,
   ReportedVolume,
   Timestamp,
@@ -43,6 +44,7 @@ export function buildReportedState({
   records,
   volumes,
   checkpoints,
+  exports,
 }: {
   hostId: HostId;
   observedGeneration: number;
@@ -54,6 +56,7 @@ export function buildReportedState({
   records: readonly InstanceRecord[];
   volumes: readonly ReportedVolume[];
   checkpoints: readonly ReportedCheckpoint[];
+  exports: readonly ReportedExport[];
 }): HostReportedState {
   return {
     hostId,
@@ -66,7 +69,6 @@ export function buildReportedState({
     volumes: [...volumes],
     instances: records.map(toReportedInstance),
     checkpoints: [...checkpoints],
-    // Writing exports is not implemented yet, so this host has none to report.
-    exports: [],
+    exports: [...exports],
   };
 }

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
   type DeploymentId,
+  type ExportId,
   type GuestPort,
   type HostDesiredState,
   type HostId,
@@ -33,7 +34,7 @@ const VOLUME_SIZE_BYTES = 8_589_934_592;
 const POCKETBASE_PORT = 8090 as GuestPort;
 
 const DESIRED_APP = {
-  generation: 3,
+  generation: 4,
   volumes: [
     {
       volumeId: 'vol-pocketbase' as VolumeId,
@@ -74,7 +75,18 @@ const DESIRED_APP = {
     },
   ],
   checkpoints: [],
-  exports: [],
+  // Written once by the host that owns the volume, then never rewritten — so bumping
+  // `generation` alone will not produce a second bundle. Asking for another means a new
+  // `exportId` and a new key, which is what the table behind this will hand out per request.
+  exports: [
+    {
+      exportId: 'exp-pocketbase-1' as ExportId,
+      appId: APP_ID,
+      volumeId: 'vol-pocketbase' as VolumeId,
+      objectKey: `exports/${APP_ID}/exp-pocketbase-1.tar.gz` as ObjectKey,
+      desiredState: 'present',
+    },
+  ],
 } satisfies Omit<HostDesiredState, 'hostId'>;
 
 export class AgentRepository extends Repository {

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -239,6 +239,7 @@ cat > /etc/nibrun/agent.env.new <<EOF
 AGENT_CONTROL_PLANE_URL=${CONTROL_PLANE_INTERNAL_URL}
 AGENT_BOOTSTRAP_TOKEN_FILE=/var/lib/nibrun/bootstrap-token
 AGENT_ARTIFACT_BUCKET=${ARTIFACTS_BUCKET}
+AGENT_EXPORT_BUCKET=${EXPORTS_BUCKET}
 # A tenant microVM reaching the api's internal port would be reaching it as the
 # host, with the host's standing. Named here rather than left to the blanket
 # private-address rule, so the ruleset on the box says why.

--- a/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
+++ b/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
@@ -33,6 +33,7 @@ const sharedEnv: Record<string, string> = {
   FILESYSTEMS_BUCKET: requiredEnv('FILESYSTEMS_BUCKET'),
   GUEST_IMAGES_BUCKET: requiredEnv('GUEST_IMAGES_BUCKET'),
   ARTIFACTS_BUCKET: requiredEnv('ARTIFACTS_BUCKET'),
+  EXPORTS_BUCKET: requiredEnv('EXPORTS_BUCKET'),
   AGENT_VERSION: revision,
   AGENT_URL: requiredEnv('AGENT_URL'),
   ZEROFS_VERSION: versions.zerofs.version,


### PR DESCRIPTION
The protocol has described exports since it was written and nothing produced one — `planReconcile` ignored `desired.exports`, and the report hardcoded an empty list.

The bundle is read with `debugfs -R rdump`, which walks inodes in userspace, holding the rule the volume path already rests on at the one point where a whole tenant filesystem gets read. This was measured on the live app host before being written: a dump of the running PocketBase volume produced a complete tree with an intact SQLite header while the VM was serving.

Exports are the one thing the agent remembers rather than observes. A host holds write-only credentials on the export bucket, so it cannot read back what it wrote — and re-writing on doubt would re-upload a tenant's entire dataset on every agent restart. `absent` forgets the record rather than deleting an object; expiry stays the bucket's lifecycle rule.

**Not settled:** consistency under concurrent writes. The bundle is taken from the attached device after a flush, as `domain/checkpoint.ts` describes, but the probe intended to demonstrate tear-freedom ran against an app that had been idle for two hours and proved nothing. A tenant writing during an export can still be captured mid-transaction.