### PR TITLE
feat(agent): stream tenant logs through the guest console

### DIFF
--- a/apps/agent/src/vm/firecracker-config.test.ts
+++ b/apps/agent/src/vm/firecracker-config.test.ts
@@ -71,6 +71,10 @@ describe('the setting that fails silently', () => {
 });
 
 describe('the kernel command line', () => {
+  test('the tenant console is not flooded by informational kernel messages', () => {
+    expect(renderKernelArgs(network)).toContain('console=ttyS0 quiet');
+  });
+
   test('it carries the three i8042 flags that halve boot time', () => {
     const args = renderKernelArgs(network);
     for (const flag of ['i8042.noaux', 'i8042.nomux', 'i8042.dumbkbd']) {

--- a/apps/agent/src/vm/firecracker-config.ts
+++ b/apps/agent/src/vm/firecracker-config.ts
@@ -13,8 +13,15 @@ const NO_BITS = 0;
 // not among them: it breaks SendCtrlAltDel on an ACPI-enabled guest, which ours is, so a
 // graceful stop would silently become a kill — the API answers 204 either way. The static `ip=`
 // form is why the guest ships no DHCP client: the kernel configures eth0 before /init runs.
+//
+// `quiet` is what makes this console the tenant's rather than the kernel's: without it a boot
+// puts ~788 printk lines on the same serial port the tenant writes to, so the first page of any
+// app's log is `BIOS-e820` rather than anything the app said. It raises the printk threshold and
+// nothing else — panics and oopses still print, and userspace writes to /dev/console are not
+// filtered at all, so both the guest init's `[nibrun] ` lines and the tenant's own output are
+// untouched.
 const BASE_KERNEL_ARGS =
-  'console=ttyS0 reboot=k panic=1 pci=off i8042.noaux i8042.nomux i8042.dumbkbd root=/dev/vda ro init=/init';
+  'console=ttyS0 quiet reboot=k panic=1 pci=off i8042.noaux i8042.nomux i8042.dumbkbd root=/dev/vda ro init=/init';
 
 export function netmaskFor(prefixLength: number): string {
   const octets: number[] = [];

--- a/infra/guest-image/AGENTS.md
+++ b/infra/guest-image/AGENTS.md
@@ -21,8 +21,12 @@ order *is* the contract.
 | `vdd` | tenant data: the NBD device ZeroFS serves, ext4 | rw | **`Writeback`** |
 
 ```
-console=ttyS0 reboot=k panic=1 pci=off i8042.noaux i8042.nomux i8042.dumbkbd root=/dev/vda ro init=/init ip=<guest-ip>::<host-ip>:<netmask>::eth0:off
+console=ttyS0 quiet reboot=k panic=1 pci=off i8042.noaux i8042.nomux i8042.dumbkbd root=/dev/vda ro init=/init ip=<guest-ip>::<host-ip>:<netmask>::eth0:off
 ```
+
+`quiet` keeps informational kernel messages out of the serial console that carries the tenant's
+stdout and stderr. Kernel warnings and failures remain visible, and writes to `/dev/console` are
+unaffected.
 
 `cache_type` on `vdd` is the one setting that fails silently: Firecracker defaults a drive to
 `Unsafe`, which **discards flush requests**, so the guest's `fsync` returns success, ZeroFS is


### PR DESCRIPTION
Suppress informational kernel boot output so each Firecracker serial console cleanly carries the guest runtime and tenant stdout and stderr into the per-VM journal.