### PR TITLE
feat(api): derive a frozen platform hostname from an app name

### DIFF
--- a/apps/api/src/lib/app-slug.test.ts
+++ b/apps/api/src/lib/app-slug.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test';
+import { DnsLabelSchema, isValidMessage, MAX_DNS_LABEL_LENGTH } from '@repo/protocol';
+import { deriveAppSlug } from '#lib/app-slug.ts';
+
+const SEPARATOR = '-';
+const SUFFIX_LENGTH = 6;
+const MAX_STEM_LENGTH = MAX_DNS_LABEL_LENGTH - SUFFIX_LENGTH - SEPARATOR.length;
+
+// Restated rather than imported from the implementation: excluding I, L, O and U is the
+// contract this file exists to hold it to, not a detail it should read back from it.
+const CROCKFORD_BASE32 = '0123456789abcdefghjkmnpqrstvwxyz';
+const AMBIGUOUS_CHARACTERS = ['i', 'l', 'o', 'u'];
+
+const SAMPLE_SIZE = 200;
+const OVERLONG_NAME_LENGTH = 200;
+
+// The hyphen lands on the last slot of the stem budget, so truncating stops right on it.
+const TRUNCATED_ONTO_HYPHEN = `${'a'.repeat(MAX_STEM_LENGTH - SEPARATOR.length)} ${'b'.repeat(
+  MAX_STEM_LENGTH,
+)}`;
+
+const stemOf = (label: string) => label.slice(0, label.lastIndexOf(SEPARATOR));
+const suffixOf = (label: string) => label.slice(label.lastIndexOf(SEPARATOR) + 1);
+
+const isDnsLabel = (label: string) => isValidMessage({ schema: DnsLabelSchema, value: label });
+
+describe('the stem carries the name it came from', () => {
+  test('a name that is already a label survives intact', () => {
+    expect(stemOf(deriveAppSlug('pocketbase'))).toBe('pocketbase');
+  });
+
+  test('case, spaces and punctuation collapse into hyphens', () => {
+    expect(stemOf(deriveAppSlug('My Great App!'))).toBe('my-great-app');
+    expect(stemOf(deriveAppSlug('  --Trimmed--  '))).toBe('trimmed');
+    expect(stemOf(deriveAppSlug('Café Résumé'))).toBe('cafe-resume');
+  });
+});
+
+describe('a name that slugifies to nothing still gets a label', () => {
+  test('emoji only', () => {
+    expect(stemOf(deriveAppSlug('🎉🎉🎉'))).toBe('app');
+  });
+
+  test('CJK only', () => {
+    expect(stemOf(deriveAppSlug('日本語のアプリ'))).toBe('app');
+  });
+
+  test('punctuation only', () => {
+    expect(stemOf(deriveAppSlug('!!! ??? ...'))).toBe('app');
+  });
+});
+
+test('a name that would slugify to a punycode prefix is neutralised', () => {
+  expect(stemOf(deriveAppSlug('xn--n3h'))).toBe('app');
+  expect(stemOf(deriveAppSlug('XN--Mgbh0fb'))).toBe('app');
+});
+
+describe('the length budget', () => {
+  test('an overlong name is truncated to fit', () => {
+    const label = deriveAppSlug('a'.repeat(OVERLONG_NAME_LENGTH));
+
+    expect(label).toHaveLength(MAX_DNS_LABEL_LENGTH);
+    expect(stemOf(label)).toBe('a'.repeat(MAX_STEM_LENGTH));
+  });
+
+  test('truncating onto a hyphen does not leave one', () => {
+    const label = deriveAppSlug(TRUNCATED_ONTO_HYPHEN);
+
+    expect(stemOf(label)).toBe('a'.repeat(MAX_STEM_LENGTH - SEPARATOR.length));
+    expect(stemOf(label).endsWith(SEPARATOR)).toBe(false);
+    expect(isDnsLabel(label)).toBe(true);
+  });
+
+  test('the suffix keeps its full length whatever the name costs', () => {
+    expect(suffixOf(deriveAppSlug('a'.repeat(OVERLONG_NAME_LENGTH)))).toHaveLength(SUFFIX_LENGTH);
+    expect(suffixOf(deriveAppSlug('x'))).toHaveLength(SUFFIX_LENGTH);
+  });
+});
+
+describe('the suffix', () => {
+  const sampled = Array.from({ length: SAMPLE_SIZE }, () => suffixOf(deriveAppSlug('app'))).join(
+    '',
+  );
+
+  test('is drawn only from Crockford base32', () => {
+    for (const character of sampled) {
+      expect(CROCKFORD_BASE32).toInclude(character);
+    }
+  });
+
+  test('never contains I, L, O or U', () => {
+    for (const character of AMBIGUOUS_CHARACTERS) {
+      expect(sampled).not.toInclude(character);
+    }
+  });
+
+  test('is what separates two apps sharing a name', () => {
+    const first = deriveAppSlug('pocketbase');
+    const second = deriveAppSlug('pocketbase');
+
+    expect(stemOf(first)).toBe(stemOf(second));
+    expect(first).not.toBe(second);
+  });
+});
+
+test('every derived label satisfies DnsLabelSchema', () => {
+  const names = [
+    'pocketbase',
+    'My Great App!',
+    '  --Trimmed--  ',
+    'Café Résumé',
+    '🎉🎉🎉',
+    '日本語のアプリ',
+    '!!! ??? ...',
+    'xn--n3h',
+    'a'.repeat(OVERLONG_NAME_LENGTH),
+    TRUNCATED_ONTO_HYPHEN,
+    SEPARATOR.repeat(MAX_DNS_LABEL_LENGTH),
+    ' ',
+    '',
+    'x',
+    '9',
+  ];
+
+  for (const name of names) {
+    expect(isDnsLabel(deriveAppSlug(name))).toBe(true);
+  }
+});

