### PR TITLE
refactor: the network is the boundary, not a shared secret

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -50,13 +50,6 @@ const NO_FAILURES = 0;
 
 const DESIRED_STATE_FILENAME = 'desired-state.json';
 
-export class MissingBootstrapTokenError extends Error {
-  constructor(path: string) {
-    super(`${path} is missing: the bootstrap credential arrives with the instance's user-data`);
-    this.name = 'MissingBootstrapTokenError';
-  }
-}
-
 export class Agent {
   readonly #config: AgentConfig;
   readonly #client: ControlPlaneClient;
@@ -283,11 +276,7 @@ export class Agent {
     this.#session = await openSession({
       client: this.#client,
       identity: this.#identity,
-      inputs: {
-        bootstrapToken: await this.#readBootstrapToken(),
-        versions: this.#versions,
-        capacity,
-      },
+      inputs: { versions: this.#versions, capacity },
     });
     logger.info({
       message: 'session opened',
@@ -295,17 +284,6 @@ export class Agent {
       expiresAt: this.#session.expiresAt,
     });
     return this.#session;
-  }
-
-  // The credential identifies the machine, not a user, and buys exactly one thing: a session.
-  // It is read from disk on every renewal rather than held in memory, so rotating the file is
-  // enough to rotate the credential.
-  async #readBootstrapToken(): Promise<SecretString> {
-    const token = await readTextFile({ path: this.#config.bootstrapTokenFile });
-    if (!token) {
-      throw new MissingBootstrapTokenError(this.#config.bootstrapTokenFile);
-    }
-    return token as SecretString;
   }
 
   #desiredStatePath() {

--- a/apps/agent/src/config.ts
+++ b/apps/agent/src/config.ts
@@ -22,7 +22,6 @@ export const NBD_TIMEOUT_SECONDS = 600;
 
 export type AgentConfig = {
   controlPlaneUrl: string;
-  bootstrapTokenFile: string;
   stateDir: string;
   runtimeDir: string;
   hostIdFile: string;
@@ -98,11 +97,6 @@ export function loadAgentConfig({
   const stateDir = optional({ env, name: 'AGENT_STATE_DIR', fallback: DEFAULT_STATE_DIR });
   return {
     controlPlaneUrl: required({ env, name: 'AGENT_CONTROL_PLANE_URL' }),
-    bootstrapTokenFile: optional({
-      env,
-      name: 'AGENT_BOOTSTRAP_TOKEN_FILE',
-      fallback: join(stateDir, 'bootstrap-token'),
-    }),
     stateDir,
     runtimeDir: optional({ env, name: 'AGENT_RUNTIME_DIR', fallback: DEFAULT_RUNTIME_DIR }),
     hostIdFile: join(stateDir, 'host-id'),

--- a/apps/agent/src/control/client.test.ts
+++ b/apps/agent/src/control/client.test.ts
@@ -55,7 +55,6 @@ describe('every request identifies the protocol it speaks', () => {
     const { calls, fetchImpl } = respondWith({ body: VALID_SESSION });
     const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
     const session = await client.openSession({
-      bootstrapToken: 'boot' as SecretString,
       versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
       capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
     });
@@ -71,7 +70,6 @@ describe('validation at the boundary', () => {
     const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
     await expect(
       client.openSession({
-        bootstrapToken: 'boot' as SecretString,
         versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
         capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
       }),
@@ -95,7 +93,6 @@ describe('validation at the boundary', () => {
     });
     const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
     const session = await client.openSession({
-      bootstrapToken: 'boot' as SecretString,
       versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
       capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
     });
@@ -109,7 +106,6 @@ describe('validation at the boundary', () => {
     const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
     await expect(
       client.openSession({
-        bootstrapToken: 'boot' as SecretString,
         versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
         capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
       }),

--- a/apps/agent/src/control/session.ts
+++ b/apps/agent/src/control/session.ts
@@ -53,7 +53,6 @@ export class HostIdentity {
 }
 
 export type SessionInputs = {
-  bootstrapToken: SecretString;
   versions: HostVersions;
   capacity: HostCapacity;
 };
@@ -69,7 +68,6 @@ export async function openSession({
 }): Promise<AgentSession> {
   const hostId = await identity.read();
   const session = await client.openSession({
-    bootstrapToken: inputs.bootstrapToken,
     ...(hostId ? { hostId } : {}),
     versions: inputs.versions,
     capacity: inputs.capacity,

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -10,7 +10,6 @@ interface CustomProcessEnv {
   readonly ARTIFACTS_BUCKET: string;
   readonly S3_ACCESS_KEY_ID: string;
   readonly S3_SECRET_ACCESS_KEY: string;
-  readonly AGENT_BOOTSTRAP_TOKEN: string;
 }
 
 const DEFAULT_PORT = '3000';
@@ -43,7 +42,6 @@ type Env = {
   GITHUB_CLIENT_SECRET: string;
   S3_ENDPOINT: URL;
   ARTIFACTS_BUCKET: string;
-  AGENT_BOOTSTRAP_TOKEN: string;
   S3_ACCESS_KEY_ID: string;
   S3_SECRET_ACCESS_KEY: string;
 };
@@ -58,7 +56,6 @@ function loadEnv(): Env {
     GITHUB_CLIENT_SECRET: required('GITHUB_CLIENT_SECRET'),
     S3_ENDPOINT: new URL(required('S3_ENDPOINT')),
     ARTIFACTS_BUCKET: required('ARTIFACTS_BUCKET'),
-    AGENT_BOOTSTRAP_TOKEN: required('AGENT_BOOTSTRAP_TOKEN'),
     S3_ACCESS_KEY_ID: required('S3_ACCESS_KEY_ID'),
     S3_SECRET_ACCESS_KEY: required('S3_SECRET_ACCESS_KEY'),
   };

--- a/apps/api/src/routes/internal/agent/controller.test.ts
+++ b/apps/api/src/routes/internal/agent/controller.test.ts
@@ -15,8 +15,6 @@ import {
 } from '@repo/protocol';
 import { StatusMap } from 'elysia';
 
-const BOOTSTRAP_TOKEN = 'bootstrap-token-for-this-test';
-
 // What an agent that has never polled reports knowing, so this is the case that
 // has to yield state rather than `unchanged`.
 const FIRST_POLL_GENERATION = 0;
@@ -35,7 +33,6 @@ const REQUIRED_ENV = {
   ARTIFACTS_BUCKET: 'test',
   S3_ACCESS_KEY_ID: 'test',
   S3_SECRET_ACCESS_KEY: 'test',
-  AGENT_BOOTSTRAP_TOKEN: BOOTSTRAP_TOKEN,
 };
 
 let app: { handle: (request: Request) => Promise<Response> };
@@ -92,7 +89,7 @@ const readAck = async (response: Response) =>
 const openSession = async (overrides: Partial<AgentSessionRequest> = {}) =>
   await post({
     route: AGENT_ROUTES.session,
-    body: { bootstrapToken: BOOTSTRAP_TOKEN, versions, capacity, ...overrides },
+    body: { versions, capacity, ...overrides },
   });
 
 describe('an agent can register and be told what to run', () => {
@@ -102,9 +99,13 @@ describe('an agent can register and be told what to run', () => {
     expect(session.hostId).toBeTruthy();
     expect(session.sessionToken).toBeTruthy();
     expect(session.poll.maxWaitSeconds).toBeGreaterThan(0);
-    // Issued rather than echoed: a session the bootstrap credential could stand in for would
-    // make expiring one meaningless.
-    expect(session.sessionToken).not.toBe(BOOTSTRAP_TOKEN);
+  });
+
+  // The endpoint carries no credential. What keeps it closed is that nothing outside the VPC
+  // can address it and no tenant can route to it, so a test asserting a rejection here would
+  // be asserting a defence this design deliberately does not have.
+  test('a session is granted on reachability alone', async () => {
+    expect((await openSession()).status).toBe(StatusMap.OK);
   });
 
   test('a host that has never polled is told its state, not that nothing changed', async () => {
@@ -183,12 +184,6 @@ describe('an agent can register and be told what to run', () => {
 });
 
 describe('nothing reaches desired state without proving what it is', () => {
-  test('a wrong bootstrap credential opens no session', async () => {
-    expect((await openSession({ bootstrapToken: 'wrong' as never })).status).toBe(
-      StatusMap.Unauthorized,
-    );
-  });
-
   test('an unknown session is refused rather than served a default host', async () => {
     const response = await post({
       route: AGENT_ROUTES.desiredState,
@@ -218,7 +213,7 @@ describe('nothing reaches desired state without proving what it is', () => {
           'content-type': 'application/json',
           [PROTOCOL_VERSION_HEADER]: String(PROTOCOL_VERSION + PROTOCOL_VERSION_SKEW),
         },
-        body: JSON.stringify({ bootstrapToken: BOOTSTRAP_TOKEN, versions, capacity }),
+        body: JSON.stringify({ versions, capacity }),
       }),
     );
 

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -18,30 +18,21 @@ const SESSION_LIFETIME_MS = SECONDS_PER_HOUR * MS_PER_SECOND;
 
 export class AgentService extends Service {
   private readonly agentRepo: AgentRepository;
-  private readonly bootstrapToken: string;
 
-  constructor({
-    agentRepo,
-    bootstrapToken,
-  }: {
-    agentRepo: AgentRepository;
-    bootstrapToken: string;
-  }) {
+  constructor({ agentRepo }: { agentRepo: AgentRepository }) {
     super();
     this.agentRepo = agentRepo;
-    this.bootstrapToken = bootstrapToken;
   }
 
   /**
-   * One credential for the fleet, because Terraform generates one and every host reads it from
-   * the same SSM path. It buys exactly one thing — a session — so revoking a host becomes
-   * expiring that session rather than rotating a secret baked into an instance.
+   * Anything that reaches this endpoint gets a session.
+   *
+   * The reachability is the control: the internal port answers inside the VPC only, and a
+   * tenant is dropped by its host's ruleset before it can route to it. The shared secret this
+   * used to check was readable on every host, so it could not distinguish the callers it was
+   * defending against from the ones it was admitting.
    */
   async openSession(request: AgentSessionRequest): Promise<AgentSession> {
-    if (!timingSafeEquals({ presented: request.bootstrapToken, expected: this.bootstrapToken })) {
-      throw new UnauthorizedError('Bootstrap token rejected.');
-    }
-
     // The agent persists what it is given and presents it next time, so a host keeps its
     // identity across a reinstall. Nothing allocates one yet, so its own is honoured.
     const hostId = request.hostId ?? (crypto.randomUUID() as HostId);
@@ -91,10 +82,4 @@ export class AgentService extends Service {
     const desired = await this.agentRepo.desiredState({ hostId: reported.hostId });
     return desired.generation;
   }
-}
-
-function timingSafeEquals({ presented, expected }: { presented: string; expected: string }) {
-  const left = Buffer.from(presented);
-  const right = Buffer.from(expected);
-  return left.length === right.length && crypto.timingSafeEqual(left, right);
 }

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -13,10 +13,7 @@ const agentRepository = new AgentRepository(sql);
 const assetsRepository = new AssetsRepository(sql);
 const healthRepository = new HealthRepository(sql);
 
-const agentService = new AgentService({
-  agentRepo: agentRepository,
-  bootstrapToken: env.AGENT_BOOTSTRAP_TOKEN,
-});
+const agentService = new AgentService({ agentRepo: agentRepository });
 const assetsService = new AssetsService(assetsRepository);
 const healthService = new HealthService(healthRepository);
 

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -231,13 +231,8 @@ cp zerofs/config.toml /etc/zerofs/config.toml.new
 chmod 0644 /etc/zerofs/config.toml.new
 changed_file /etc/zerofs/config.toml && NEEDS_RESTART+=(zerofs) || true
 
-secret agent_bootstrap_token > /var/lib/nibrun/bootstrap-token.new
-chmod 0600 /var/lib/nibrun/bootstrap-token.new
-changed_file /var/lib/nibrun/bootstrap-token && NEEDS_RESTART+=(agent) || true
-
 cat > /etc/nibrun/agent.env.new <<EOF
 AGENT_CONTROL_PLANE_URL=${CONTROL_PLANE_INTERNAL_URL}
-AGENT_BOOTSTRAP_TOKEN_FILE=/var/lib/nibrun/bootstrap-token
 AGENT_ARTIFACT_BUCKET=${ARTIFACTS_BUCKET}
 AGENT_EXPORT_BUCKET=${EXPORTS_BUCKET}
 # A tenant microVM reaching the api's internal port would be reaching it as the

--- a/infra/deploy/on_box_deploy.sh
+++ b/infra/deploy/on_box_deploy.sh
@@ -43,9 +43,6 @@ API_BETTER_AUTH_SECRET="$(secret api_better_auth_secret)"
 API_GITHUB_CLIENT_SECRET="$(secret api_github_client_secret)"
 API_S3_ACCESS_KEY_ID="$(secret api_s3_access_key_id)"
 API_S3_SECRET_ACCESS_KEY="$(secret api_s3_secret_access_key)"
-# The same parameter every app host reads, so the api can recognise the
-# credential a host presents rather than trusting whatever arrives.
-AGENT_BOOTSTRAP_TOKEN="$(secret agent_bootstrap_token)"
 
 # Everything written from here on carries a secret: the PEMs below, then .env.
 umask 077
@@ -77,7 +74,6 @@ API_BASE_URL=https://${API_HOSTNAME}
 API_BETTER_AUTH_SECRET=${API_BETTER_AUTH_SECRET}
 API_GITHUB_CLIENT_ID=${API_GITHUB_CLIENT_ID}
 API_GITHUB_CLIENT_SECRET=${API_GITHUB_CLIENT_SECRET}
-AGENT_BOOTSTRAP_TOKEN=${AGENT_BOOTSTRAP_TOKEN}
 
 API_DB_USER=${API_DB_USER}
 API_DB_PASSWORD=${API_DB_PASSWORD}

--- a/infra/terraform/ssm.tf
+++ b/infra/terraform/ssm.tf
@@ -151,28 +151,6 @@ resource "aws_ssm_parameter" "filesystems_encryption_password" {
   }
 }
 
-# What an agent presents once, to exchange for a session. It identifies the
-# machine class rather than a user, and buys nothing else — so revoking a host is
-# expiring its session rather than rotating this.
-#
-# Read by the instance with its own role rather than baked into user_data, which
-# is the repo's established path for every other secret and, unlike user_data,
-# can be rotated without replacing the instance.
-resource "random_password" "agent_bootstrap_token" {
-  length  = 48
-  special = false
-}
-
-resource "aws_ssm_parameter" "agent_bootstrap_token" {
-  name  = "${var.ssm_secret_prefix}/agent_bootstrap_token"
-  type  = "SecureString"
-  value = random_password.agent_bootstrap_token.result
-
-  tags = {
-    Name = "${local.resource_name_prefix}-agent-bootstrap-token"
-  }
-}
-
 # Credentials of the api's own IAM user (iam_api.tf), not generated here.
 resource "aws_ssm_parameter" "api_s3_access_key_id" {
   name  = "${var.ssm_secret_prefix}/api_s3_access_key_id"

--- a/packages/protocol/src/control/session.ts
+++ b/packages/protocol/src/control/session.ts
@@ -38,14 +38,20 @@ export const DEFAULT_AGENT_POLL_SETTINGS: AgentPollSettings = {
 };
 
 /**
- * Opens a session from a bootstrap credential delivered with the machine.
+ * Opens a session.
  *
- * The credential identifies the machine, not a user, and buys exactly one thing: a session
- * token. Everything afterwards presents the session, so revoking a host is expiring a session
- * rather than rotating a credential baked into an instance.
+ * There is deliberately no credential here. The internal port is reachable from inside the VPC
+ * and nowhere else, and a tenant microVM is denied it by the host's own ruleset before it can
+ * route anywhere — so a caller that reaches this endpoint has already crossed the boundary that
+ * matters. The fleet-wide secret this used to carry was not a second boundary: it sat readable
+ * on every host, so anything positioned to abuse the endpoint could read it, and rotating it
+ * meant redeploying the fleet and the control plane together.
+ *
+ * What nothing here does yet is tell one host from another — `hostId` is honoured as presented.
+ * That wants a claim a file cannot be copied into, such as an instance identity document, and
+ * a shared secret every host already holds was never going to be it.
  */
 export const AgentSessionRequestSchema = Type.Object({
-  bootstrapToken: SecretStringSchema,
   // Absent on a host's very first registration; the control plane assigns one and the agent
   // persists it, so a reinstalled agent rejoins as the same host rather than as a new one.
   hostId: Type.Optional(HostIdSchema),


### PR DESCRIPTION
Removes the agent bootstrap token from the protocol, both sides and the infrastructure.

It was one 48-character string in SSM that every app host wrote to disk and presented once to exchange for a session. As authentication it could not work: it sat readable on every host, so anything positioned to abuse the endpoint could also read it, and it said nothing about *which* host was calling — `hostId` is honoured as presented either way. The cost was real though: rotating it meant redeploying the fleet and the control plane together.

What actually keeps the endpoint closed is that nothing outside the VPC can address it and no tenant can route to it. The second of those was only true by accident until #55 — guests booted before the ruleset existed, a failed apply was logged and stepped past, and `table ip` never saw IPv6 at all. With those closed, the token was guarding a door that is now shut.

### What this does not do

It does not give the control plane per-host identity — nothing did. `hostId` is still self-asserted, so any caller that reaches the endpoint can claim to be any host. That wants a claim a file cannot be copied into, such as an EC2 instance identity document, which the agent is already positioned to fetch since it reads IMDS for its S3 credentials. Worth doing before the fleet is more than one box; separate change.

### Deploy order

Safe in either direction. Protocol schemas do not set `additionalProperties: false`, so an old agent still sending the field meets a new api that ignores it. A new agent meeting an old api fails session validation and retries with backoff until the api rolls.

The SSM parameter and `random_password` are removed, so `terraform apply` will destroy them — no `allow_destroy` needed, they are not protected resources.