### PR TITLE
fix(agent): a volume is reported for existing, not for being created

### DIFF
--- a/apps/agent/src/reconcile/plan.test.ts
+++ b/apps/agent/src/reconcile/plan.test.ts
@@ -19,7 +19,7 @@ import {
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
 } from '@repo/protocol';
-import { type ObservedState, planReconcile } from '#reconcile/plan.ts';
+import { type ObservedState, type ObservedVolume, planReconcile } from '#reconcile/plan.ts';
 
 const APP = 'app-1' as AppId;
 const VOLUME = 'vol-1' as VolumeId;
@@ -71,6 +71,17 @@ const desiredState = (overrides: Partial<HostDesiredState> = {}): HostDesiredSta
   exports: [],
   ...overrides,
 });
+
+function observedVolume(overrides: Partial<ObservedVolume> = {}): ObservedVolume {
+  return {
+    volumeId: VOLUME,
+    attached: true,
+    sizeBytes: VOLUME_SIZE_BYTES,
+    storagePrefix: 's3://filesystems/host-1' as ObjectKey,
+    devicePath: '/dev/nbd0',
+    ...overrides,
+  };
+}
 
 const observedState = (overrides: Partial<ObservedState> = {}): ObservedState => ({
   instances: [],
@@ -248,7 +259,7 @@ describe('volumes are not authoritative', () => {
     const plan = planReconcile({
       desired: desiredState(),
       observed: observedState({
-        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+        volumes: [observedVolume()],
       }),
     });
     expect(plan.volumes).toEqual([]);
@@ -258,7 +269,7 @@ describe('volumes are not authoritative', () => {
     const plan = planReconcile({
       desired: desiredState({ volumes: [desiredVolume({ desiredState: 'absent' })] }),
       observed: observedState({
-        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+        volumes: [observedVolume()],
       }),
     });
     expect(plan.volumes[0]?.action).toBe('teardown');
@@ -268,7 +279,7 @@ describe('volumes are not authoritative', () => {
     const plan = planReconcile({
       desired: desiredState({ volumes: [desiredVolume({ desiredState: 'absent' })] }),
       observed: observedState({
-        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+        volumes: [observedVolume()],
         instances: [
           {
             instanceId: INSTANCE,
@@ -299,7 +310,7 @@ describe('volumes are not authoritative', () => {
     const small = planReconcile({
       desired: desiredState({ volumes: [desiredVolume({ sizeBytes: GROWN_VOLUME_SIZE_BYTES })] }),
       observed: observedState({
-        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+        volumes: [observedVolume()],
       }),
     });
     expect(small.volumes[0]?.action).toBe('provision');
@@ -307,7 +318,7 @@ describe('volumes are not authoritative', () => {
     const converged = planReconcile({
       desired: desiredState({ volumes: [desiredVolume()] }),
       observed: observedState({
-        volumes: [{ volumeId: VOLUME, attached: true, sizeBytes: VOLUME_SIZE_BYTES }],
+        volumes: [observedVolume()],
       }),
     });
     expect(converged.volumes).toEqual([{ action: 'none', volumeId: VOLUME }]);
@@ -346,14 +357,16 @@ describe('checkpoints', () => {
 
 describe('exports', () => {
   const exportId = 'exp-1' as ExportId;
-  const desiredExport = (overrides = {}) => ({
-    exportId,
-    appId: APP,
-    volumeId: VOLUME,
-    objectKey: 'exports/app-1/exp-1.tar.gz' as ObjectKey,
-    desiredState: 'present' as const,
-    ...overrides,
-  });
+  function desiredExport(overrides = {}) {
+    return {
+      exportId,
+      appId: APP,
+      volumeId: VOLUME,
+      objectKey: 'exports/app-1/exp-1.tar.gz' as ObjectKey,
+      desiredState: 'present' as const,
+      ...overrides,
+    };
+  }
 
   test('a bundle this host has not written is written', () => {
     const plan = planReconcile({

--- a/apps/agent/src/reconcile/plan.ts
+++ b/apps/agent/src/reconcile/plan.ts
@@ -9,6 +9,7 @@ import type {
   ExportId,
   HostDesiredState,
   InstanceId,
+  ObjectKey,
   VolumeId,
 } from '@repo/protocol';
 
@@ -30,10 +31,19 @@ export type ObservedInstance = {
   exited: boolean;
 };
 
+/**
+ * A device file found in a ZeroFS filesystem, and where it was found.
+ *
+ * `storagePrefix` and `devicePath` are carried here rather than looked up again by whoever
+ * reports: this is the only point that knows which filesystem the file was enumerated from, and
+ * a second derivation of it is a second thing that can disagree.
+ */
 export type ObservedVolume = {
   volumeId: VolumeId;
   attached: boolean;
   sizeBytes: number;
+  storagePrefix: ObjectKey;
+  devicePath?: string;
 };
 
 export type ObservedCheckpoint = {

--- a/apps/agent/src/reconcile/reconciler.ts
+++ b/apps/agent/src/reconcile/reconciler.ts
@@ -39,7 +39,7 @@ import {
 import { type RouteTarget, renderableRoutes } from '#report/routes.ts';
 import type { VmManager } from '#vm/manager.ts';
 import type { SystemdVmUnits, UnitStatus } from '#vm/systemd.ts';
-import type { VolumeManager } from '#volumes/manager.ts';
+import { toReportedVolume, type VolumeManager } from '#volumes/manager.ts';
 import type { ZerofsTopology } from '#volumes/topology.ts';
 import type { ZerofsAdmin } from '#volumes/zerofs.ts';
 
@@ -196,7 +196,7 @@ export class Reconciler {
     this.#syncDesired(desired);
 
     await this.#applyStops(plan);
-    await this.#applyVolumes(plan);
+    await this.#applyVolumes({ plan, observed });
     await this.#applyStarts(plan);
     await this.#applyCheckpoints({ plan, desired });
     // After starts, so an export never competes with a boot for the device it reads, and before
@@ -336,7 +336,13 @@ export class Reconciler {
     }
   }
 
-  async #applyVolumes(plan: ReconcilePlan): Promise<void> {
+  async #applyVolumes({
+    plan,
+    observed,
+  }: {
+    plan: ReconcilePlan;
+    observed: ObservedState;
+  }): Promise<void> {
     const reports: ReportedVolume[] = [];
     for (const action of plan.volumes) {
       if (action.action === 'provision') {
@@ -350,7 +356,13 @@ export class Reconciler {
         });
       }
     }
-    this.#volumeReports = mergeVolumeReports({ existing: this.#volumeReports, updates: reports });
+    // Rebuilt from what this reconcile found rather than added to what the last one left, so a
+    // volume nobody touched still reports itself. What just happened to a volume wins over what
+    // it looked like beforehand — a provision that failed says so.
+    this.#volumeReports = mergeVolumeReports({
+      existing: observed.volumes.map(toReportedVolume),
+      updates: reports,
+    });
   }
 
   async #provision(desired: DesiredVolume): Promise<ReportedVolume> {

--- a/apps/agent/src/volumes/manager.test.ts
+++ b/apps/agent/src/volumes/manager.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import type { ObjectKey, VolumeId } from '@repo/protocol';
+import type { ObservedVolume } from '#reconcile/plan.ts';
+import { toReportedVolume } from '#volumes/manager.ts';
+
+const VOLUME = 'vol-1' as VolumeId;
+const HOST_PREFIX = 'filesystems/host-1' as ObjectKey;
+const VOLUME_SIZE_BYTES = 8_589_934_592;
+
+function observed(overrides: Partial<ObservedVolume> = {}): ObservedVolume {
+  return {
+    volumeId: VOLUME,
+    attached: true,
+    sizeBytes: VOLUME_SIZE_BYTES,
+    storagePrefix: HOST_PREFIX,
+    devicePath: '/dev/nbd0',
+    ...overrides,
+  };
+}
+
+describe('a volume reports itself from having been found', () => {
+  // The regression: reports used to accumulate from provisioning, so a volume nobody touched
+  // this reconcile went unreported — and after a restart a host serving a volume reported none.
+  test('a healthy volume is reportable without anything having provisioned it', () => {
+    expect(toReportedVolume(observed())).toEqual({
+      volumeId: VOLUME,
+      state: 'ready',
+      sizeBytes: VOLUME_SIZE_BYTES,
+      storagePrefix: HOST_PREFIX,
+      devicePath: '/dev/nbd0',
+    });
+  });
+
+  test('a device file with nothing attached to it is detached rather than ready', () => {
+    expect(toReportedVolume(observed({ attached: false })).state).toBe('detached');
+  });
+
+  // Where the volume went is what the control plane cannot derive for itself, so it is the one
+  // field that must survive being reported by a host that merely found the file.
+  test('the storage prefix is carried even when no device is attached', () => {
+    const report = toReportedVolume(observed({ attached: false, devicePath: undefined }));
+    expect(report.storagePrefix).toBe(HOST_PREFIX);
+    expect(report).not.toHaveProperty('devicePath');
+  });
+});

--- a/apps/agent/src/volumes/manager.ts
+++ b/apps/agent/src/volumes/manager.ts
@@ -18,6 +18,25 @@ export type VolumeManagerOptions = {
   allocator: SlotAllocator;
 };
 
+/**
+ * What the host can say about a volume purely from having found it.
+ *
+ * The report is derived from the observation rather than accumulated from provisioning, so a
+ * volume that is simply healthy still reports itself. Building it the other way round meant a
+ * volume was described in the one reconcile that created it and never again — and since these
+ * reports do not survive a restart, an agent that came back reported no volumes at all while
+ * serving one.
+ */
+export function toReportedVolume(observed: ObservedVolume): ReportedVolume {
+  return {
+    volumeId: observed.volumeId,
+    state: observed.attached ? 'ready' : 'detached',
+    sizeBytes: observed.sizeBytes,
+    storagePrefix: observed.storagePrefix,
+    ...(observed.devicePath ? { devicePath: observed.devicePath } : {}),
+  };
+}
+
 export class VolumeManager {
   readonly #options: VolumeManagerOptions;
 
@@ -124,10 +143,15 @@ export class VolumeManager {
       if (sizeBytes === undefined) {
         continue;
       }
+      const slot = this.#slotFor({ volumeId, appIdByVolume });
       observed.push({
         volumeId,
         sizeBytes,
-        attached: await this.#isAttachedFor({ volumeId, appIdByVolume }),
+        storagePrefix: filesystem.storagePrefix,
+        attached: slot
+          ? await isAttached({ runner: this.#options.runner, devicePath: slot.nbdDevicePath })
+          : false,
+        ...(slot ? { devicePath: slot.nbdDevicePath } : {}),
       });
     }
     return observed;
@@ -142,21 +166,14 @@ export class VolumeManager {
     }
   }
 
-  async #isAttachedFor({
+  #slotFor({
     volumeId,
     appIdByVolume,
   }: {
     volumeId: VolumeId;
     appIdByVolume: ReadonlyMap<VolumeId, AppId>;
-  }): Promise<boolean> {
+  }) {
     const appId = appIdByVolume.get(volumeId);
-    if (appId === undefined) {
-      return false;
-    }
-    const slot = this.#options.allocator.lookup(appId);
-    if (!slot) {
-      return false;
-    }
-    return await isAttached({ runner: this.#options.runner, devicePath: slot.nbdDevicePath });
+    return appId === undefined ? undefined : this.#options.allocator.lookup(appId);
   }
 }


### PR DESCRIPTION
A host serving a volume reported none — `volumes: 0` next to a running instance.

Volume reports were accumulated from provisioning rather than derived from observation: `#applyVolumes` only recorded a volume in the reconcile that created it, a healthy volume plans `none`, and the list is in-memory. The description survived until the next agent restart and then never came back, because nothing re-provisions a volume that is already correct.

The observation already existed and already ran every reconcile — `VolumeManager.observe()` enumerates the device files and checks what is attached. It just couldn't name where it found them, so `storagePrefix` and the device path now travel with the observation and the report is built from that. What happened during a reconcile still wins over what was observed before it, so a failed provision still reports the failure.

This is what `ReportedVolume.storagePrefix` was added for in #40: the control plane cannot derive where a volume went, and a value it only learns once is a value it loses.