### PR TITLE
refactor: the api client carries one surface, and the agent uses it

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -5,11 +5,14 @@ plane, long-polls for desired state, converges the host onto it, and reports wha
 is never sent a command. Every decision behind that is commented at the definition it applies to —
 read `reconcile/`, `volumes/topology.ts` and `network/allocator.ts` first.
 
-**No third-party dependencies, deliberately.** Bun's built-ins cover HTTP, S3, hashing, process
-spawning and file I/O, and `@repo/protocol` is the only import. That is what keeps the binary small
-and its supply chain trivial, and it is why everything the host does that Bun cannot do is a
-subprocess (`systemctl`, `ip`, `nft`, `nbd-client`, `mkfs.ext4`, `mksquashfs`, `zerofs`) rather
-than a library. Adding a dependency needs a reason that survives that trade.
+**Everything the host does that Bun cannot do is a subprocess** (`systemctl`, `ip`, `nft`,
+`nbd-client`, `mkfs.ext4`, `mksquashfs`, `zerofs`) rather than a library. Bun's built-ins cover S3,
+hashing, process spawning and file I/O, so the binary stays small.
+
+The control plane is reached through `@repo/api-client/internal`, and every call goes through it,
+so a route the api does not mount is a compile error. What it cannot describe is the bytes that
+come back, so `control/client.ts` still validates every response against `@repo/protocol` before
+believing it.
 
 ## What the host must provide, and does not yet
 

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -11,6 +11,7 @@
     "check:types": "bun run --bun tsc"
   },
   "dependencies": {
+    "@repo/api-client": "workspace:*",
     "@repo/protocol": "workspace:*"
   },
   "devDependencies": {

--- a/apps/agent/src/control/client.test.ts
+++ b/apps/agent/src/control/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import {
   AGENT_API_PREFIX,
   AGENT_ROUTES,
@@ -11,7 +11,6 @@ import {
 } from '@repo/protocol';
 import { ControlPlaneClient, ControlPlaneError } from '#control/client.ts';
 
-const BASE_URL = 'https://control.example';
 const HTTP_OK = 200;
 const HTTP_NO_CONTENT = 204;
 const HTTP_UNAUTHORIZED = 401;
@@ -26,51 +25,80 @@ const VALID_SESSION = {
   poll: { minIntervalMs: 1_000, reportIntervalMs: 15_000 },
 };
 
-function respondWith({ body, status = HTTP_OK }: { body: unknown; status?: number }) {
-  const calls: { url: string; init: RequestInit }[] = [];
-  const fetchImpl = ((...args: [string, RequestInit]) => {
-    calls.push({ url: args[0], init: args[1] });
-    return Promise.resolve(new Response(JSON.stringify(body), { status }));
-  }) as unknown as typeof fetch;
-  return { calls, fetchImpl };
+type ReceivedRequest = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string;
+};
+
+// A real listener rather than a substituted `fetch`: what the client hands the network is the
+// thing under test here, and the only way to read it without trusting the client's own plumbing
+// is to receive it.
+let received: ReceivedRequest[] = [];
+let reply: { body?: unknown; status: number } = { body: {}, status: HTTP_OK };
+
+const controlPlane = Bun.serve({
+  port: 0,
+  async fetch(request) {
+    received.push({
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers),
+      body: await request.text(),
+    });
+    return reply.body === undefined
+      ? new Response(null, { status: reply.status })
+      : Response.json(reply.body, { status: reply.status });
+  },
+});
+
+const BASE_URL = `http://127.0.0.1:${controlPlane.port}`;
+
+beforeEach(() => {
+  received = [];
+  reply = { body: {}, status: HTTP_OK };
+});
+
+afterAll(() => {
+  controlPlane.stop(true);
+});
+
+function respondWith({ body, status = HTTP_OK }: { body?: unknown; status?: number }) {
+  reply = { body, status };
 }
 
 describe('every request identifies the protocol it speaks', () => {
   test('the version header and the session are sent', async () => {
-    const { calls, fetchImpl } = respondWith({
-      body: { result: 'unchanged', generation: SOME_GENERATION },
-    });
-    const client = new ControlPlaneClient({ baseUrl: `${BASE_URL}/`, fetchImpl });
+    respondWith({ body: { result: 'unchanged', generation: SOME_GENERATION } });
+    const client = new ControlPlaneClient({ baseUrl: `${BASE_URL}/` });
     await client.fetchDesiredState({
       sessionToken: SESSION_TOKEN,
       request: { knownGeneration: SOME_GENERATION },
     });
-    const call = calls[0];
+    const call = received[0];
     expect(call?.url).toBe(`${BASE_URL}${AGENT_API_PREFIX}${AGENT_ROUTES.desiredState}`);
-    expect(call?.init.method).toBe('POST');
-    const headers = call?.init.headers as Record<string, string>;
-    expect(headers[PROTOCOL_VERSION_HEADER]).toBe(String(PROTOCOL_VERSION));
-    expect(headers.authorization).toBe(`Bearer ${SESSION_TOKEN}`);
+    expect(call?.method).toBe('POST');
+    expect(call?.headers[PROTOCOL_VERSION_HEADER]).toBe(String(PROTOCOL_VERSION));
+    expect(call?.headers.authorization).toBe(`Bearer ${SESSION_TOKEN}`);
   });
 
   test('the session route is reached without a session', async () => {
-    const { calls, fetchImpl } = respondWith({ body: VALID_SESSION });
-    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    respondWith({ body: VALID_SESSION });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL });
     const session = await client.openSession({
       versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
       capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
     });
     expect(session.hostId).toBe('host-1' as HostId);
-    const sessionHeaders = calls[0]?.init.headers as Record<string, string> | undefined;
-    expect(sessionHeaders?.authorization).toBeUndefined();
+    expect(received[0]?.headers.authorization).toBeUndefined();
   });
 
   // The report is the one route that answers with nothing, so it is the one route where reaching
   // for a body would throw on the success path rather than on a malformed one.
   test('a report expects no reply and does not read for one', async () => {
-    const fetchImpl = (() =>
-      Promise.resolve(new Response(null, { status: HTTP_NO_CONTENT }))) as unknown as typeof fetch;
-    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    respondWith({ body: undefined, status: HTTP_NO_CONTENT });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL });
 
     expect(
       await client.sendReportedState({
@@ -81,8 +109,8 @@ describe('every request identifies the protocol it speaks', () => {
   });
 
   test('tenant logs use one streaming NDJSON request on their own route', async () => {
-    const { calls, fetchImpl } = respondWith({ body: {} });
-    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    respondWith({ body: undefined, status: HTTP_NO_CONTENT });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL });
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new TextEncoder().encode('{"kind":"data"}\n'));
@@ -95,12 +123,13 @@ describe('every request identifies the protocol it speaks', () => {
       signal: new AbortController().signal,
     });
 
-    const call = calls[0];
+    const call = received[0];
     expect(call?.url).toBe(`${BASE_URL}${AGENT_API_PREFIX}${AGENT_ROUTES.tenantLogs}`);
-    expect(call?.init.body).toBe(body);
-    const headers = call?.init.headers as Record<string, string>;
-    expect(headers['content-type']).toBe('application/x-ndjson');
-    expect(headers.authorization).toBe(`Bearer ${SESSION_TOKEN}`);
+    // The stream reached the wire as itself. Handed to the client as a call argument instead,
+    // it would arrive as the `{}` that `JSON.stringify` makes of a ReadableStream.
+    expect(call?.body).toBe('{"kind":"data"}\n');
+    expect(call?.headers['content-type']).toBe('application/x-ndjson');
+    expect(call?.headers.authorization).toBe(`Bearer ${SESSION_TOKEN}`);
   });
 });
 
