### PR TITLE
feat(api): deployments

### DIFF
--- a/apps/api/src/db/migrations/0009_create_nibrun_deployments.sql
+++ b/apps/api/src/db/migrations/0009_create_nibrun_deployments.sql
@@ -1,0 +1,77 @@
+-- A deployment is one artifact plus the configuration it was launched with. `app_configs` is
+-- append-only, so naming the row is enough to pin it: a rollback replays exactly what ran
+-- rather than whatever the app has been reconfigured with since, and without a second copy of
+-- the config that could drift from the first.
+--
+-- One deployment is one microVM, so what the protocol calls an instance is these columns
+-- rather than a table: there is never a second row to point at, and a join would only ever
+-- find the row it started from.
+--
+-- One `state` and no wish beside it: a deployment's life is linear, so every step of it is a
+-- state it can be named in. `pending` is asked for and not yet started, `superseded` is
+-- replaced by a newer one — neither needs a second column to be sayable. What the host says
+-- about the microVM lands in the columns below it.
+--
+-- `superseded` and `failed` are terminal; a deployment in any other state is one the app is
+-- still running, which is what the index below keeps to one per app. Nothing ever moves
+-- backwards: going back to an older release is a new row naming the one it replays, so the
+-- history says that a rollback happened rather than losing the release it rewound.
+--
+-- The CHECK repeats DEPLOYMENT_STATES from @repo/protocol and nothing compares the two, so
+-- adding a state there is also a migration here.
+
+CREATE TABLE nibrun.deployments (
+  id                        uuid PRIMARY KEY DEFAULT uuidv7(),
+  app_id                    uuid NOT NULL REFERENCES nibrun.apps (id) ON DELETE RESTRICT,
+  artifact_id               uuid NOT NULL REFERENCES nibrun.artifacts (id) ON DELETE RESTRICT,
+  config_id                 uuid NOT NULL REFERENCES nibrun.app_configs (id) ON DELETE RESTRICT,
+  rollback_of_deployment_id uuid REFERENCES nibrun.deployments (id) ON DELETE RESTRICT,
+  state                     text NOT NULL DEFAULT 'pending',
+  host_port                 integer,
+  guest_ipv4                text,
+  restart_count             integer NOT NULL DEFAULT 0,
+  message                   text,
+  started_at                timestamptz,
+  last_healthy_at           timestamptz,
+  activated_at              timestamptz,
+  created_at                timestamptz GENERATED ALWAYS AS (uuid_extract_timestamp(id)) VIRTUAL,
+  updated_at                timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT deployments_state_check
+    CHECK (state IN ('pending', 'starting', 'active', 'superseded', 'failed'))
+);
+
+COMMENT ON COLUMN nibrun.deployments.id IS $c$@type import('@repo/protocol').DeploymentId$c$;
+COMMENT ON COLUMN nibrun.deployments.app_id IS $c$@type import('@repo/protocol').AppId$c$;
+COMMENT ON COLUMN nibrun.deployments.artifact_id IS $c$@type import('@repo/protocol').ArtifactId$c$;
+COMMENT ON COLUMN nibrun.deployments.config_id IS 'The app config version this deployment was launched with.';
+COMMENT ON COLUMN nibrun.deployments.state IS $c$@type import('@repo/protocol').DeploymentState$c$;
+COMMENT ON COLUMN nibrun.deployments.host_port IS $c$@type import('@repo/protocol').HostPort$c$;
+COMMENT ON COLUMN nibrun.deployments.guest_ipv4 IS $c$@type import('@repo/protocol').Ipv4Address$c$;
+COMMENT ON COLUMN nibrun.deployments.message IS 'Why the deployment is in the state it is in, as the host put it. Never the tenant''s own output, which has a streaming path of its own.';
+COMMENT ON COLUMN nibrun.deployments.rollback_of_deployment_id IS $c$The deployment this one replays, when it was made to go back to one. @type import('@repo/protocol').DeploymentId$c$;
+COMMENT ON COLUMN nibrun.deployments.created_at IS 'Derived from the uuidv7 id; the moment the row was created. @notNull';
+
+CREATE INDEX deployments_app_id_idx ON nibrun.deployments (app_id);
+
+-- Not redundant with the primary key: this is the index the artifact_id foreign key's own
+-- check reads, and without it deleting an artifact seq-scans every deployment.
+CREATE INDEX deployments_artifact_id_idx ON nibrun.deployments (artifact_id);
+
+CREATE INDEX deployments_config_id_idx ON nibrun.deployments (config_id);
+
+CREATE INDEX deployments_rollback_of_idx ON nibrun.deployments (rollback_of_deployment_id);
+
+-- One app runs one deployment at a time, and which one is a fact about the row rather than a
+-- column on the app, so the constraint that keeps it single lives here. Unique rather than an
+-- ordinary index: two callers deploying at once each supersede what they can see and neither
+-- sees the other's insert, so this is what makes the loser a conflict instead of a second
+-- microVM contending for the app's host port.
+--
+-- Named as the states that are *not* terminal, so a state added later is live unless it says
+-- otherwise. Changing that list means rebuilding this index: a partial index decides
+-- membership when a row is written, so rows already in it keep the old answer.
+CREATE UNIQUE INDEX deployments_live_idx
+  ON nibrun.deployments (app_id) WHERE state NOT IN ('superseded', 'failed');
+
+CREATE TRIGGER set_updated_at BEFORE UPDATE ON nibrun.deployments
+  FOR EACH ROW EXECUTE FUNCTION nibrun.set_updated_at();

--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -235,6 +235,111 @@ export interface ISelectArtifactByIdResult {
     created_at: Date;
 }
 
