### PR TITLE
fix(agent): a tenant cannot reach the host it runs on

### DIFF
--- a/apps/agent/src/network/firewall.test.ts
+++ b/apps/agent/src/network/firewall.test.ts
@@ -3,9 +3,12 @@ import type { GuestPort, HostPort, Ipv4Address } from '@repo/protocol';
 import {
   type FirewallState,
   INSTANCE_METADATA_ADDRESS,
+  INSTANCE_METADATA_ADDRESS_V6,
   NFTABLES_TABLE,
   renderRuleset,
 } from '#network/firewall.ts';
+
+const DNS_PORT = 53;
 
 const instance = {
   hostPort: 21_000 as HostPort,
@@ -68,6 +71,50 @@ describe('the three isolation rules are never optional', () => {
     expect(dropsFrom(renderRuleset(state())).some((line) => line.includes('guest to host'))).toBe(
       true,
     );
+  });
+
+  // A resolver accepted by address alone opens every port on it. Harmless for a VPC resolver,
+  // and a hole in the guest-to-host drop the moment the address given is one of the host's own.
+  test('a named resolver is reachable on port 53 and not on everything else', () => {
+    const input = renderRuleset(state({ guestDnsServers: ['10.0.0.2'] }))
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.includes('10.0.0.2') && line.endsWith('accept'));
+
+    expect(input.length).toBeGreaterThan(0);
+    for (const rule of input) {
+      expect(rule).toContain(`dport ${DNS_PORT}`);
+    }
+  });
+});
+
+// `table ip` cannot see v6 at all, and a tap carries a link-local v6 address from the moment it
+// is created — so without a second table every isolation rule above is one family wide.
+describe('the same isolation holds over ipv6', () => {
+  test('guests cannot reach the host over its link-local address', () => {
+    const v6 = renderRuleset(state()).split(`table ip6 ${NFTABLES_TABLE} {`)[1] ?? '';
+    expect(v6).toContain('guest to host');
+    expect(v6).toContain('fe80::/10');
+  });
+
+  test('guests cannot reach each other or the metadata endpoint over v6', () => {
+    const v6 = renderRuleset(state()).split(`table ip6 ${NFTABLES_TABLE} {`)[1] ?? '';
+    expect(v6).toContain('guest to guest');
+    expect(v6).toContain(INSTANCE_METADATA_ADDRESS_V6);
+  });
+
+  // Blocking v6 outright would have been the smaller change and the wrong one: public v6 is
+  // egress a tenant is entitled to, exactly as public v4 is.
+  test('public v6 is not blocked, only the internal ranges', () => {
+    const v6 = renderRuleset(state()).split(`table ip6 ${NFTABLES_TABLE} {`)[1] ?? '';
+    expect(v6).toContain('::1/128');
+    expect(v6).toContain('fc00::/7');
+    expect(v6).not.toContain('::/0');
+  });
+
+  test('the v6 table is rebuilt from state like the v4 one', () => {
+    const ruleset = renderRuleset(state());
+    expect(ruleset).toContain(`table ip6 ${NFTABLES_TABLE}\ndelete table ip6 ${NFTABLES_TABLE}\n`);
   });
 });
 

--- a/apps/agent/src/network/firewall.ts
+++ b/apps/agent/src/network/firewall.ts
@@ -5,6 +5,7 @@ export const NFTABLES_TABLE = 'nibrun';
 const TAP_MATCH = `"${TAP_NAME_PREFIX}*"`;
 
 export const INSTANCE_METADATA_ADDRESS = '169.254.169.254';
+export const INSTANCE_METADATA_ADDRESS_V6 = 'fd00:ec2::254';
 
 const DNS_PORT = 53;
 
@@ -22,6 +23,12 @@ const PRIVATE_DESTINATIONS = [
   '127.0.0.0/8',
   '100.64.0.0/10',
 ] as const;
