### PR TITLE
chore(infra): give an export seven days rather than one

### DIFF
--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -47,8 +47,8 @@ variable "app_host_data_volume_size" {
 
 variable "export_retention_days" {
   type        = number
-  default     = 1
-  description = "How long a downloadable export survives. A security bound rather than a retention policy: the bundle carries the tenant's environment variables and their whole dataset. S3 lifecycle expiry runs daily, so 1 is the smallest meaningful value."
+  default     = 7
+  description = "How long a downloadable export survives before S3 deletes it. A security bound rather than a retention policy: the bundle carries the tenant's environment variables and their whole dataset. Expiry is evaluated in a daily batch, so this is a floor and not a timer — an object lives at least this long and is removed some hours after. 1 is the smallest meaningful value."
 }
 
 variable "internal_port" {


### PR DESCRIPTION
S3 deletes the bundle itself under the lifecycle rule that already existed; only the bound moves. One day is shorter than a person who requested a download reliably gets to it.

The bound is still a security property rather than a retention policy — the bundle carries the tenant's environment variables and their whole dataset — so the description now also says what the rule actually promises: expiry is evaluated in a daily batch, which makes this a floor and not a timer.