### PR TITLE
fix(agent): a deferred teardown eventually happens

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -64,6 +64,7 @@ export class Agent {
   readonly #reconciler: Reconciler;
   readonly #versions: HostVersions;
   #session: AgentSession | undefined;
+  #lastDesired: HostDesiredState | undefined;
   #knownGeneration = FIRST_GENERATION;
   #running = true;
 
@@ -156,6 +157,7 @@ export class Agent {
     const cached = await this.#readCachedDesiredState();
     if (cached) {
       this.#knownGeneration = cached.generation;
+      this.#lastDesired = cached;
       await this.#reconcileSafely(cached);
     }
 
@@ -182,7 +184,13 @@ export class Agent {
         if (response.result === 'changed') {
           await writeJsonFile({ path: this.#desiredStatePath(), value: response.state });
           this.#knownGeneration = response.state.generation;
+          this.#lastDesired = response.state;
           await this.#reconcileSafely(response.state);
+        } else if (this.#reconciler.deferredWork && this.#lastDesired) {
+          // The only thing that re-runs a reconcile is the generation changing, and work the
+          // last one deferred does not change it. A volume waiting on an instance to stop would
+          // otherwise sit until some unrelated edit came along to carry it.
+          await this.#reconcileSafely(this.#lastDesired);
         }
         await Bun.sleep(session.poll.minIntervalMs);
       } catch (error) {

--- a/apps/agent/src/reconcile/plan.test.ts
+++ b/apps/agent/src/reconcile/plan.test.ts
@@ -19,7 +19,12 @@ import {
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
 } from '@repo/protocol';
-import { type ObservedState, type ObservedVolume, planReconcile } from '#reconcile/plan.ts';
+import {
+  hasDeferredWork,
+  type ObservedState,
+  type ObservedVolume,
+  planReconcile,
+} from '#reconcile/plan.ts';
 
 const APP = 'app-1' as AppId;
 const VOLUME = 'vol-1' as VolumeId;
@@ -298,6 +303,20 @@ describe('volumes are not authoritative', () => {
       desired: desiredVolume({ desiredState: 'absent' }),
       blockedBy: [INSTANCE],
     });
+    // Deleting an app takes two passes — stop the instance, then tear the volume down — and
+    // only a generation change runs a pass. Without this the second one never comes.
+    expect(hasDeferredWork(plan)).toBe(true);
+  });
+
+  test('a plan that finished everything leaves nothing to re-run for', () => {
+    const plan = planReconcile({
+      desired: desiredState({ volumes: [desiredVolume()] }),
+      observed: observedState({
+        volumes: [observedVolume()],
+      }),
+    });
+    expect(plan.volumes[0]?.action).toBe('none');
+    expect(hasDeferredWork(plan)).toBe(false);
   });
 
   test('an unattached volume is provisioned and a grown one re-provisioned', () => {

--- a/apps/agent/src/reconcile/plan.ts
+++ b/apps/agent/src/reconcile/plan.ts
@@ -111,6 +111,19 @@ export type ReconcilePlan = {
   exports: ExportPlan[];
 };
 
+/**
+ * Whether this plan left work it could not finish on this pass.
+ *
+ * A blocked teardown is the case that matters: the volume is still held by an instance this
+ * reconcile is only now stopping, so it converges on a later pass. Nothing would otherwise run
+ * one — the agent reconciles when the poll reports a new generation, and a volume it deferred
+ * does not change the generation — so the deletion would wait for an unrelated change to come
+ * along and carry it.
+ */
+export function hasDeferredWork(plan: ReconcilePlan): boolean {
+  return plan.volumes.some((action) => action.action === 'blocked');
+}
+
 const byId = <Item, Key extends string>({
   items,
   key,

--- a/apps/agent/src/reconcile/reconciler.ts
+++ b/apps/agent/src/reconcile/reconciler.ts
@@ -27,6 +27,7 @@ import type { CaddyProxy } from '#proxy/caddy.ts';
 import {
   type CheckpointPlan,
   type ExportPlan,
+  hasDeferredWork,
   type ObservedState,
   planReconcile,
   type ReconcilePlan,
@@ -84,6 +85,7 @@ export class Reconciler {
   readonly #exportReports = new Map<ExportId, ReportedExport>();
   #observedGeneration = NO_GENERATION;
   #converged = false;
+  #deferredWork = false;
 
   constructor(options: ReconcilerOptions) {
     this.#options = options;
@@ -96,6 +98,12 @@ export class Reconciler {
 
   get converged() {
     return this.#converged;
+  }
+
+  // Whether the last reconcile deferred something, and therefore whether running it again
+  // against the same desired state would do anything.
+  get deferredWork() {
+    return this.#deferredWork;
   }
 
   records(): InstanceRecord[] {
@@ -193,6 +201,7 @@ export class Reconciler {
   async reconcile({ desired }: { desired: HostDesiredState }): Promise<void> {
     const observed = await this.observe();
     const plan = planReconcile({ desired, observed });
+    this.#deferredWork = hasDeferredWork(plan);
     this.#syncDesired(desired);
 
     await this.#applyStops(plan);

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -132,15 +132,19 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
 
 # --- Tenant filesystems ---
 #
-# ZeroFS's backing store: one prefix per app, holding the segments that make up
-# that app's disk. Deliberately not a prefix inside artifacts.
+# ZeroFS's backing store. Deliberately not a prefix inside artifacts.
 #
-# Versioning is why it cannot share: artifacts has it enabled, and ZeroFS's GC
-# deletes dead segments continuously, so on a versioned bucket every delete
-# would become a delete marker with the object retained — storage growing
-# without bound while the GC reports reclaiming space. Never enable versioning
-# here. The access patterns are opposite too, and deleting an app means
-# bulk-deleting a prefix, which should happen nowhere near users' binaries.
+# **A prefix here is one host, not one app.** v1 runs a single ZeroFS per app
+# host, so every tenant placed on that host shares its prefix — see the topology
+# note in `apps/agent/src/volumes/topology.ts`. Deleting one app is removing its
+# device file from inside that filesystem, which is what the agent's volume
+# teardown does. Deleting the prefix destroys every tenant on the host.
+#
+# Versioning is why it cannot share with artifacts: artifacts has it enabled,
+# and ZeroFS's GC deletes dead segments continuously, so on a versioned bucket
+# every delete would become a delete marker with the object retained — storage
+# growing without bound while the GC reports reclaiming space. Never enable
+# versioning here.
 #
 # Never put a lifecycle expiry on this bucket either. It holds live data: the
 # host's local disk is the cache, and this is what it is a cache of.


### PR DESCRIPTION
Deleting an app takes two reconciles: the first stops the instance and defers the volume because something still holds it, the second tears it down. But only a generation change runs a reconcile, and deferring a volume doesn't change the generation — so the second pass never came, and the volume waited for an unrelated edit to carry it.

The poll loop now re-runs the last desired state when the previous plan left something blocked, bounded by the long poll — the right cadence for work waiting on a VM to stop.

Also corrects the tenant-filesystem comment in `s3.tf`, which described "one prefix per app" and called deleting an app "bulk-deleting a prefix". v1 runs one ZeroFS per host, so a prefix *is* a host and every tenant on it shares one. Following that comment would have destroyed every tenant on the box to remove a single app.