### PR TITLE
refactor(agent): declare functions with function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Bun + TypeScript monorepo (`apps/*`, `packages/*`).
 - Single source of truth — never duplicate keys, enum values, or type info that belongs to a class/module; derive from the source instead
 - Biome enforces `useMaxParams: 1` — wrap multiple params in an object
 - Only re-export from index files - Biome enforces that
+- Declare functions with `function`, never a `const` bound to an arrow. Applies
+  to test fixtures and one-line helpers too
 
 ## Validation
 

--- a/apps/agent/src/exports/bundle.test.ts
+++ b/apps/agent/src/exports/bundle.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DesiredArtifact, ObjectKey, Sha256Digest } from '@repo/protocol';
 import { EmptyDumpError, writeBundle } from '#exports/bundle.ts';
-import type { CommandRequest, CommandResult } from '#lib/exec.ts';
+import type { CommandRequest, CommandResult, CommandRunner } from '#lib/exec.ts';
 import type { ArtifactBytes } from '#vm/artifacts.ts';
 
 const DEVICE_PATH = '/dev/nbd7';
@@ -23,11 +23,13 @@ const artifacts: ArtifactBytes = {
     ),
 };
 
-const artifact = (): DesiredArtifact => ({
-  digest: new Bun.CryptoHasher('sha256').update(BINARY_BYTES).digest('hex') as Sha256Digest,
-  sizeBytes: BINARY_BYTES.byteLength,
-  objectKey: 'artifacts/app-1/server' as ObjectKey,
-});
+function artifact(): DesiredArtifact {
+  return {
+    digest: new Bun.CryptoHasher('sha256').update(BINARY_BYTES).digest('hex') as Sha256Digest,
+    sizeBytes: BINARY_BYTES.byteLength,
+    objectKey: 'artifacts/app-1/server' as ObjectKey,
+  };
+}
 
 let stagingDir: string;
 
@@ -41,19 +43,21 @@ afterEach(async () => {
 
 // The dump is what a real `debugfs` would leave behind, so the tar step downstream has
 // something to archive.
-const runnerWritingDump = (calls: CommandRequest[]) => async (request: CommandRequest) => {
-  calls.push(request);
-  const [command] = request.command;
-  if (command === 'debugfs') {
-    const destination = join(stagingDir, 'data');
-    await mkdir(join(destination, 'pb_data'), { recursive: true });
-    await writeFile(join(destination, 'pb_data', 'data.db'), 'tenant');
-  }
-  if (command === 'tar') {
-    await writeFile(join(stagingDir, 'bundle.tar.gz'), 'archive');
-  }
-  return OK;
-};
+function runnerWritingDump(calls: CommandRequest[]): CommandRunner {
+  return async (request: CommandRequest) => {
+    calls.push(request);
+    const [command] = request.command;
+    if (command === 'debugfs') {
+      const destination = join(stagingDir, 'data');
+      await mkdir(join(destination, 'pb_data'), { recursive: true });
+      await writeFile(join(destination, 'pb_data', 'data.db'), 'tenant');
+    }
+    if (command === 'tar') {
+      await writeFile(join(stagingDir, 'bundle.tar.gz'), 'archive');
+    }
+    return OK;
+  };
+}
 
 test('reads the device with debugfs and never mounts it', async () => {
   const calls: CommandRequest[] = [];

--- a/apps/agent/src/exports/manager.ts
+++ b/apps/agent/src/exports/manager.ts
@@ -13,17 +13,20 @@ const UPLOAD_PART_SIZE_BYTES = 8_388_608;
 const UPLOAD_QUEUE_SIZE = 4;
 const UPLOAD_RETRIES = 3;
 
-const isObject = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === 'object' && !Array.isArray(value);
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
 
 // Structural rather than schema-driven, for the same reason as `readInstanceRecords`: this is
 // the agent's own note of what it wrote, not a message from another program. A record that
 // cannot be read back is dropped, which costs one re-written bundle rather than a failed start.
-const isReportedExport = (value: unknown): value is ReportedExport =>
-  isObject(value) && typeof value.exportId === 'string' && typeof value.state === 'string';
+function isReportedExport(value: unknown): value is ReportedExport {
+  return isObject(value) && typeof value.exportId === 'string' && typeof value.state === 'string';
+}
 
-export const readExportReports = (value: unknown): ReportedExport[] =>
-  Array.isArray(value) ? value.filter(isReportedExport) : [];
+export function readExportReports(value: unknown): ReportedExport[] {
+  return Array.isArray(value) ? value.filter(isReportedExport) : [];
+}
 
 export type ExportManagerOptions = {
   runner: CommandRunner;


### PR DESCRIPTION
Records the convention in `AGENTS.md` and applies it to the export code, which is where it was broken most recently.

The rest of the repo still binds arrows to consts — `plan.test.ts` fixtures, `device-file.ts` helpers, and others. Converting all of it is a wide diff over code nobody is otherwise touching, so it is left for whoever next edits each file. Happy to do the sweep as its own PR if you'd rather have it done in one go.