### PR TITLE
feat(protocol): an artifact carries the name it was uploaded under

### DIFF
--- a/apps/agent/src/exports/bundle.test.ts
+++ b/apps/agent/src/exports/bundle.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, beforeEach, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { DesiredArtifact, ObjectKey, Sha256Digest } from '@repo/protocol';
-import { EmptyDumpError, writeBundle } from '#exports/bundle.ts';
+import type { DesiredArtifact, Filename, ObjectKey, Sha256Digest } from '@repo/protocol';
+import {
+  bundleBinaryName,
+  EmptyDumpError,
+  UnsafeFilenameError,
+  writeBundle,
+} from '#exports/bundle.ts';
 import type { CommandRequest, CommandResult, CommandRunner } from '#lib/exec.ts';
 import type { ArtifactBytes } from '#vm/artifacts.ts';
 
@@ -23,11 +28,14 @@ const artifacts: ArtifactBytes = {
     ),
 };
 
-function artifact(): DesiredArtifact {
+function artifact(overrides: Partial<DesiredArtifact> = {}): DesiredArtifact {
   return {
     digest: new Bun.CryptoHasher('sha256').update(BINARY_BYTES).digest('hex') as Sha256Digest,
     sizeBytes: BINARY_BYTES.byteLength,
-    objectKey: 'artifacts/app-1/server' as ObjectKey,
+    // A uuid, as the api will assign: it carries no name, which is why `filename` exists.
+    objectKey: 'artifacts/9f1c2f0e-0d4e-4a1b-9c3a-1f8b6d2e7a45' as ObjectKey,
+    filename: 'pocketbase' as Filename,
+    ...overrides,
   };
 }
 
@@ -81,7 +89,7 @@ test('reads the device with debugfs and never mounts it', async () => {
   expect(dump?.command).not.toContain('-w');
 });
 
-test('archives the data tree and the binary, and not the archive itself', async () => {
+test('archives the data tree and the binary under its uploaded name', async () => {
   const calls: CommandRequest[] = [];
   const bundle = await writeBundle({
     runner: runnerWritingDump(calls),
@@ -99,10 +107,29 @@ test('archives the data tree and the binary, and not the archive itself', async 
     '-C',
     stagingDir,
     'data',
-    'server',
+    'pocketbase',
   ]);
+  // `.` would sweep the archive into itself.
   expect(tar?.command).not.toContain('.');
   expect(bundle.sizeBytes).toBeGreaterThan(0);
+});
+
+describe('the bundle keeps the name the binary was uploaded under', () => {
+  test('the uploaded name is what lands in the archive', () => {
+    expect(bundleBinaryName(artifact({ filename: 'pocketbase' as Filename }))).toBe('pocketbase');
+  });
+
+  // The schema rejects all of these, so reaching here means a peer that did not honour it.
+  // The bundle is extracted by a person on their own machine; a name that escapes the archive
+  // root writes wherever the traversal points, so it fails rather than being corrected.
+  test.each(['../escape', 'nested/path', '.hidden', '..', '-rf'])(
+    'a name that is a path rather than a filename is refused: %s',
+    (hostile) => {
+      expect(() => bundleBinaryName(artifact({ filename: hostile as Filename }))).toThrow(
+        UnsafeFilenameError,
+      );
+    },
+  );
 });
 
 test('a dump that produced nothing is an error rather than an empty bundle', () => {

--- a/apps/agent/src/exports/bundle.ts
+++ b/apps/agent/src/exports/bundle.ts
@@ -1,12 +1,11 @@
 import { mkdir, readdir, rm, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import type { DesiredArtifact } from '@repo/protocol';
 import { type CommandRunner, runCommandOrThrow } from '#lib/exec.ts';
 import { type ArtifactBytes, downloadAndVerify } from '#vm/artifacts.ts';
 
 const STAGING_MODE = 0o700;
 const DATA_DIRECTORY = 'data';
-const BINARY_NAME = 'server';
 const BUNDLE_NAME = 'bundle.tar.gz';
 // A tenant filesystem is unbounded where every other subprocess here is not, and the default
 // would abort a large export part-way with nothing to distinguish it from a broken device.
@@ -16,6 +15,13 @@ export class EmptyDumpError extends Error {
   constructor(devicePath: string) {
     super(`debugfs produced nothing from ${devicePath}`);
     this.name = 'EmptyDumpError';
+  }
+}
+
+export class UnsafeFilenameError extends Error {
+  constructor(filename: string) {
+    super(`Refusing to write ${JSON.stringify(filename)} into a bundle: it is not a filename`);
+    this.name = 'UnsafeFilenameError';
   }
 }
 
@@ -53,6 +59,23 @@ async function dumpFilesystem({
 }
 
 /**
+ * The name the binary takes inside the bundle.
+ *
+ * Re-checked rather than trusted from the wire, and refused rather than corrected. The schema
+ * already constrains it to a single segment, so anything reaching here that is not one came
+ * from a peer that did not honour the contract — and this value becomes a path inside an
+ * archive somebody extracts on their own machine. Renaming it quietly would leave both the
+ * broken control plane and the attempt unnoticed.
+ */
+export function bundleBinaryName(artifact: DesiredArtifact): string {
+  const { filename } = artifact;
+  if (filename !== basename(filename) || filename.startsWith('.') || filename.startsWith('-')) {
+    throw new UnsafeFilenameError(filename);
+  }
+  return filename;
+}
+
+/**
  * Builds the downloadable copy of one app: the binary it runs and the filesystem it wrote.
  *
  * The binary is fetched from the artifact bucket rather than lifted out of the local squashfs
@@ -75,11 +98,12 @@ export async function writeBundle({
   await rm(stagingDir, { recursive: true, force: true });
   await mkdir(stagingDir, { recursive: true, mode: STAGING_MODE });
 
+  const binaryName = bundleBinaryName(artifact);
   await dumpFilesystem({ runner, devicePath, destination: join(stagingDir, DATA_DIRECTORY) });
   await downloadAndVerify({
     source: artifacts,
     artifact,
-    destination: join(stagingDir, BINARY_NAME),
+    destination: join(stagingDir, binaryName),
   });
 
   const bundlePath = join(stagingDir, BUNDLE_NAME);
@@ -87,7 +111,7 @@ export async function writeBundle({
     runner,
     request: {
       // Named entries rather than `.`, which would sweep the archive into itself.
-      command: ['tar', 'czf', bundlePath, '-C', stagingDir, DATA_DIRECTORY, BINARY_NAME],
+      command: ['tar', 'czf', bundlePath, '-C', stagingDir, DATA_DIRECTORY, binaryName],
       timeoutMs: DUMP_TIMEOUT_MS,
     },
   });

--- a/apps/agent/src/reconcile/plan.test.ts
+++ b/apps/agent/src/reconcile/plan.test.ts
@@ -6,6 +6,7 @@ import type {
   DesiredInstance,
   DesiredVolume,
   ExportId,
+  Filename,
   HostDesiredState,
   HostId,
   InstanceId,
@@ -46,6 +47,7 @@ const desiredInstance = (overrides: Partial<DesiredInstance> = {}): DesiredInsta
     digest: DIGEST,
     sizeBytes: ARTIFACT_SIZE_BYTES,
     objectKey: 'artifacts/a' as ObjectKey,
+    filename: 'server' as Filename,
   },
   config: {
     guestPort: DEFAULT_GUEST_PORT,

--- a/apps/agent/src/vm/artifacts.test.ts
+++ b/apps/agent/src/vm/artifacts.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { DesiredArtifact, ObjectKey, Sha256Digest } from '@repo/protocol';
+import type { DesiredArtifact, Filename, ObjectKey, Sha256Digest } from '@repo/protocol';
 import {
   type ArtifactBytes,
   ArtifactSizeError,
@@ -31,12 +31,15 @@ const bytesOf = (chunks: Uint8Array[]): ArtifactBytes => ({
     ),
 });
 
-const artifact = (overrides: Partial<DesiredArtifact> = {}): DesiredArtifact => ({
-  digest: CONTENT_DIGEST,
-  sizeBytes: CONTENT.byteLength,
-  objectKey: 'artifacts/app-1/binary' as ObjectKey,
-  ...overrides,
-});
+function artifact(overrides: Partial<DesiredArtifact> = {}): DesiredArtifact {
+  return {
+    digest: CONTENT_DIGEST,
+    sizeBytes: CONTENT.byteLength,
+    objectKey: 'artifacts/app-1/binary' as ObjectKey,
+    filename: 'server' as Filename,
+    ...overrides,
+  };
+}
 
 let directory: string;
 

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_RESTART_POLICY,
   type DeploymentId,
   type ExportId,
+  type Filename,
   type GuestPort,
   type HostDesiredState,
   type HostId,
@@ -54,6 +55,7 @@ const DESIRED_APP = {
         // Uploaded by hand; the agent hashes the stream as it downloads and refuses
         // on either mismatch, so both values below are load-bearing.
         objectKey: 'artifacts/app-pocketbase/pb-0-39-10' as ObjectKey,
+        filename: 'pocketbase' as Filename,
         digest: 'f119018534e7a9e0db837c2811dda589d03bbdb78a03decc0664aac864e53814' as Sha256Digest,
         sizeBytes: 32_096_418,
       },

--- a/packages/protocol/src/control/desired-state.ts
+++ b/packages/protocol/src/control/desired-state.ts
@@ -10,7 +10,7 @@ import {
   VolumeIdSchema,
 } from '#domain/identifiers.ts';
 import { stringEnum } from '#lib/string-enum.ts';
-import { ByteSizeSchema, ObjectKeySchema, Sha256DigestSchema } from '#lib/wire.ts';
+import { ByteSizeSchema, FilenameSchema, ObjectKeySchema, Sha256DigestSchema } from '#lib/wire.ts';
 
 // What a host should be running. There is deliberately nothing here shaped like `start(x)` or
 // `stop(x)`: the control plane describes a world and the agent converges on it, so a missed
@@ -29,10 +29,20 @@ export const DesiredPresenceSchema = stringEnum(DESIRED_PRESENCE);
 
 export type DesiredPresence = typeof DesiredPresenceSchema.static;
 
+/**
+ * `filename` is what the uploader called the binary, and it exists because `objectKey` cannot
+ * answer that: keys are assigned to avoid collisions, so they carry no name. Nothing on the
+ * host boots from it — the guest execs a fixed path by boot contract — and its only use is the
+ * name the binary takes inside an export, which is the one place a person sees it again.
+ *
+ * Required, because an upload nobody has completed is not deployable: by the time an artifact
+ * appears here it has been named, so there is no nameless case for a host to handle.
+ */
 export const DesiredArtifactSchema = Type.Object({
   digest: Sha256DigestSchema,
   sizeBytes: ByteSizeSchema,
   objectKey: ObjectKeySchema,
+  filename: FilenameSchema,
 });
 
 export type DesiredArtifact = typeof DesiredArtifactSchema.static;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -167,6 +167,8 @@ export {
   DEFAULT_GUEST_PORT,
   type DnsLabel,
   DnsLabelSchema,
+  type Filename,
+  FilenameSchema,
   type GuestPort,
   GuestPortSchema,
   type Hostname,

--- a/packages/protocol/src/lib/wire.ts
+++ b/packages/protocol/src/lib/wire.ts
@@ -31,6 +31,14 @@ const MAX_IPV4_LENGTH = 15;
 
 const MAX_OBJECT_KEY_LENGTH = 1024;
 
+// A single path segment and nothing else. The value originates with whoever uploaded the
+// binary and its only use is as a name inside an archive someone later extracts, so a
+// separator or a `..` is the difference between a filename and a path traversal. Requiring
+// the first character to be alphanumeric is what excludes both `.` and `..` outright, along
+// with a leading dash that would read as a flag to whatever unpacks it.
+const FILENAME_PATTERN = '^[0-9A-Za-z][0-9A-Za-z._-]{0,126}$';
+const MAX_FILENAME_LENGTH = 127;
+
 const MIN_PORT = 1;
 const MAX_PORT = 65_535;
 
@@ -92,6 +100,15 @@ export const ObjectKeySchema = Type.String({
   minLength: 1,
   maxLength: MAX_OBJECT_KEY_LENGTH,
 }) as BrandedSchema<TString, ObjectKey>;
+
+export type Filename = Brand<string, 'Filename'>;
+
+export const FilenameSchema = Type.String({
+  description: 'One path segment, safe to use as a name inside an archive.',
+  pattern: FILENAME_PATTERN,
+  minLength: 1,
+  maxLength: MAX_FILENAME_LENGTH,
+}) as BrandedSchema<TString, Filename>;
 
 // The port the tenant's binary listens on inside its guest, and the port the agent forwards
 // to it on the host, are different numbers that mean different things. They are branded

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_RESTART_POLICY,
   type DeploymentId,
   DesiredStateResponseSchema,
+  type Filename,
   type GuestPort,
   type HostDesiredState,
   HostDesiredStateSchema,
@@ -28,7 +29,7 @@ import {
   TimestampSchema,
   type VolumeId,
 } from '#index.ts';
-import { GuestPortSchema, HostPortSchema } from '#lib/wire.ts';
+import { FilenameSchema, GuestPortSchema, HostPortSchema } from '#lib/wire.ts';
 
 const TENANT_SECRET = 'sk-live-do-not-log-this' as SecretString;
 
@@ -60,6 +61,7 @@ const desiredState = (): HostDesiredState => ({
         digest: hexDigest() as never,
         sizeBytes: 2048,
         objectKey: 'artifacts/app_1/a' as ObjectKey,
+        filename: 'server' as Filename,
       },
       config: {
         guestPort: DEFAULT_GUEST_PORT,
@@ -105,6 +107,20 @@ describe('branding leaves runtime validation intact', () => {
     expect(isValidMessage({ schema: GuestPortSchema, value: 0 })).toBe(false);
     expect(isValidMessage({ schema: GuestPortSchema, value: 65_536 })).toBe(false);
     expect(isValidMessage({ schema: GuestPortSchema, value: 3000.5 })).toBe(false);
+  });
+
+  // A filename crosses the wire from whoever uploaded the binary and becomes a path inside an
+  // archive someone extracts, so anything that is not a single segment is refused here first.
+  test('a filename is one path segment and never a path', () => {
+    expect(isValidMessage({ schema: FilenameSchema, value: 'pocketbase' })).toBe(true);
+    expect(isValidMessage({ schema: FilenameSchema, value: 'pb-0.39.10_linux-amd64' })).toBe(true);
+    expect(isValidMessage({ schema: FilenameSchema, value: '../escape' })).toBe(false);
+    expect(isValidMessage({ schema: FilenameSchema, value: 'nested/path' })).toBe(false);
+    expect(isValidMessage({ schema: FilenameSchema, value: '..' })).toBe(false);
+    expect(isValidMessage({ schema: FilenameSchema, value: '.hidden' })).toBe(false);
+    expect(isValidMessage({ schema: FilenameSchema, value: '-rf' })).toBe(false);
+    expect(isValidMessage({ schema: FilenameSchema, value: 'nul\u0000byte' })).toBe(false);
+    expect(isValidMessage({ schema: FilenameSchema, value: '' })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Keys are assigned to avoid collisions, so they carry no name — a uuid key tells an export nothing about what the binary was called, and the bundle was naming it `server` after the path the guest execs.

`filename` is optional because it is genuinely unknown until an upload is completed, and a host that cannot name a binary says so by falling back rather than inventing one. Nothing boots from it: the guest still execs `/mnt/artifact/server` by boot contract. This is only the name a person sees when they open what they downloaded.

It is also the first value in this protocol that originates with a user and becomes a path. The schema constrains it to a single segment, and `bundleBinaryName` re-checks rather than trusting it — a schema is a claim about a peer, and this string is written into an archive somebody extracts on their own machine.