### PR TITLE
fix: stop gitignore from swallowing a source module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,13 @@ dist
 coverage
 *.lcov
 
-# logs
-logs
-_.log
-report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+# logs. Anchored and suffixed, because an unanchored `logs` matches a directory of
+# that name at any depth — including a source module — and git reports nothing when
+# it does. The two patterns below had their asterisks replaced by underscores at
+# some point, which left them matching nothing at all.
+/logs/
+*.log
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Dozzle's user list — rendered on the box from SSM, holds a password hash.
 dozzle/data/


### PR DESCRIPTION
`logs` with no anchor matches a directory of that name at **any depth**, so `apps/agent/src/logs/` — six files, 540 lines of the tenant log receiver — is invisible to git today. It typechecks and its tests pass locally because the files are on disk. Committing and pushing would have shipped an agent importing a module that is not in the repository, and `git status` says nothing at any point along the way.

Anchored to the root and made directory-only, which is what the rule meant.

The two patterns beside it had their asterisks replaced by underscores at some point — `_.log` matches a file literally named `_.log`, and `report.[0-9]_.[0-9]_...` matches nothing. Restored, so log output is actually ignored as the section header claims.

`apps/api/public/` stays ignored; the api build cleans and repopulates it, so that one is correct.

Nothing currently tracked matches the new patterns, so nothing is newly hidden.