--- a/apps/api/src/lib/app-slug.ts
+++ b/apps/api/src/lib/app-slug.ts
@@ -1,0 +1,62 @@
+import { type DnsLabel, MAX_DNS_LABEL_LENGTH } from '@repo/protocol';
+
+const SEPARATOR = '-';
+
+// Crockford base32: no I, L, O or U. The suffix is the part of a URL that gets read down a
+// phone, so the characters that are ambiguous out loud are gone — and dropping U takes most
+// accidental profanity out of the random part with it.
+const SUFFIX_ALPHABET = '0123456789abcdefghjkmnpqrstvwxyz';
+const SUFFIX_LENGTH = 6;
+
+const MAX_STEM_LENGTH = MAX_DNS_LABEL_LENGTH - SUFFIX_LENGTH - SEPARATOR.length;
+
+// A name of only emoji, CJK or punctuation slugifies to nothing, and every one of those is a
+// name a user is allowed to pick. Creation must not fail on it.
+const FALLBACK_STEM = 'app';
+
+// Reserved by IDNA: a label starting with it announces itself as an encoded Unicode name, and
+// resolvers are entitled to read it as one.
+const PUNYCODE_PREFIX = 'xn--';
+
+const COMBINING_MARKS = /\p{M}+/gu;
+const ILLEGAL_RUN = /[^a-z0-9-]+/g;
+const LEADING_HYPHENS = /^-+/;
+const TRAILING_HYPHENS = /-+$/;
+
+/**
+ * Derives the DNS label an app is served under from the name its owner gave it.
+ *
+ * The label is a snapshot taken once, at creation, and never recomputed: by the time an app is
+ * renamed its URL is in somebody else's bookmarks, and a URL that moves is a broken one. The
+ * random suffix is what makes taking that snapshot safe — two owners naming an app the same
+ * thing get two labels rather than a collision.
+ */
+export function deriveAppSlug(name: string): DnsLabel {
+  return `${stemOf(name)}${SEPARATOR}${randomSuffix()}` as DnsLabel;
+}
+
+function stemOf(name: string): string {
+  const slugified = name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(COMBINING_MARKS, '')
+    .replace(ILLEGAL_RUN, SEPARATOR)
+    .replace(LEADING_HYPHENS, '')
+    .replace(TRAILING_HYPHENS, '');
+
+  if (slugified.length === 0 || slugified.startsWith(PUNYCODE_PREFIX)) {
+    return FALLBACK_STEM;
+  }
+
+  // Only the stem gives way to the length budget, and truncation can land on a hyphen that
+  // would then double up against the separator.
+  return slugified.slice(0, MAX_STEM_LENGTH).replace(TRAILING_HYPHENS, '');
+}
+
+// The alphabet divides 256 exactly, so a byte modulo it is uniform and needs no resampling.
+const suffixCharacter = (byte: number) => SUFFIX_ALPHABET.charAt(byte % SUFFIX_ALPHABET.length);
+
+function randomSuffix(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(SUFFIX_LENGTH));
+  return Array.from(bytes, suffixCharacter).join('');
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -212,6 +212,7 @@ export {
   HostPortSchema,
   type Ipv4Address,
   Ipv4AddressSchema,
+  MAX_DNS_LABEL_LENGTH,
   type ObjectKey,
   ObjectKeySchema,
   type Sha256Digest,

--- a/packages/protocol/src/lib/wire.ts
+++ b/packages/protocol/src/lib/wire.ts
@@ -19,7 +19,7 @@ const TIMESTAMP_PATTERN =
 const MAX_TIMESTAMP_LENGTH = 35;
 
 const DNS_LABEL_PATTERN = '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$';
-const MAX_DNS_LABEL_LENGTH = 63;
+export const MAX_DNS_LABEL_LENGTH = 63;
 
 const HOSTNAME_PATTERN =
   '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$';


### PR DESCRIPTION
Derives the DNS label an app is served under from the name its owner gave it: a slugified stem plus Crockford base32 entropy, fitted to the 63-character budget by truncating the stem and never the suffix.

The label is a snapshot taken once, at creation, and never recomputed — by the time an app is renamed its URL is in somebody else's bookmarks. The entropy is what makes taking that snapshot safe, and it also removes the need for a reserved-word denylist: no generated label can equal a bare `api` or `www`.