+/** Result of query `SelectDeployableArtifact`. */
+export interface ISelectDeployableArtifactResult {
+    id: import("@repo/protocol").ArtifactId;
+}
+
+/** Result of query `InsertDeployment`. */
+export interface IInsertDeploymentResult {
+    id: import("@repo/protocol").DeploymentId;
+}
+
+/** Result of query `SelectDeploymentToReplay`. */
+export interface ISelectDeploymentToReplayResult {
+    id: import("@repo/protocol").DeploymentId;
+}
+
+/** Result of query `InsertReplayedDeployment`. */
+export interface IInsertReplayedDeploymentResult {
+    id: import("@repo/protocol").DeploymentId;
+}
+
+/** Result of query `SelectDeploymentsByApp`. */
+export interface ISelectDeploymentsByAppResult {
+    id: import("@repo/protocol").DeploymentId;
+    app_id: import("@repo/protocol").AppId;
+    artifact_id: import("@repo/protocol").ArtifactId;
+    state: import("@repo/protocol").DeploymentState;
+    activated_at: Date | null;
+    /** The deployment this one replays, when it was made to go back to one. */
+    rollback_of_deployment_id: import("@repo/protocol").DeploymentId | null;
+    created_at: Date;
+    guest_port: import("@repo/protocol").GuestPort;
+    args: string[];
+    vcpu_count: number;
+    memory_mib: number;
+    health_check_path: string | null;
+    health_check_interval_ms: number;
+    health_check_timeout_ms: number;
+    health_check_grace_period_ms: number;
+    health_check_healthy_threshold: number;
+    health_check_unhealthy_threshold: number;
+    restart_max_restarts: number;
+    restart_initial_backoff_ms: number;
+    restart_max_backoff_ms: number;
+    restart_backoff_factor: number;
+    restart_reset_after_ms: number;
+}
+
+/** Result of query `SelectDeploymentById`. */
+export interface ISelectDeploymentByIdResult {
+    id: import("@repo/protocol").DeploymentId;
+    app_id: import("@repo/protocol").AppId;
+    artifact_id: import("@repo/protocol").ArtifactId;
+    state: import("@repo/protocol").DeploymentState;
+    activated_at: Date | null;
+    /** The deployment this one replays, when it was made to go back to one. */
+    rollback_of_deployment_id: import("@repo/protocol").DeploymentId | null;
+    created_at: Date;
+    guest_port: import("@repo/protocol").GuestPort;
+    args: string[];
+    vcpu_count: number;
+    memory_mib: number;
+    health_check_path: string | null;
+    health_check_interval_ms: number;
+    health_check_timeout_ms: number;
+    health_check_grace_period_ms: number;
+    health_check_healthy_threshold: number;
+    health_check_unhealthy_threshold: number;
+    restart_max_restarts: number;
+    restart_initial_backoff_ms: number;
+    restart_max_backoff_ms: number;
+    restart_backoff_factor: number;
+    restart_reset_after_ms: number;
+}
+
+/** Result of query `SupersedeLiveDeployment`. */
+export interface ISupersedeLiveDeploymentResult {
+}
+
+/** Result of query `SelectInsertedDeployment`. */
+export interface ISelectInsertedDeploymentResult {
+    id: import("@repo/protocol").DeploymentId;
+    app_id: import("@repo/protocol").AppId;
+    artifact_id: import("@repo/protocol").ArtifactId;
+    state: import("@repo/protocol").DeploymentState;
+    activated_at: Date | null;
+    /** The deployment this one replays, when it was made to go back to one. */
+    rollback_of_deployment_id: import("@repo/protocol").DeploymentId | null;
+    created_at: Date;
+    guest_port: import("@repo/protocol").GuestPort;
+    args: string[];
+    vcpu_count: number;
+    memory_mib: number;
+    health_check_path: string | null;
+    health_check_interval_ms: number;
+    health_check_timeout_ms: number;
+    health_check_grace_period_ms: number;
+    health_check_healthy_threshold: number;
+    health_check_unhealthy_threshold: number;
+    restart_max_restarts: number;
+    restart_initial_backoff_ms: number;
+    restart_max_backoff_ms: number;
+    restart_backoff_factor: number;
+    restart_reset_after_ms: number;
+}
+
 /** Result of query `SelectHealthPing`. */
 export interface ISelectHealthPingResult {
     ok: number | null;
@@ -259,6 +364,14 @@ export interface Queries {
     InsertArtifact: IInsertArtifactResult;
     SelectArtifactsByApp: ISelectArtifactsByAppResult;
     SelectArtifactById: ISelectArtifactByIdResult;
+    SelectDeployableArtifact: ISelectDeployableArtifactResult;
+    InsertDeployment: IInsertDeploymentResult;
+    SelectDeploymentToReplay: ISelectDeploymentToReplayResult;
+    InsertReplayedDeployment: IInsertReplayedDeploymentResult;
+    SelectDeploymentsByApp: ISelectDeploymentsByAppResult;
+    SelectDeploymentById: ISelectDeploymentByIdResult;
+    SupersedeLiveDeployment: ISupersedeLiveDeploymentResult;
+    SelectInsertedDeployment: ISelectInsertedDeploymentResult;
     SelectHealthPing: ISelectHealthPingResult;
 }
 

--- a/apps/api/src/repositories/deployments.repository.ts
+++ b/apps/api/src/repositories/deployments.repository.ts
@@ -1,0 +1,201 @@
+import type { TypedSQL } from '@ilbertt/bun-sqlgen';
+import type { AppId, ArtifactId, DeploymentId, OwnerId } from '@repo/protocol';
+import type { Queries } from '#db/queries.gen.d.ts';
+import { Repository } from '#repositories/repository.ts';
+
+export type DeploymentRow = Queries['SelectDeploymentById'];
+
+export type OwnedApp = { appId: AppId; ownerId: OwnerId };
+
+export type CreateDeploymentInput = OwnedApp & { artifactId: ArtifactId };
+
+/**
+ * Going back to a release is a new row naming the one it replays, rather than that one revived:
+ * a deployment never moves backwards, and the history keeps both the release and the rollback.
+ */
+export type RollbackDeploymentInput = OwnedApp & { rollbackOf: DeploymentId };
+
+type Transaction = TypedSQL<Queries>;
+
+export type DeploymentByIdInput = {
+  appId: AppId;
+  deploymentId: DeploymentId;
+  ownerId: OwnerId;
+};
+
+export type DeploymentsByAppInput = {
+  appId: AppId;
+  ownerId: OwnerId;
+};
+
+export abstract class DeploymentsRepositoryContract {
+  abstract insert(input: CreateDeploymentInput): Promise<DeploymentRow | null>;
+  abstract insertRollback(input: RollbackDeploymentInput): Promise<DeploymentRow | null>;
+  abstract listByApp(input: DeploymentsByAppInput): Promise<DeploymentRow[]>;
+  abstract findById(input: DeploymentByIdInput): Promise<DeploymentRow | null>;
+}
+
+export class DeploymentsRepository extends Repository implements DeploymentsRepositoryContract {
+  /**
+   * The app's config id is pinned rather than its contents copied: `app_configs` never changes
+   * a row, so the deployment keeps what it was launched with while a later patch moves the app
+   * on to a new version.
+   *
+   * Creating one is asking for it to run — there is no second call that means it — so whatever
+   * the app was running is superseded first. `deployments_live_idx` admits one live row per app,
+   * so it has to leave in this same transaction or the insert meets it.
+   */
+  insert({ appId, ownerId, artifactId }: CreateDeploymentInput): Promise<DeploymentRow | null> {
+    return this.sql.begin(async (tx) => {
+      // Asked before anything is superseded: returning from this callback commits, so an
+      // artifact this owner does not have must leave the running deployment alone rather than
+      // stand it down on behalf of a request that goes on to write nothing.
+      const [deployable] = await tx.SelectDeployableArtifact`
+        SELECT ar.id
+        FROM nibrun.artifacts ar
+        JOIN nibrun.apps a ON a.id = ar.app_id
+        WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.owner_id = ${ownerId}
+      `;
+      if (!deployable) {
+        return null;
+      }
+      await this.supersedeLive({ tx, appId, ownerId });
+
+      // INSERT … SELECT rather than VALUES, so the predicate that decides ownership is the one
+      // the row is written through rather than one checked beside it.
+      const [inserted] = await tx.InsertDeployment`
+        INSERT INTO nibrun.deployments (app_id, artifact_id, config_id)
+        SELECT a.id, ar.id, c.id
+        FROM nibrun.apps a
+        JOIN nibrun.artifacts ar ON ar.app_id = a.id
+        JOIN LATERAL (
+          SELECT id FROM nibrun.app_configs c
+          WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1
+        ) c ON true
+        WHERE a.id = ${appId} AND a.owner_id = ${ownerId} AND ar.id = ${artifactId}
+        RETURNING id
+      `;
+      return inserted ? await this.selectDeployment({ tx, deploymentId: inserted.id }) : null;
+    });
+  }
+
+  /**
+   * Replays an earlier deployment as a new one, taking both the artifact and the config it
+   * pinned. `app_configs` never changes a row, so that is the release as it ran rather than
+   * that artifact rebuilt against today's configuration.
+   *
+   * The deployment being replayed is matched through the app the caller owns, so one belonging
+   * to another app is not a deployment this request can name.
+   */
+  insertRollback({
+    appId,
+    ownerId,
+    rollbackOf,
+  }: RollbackDeploymentInput): Promise<DeploymentRow | null> {
+    return this.sql.begin(async (tx) => {
+      const [replayable] = await tx.SelectDeploymentToReplay`
+        SELECT d.id
+        FROM nibrun.deployments d
+        JOIN nibrun.apps a ON a.id = d.app_id
+        WHERE d.id = ${rollbackOf} AND d.app_id = ${appId} AND a.owner_id = ${ownerId}
+      `;
+      if (!replayable) {
+        return null;
+      }
+      await this.supersedeLive({ tx, appId, ownerId });
+
+      const [inserted] = await tx.InsertReplayedDeployment`
+        INSERT INTO nibrun.deployments
+          (app_id, artifact_id, config_id, rollback_of_deployment_id)
+        SELECT src.app_id, src.artifact_id, src.config_id, src.id
+        FROM nibrun.deployments src
+        JOIN nibrun.apps a ON a.id = src.app_id
+        WHERE src.id = ${rollbackOf} AND src.app_id = ${appId} AND a.owner_id = ${ownerId}
+        RETURNING id
+      `;
+      return inserted ? await this.selectDeployment({ tx, deploymentId: inserted.id }) : null;
+    });
+  }
+
+  listByApp({ appId, ownerId }: DeploymentsByAppInput): Promise<DeploymentRow[]> {
+    return this.sql.SelectDeploymentsByApp`
+      /* @notNull created_at */
+      SELECT d.id, d.app_id, d.artifact_id, d.state, d.activated_at,
+             d.rollback_of_deployment_id, d.created_at,
+               c.guest_port, c.args, c.vcpu_count, c.memory_mib,
+               c.health_check_path, c.health_check_interval_ms, c.health_check_timeout_ms,
+               c.health_check_grace_period_ms, c.health_check_healthy_threshold,
+               c.health_check_unhealthy_threshold,
+               c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
+               c.restart_backoff_factor, c.restart_reset_after_ms
+      FROM nibrun.deployments d
+      JOIN nibrun.apps a ON a.id = d.app_id
+      JOIN nibrun.app_configs c ON c.id = d.config_id
+      WHERE d.app_id = ${appId} AND a.owner_id = ${ownerId}
+      ORDER BY d.id DESC
+    `;
+  }
+
+  async findById({
+    appId,
+    deploymentId,
+    ownerId,
+  }: DeploymentByIdInput): Promise<DeploymentRow | null> {
+    const [row] = await this.sql.SelectDeploymentById`
+      /* @notNull created_at */
+      SELECT d.id, d.app_id, d.artifact_id, d.state, d.activated_at,
+             d.rollback_of_deployment_id, d.created_at,
+               c.guest_port, c.args, c.vcpu_count, c.memory_mib,
+               c.health_check_path, c.health_check_interval_ms, c.health_check_timeout_ms,
+               c.health_check_grace_period_ms, c.health_check_healthy_threshold,
+               c.health_check_unhealthy_threshold,
+               c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
+               c.restart_backoff_factor, c.restart_reset_after_ms
+      FROM nibrun.deployments d
+      JOIN nibrun.apps a ON a.id = d.app_id
+      JOIN nibrun.app_configs c ON c.id = d.config_id
+      WHERE d.app_id = ${appId} AND d.id = ${deploymentId} AND a.owner_id = ${ownerId}
+    `;
+    return row ?? null;
+  }
+
+  private async supersedeLive({
+    tx,
+    appId,
+    ownerId,
+  }: OwnedApp & { tx: Transaction }): Promise<void> {
+    await tx.SupersedeLiveDeployment`
+      UPDATE nibrun.deployments d
+      SET state = 'superseded'
+      FROM nibrun.apps a
+      WHERE a.id = d.app_id
+        AND d.app_id = ${appId}
+        AND a.owner_id = ${ownerId}
+        AND d.state NOT IN ('superseded', 'failed')
+    `;
+  }
+
+  private async selectDeployment({
+    tx,
+    deploymentId,
+  }: {
+    tx: Transaction;
+    deploymentId: DeploymentId;
+  }): Promise<DeploymentRow | null> {
+    const [row] = await tx.SelectInsertedDeployment`
+      /* @notNull created_at */
+      SELECT d.id, d.app_id, d.artifact_id, d.state, d.activated_at,
+             d.rollback_of_deployment_id, d.created_at,
+             c.guest_port, c.args, c.vcpu_count, c.memory_mib,
+             c.health_check_path, c.health_check_interval_ms, c.health_check_timeout_ms,
+             c.health_check_grace_period_ms, c.health_check_healthy_threshold,
+             c.health_check_unhealthy_threshold,
+             c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
+             c.restart_backoff_factor, c.restart_reset_after_ms
+      FROM nibrun.deployments d
+      JOIN nibrun.app_configs c ON c.id = d.config_id
+      WHERE d.id = ${deploymentId}
+    `;
+    return row ?? null;
+  }
+}

--- a/apps/api/src/routes/api/apps/[id]/controller.ts
+++ b/apps/api/src/routes/api/apps/[id]/controller.ts
@@ -2,6 +2,7 @@ import type { OwnerId } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import { AppArtifactsController } from '#routes/api/apps/[id]/artifacts/controller.ts';
+import { AppDeploymentsController } from '#routes/api/apps/[id]/deployments/controller.ts';
 import { AppParamsSchema } from '#routes/api/apps/[id]/model.ts';
 import { AppConfigPatchSchema, AppResponseSchema } from '#routes/api/apps/model.ts';
 import { AppsServicePlugin, loggerPlugin } from '#services/plugins.ts';
@@ -51,4 +52,5 @@ export const AppByIdController = new Elysia({ prefix: '/:id' })
       response: { [StatusMap.Accepted]: AppResponseSchema },
     },
   )