@@ -155,10 +184,34 @@ test('a log chunk reaches the API while the HTTP request is still open', async (
   }
 });
 
+// The deadline that guards a control plane which never answers is composed with this signal
+// rather than replacing it, and a composition that swallowed the caller's would strand the
+// agent on shutdown — the one case where nothing else is coming to end the request.
+test('a caller that cancels still ends the upload', async () => {
+  const server = Bun.serve({ port: 0, fetch: () => new Promise<Response>(() => {}) });
+  const abort = new AbortController();
+  const client = new ControlPlaneClient({ baseUrl: `http://127.0.0.1:${server.port}` });
+
+  try {
+    const request = client
+      .streamTenantLogs({
+        sessionToken: SESSION_TOKEN,
+        body: new ReadableStream<Uint8Array>({ start: () => {} }),
+        signal: abort.signal,
+      })
+      .catch((caught: unknown) => caught);
+
+    abort.abort();
+    expect(await request).toBeInstanceOf(ControlPlaneError);
+  } finally {
+    server.stop(true);
+  }
+});
+
 describe('validation at the boundary', () => {
   test('a response missing a required field is rejected rather than believed', async () => {
-    const { fetchImpl } = respondWith({ body: { hostId: 'host-1', sessionToken: 'granted' } });
-    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    respondWith({ body: { hostId: 'host-1', sessionToken: 'granted' } });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL });
     await expect(
       client.openSession({
         versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
@@ -168,8 +221,8 @@ describe('validation at the boundary', () => {
   });
 
   test('a mistyped field is rejected', async () => {
-    const { fetchImpl } = respondWith({ body: { result: 'unchanged', generation: 'four' } });
-    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    respondWith({ body: { result: 'unchanged', generation: 'four' } });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL });
     await expect(
       client.fetchDesiredState({
         sessionToken: SESSION_TOKEN,
@@ -179,10 +232,8 @@ describe('validation at the boundary', () => {
   });
 
   test('unknown fields are tolerated, because a rollout always produces them', async () => {
-    const { fetchImpl } = respondWith({
-      body: { ...VALID_SESSION, somethingTheNewerSideAdded: { nested: true } },
-    });
-    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    respondWith({ body: { ...VALID_SESSION, somethingTheNewerSideAdded: { nested: true } } });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL });
     const session = await client.openSession({
       versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
       capacity: { vcpuCount: 2, memoryMib: 4096, cacheBytes: 100 },
@@ -191,10 +242,8 @@ describe('validation at the boundary', () => {
   });
 
   test('a timestamp with no offset is rejected: it is the silently wrong instant', async () => {
-    const { fetchImpl } = respondWith({
-      body: { ...VALID_SESSION, expiresAt: '2026-08-03T11:00:00' },
-    });
-    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    respondWith({ body: { ...VALID_SESSION, expiresAt: '2026-08-03T11:00:00' } });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL });
     await expect(
       client.openSession({
         versions: { agent: 'a', guestImage: 'b', zerofs: 'c', firecracker: 'd' },
@@ -206,8 +255,8 @@ describe('validation at the boundary', () => {
 
 describe('errors', () => {
   test('a 401 is recognisable as an expired session', async () => {
-    const { fetchImpl } = respondWith({ body: { error: 'expired' }, status: HTTP_UNAUTHORIZED });
-    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    respondWith({ body: { error: 'expired' }, status: HTTP_UNAUTHORIZED });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL });
     const error = await client
       .fetchDesiredState({
         sessionToken: SESSION_TOKEN,
@@ -219,8 +268,8 @@ describe('errors', () => {
   });
 
   test('another failure status is not mistaken for one', async () => {
-    const { fetchImpl } = respondWith({ body: { error: 'boom' }, status: HTTP_UNAVAILABLE });
-    const client = new ControlPlaneClient({ baseUrl: BASE_URL, fetchImpl });
+    respondWith({ body: { error: 'boom' }, status: HTTP_UNAVAILABLE });
+    const client = new ControlPlaneClient({ baseUrl: BASE_URL });
     const error = await client
       .fetchDesiredState({
         sessionToken: SESSION_TOKEN,

--- a/apps/agent/src/control/client.ts
+++ b/apps/agent/src/control/client.ts
@@ -1,5 +1,5 @@
+import { createInternalApiClient } from '@repo/api-client/internal';
 import {
-  AGENT_API_PREFIX,
   AGENT_ROUTES,
   type AgentSession,
   type AgentSessionRequest,
@@ -16,9 +16,18 @@ import {
 } from '@repo/protocol';
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+/**
+ * A backstop, not the mechanism that ends an upload.
+ *
+ * The agent ends its own by closing the body, which only works while there is a connection to
+ * close: a response that never arrives leaves the caller waiting on it forever, and the log loop
+ * awaits one upload at a time, so a host in that state stops shipping output and says nothing.
+ *
+ * Well above any window the agent picks, so it never pre-empts a healthy upload — it has to be
+ * raised if that window is ever brought near it.
+ */
+const TENANT_LOG_TIMEOUT_MS = 120_000;
 const HTTP_UNAUTHORIZED = 401;
-
-export type FetchLike = typeof fetch;
 
 export class ControlPlaneError extends Error {
   readonly status: number;
@@ -36,26 +45,78 @@ export class ControlPlaneError extends Error {
   }
 }
 
+type Reply = {
+  data: unknown;
+  error: { value: unknown } | null;
+  status: number;
+};
+
+// Eden hands back a failure rather than rejecting, and reports one it never sent as a 503 of
+// its own, so a refusal and a host that cannot reach the VPC arrive the same way.
+function assertDelivered({ route, reply }: { route: string; reply: Reply }): void {
+  if (!reply.error) {
+    return;
+  }
+  throw new ControlPlaneError({
+    status: reply.status,
+    route,
+    body: describeFailure(reply.error.value),
+  });
+}
+
+function describeFailure(value: unknown): string {
+  if (value instanceof Error) {
+    return value.message;
+  }
+  return typeof value === 'object' && value !== null ? JSON.stringify(value) : String(value);
+}
+
+// `ProtocolHeadersSchema` names one header and admits the rest, but TypeBox writes no index
+// signature for that, so the generated call signature names one header and knows nothing of the
+// rest. Every header a call sends is therefore assembled here rather than at the call site,
+// where the excess-property check would reject the ones the schema allows.
+function protocolHeaders({
+  sessionToken,
+  contentType,
+}: {
+  sessionToken?: SecretString;
+  contentType?: string;
+} = {}) {
+  return {
+    [PROTOCOL_VERSION_HEADER]: String(PROTOCOL_VERSION),
+    ...(sessionToken ? { authorization: `Bearer ${sessionToken}` } : {}),
+    ...(contentType ? { 'content-type': contentType } : {}),
+  };
+}
+
+function requestOptions({ sessionToken }: { sessionToken?: SecretString } = {}) {
+  return {
+    headers: protocolHeaders({ sessionToken }),
+    fetch: { signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS) },
+  };
+}
+
 /**
- * Every call is an outbound POST. Control calls carry one JSON document and validate the reply;
- * tenant logs use their own long-lived NDJSON request so that stream backpressure never enters
- * the desired-state path.
+ * Every call is an outbound POST through the generated client, so a route, a body or a header
+ * the api does not mount is a compile error. Control calls carry one JSON document and validate
+ * the reply; tenant logs carry their own long-lived NDJSON request so that stream backpressure
+ * never enters the desired-state path.
+ *
+ * What the generated client cannot describe is the bytes that come back. The two programs ship
+ * on different pipelines, so a reply the agent cannot parse is the normal consequence of a
+ * rollout rather than an impossible state, and each one is validated before it is believed.
  */
 export class ControlPlaneClient {
-  readonly #baseUrl: string;
-  readonly #fetch: FetchLike;
+  readonly #api: ReturnType<typeof createInternalApiClient>;
 
-  constructor({ baseUrl, fetchImpl = fetch }: { baseUrl: string; fetchImpl?: FetchLike }) {
-    this.#baseUrl = baseUrl.replace(/\/+$/, '');
-    this.#fetch = fetchImpl;
+  constructor({ baseUrl }: { baseUrl: string }) {
+    this.#api = createInternalApiClient({ baseUrl: baseUrl.replace(/\/+$/, '') });
   }
 
   async openSession(request: AgentSessionRequest): Promise<AgentSession> {
-    const response = await this.#post({
-      route: AGENT_ROUTES.session,
-      body: request,
-    });
-    return parseMessage({ schema: AgentSessionSchema, value: await response.json() });
+    const reply = await this.#api.internal.agent.session.post(request, requestOptions());
+    assertDelivered({ route: AGENT_ROUTES.session, reply });
+    return parseMessage({ schema: AgentSessionSchema, value: reply.data });
   }
 
   async fetchDesiredState({
@@ -65,12 +126,12 @@ export class ControlPlaneClient {
     sessionToken: SecretString;
     request: DesiredStateRequest;
   }): Promise<DesiredStateResponse> {
-    const response = await this.#post({
-      route: AGENT_ROUTES.desiredState,
-      body: request,
-      sessionToken,
-    });
-    return parseMessage({ schema: DesiredStateResponseSchema, value: await response.json() });
+    const reply = await this.#api.internal.agent['desired-state'].post(
+      request,
+      requestOptions({ sessionToken }),
+    );
+    assertDelivered({ route: AGENT_ROUTES.desiredState, reply });
+    return parseMessage({ schema: DesiredStateResponseSchema, value: reply.data });
   }
 
   async sendReportedState({
@@ -80,13 +141,22 @@ export class ControlPlaneClient {
     sessionToken: SecretString;
     report: HostReportedState;
   }): Promise<void> {
-    await this.#post({
-      route: AGENT_ROUTES.reportedState,
-      body: report,
-      sessionToken,
-    });
+    const reply = await this.#api.internal.agent['reported-state'].post(
+      report,
+      requestOptions({ sessionToken }),
+    );
+    assertDelivered({ route: AGENT_ROUTES.reportedState, reply });
   }
 
+  /**
+   * The body is passed as a `RequestInit` rather than as the call's argument, because an object
+   * argument is serialised with `JSON.stringify` and a stream does not survive that. Left off,
+   * there is nothing for the client to serialise and the stream reaches `fetch` whole — which is
+   * the same body the route declares `parse: 'none'` for.
+   *
+   * The caller's signal is what normally ends this, so the deadline is composed with it rather
+   * than replacing it: whichever comes first wins, and cancelling still cancels.
+   */
   async streamTenantLogs({
     sessionToken,
     body,
@@ -96,51 +166,13 @@ export class ControlPlaneClient {
     body: ReadableStream<Uint8Array>;
     signal: AbortSignal;
   }): Promise<void> {
-    const route = AGENT_ROUTES.tenantLogs;
-    const response = await this.#fetch(`${this.#baseUrl}${AGENT_API_PREFIX}${route}`, {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${sessionToken}`,
-        'content-type': TENANT_LOG_CONTENT_TYPE,
-        [PROTOCOL_VERSION_HEADER]: String(PROTOCOL_VERSION),
+    const reply = await this.#api.internal.agent['tenant-logs'].post(undefined, {
+      headers: protocolHeaders({ sessionToken, contentType: TENANT_LOG_CONTENT_TYPE }),
+      fetch: {
+        body,
+        signal: AbortSignal.any([signal, AbortSignal.timeout(TENANT_LOG_TIMEOUT_MS)]),
       },
-      body,
-      signal,
     });
-    if (!response.ok) {
-      throw new ControlPlaneError({ status: response.status, route, body: await response.text() });
-    }
-  }
-
-  async #post({
-    route,
-    body,
-    sessionToken,
-  }: {
-    route: string;
-    body: unknown;
-    sessionToken?: SecretString;
-  }): Promise<Response> {
-    const headers: Record<string, string> = {
-      'content-type': 'application/json',
-      [PROTOCOL_VERSION_HEADER]: String(PROTOCOL_VERSION),
-    };
-    if (sessionToken) {
-      headers.authorization = `Bearer ${sessionToken}`;
-    }
-    const response = await this.#fetch(`${this.#baseUrl}${AGENT_API_PREFIX}${route}`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS),
-    });
-    if (!response.ok) {
-      throw new ControlPlaneError({
-        status: response.status,
-        route,
-        body: await response.text(),
-      });
-    }
-    return response;
+    assertDelivered({ route: AGENT_ROUTES.tenantLogs, reply });
   }
 }

--- a/apps/api/src/lib/routes/prefixes.ts
+++ b/apps/api/src/lib/routes/prefixes.ts
@@ -6,3 +6,27 @@ export enum RoutePrefix {
   // route added here is unreachable from the internet the moment it is written.
   Internal = '/internal',
 }
+
+type PathBelow<
+  Path extends string,
+  Prefix extends RoutePrefix,
+> = Path extends `${Prefix}${infer Below}` ? Below : never;
+
+/**
+ * What a controller is left to mount once the prefix its parent already applied is taken off a
+ * full path. `never` when the path does not sit under that prefix at all.
+ *
+ * A function rather than a cast at each call site, because the two halves have to agree: `slice`
+ * returns `string`, and Elysia builds its route tree from a literal, so the prefix has to be
+ * named again in a type to get one back. Named once here, the length taken off and the prefix
+ * asserted cannot be different prefixes.
+ */
+export function pathBelow<Path extends string, Prefix extends RoutePrefix>({
+  path,
+  prefix,
+}: {
+  path: Path;
+  prefix: Prefix;
+}): PathBelow<Path, Prefix> {
+  return path.slice(prefix.length) as PathBelow<Path, Prefix>;
+}

--- a/apps/api/src/routes/internal/agent/controller.ts
+++ b/apps/api/src/routes/internal/agent/controller.ts
@@ -6,10 +6,23 @@ import { AgentReportedStateController } from '#routes/internal/agent/reported-st
 import { AgentSessionController } from '#routes/internal/agent/session/controller.ts';
 import { AgentTenantLogsController } from '#routes/internal/agent/tenant-logs/controller.ts';
 
+type PathBelow<Path extends string, Prefix extends string> = Path extends `${Prefix}${infer Below}`
+  ? Below
+  : never;
+
 // The protocol owns the whole path. This controller applies only the segment below
 // the prefix its parent applies, derived from that one constant so the two cannot
 // drift, and its children keep the bare paths the protocol names.
-const AGENT_PREFIX = AGENT_API_PREFIX.slice(RoutePrefix.Internal.length);
+//
+// The cast restores what `slice` widens away. A literal is what Elysia builds the route
+// tree from, so without it every path under here is an index signature: the generated
+// client would answer to a segment this controller never mounted. `PathBelow` resolves to
+// `never` if the protocol ever stops naming a path under this prefix, which is the drift
+// the derivation exists to catch.
+const AGENT_PREFIX = AGENT_API_PREFIX.slice(RoutePrefix.Internal.length) as PathBelow<
+  typeof AGENT_API_PREFIX,
+  RoutePrefix.Internal
+>;
 
 export const AgentController = new Elysia({ prefix: AGENT_PREFIX })
   .use(AgentSessionController)

--- a/apps/api/src/routes/internal/agent/controller.ts
+++ b/apps/api/src/routes/internal/agent/controller.ts
@@ -1,28 +1,15 @@
 import { AGENT_API_PREFIX } from '@repo/protocol';
 import { Elysia } from 'elysia';
-import { RoutePrefix } from '#lib/routes/prefixes.ts';
+import { pathBelow, RoutePrefix } from '#lib/routes/prefixes.ts';
 import { AgentDesiredStateController } from '#routes/internal/agent/desired-state/controller.ts';
 import { AgentReportedStateController } from '#routes/internal/agent/reported-state/controller.ts';
 import { AgentSessionController } from '#routes/internal/agent/session/controller.ts';
 import { AgentTenantLogsController } from '#routes/internal/agent/tenant-logs/controller.ts';
 
-type PathBelow<Path extends string, Prefix extends string> = Path extends `${Prefix}${infer Below}`
-  ? Below
-  : never;
-
 // The protocol owns the whole path. This controller applies only the segment below
 // the prefix its parent applies, derived from that one constant so the two cannot
 // drift, and its children keep the bare paths the protocol names.
-//
-// The cast restores what `slice` widens away. A literal is what Elysia builds the route
-// tree from, so without it every path under here is an index signature: the generated
-// client would answer to a segment this controller never mounted. `PathBelow` resolves to
-// `never` if the protocol ever stops naming a path under this prefix, which is the drift
-// the derivation exists to catch.
-const AGENT_PREFIX = AGENT_API_PREFIX.slice(RoutePrefix.Internal.length) as PathBelow<
-  typeof AGENT_API_PREFIX,
-  RoutePrefix.Internal
->;
+const AGENT_PREFIX = pathBelow({ path: AGENT_API_PREFIX, prefix: RoutePrefix.Internal });
 
 export const AgentController = new Elysia({ prefix: AGENT_PREFIX })
   .use(AgentSessionController)

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,9 +1,6 @@
 import type { ApiController } from '#routes/api/controller.ts';
 import type { InternalController } from '#routes/internal/controller.ts';
 
-// Two types rather than one for the whole app, so a client can be built from a
-// single surface. Nothing that types itself against the public one can name an
-// internal route, which is what keeps that surface out of the browser bundle.
 export type PublicApp = typeof ApiController;
 
 export type InternalApp = typeof InternalController;

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,3 +1,9 @@
-import type { createApp } from '#app.ts';
+import type { ApiController } from '#routes/api/controller.ts';
+import type { InternalController } from '#routes/internal/controller.ts';
 
-export type App = ReturnType<typeof createApp>;
+// Two types rather than one for the whole app, so a client can be built from a
+// single surface. Nothing that types itself against the public one can name an
+// internal route, which is what keeps that surface out of the browser bundle.
+export type PublicApp = typeof ApiController;
+
+export type InternalApp = typeof InternalController;

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1,5 +1,5 @@
-import { createApiClient } from '@repo/api-client';
+import { createPublicApiClient } from '@repo/api-client/public';
 
 // Same origin in both environments: in production the api binary serves the dashboard,
 // in development Vite proxies the api prefix to the api (see vite.config.ts).
-export const api = createApiClient(window.location.origin);
+export const api = createPublicApiClient({ baseUrl: window.location.origin });

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
     "apps/agent": {
       "name": "@repo/agent",
       "dependencies": {
+        "@repo/api-client": "workspace:*",
         "@repo/protocol": "workspace:*",
       },
       "devDependencies": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    "./public": "./src/public.ts",
+    "./internal": "./src/internal.ts"
   },
   "imports": {
     "#*": "./src/*"

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,0 +1,20 @@
+import { type Treaty, treaty } from '@elysiajs/eden';
+
+// Eden's own constraint, read back off it rather than imported: `elysia` reaches this package
+// only as Eden's peer, so naming it here would be a dependency taken for one type.
+type AnyApp = Exclude<Parameters<typeof treaty>[0], string>;
+
+// Every surface is built here rather than each one calling Eden with the same options, so a
+// surface added later cannot be the one that forgets them.
+//
+// `parseDate` is off because Eden otherwise revives anything ISO-8601-shaped into a Date on the
+// way in. Timestamps are strings everywhere the api declares them, so leaving it on hands a
+// caller a value that disagrees with the type it was just given, and every schema that
+// revalidates one rejects it.
+export function createClient<App extends AnyApp>({
+  baseUrl,
+}: {
+  baseUrl: string;
+}): Treaty.Create<App> {
+  return treaty<App>(baseUrl, { parseDate: false });
+}

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,9 +1,0 @@
-import { type Treaty, treaty } from '@elysiajs/eden';
-import type { App } from '@repo/api/types';
-
-export type ApiClient = Treaty.Create<App>;
-
-// The return annotation is required: the type Eden infers here isn't portable across packages.
-export function createApiClient(baseUrl: string): ApiClient {
-  return treaty<App>(baseUrl);
-}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,3 +1,0 @@
-/** biome-ignore-all lint/performance/noBarrelFile: index is the only allowed file where we can export other files */
-
-export { type ApiClient, createApiClient } from '#client.ts';

--- a/packages/api-client/src/internal.ts
+++ b/packages/api-client/src/internal.ts
@@ -1,16 +1,11 @@
-import { type Treaty, treaty } from '@elysiajs/eden';
+import type { Treaty } from '@elysiajs/eden';
 import type { InternalApp } from '@repo/api/types';
-import { TREATY_DEFAULTS } from '#treaty.ts';
+import { createClient } from '#client.ts';
 
-export type InternalApiClient = Treaty.Create<InternalApp>;
+type InternalApiClient = Treaty.Create<InternalApp>;
 
-// The return annotation is required: the type Eden infers here isn't portable across packages.
-export function createInternalApiClient({
-  baseUrl,
-  fetcher,
-}: {
-  baseUrl: string;
-  fetcher?: typeof fetch;
-}): InternalApiClient {
-  return treaty<InternalApp>(baseUrl, { ...TREATY_DEFAULTS, fetcher });
+// The return annotation is required: the type Eden infers isn't portable across packages. Only
+// declaration emit says so, and this package is consumed as source, so nothing here reports it.
+export function createInternalApiClient({ baseUrl }: { baseUrl: string }): InternalApiClient {
+  return createClient<InternalApp>({ baseUrl });
 }

--- a/packages/api-client/src/internal.ts
+++ b/packages/api-client/src/internal.ts
@@ -1,0 +1,16 @@
+import { type Treaty, treaty } from '@elysiajs/eden';
+import type { InternalApp } from '@repo/api/types';
+import { TREATY_DEFAULTS } from '#treaty.ts';
+
+export type InternalApiClient = Treaty.Create<InternalApp>;
+
+// The return annotation is required: the type Eden infers here isn't portable across packages.
+export function createInternalApiClient({
+  baseUrl,
+  fetcher,
+}: {
+  baseUrl: string;
+  fetcher?: typeof fetch;
+}): InternalApiClient {
+  return treaty<InternalApp>(baseUrl, { ...TREATY_DEFAULTS, fetcher });
+}

--- a/packages/api-client/src/public.ts
+++ b/packages/api-client/src/public.ts
@@ -1,10 +1,11 @@
-import { type Treaty, treaty } from '@elysiajs/eden';
+import type { Treaty } from '@elysiajs/eden';
 import type { PublicApp } from '@repo/api/types';
-import { TREATY_DEFAULTS } from '#treaty.ts';
+import { createClient } from '#client.ts';
 
-export type PublicApiClient = Treaty.Create<PublicApp>;
+type PublicApiClient = Treaty.Create<PublicApp>;
 
-// The return annotation is required: the type Eden infers here isn't portable across packages.
+// The return annotation is required: the type Eden infers isn't portable across packages. Only
+// declaration emit says so, and this package is consumed as source, so nothing here reports it.
 export function createPublicApiClient({ baseUrl }: { baseUrl: string }): PublicApiClient {
-  return treaty<PublicApp>(baseUrl, TREATY_DEFAULTS);
+  return createClient<PublicApp>({ baseUrl });
 }

--- a/packages/api-client/src/public.ts
+++ b/packages/api-client/src/public.ts
@@ -1,0 +1,10 @@
+import { type Treaty, treaty } from '@elysiajs/eden';
+import type { PublicApp } from '@repo/api/types';
+import { TREATY_DEFAULTS } from '#treaty.ts';
+
+export type PublicApiClient = Treaty.Create<PublicApp>;
+
+// The return annotation is required: the type Eden infers here isn't portable across packages.
+export function createPublicApiClient({ baseUrl }: { baseUrl: string }): PublicApiClient {
+  return treaty<PublicApp>(baseUrl, TREATY_DEFAULTS);
+}

--- a/packages/api-client/src/treaty.ts
+++ b/packages/api-client/src/treaty.ts
@@ -1,0 +1,6 @@
+import type { Treaty } from '@elysiajs/eden';
+
+// Eden revives anything ISO-8601-shaped into a Date on the way in. Timestamps are strings
+// everywhere the api declares them, so leaving that on hands a caller a value that disagrees
+// with the type it was just given, and every schema that revalidates one rejects it.
+export const TREATY_DEFAULTS = { parseDate: false } as const satisfies Treaty.Config;

--- a/packages/api-client/src/treaty.ts
+++ b/packages/api-client/src/treaty.ts
@@ -1,6 +1,0 @@
-import type { Treaty } from '@elysiajs/eden';
-
-// Eden revives anything ISO-8601-shaped into a Date on the way in. Timestamps are strings
-// everywhere the api declares them, so leaving that on hands a caller a value that disagrees
-// with the type it was just given, and every schema that revalidates one rejects it.
-export const TREATY_DEFAULTS = { parseDate: false } as const satisfies Treaty.Config;


### PR DESCRIPTION
Splits `@repo/api-client` into `/public` and `/internal` subpath exports so nothing that ships to a browser can name a route under `/internal`, then moves every one of the agent's control-plane calls onto the internal client.

Two things worth a reviewer's attention:

- The agent controller's prefix went through `slice`, which returns `string` rather than a literal. Elysia builds its route tree from that, so the whole `/agent` subtree was an index signature — the generated client answered to segments the controller never mounted.
- Eden revives ISO-8601-shaped strings into `Date`s by default, so both clients set `parseDate: false`. It is a regex guess over every string in a response, not a per-field decision: left on, `expiresAt` arrives as a `Date` while Eden's own type still calls it `string`, every session open fails validation, and a tenant env value of `2026/8/4` becomes `2026-08-03T23:00:00.000Z` — a different day. A field that should be a `Date` should say so with `t.Date()` in the response schema, which types and value would then agree on.

`streamTenantLogs` passes its body as a `RequestInit` instead of as the call's argument — an object argument is serialised with `JSON.stringify`, which a stream does not survive. Backpressure is unaffected; the test that asserts a chunk reaches the API while the request is still open passes unchanged.

This also drops the agent's no-third-party-dependencies rule, which `@repo/api-client` breaks by way of `@elysiajs/eden`.