+
+// The same blanket, in the family `table ip` cannot see. A tap is assigned a link-local v6
+// address the moment it exists, so without these every service on the host is reachable from
+// inside a microVM over `fe80::` with nothing in the way — whether or not v6 egress is
+// configured. Public v6 stays reachable, exactly as public v4 does.
+const PRIVATE_DESTINATIONS_V6 = ['::1/128', 'fe80::/10', 'fc00::/7'] as const;
 
 const CHAIN_INDENT = '  ';
 const RULE_INDENT = '    ';
@@ -71,6 +78,15 @@ export function renderRuleset(state: FirewallState): string {
     '',
     ...natChains(state),
     '}',
+    '',
+    `table ip6 ${NFTABLES_TABLE}`,
+    `delete table ip6 ${NFTABLES_TABLE}`,
+    '',
+    `table ip6 ${NFTABLES_TABLE} {`,
+    ...forwardChainV6(),
+    '',
+    ...inputChainV6(),
+    '}',
   ];
   return `${lines.join('\n')}\n`;
 }
@@ -104,7 +120,39 @@ function inputChain({ guestDnsServers }: FirewallState): string[] {
     rules: [
       'type filter hook input priority filter; policy accept;',
       `iifname ${TAP_MATCH} ct state established,related accept`,
-      ...guestDnsServers.map((server) => `iifname ${TAP_MATCH} ip daddr ${server} accept`),
+      // Port-matched like the forward chain rather than accepting the address outright: a
+      // resolver that happened to be one of the host's own addresses would otherwise open
+      // every port on the host to every tenant.
+      ...guestDnsServers.flatMap((server) => [
+        `iifname ${TAP_MATCH} ip daddr ${server} udp dport ${DNS_PORT} accept`,
+        `iifname ${TAP_MATCH} ip daddr ${server} tcp dport ${DNS_PORT} accept`,
+      ]),
+      `iifname ${TAP_MATCH} drop comment "guest to host"`,
+    ],
+  });
+}
+
+// No NAT counterpart: guests are given a v4 /30 and no v6 address, so nothing here forwards or
+// masquerades. These are the drops that hold whether or not that ever changes.
+function forwardChainV6(): string[] {
+  return chain({
+    header: 'forward {',
+    rules: [
+      'type filter hook forward priority filter; policy accept;',
+      'ct state established,related accept',
+      `iifname ${TAP_MATCH} ip6 daddr ${INSTANCE_METADATA_ADDRESS_V6} drop comment "instance metadata endpoint"`,
+      `iifname ${TAP_MATCH} oifname ${TAP_MATCH} drop comment "guest to guest"`,
+      `iifname ${TAP_MATCH} ip6 daddr ${set(PRIVATE_DESTINATIONS_V6)} drop comment "private destinations"`,
+    ],
+  });
+}
+
+function inputChainV6(): string[] {
+  return chain({
+    header: 'input {',
+    rules: [
+      'type filter hook input priority filter; policy accept;',
+      `iifname ${TAP_MATCH} ct state established,related accept`,
       `iifname ${TAP_MATCH} drop comment "guest to host"`,
     ],
   });

--- a/apps/agent/src/reconcile/reconciler.ts
+++ b/apps/agent/src/reconcile/reconciler.ts
@@ -28,6 +28,7 @@ import {
   type CheckpointPlan,
   type ExportPlan,
   hasDeferredWork,
+  type InstancePlan,
   type ObservedState,
   planReconcile,
   type ReconcilePlan,
@@ -86,6 +87,8 @@ export class Reconciler {
   #observedGeneration = NO_GENERATION;
   #converged = false;
   #deferredWork = false;
+  // Whether this host's isolation ruleset is in the kernel. A tenant is not started without it.
+  #isolated = false;
 
   constructor(options: ReconcilerOptions) {
     this.#options = options;
@@ -206,12 +209,17 @@ export class Reconciler {
 
     await this.#applyStops(plan);
     await this.#applyVolumes({ plan, observed });
+    // Before anything boots. The isolation rules do not depend on which instances exist, and
+    // nothing persists the ruleset across a reboot — so a host that came back and started its
+    // VMs first would serve tenants through a kernel with no `nibrun` table in it at all.
+    await this.#applyNetwork();
     await this.#applyStarts(plan);
     await this.#applyCheckpoints({ plan, desired });
     // After starts, so an export never competes with a boot for the device it reads, and before
     // teardowns, so a volume marked absent in the same generation is still there to read from.
     await this.#applyExports({ plan, desired });
     await this.#applyTeardowns(plan);
+    // Again, because the instances started above are the ones whose forwards this renders.
     await this.#applyNetwork();
     await this.#applyRoutes();
     await this.#persist();
@@ -413,11 +421,30 @@ export class Reconciler {
     }
   }
 
+  /**
+   * A tenant only ever boots onto a host whose isolation ruleset is in the kernel.
+   *
+   * The guest is an arbitrary binary on a tap in the guest network, one routing decision away
+   * from the control plane, this host's own services and every neighbouring tenant. Nothing but
+   * that ruleset stands between them, so its absence is a reason not to run rather than
+   * something to log and continue past.
+   */
   async #applyStarts(plan: ReconcilePlan): Promise<void> {
-    for (const action of plan.instances) {
-      if (action.action !== 'start' && action.action !== 'replace') {
-        continue;
-      }
+    const starts = plan.instances.filter(
+      (action): action is Extract<InstancePlan, { action: 'start' | 'replace' }> =>
+        action.action === 'start' || action.action === 'replace',
+    );
+    if (starts.length === 0) {
+      return;
+    }
+    if (!this.#isolated) {
+      logger.error({
+        message: 'instance starts refused: isolation ruleset is not applied',
+        refused: starts.length,
+      });
+      return;
+    }
+    for (const action of starts) {
       await this.#start({ desired: action.desired });
     }
   }
@@ -644,7 +671,13 @@ export class Reconciler {
           guestDnsServers: this.#options.config.guestDnsServers,
         },
       });
+      this.#isolated = true;
     } catch (error) {
+      // Left false rather than thrown: `nft -f` replaces the table in one transaction, so a
+      // failed apply leaves whatever was already in the kernel. Tearing down running tenants
+      // over a transient failure would be the bigger outage — refusing to add new ones is the
+      // part that has to hold.
+      this.#isolated = false;
       logger.error({ message: 'firewall apply failed', ...describeError(error) });
     }
   }