-  .use(AppArtifactsController);
+  .use(AppArtifactsController)
+  .use(AppDeploymentsController);

--- a/apps/api/src/routes/api/apps/[id]/deployments/[deploymentId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[id]/deployments/[deploymentId]/controller.ts
@@ -1,0 +1,29 @@
+import type { OwnerId } from '@repo/protocol';
+import { Elysia, StatusMap } from 'elysia';
+import { authPlugin } from '#lib/auth/plugin.ts';
+import {
+  DeploymentParamsSchema,
+  DeploymentResponseSchema,
+} from '#routes/api/apps/[id]/deployments/model.ts';
+import { DeploymentsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+
+export const AppDeploymentByIdController = new Elysia({ prefix: '/:deploymentId' })
+  .use(loggerPlugin('appDeploymentByIdController'))
+  .use(authPlugin)
+  .use(DeploymentsServicePlugin)
+  .guard({ auth: true })
+  .get(
+    '/',
+    async ({ deploymentsService, params, user, status }) => {
+      const deployment = await deploymentsService.get({
+        appId: params.id,
+        deploymentId: params.deploymentId,
+        ownerId: user.id as OwnerId,
+      });
+      return status(StatusMap.OK, deployment);
+    },
+    {
+      params: DeploymentParamsSchema,
+      response: { [StatusMap.OK]: DeploymentResponseSchema },
+    },
+  );

--- a/apps/api/src/routes/api/apps/[id]/deployments/controller.test.ts
+++ b/apps/api/src/routes/api/apps/[id]/deployments/controller.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { StatusMap } from 'elysia';
+
+const BETTER_AUTH_SECRET_LENGTH = 32;
+
+// The api reads its configuration when the service graph is constructed, so the environment
+// has to exist before the app module is imported. Postgres is pointed at a closed port: every
+// route below is refused before it would reach a query.
+const REQUIRED_ENV = {
+  DATABASE_URL: 'postgres://nobody@127.0.0.1:1/none',
+  BETTER_AUTH_SECRET: 'x'.repeat(BETTER_AUTH_SECRET_LENGTH),
+  GITHUB_CLIENT_ID: 'test',
+  GITHUB_CLIENT_SECRET: 'test',
+  S3_ENDPOINT: 'http://127.0.0.1:1',
+  VICTORIALOGS_ENDPOINT: 'http://127.0.0.1:1',
+  ARTIFACTS_BUCKET: 'test',
+  S3_ACCESS_KEY_ID: 'test',
+  S3_SECRET_ACCESS_KEY: 'test',
+  S3_REGION: 'test',
+  APP_HOST_DOMAIN: 'apps.test',
+};
+
+const APP_ID = 'app-1';
+const DEPLOYMENT_ID = 'deployment-1';
+const DEPLOYMENTS = `http://localhost/api/apps/${APP_ID}/deployments`;
+
+let app: { handle: (request: Request) => Promise<Response> };
+
+beforeAll(async () => {
+  Object.assign(process.env, REQUIRED_ENV);
+  const { createApp } = await import('#app.ts');
+  app = createApp();
+});
+
+function get(url: string) {
+  return app.handle(new Request(url));
+}
+
+function send({ method, url, body }: { method: string; url: string; body?: unknown }) {
+  return app.handle(
+    new Request(url, {
+      method,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body ?? {}),
+    }),
+  );
+}
+
+// A 401 rather than a 404 is what proves the route is mounted: an unmounted path under /api
+// answers 404, so these assertions cover both the auth gate and the route tree.
+describe('a deployment belongs to an app, and an app belongs to someone', () => {
+  test('listing an app deployments without a session is refused', async () => {
+    expect((await get(DEPLOYMENTS)).status).toBe(StatusMap.Unauthorized);
+  });
+
+  test('creating one is refused', async () => {
+    const response = await send({
+      method: 'POST',
+      url: DEPLOYMENTS,
+      body: { artifactId: 'artifact-1' },
+    });
+
+    expect(response.status).toBe(StatusMap.Unauthorized);
+  });
+
+  test('fetching one is refused', async () => {
+    expect((await get(`${DEPLOYMENTS}/${DEPLOYMENT_ID}`)).status).toBe(StatusMap.Unauthorized);
+  });
+
+  test('going back to one is refused, on the same route that deploys', async () => {
+    const response = await send({
+      method: 'POST',
+      url: DEPLOYMENTS,
+      body: { rollbackOf: DEPLOYMENT_ID },
+    });
+
+    expect(response.status).toBe(StatusMap.Unauthorized);
+  });
+});

--- a/apps/api/src/routes/api/apps/[id]/deployments/controller.ts
+++ b/apps/api/src/routes/api/apps/[id]/deployments/controller.ts
@@ -1,0 +1,48 @@
+import type { OwnerId } from '@repo/protocol';
+import { Elysia, StatusMap } from 'elysia';
+import { authPlugin } from '#lib/auth/plugin.ts';
+import { AppDeploymentByIdController } from '#routes/api/apps/[id]/deployments/[deploymentId]/controller.ts';
+import {
+  CreateDeploymentBodySchema,
+  DeploymentResponseSchema,
+  ListDeploymentsResponseSchema,
+} from '#routes/api/apps/[id]/deployments/model.ts';
+import { AppParamsSchema } from '#routes/api/apps/[id]/model.ts';
+import { DeploymentsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+
+export const AppDeploymentsController = new Elysia({ prefix: '/deployments' })
+  .use(loggerPlugin('appDeploymentsController'))
+  .use(authPlugin)
+  .use(DeploymentsServicePlugin)
+  .guard({ auth: true })
+  .get(
+    '/',
+    async ({ deploymentsService, params, user, status }) => {
+      const deployments = await deploymentsService.list({
+        appId: params.id,
+        ownerId: user.id as OwnerId,
+      });
+      return status(StatusMap.OK, { deployments });
+    },
+    {
+      params: AppParamsSchema,
+      response: { [StatusMap.OK]: ListDeploymentsResponseSchema },
+    },
+  )
+  .post(
+    '/',
+    async ({ deploymentsService, params, body, user, status }) => {
+      const deployment = await deploymentsService.createOrRollback({
+        appId: params.id,
+        ownerId: user.id as OwnerId,
+        source: body,
+      });
+      return status(StatusMap.Created, deployment);
+    },
+    {
+      params: AppParamsSchema,
+      body: CreateDeploymentBodySchema,
+      response: { [StatusMap.Created]: DeploymentResponseSchema },
+    },
+  )
+  .use(AppDeploymentByIdController);

--- a/apps/api/src/routes/api/apps/[id]/deployments/model.ts
+++ b/apps/api/src/routes/api/apps/[id]/deployments/model.ts
@@ -1,0 +1,28 @@
+import { ArtifactIdSchema, DeploymentIdSchema, DeploymentSchema } from '@repo/protocol';
+import { t } from 'elysia';
+import { AppParamsSchema } from '#routes/api/apps/[id]/model.ts';
+import { PublicAppConfigSchema } from '#routes/api/apps/model.ts';
+
+export const DeploymentParamsSchema = t.Composite([
+  AppParamsSchema,
+  t.Object({ deploymentId: DeploymentIdSchema }),
+]);
+
+/**
+ * An artifact to run, or a release to go back to — never both and never neither. A union rather
+ * than two optional fields, so a request naming both is a schema error rather than a rule the
+ * handler has to remember to apply.
+ */
+export const CreateDeploymentBodySchema = t.Union([
+  t.Object({ artifactId: ArtifactIdSchema }, { additionalProperties: false }),
+  t.Object({ rollbackOf: DeploymentIdSchema }, { additionalProperties: false }),
+]);
+
+export const DeploymentResponseSchema = t.Composite([
+  t.Omit(DeploymentSchema, ['config']),
+  t.Object({ config: PublicAppConfigSchema }),
+]);
+
+export const ListDeploymentsResponseSchema = t.Object({
+  deployments: t.Array(DeploymentResponseSchema),
+});

--- a/apps/api/src/services/deployments.service.test.ts
+++ b/apps/api/src/services/deployments.service.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type AppId,
+  type ArtifactId,
+  DEFAULT_HEALTH_CHECK,
+  DEFAULT_INSTANCE_RESOURCES,
+  DEFAULT_RESTART_POLICY,
+  type DeploymentId,
+  type GuestPort,
+  type OwnerId,
+  type Timestamp,
+} from '@repo/protocol';
+import { SQL } from 'bun';
+import { type PublicAppConfig, VOLUME_SIZE_BYTES } from '#lib/app-config.ts';
+import { ConflictError, NotFoundError } from '#lib/errors.ts';
+import type {
+  CreateDeploymentInput,
+  DeploymentByIdInput,
+  DeploymentRow,
+  DeploymentsByAppInput,
+  DeploymentsRepositoryContract,
+  RollbackDeploymentInput,
+} from '#repositories/deployments.repository.ts';
+import { DeploymentsService } from '#services/deployments.service.ts';
+
+const OWNER_ID = 'owner-1' as OwnerId;
+const APP_ID = 'app-1' as AppId;
+const ARTIFACT_ID = 'artifact-1' as ArtifactId;
+const DEPLOYMENT_ID = 'deployment-1' as DeploymentId;
+
+const GUEST_PORT = 8090 as GuestPort;
+const OWNER_SCOPED_METHODS = 4;
+const CREATED_AT = new Date('2026-08-04T10:00:00.000Z');
+const ACTIVATED_AT = new Date('2026-08-04T11:30:00.000Z');
+
+// The config version this deployment pins. `app_configs` never changes a row, so this is what
+// the deployment was launched with however the app has since been reconfigured.
+const PINNED_CONFIG: PublicAppConfig = {
+  volumeSizeBytes: VOLUME_SIZE_BYTES,
+  guestPort: GUEST_PORT,
+  args: ['serve'],
+  resources: DEFAULT_INSTANCE_RESOURCES,
+  healthCheck: DEFAULT_HEALTH_CHECK,
+  restartPolicy: DEFAULT_RESTART_POLICY,
+};
+
+// What Postgres raises when a second deployment reaches `deployments_live_idx` first.
+function liveIndexViolation(): SQL.PostgresError {
+  return new SQL.PostgresError('duplicate key value violates unique constraint', {
+    code: 'ERR_POSTGRES_SERVER_ERROR',
+    errno: '23505',
+    constraint: 'deployments_live_idx',
+  });
+}
+
+function deploymentRow(overrides: Partial<DeploymentRow> = {}): DeploymentRow {
+  return {
+    id: DEPLOYMENT_ID,
+    app_id: APP_ID,
+    artifact_id: ARTIFACT_ID,
+    state: 'pending',
+    activated_at: null,
+    rollback_of_deployment_id: null,
+    created_at: CREATED_AT,
+    guest_port: PINNED_CONFIG.guestPort,
+    args: [...PINNED_CONFIG.args],
+    vcpu_count: PINNED_CONFIG.resources.vcpuCount,
+    memory_mib: PINNED_CONFIG.resources.memoryMib,
+    health_check_path: PINNED_CONFIG.healthCheck.path ?? null,
+    health_check_interval_ms: PINNED_CONFIG.healthCheck.intervalMs,
+    health_check_timeout_ms: PINNED_CONFIG.healthCheck.timeoutMs,
+    health_check_grace_period_ms: PINNED_CONFIG.healthCheck.gracePeriodMs,
+    health_check_healthy_threshold: PINNED_CONFIG.healthCheck.healthyThreshold,
+    health_check_unhealthy_threshold: PINNED_CONFIG.healthCheck.unhealthyThreshold,
+    restart_max_restarts: PINNED_CONFIG.restartPolicy.maxRestarts,
+    restart_initial_backoff_ms: PINNED_CONFIG.restartPolicy.initialBackoffMs,
+    restart_max_backoff_ms: PINNED_CONFIG.restartPolicy.maxBackoffMs,
+    restart_backoff_factor: PINNED_CONFIG.restartPolicy.backoffFactor,
+    restart_reset_after_ms: PINNED_CONFIG.restartPolicy.resetAfterMs,
+    ...overrides,
+  };
+}
+
+type FakeBehaviour = {
+  rows?: DeploymentRow[];
+  row?: DeploymentRow | null;
+  runError?: unknown;
+};
+
+class FakeDeploymentsRepository implements DeploymentsRepositoryContract {
+  readonly calls: Array<Record<string, unknown>> = [];
+  readonly #behaviour: FakeBehaviour;
+
+  constructor(behaviour: FakeBehaviour = {}) {
+    this.#behaviour = behaviour;
+  }
+
+  insert(input: CreateDeploymentInput): Promise<DeploymentRow | null> {
+    this.calls.push(input);
+    if (this.#behaviour.runError) {
+      return Promise.reject(this.#behaviour.runError);
+    }
+    return Promise.resolve(this.#behaviour.row ?? null);
+  }
+
+  listByApp(input: DeploymentsByAppInput): Promise<DeploymentRow[]> {
+    this.calls.push(input);
+    return Promise.resolve(this.#behaviour.rows ?? []);
+  }
+
+  findById(input: DeploymentByIdInput): Promise<DeploymentRow | null> {
+    this.calls.push(input);
+    return Promise.resolve(this.#behaviour.row ?? null);
+  }
+
+  insertRollback(input: RollbackDeploymentInput): Promise<DeploymentRow | null> {
+    this.calls.push(input);
+    if (this.#behaviour.runError) {
+      return Promise.reject(this.#behaviour.runError);
+    }
+    return Promise.resolve(this.#behaviour.row ?? null);
+  }
+}
+
+function serviceWith(behaviour: FakeBehaviour = {}) {
+  const deploymentsRepo = new FakeDeploymentsRepository(behaviour);
+  return { deploymentsRepo, service: new DeploymentsService({ deploymentsRepo }) };
+}
+
+describe('a deployment publishes the config version it pins', () => {
+  test('the pinned config reaches the wire, and carries no environment to leak', async () => {
+    const { service } = serviceWith({ row: deploymentRow() });
+
+    const deployment = await service.createOrRollback({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      source: { artifactId: ARTIFACT_ID },
+    });
+
+    expect(deployment.config).toEqual({
+      volumeSizeBytes: VOLUME_SIZE_BYTES,
+      guestPort: GUEST_PORT,
+      args: ['serve'],
+      resources: DEFAULT_INSTANCE_RESOURCES,
+      healthCheck: DEFAULT_HEALTH_CHECK,
+      restartPolicy: DEFAULT_RESTART_POLICY,
+    });
+    expect('environment' in deployment.config).toBe(false);
+  });
+
+  test('columns become the wire shape the protocol describes', async () => {
+    const { service } = serviceWith({ row: deploymentRow() });
+
+    expect(
+      await service.get({ appId: APP_ID, deploymentId: DEPLOYMENT_ID, ownerId: OWNER_ID }),
+    ).toMatchObject({
+      id: DEPLOYMENT_ID,
+      appId: APP_ID,
+      artifactId: ARTIFACT_ID,
+      state: 'pending',
+      createdAt: CREATED_AT.toISOString(),
+    });
+  });
+
+  // `activatedAt` is optional on the wire, so a deployment that has never run must omit it
+  // rather than publish a null the schema would reject.
+  test('a deployment that has never run carries no activation instant', async () => {
+    const { service } = serviceWith({ row: deploymentRow() });
+
+    const deployment = await service.get({
+      appId: APP_ID,
+      deploymentId: DEPLOYMENT_ID,
+      ownerId: OWNER_ID,
+    });
+
+    expect('activatedAt' in deployment).toBe(false);
+  });
+
+  test('and one that has carries it as an ISO instant', async () => {
+    const { service } = serviceWith({
+      row: deploymentRow({ state: 'active', activated_at: ACTIVATED_AT }),
+    });
+
+    const deployment = await service.get({
+      appId: APP_ID,
+      deploymentId: DEPLOYMENT_ID,
+      ownerId: OWNER_ID,
+    });
+
+    expect(deployment.activatedAt).toBe(ACTIVATED_AT.toISOString() as Timestamp);
+  });
+});
+
+describe('an app the caller does not own is indistinguishable from one that does not exist', () => {
+  test('creating against an unowned app or a foreign artifact is a 404, never a 403', async () => {
+    const { service } = serviceWith({ row: null });
+
+    await expect(
+      service.createOrRollback({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        source: { artifactId: ARTIFACT_ID },
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test('fetching one is too', async () => {
+    const { service } = serviceWith({ row: null });
+
+    await expect(
+      service.get({ appId: APP_ID, deploymentId: DEPLOYMENT_ID, ownerId: OWNER_ID }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test('going back to one belonging to another app is too', async () => {
+    const { service } = serviceWith({ row: null });
+
+    await expect(
+      service.createOrRollback({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        source: { rollbackOf: DEPLOYMENT_ID },
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test("listing yields nothing rather than another owner's rows", async () => {
+    const { service } = serviceWith({ rows: [] });
+
+    expect(await service.list({ appId: APP_ID, ownerId: OWNER_ID })).toEqual([]);
+  });
+
+  // The owner is a predicate the database applies, so a service that forgets to pass it down
+  // turns every query into a cross-tenant read.
+  test('every call carries the owner down to the query', async () => {
+    const { deploymentsRepo, service } = serviceWith({ row: deploymentRow(), rows: [] });
+
+    await service.createOrRollback({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      source: { artifactId: ARTIFACT_ID },
+    });
+    await service.list({ appId: APP_ID, ownerId: OWNER_ID });
+    await service.get({ appId: APP_ID, deploymentId: DEPLOYMENT_ID, ownerId: OWNER_ID });
+    await service.createOrRollback({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      source: { rollbackOf: DEPLOYMENT_ID },
+    });
+
+    expect(deploymentsRepo.calls).toHaveLength(OWNER_SCOPED_METHODS);
+    for (const call of deploymentsRepo.calls) {
+      expect(call.ownerId).toBe(OWNER_ID);
+    }
+  });
+});
+
+describe('creating a deployment is asking for it to run', () => {
+  // There is no second call that means it, so a caller that never activates still gets a deploy
+  // rather than a row nobody looks at.
+  test('a new deployment comes back pending rather than stopped', async () => {
+    const { service } = serviceWith({ row: deploymentRow({ state: 'pending' }) });
+
+    const deployment = await service.createOrRollback({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      source: { artifactId: ARTIFACT_ID },
+    });
+
+    expect(deployment.state).toBe('pending');
+  });
+
+  // Same index, same race, whichever call is asking: creating now claims the running slot too.
+  test('losing the race while creating is a conflict, not a 500', async () => {
+    const { service } = serviceWith({ runError: liveIndexViolation() });
+
+    await expect(
+      service.createOrRollback({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        source: { artifactId: ARTIFACT_ID },
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});
+
+describe('going back to a release is a new deployment, not an old one revived', () => {
+  // Which of the two the body is saying is the whole difference, so this is what proves the
+  // service reads it rather than treating every request as a fresh artifact.
+  test('naming a deployment replays it rather than deploying an artifact', async () => {
+    const { deploymentsRepo, service } = serviceWith({ row: deploymentRow() });
+
+    await service.createOrRollback({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      source: { rollbackOf: DEPLOYMENT_ID },
+    });
+
+    expect(deploymentsRepo.calls).toEqual([
+      { appId: APP_ID, ownerId: OWNER_ID, rollbackOf: DEPLOYMENT_ID },
+    ]);
+  });
+
+  // The row it replays keeps its own state and its own history; this is a new release that
+  // happens to run what that one ran.
+  test('the rollback is its own row, naming the one it replays', async () => {
+    const { service } = serviceWith({
+      row: deploymentRow({ rollback_of_deployment_id: DEPLOYMENT_ID }),
+    });
+
+    expect(
+      (
+        await service.createOrRollback({
+          appId: APP_ID,
+          ownerId: OWNER_ID,
+          source: { rollbackOf: DEPLOYMENT_ID },
+        })
+      ).rollbackOf,
+    ).toBe(DEPLOYMENT_ID);
+  });
+
+  // Two callers racing meet the partial unique index, not each other. The loser is told to
+  // retry rather than left believing it won.
+  test('losing the race to the live index is a conflict, not a 500', async () => {
+    const { service } = serviceWith({ runError: liveIndexViolation() });
+
+    await expect(
+      service.createOrRollback({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        source: { rollbackOf: DEPLOYMENT_ID },
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  test('any other database failure is not disguised as one', async () => {
+    const boom = new Error('connection reset');
+    const { service } = serviceWith({ runError: boom });
+
+    await expect(
+      service.createOrRollback({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        source: { rollbackOf: DEPLOYMENT_ID },
+      }),
+    ).rejects.toBe(boom);
+  });
+});

--- a/apps/api/src/services/deployments.service.ts
+++ b/apps/api/src/services/deployments.service.ts
@@ -1,0 +1,99 @@
+import type { ArtifactId, Deployment } from '@repo/protocol';
+import { type PublicAppConfig, toAppConfig } from '#lib/app-config.ts';
+import { ConflictError, NotFoundError } from '#lib/errors.ts';
+import { isUniqueViolation } from '#lib/pg-errors.ts';
+import { toTimestamp } from '#lib/timestamp.ts';
+import type {
+  DeploymentByIdInput,
+  DeploymentRow,
+  DeploymentsByAppInput,
+  DeploymentsRepositoryContract,
+  OwnedApp,
+  RollbackDeploymentInput,
+} from '#repositories/deployments.repository.ts';
+import { Service } from '#services/service.ts';
+
+const LIVE_DEPLOYMENT_CONSTRAINT = 'deployments_live_idx';
+
+export type PublicDeployment = Omit<Deployment, 'config'> & { config: PublicAppConfig };
+
+/**
+ * An artifact to run, or a release to go back to. Which of the two a request is saying decides
+ * where the artifact and the config come from, and nothing else about it differs.
+ */
+export type DeploymentSource =
+  | { artifactId: ArtifactId }
+  | Pick<RollbackDeploymentInput, 'rollbackOf'>;
+
+export class DeploymentsService extends Service {
+  private readonly deploymentsRepo: DeploymentsRepositoryContract;
+
+  constructor({ deploymentsRepo }: { deploymentsRepo: DeploymentsRepositoryContract }) {
+    super();
+    this.deploymentsRepo = deploymentsRepo;
+  }
+
+  /**
+   * Creating a deployment is asking for it to run — there is no second call that means it — so
+   * this stands down whatever the app was running. Going back to an older release is the same
+   * request naming that release, and this is where the body decides which of the two it is.
+   *
+   * What comes back is still `pending`: a host has to boot it and say so.
+   */
+  createOrRollback({
+    source,
+    ...owned
+  }: OwnedApp & { source: DeploymentSource }): Promise<PublicDeployment> {
+    if ('rollbackOf' in source) {
+      return this.published(
+        this.deploymentsRepo.insertRollback({ ...owned, rollbackOf: source.rollbackOf }),
+      );
+    }
+    return this.published(this.deploymentsRepo.insert({ ...owned, artifactId: source.artifactId }));
+  }
+
+  async list(input: DeploymentsByAppInput): Promise<PublicDeployment[]> {
+    const rows = await this.deploymentsRepo.listByApp(input);
+    return rows.map(toPublicDeployment);
+  }
+
+  async get(input: DeploymentByIdInput): Promise<PublicDeployment> {
+    const row = await this.deploymentsRepo.findById(input);
+    if (!row) {
+      throw new NotFoundError('Deployment not found.');
+    }
+    return toPublicDeployment(row);
+  }
+
+  /**
+   * Both ways of asking end here. A source the caller does not own wrote nothing, which is a
+   * 404 rather than a 403 — a deployment they cannot see must not be confirmed to exist. Two
+   * callers racing meet `deployments_live_idx` rather than each other, so the loser is told to
+   * retry instead of leaving the app with two live deployments.
+   */
+  private async published(write: Promise<DeploymentRow | null>): Promise<PublicDeployment> {
+    const row = await write.catch((error: unknown) => {
+      if (isUniqueViolation({ error, constraint: LIVE_DEPLOYMENT_CONSTRAINT })) {
+        throw new ConflictError('Another deployment for this app is being started.');
+      }
+      throw error;
+    });
+    if (!row) {
+      throw new NotFoundError('App, artifact or deployment not found.');
+    }
+    return toPublicDeployment(row);
+  }
+}
+
+function toPublicDeployment(row: DeploymentRow): PublicDeployment {
+  return {
+    id: row.id,
+    appId: row.app_id,
+    artifactId: row.artifact_id,
+    config: toAppConfig(row),
+    state: row.state,
+    createdAt: toTimestamp(row.created_at),
+    ...(row.activated_at && { activatedAt: toTimestamp(row.activated_at) }),
+    ...(row.rollback_of_deployment_id && { rollbackOf: row.rollback_of_deployment_id }),
+  };
+}

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -8,12 +8,14 @@ import { AppsRepository } from '#repositories/apps.repository.ts';
 import { ArtifactStorageRepository } from '#repositories/artifact-storage.repository.ts';
 import { ArtifactsRepository } from '#repositories/artifacts.repository.ts';
 import { AssetsRepository } from '#repositories/assets.repository.ts';
+import { DeploymentsRepository } from '#repositories/deployments.repository.ts';
 import { FilesystemRepository } from '#repositories/filesystem.repository.ts';
 import { HealthRepository } from '#repositories/health.repository.ts';
 import { AgentService } from '#services/agent.service.ts';
 import { AppsService } from '#services/apps.service.ts';
 import { ArtifactsService } from '#services/artifacts.service.ts';
 import { AssetsService } from '#services/assets.service.ts';
+import { DeploymentsService } from '#services/deployments.service.ts';
 import { FilesystemService } from '#services/filesystem.service.ts';
 import { HealthService } from '#services/health.service.ts';
 
@@ -23,6 +25,7 @@ const healthRepository = new HealthRepository(sql);
 const filesystemRepository = new FilesystemRepository(sql);
 const appsRepository = new AppsRepository(sql);
 const artifactsRepository = new ArtifactsRepository(sql);
+const deploymentsRepository = new DeploymentsRepository(sql);
 const artifactStorageRepository = new ArtifactStorageRepository(s3);
 
 const agentService = new AgentService({ agentRepo: agentRepository });
@@ -38,6 +41,7 @@ const artifactsService = new ArtifactsService({
   storageRepo: artifactStorageRepository,
   appsRepo: appsRepository,
 });
+const deploymentsService = new DeploymentsService({ deploymentsRepo: deploymentsRepository });
 
 export function loggerPlugin(name: string) {
   const logger = createLogger(name);
@@ -72,4 +76,9 @@ export const AppsServicePlugin = new Elysia({ name: 'service.apps' }).decorate(
 export const ArtifactsServicePlugin = new Elysia({ name: 'service.artifacts' }).decorate(
   'artifactsService',
   artifactsService,
+);
+
+export const DeploymentsServicePlugin = new Elysia({ name: 'service.deployments' }).decorate(
+  'deploymentsService',
+  deploymentsService,
 );

--- a/packages/protocol/src/domain/deployment.ts
+++ b/packages/protocol/src/domain/deployment.ts
@@ -4,14 +4,7 @@ import { AppIdSchema, ArtifactIdSchema, DeploymentIdSchema } from '#domain/ident
 import { stringEnum } from '#lib/string-enum.ts';
 import { TimestampSchema } from '#lib/wire.ts';
 
-export const DEPLOYMENT_STATES = [
-  'pending',
-  'starting',
-  'active',
-  'superseded',
-  'failed',
-  'cancelled',
-] as const;
+export const DEPLOYMENT_STATES = ['pending', 'starting', 'active', 'superseded', 'failed'] as const;
 
 export const DeploymentStateSchema = stringEnum(DEPLOYMENT_STATES);
 
@@ -25,6 +18,10 @@ export const DeploymentSchema = Type.Object({
   state: DeploymentStateSchema,
   createdAt: TimestampSchema,
   activatedAt: Type.Optional(TimestampSchema),
+  // Present when this deployment was made by going back to an older one, naming the one it
+  // replays. A rollback is a new deployment rather than an old one revived, so this is what
+  // says a release happened twice.
+  rollbackOf: Type.Optional(DeploymentIdSchema),
 });
 
 export type Deployment = typeof DeploymentSchema.static;


### PR DESCRIPTION
A deployment is one artifact plus the app configuration it was launched with, snapshotted at creation so that rolling back replays exactly what ran rather than whatever the app has been reconfigured with since.

Activation is a route rather than a state a caller assigns: a partial unique index admits one active deployment per app, and the outgoing row is superseded in the same transaction as the incoming one arrives, so an app is never briefly serving nothing.

Every statement reaches the owner through `nibrun.apps` in the same round trip. Secrets storage remains deferred — the snapshot's `environment` is persisted empty and never reaches the wire.