### PR DESCRIPTION
Four ways a tenant could reach the host or its neighbours, in descending order of how reachable they were.

**Guests booted before the ruleset existed.** `#applyStarts` ran ahead of `#applyNetwork`, nothing persists nftables across a reboot, and a host that reboots now brings its VMs back up (#46) — so a rebooted host started tenants into a kernel with no `nibrun` table at all and only wrote one afterwards. The ruleset is now applied before anything boots, and again after, since that second pass renders the forwards for the instances the first pass allowed to start.

**A failed apply was logged and stepped past.** A host that cannot write its isolation rules kept starting tenants; it now refuses. Running VMs are left alone deliberately — `nft -f` replaces the table in one transaction, so a failed apply leaves the previous ruleset in place, and tearing down live tenants over a transient failure is the bigger outage.

**`table ip` cannot see IPv6.** A tap carries a link-local v6 address from creation, so every service on the host was reachable from inside a microVM over `fe80::` with nothing in the way. Mirrored rather than disabled: public v6 is egress a tenant is entitled to exactly as public v4 is, so the v6 table blocks the internal ranges and nothing else.

**A named resolver was accepted by address alone** on the input chain, opening every port on it rather than 53.

Removing the bootstrap token from the infra follows separately, once this has landed and been verified on a host.

### Not verified against a real kernel

`AGENTS.md` already flags that the ruleset is asserted as text and never loaded. This adds a second table, and `nft -f` rejects the whole file on any syntax error — worth one check-mode run on an app host before merge.