### PR TITLE
fix: a quiet tenant is not a dead log stream

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -58,6 +58,10 @@ const LOG_RECONNECT_FLOOR_MS = 250;
 // upload that worked. Counting it as a failure is what keeps a misconfigured edge from becoming
 // a silent reconnect loop that never backs off and never says anything.
 const MIN_HEALTHY_LOG_STREAM_MS = 5_000;
+// Comfortably inside both the control plane's own idle timeout and the 60s an AWS load balancer
+// defaults to, because the cost of being wrong in one direction is a byte and in the other is
+// every quiet host reconnecting on a timer.
+const LOG_KEEPALIVE_INTERVAL_MS = 20_000;
 
 export class Agent {
   readonly #config: AgentConfig;
@@ -234,6 +238,10 @@ export class Agent {
       this.#logUploadAbort = abort;
       const body = this.#logQueue.readable();
       const startedAtMs = performance.now();
+      const keepalive = setInterval(() => {
+        this.#logQueue.keepalive();
+      }, LOG_KEEPALIVE_INTERVAL_MS);
+      keepalive.unref();
       try {
         const session = await this.#ensureSession();
         await this.#client.streamTenantLogs({
@@ -258,6 +266,7 @@ export class Agent {
         }
         logger.warn({ message: 'tenant log stream failed', ...describeError(error) });
       } finally {
+        clearInterval(keepalive);
         abort.abort();
         if (this.#logUploadAbort === abort) {
           this.#logUploadAbort = undefined;

--- a/apps/agent/src/logs/queue.test.ts
+++ b/apps/agent/src/logs/queue.test.ts
@@ -28,6 +28,18 @@ describe('the bounded upload queue', () => {
     await reader.cancel();
   });
 
+  // A host whose apps are quiet still has to hold the request open, and every timeout between
+  // here and the control plane counts silence as a dead connection.
+  test('a keepalive is an empty line, so it carries no event', async () => {
+    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    expect(queue.keepalive()).toBe(true);
+
+    const reader = queue.readable().getReader();
+    const result = await reader.read();
+    expect(new TextDecoder().decode(result.value)).toBe('\n');
+    await reader.cancel();
+  });
+
   test('it refuses growth past its byte limit instead of blocking the producer', () => {
     const queue = new TenantLogQueue({ maxBytes: 1 });
     expect(queue.push(event())).toBe(false);

--- a/apps/agent/src/logs/queue.ts
+++ b/apps/agent/src/logs/queue.ts
@@ -28,7 +28,24 @@ export class TenantLogQueue {
     const chunk = new Uint8Array(json.byteLength + NEWLINE.byteLength);
     chunk.set(json);
     chunk.set(NEWLINE, json.byteLength);
+    return this.#offer(chunk);
+  }
 
+  /**
+   * An empty line: NDJSON framing carrying no event, which the control plane skips.
+   *
+   * A host whose apps are quiet sends nothing for as long as they stay quiet, and every timeout
+   * between here and the control plane reads that silence as a dead connection. This is what
+   * makes the request outlive the tenant's own talkativeness.
+   */
+  keepalive(): boolean {
+    if (this.#closed) {
+      return false;
+    }
+    return this.#offer(NEWLINE);
+  }
+
+  #offer(chunk: Uint8Array): boolean {
     if (this.#waiting) {
       const waiting = this.#waiting;
       this.#waiting = undefined;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,16 +7,6 @@ await runMigrations();
 // Imported dynamically so the migrations run before the app opens its pool.
 const { createApp } = await import('#app.ts');
 
-// Bun closes a request that has gone quiet for ten seconds, which is the resting state of a
-// tenant log stream: an app that is not printing sends nothing, and the agent holds the request
-// open anyway. This is Bun's ceiling, and the agent keeps the connection under it with a
-// keepalive rather than relying on the tenant to keep talking.
-const IDLE_TIMEOUT_SECONDS = 255;
-
-const { server } = createApp().listen({
-  port: env.PORT,
-  hostname: '0.0.0.0',
-  idleTimeout: IDLE_TIMEOUT_SECONDS,
-});
+const { server } = createApp().listen({ port: env.PORT, hostname: '0.0.0.0' });
 
 createLogger('api').info(`listening on ${server!.url.origin}`);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,16 @@ await runMigrations();
 // Imported dynamically so the migrations run before the app opens its pool.
 const { createApp } = await import('#app.ts');
 
-const { server } = createApp().listen({ port: env.PORT, hostname: '0.0.0.0' });
+// Bun closes a request that has gone quiet for ten seconds, which is the resting state of a
+// tenant log stream: an app that is not printing sends nothing, and the agent holds the request
+// open anyway. This is Bun's ceiling, and the agent keeps the connection under it with a
+// keepalive rather than relying on the tenant to keep talking.
+const IDLE_TIMEOUT_SECONDS = 255;
+
+const { server } = createApp().listen({
+  port: env.PORT,
+  hostname: '0.0.0.0',
+  idleTimeout: IDLE_TIMEOUT_SECONDS,
+});
 
 createLogger('api').info(`listening on ${server!.url.origin}`);

--- a/apps/api/src/lib/agent/tenant-logs.ts
+++ b/apps/api/src/lib/agent/tenant-logs.ts
@@ -1,5 +1,8 @@
 import { parseMessage, type TenantLogEvent, TenantLogEventSchema } from '@repo/protocol';
 import { BadRequestError } from '#lib/errors.ts';
+import { createLogger } from '#lib/logger.ts';
+
+const streamLogger = createLogger('agentTenantLogs');
 
 // The protocol caps one chunk's text far below this, so a line that outgrows it is a body with
 // no newlines in it rather than a large event. This request stays open for the life of a host,
@@ -27,11 +30,24 @@ export async function* tenantLogEvents({
   let pending = '';
   try {
     for (;;) {
-      const { done, value } = await reader.read();
-      if (done) {
+      let chunk: Awaited<ReturnType<typeof reader.read>>;
+      try {
+        chunk = await reader.read();
+      } catch (error) {
+        // Nothing but the connection can fail this read, and a host going away is how this
+        // request ends far more often than the host politely stopping — an agent restart, a
+        // deploy, a timeout anywhere in between. Everything it sent before this was delivered,
+        // so the stream is over, not broken, and answering with a fault would only make the
+        // agent treat its own reconnect as an error.
+        streamLogger.info('tenant log stream disconnected', {
+          reason: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      }
+      if (chunk.done) {
         break;
       }
-      pending += decoder.decode(value, { stream: true });
+      pending += decoder.decode(chunk.value, { stream: true });
       for (
         let newline = pending.indexOf(NEWLINE);
         newline >= 0;

--- a/apps/api/src/routes/internal/agent/controller.test.ts
+++ b/apps/api/src/routes/internal/agent/controller.test.ts
@@ -263,6 +263,38 @@ describe('an agent streams tenant output on a request of its own', () => {
     expect(response.status).toBe(StatusMap['Bad Request']);
   });
 
+  // A host stops sending by going away far more often than by closing politely — an agent
+  // restart, a deploy, a timeout in between. Answering that with a fault makes the agent log a
+  // failure for its own reconnect, and makes a 500 the ordinary outcome of this route.
+  test('a host that goes away mid-stream ends it rather than failing it', async () => {
+    const session = await readSession(await openSession());
+    let send!: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        send = controller;
+      },
+    });
+
+    const response = postTenantLogs({ body, sessionToken: session.sessionToken });
+    send.enqueue(new TextEncoder().encode(tenantLogLine()));
+    await Bun.sleep(SETTLE_MS);
+    send.error(new DOMException('The connection was closed.', 'AbortError'));
+
+    expect((await response).status).toBe(StatusMap['No Content']);
+  });
+
+  // What the agent sends to stop the connection reading as idle. It has to survive the decoder
+  // without becoming an event or an error, or the keepalive would break the stream it protects.
+  test('an empty line is a keepalive, not an event and not a fault', async () => {
+    const session = await readSession(await openSession());
+    const response = await postTenantLogs({
+      body: `\n${tenantLogLine()}\n\n`,
+      sessionToken: session.sessionToken,
+    });
+
+    expect(response.status).toBe(StatusMap['No Content']);
+  });
+
   test('a stream arriving without a session is refused', async () => {
     expect((await postTenantLogs({ body: tenantLogLine() })).status).toBe(StatusMap.Unauthorized);
   });

--- a/apps/api/src/routes/internal/agent/tenant-logs/controller.ts
+++ b/apps/api/src/routes/internal/agent/tenant-logs/controller.ts
@@ -6,6 +6,12 @@ import { tenantLogEvents } from '#lib/agent/tenant-logs.ts';
 import { ProtocolHeadersSchema } from '#routes/internal/agent/model.ts';
 import { AgentServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
+// Bun closes a request that has gone ten seconds without data, and this one is quiet whenever
+// the apps on a host are: silence here is the resting state, not a stall. Raised for this
+// request alone rather than for the listener, so every other route still drops a stalled client
+// at the default. Bun's ceiling, because the floor is a host reconnecting on a timer.
+const TENANT_LOG_IDLE_TIMEOUT_SECONDS = 255;
+
 // `parse: 'none'` is what makes this route possible: the default parser reads a body to its end
 // before the handler runs, and this body does not have one until the host stops sending. The
 // reply comes after the stream, never on its headers — the agent counts a response as the end of
@@ -15,7 +21,8 @@ export const AgentTenantLogsController = new Elysia()
   .use(AgentServicePlugin)
   .post(
     AGENT_ROUTES.tenantLogs,
-    async ({ agentService, request, headers, status }) => {
+    async ({ agentService, request, headers, status, server }) => {
+      server?.timeout(request, TENANT_LOG_IDLE_TIMEOUT_SECONDS);
       assertProtocolVersion(headers);
       const hostId = await agentService.hostForSession({ sessionToken: sessionTokenFrom(headers) });
       await agentService.ingestTenantLogs({


### PR DESCRIPTION
Every tenant log stream was being cut after ten seconds of silence and the cut was answered with a 500.

```
ERROR [http] POST /internal/agent/tenant-logs 500 (28573ms)
AbortError: The connection was closed.
```

Bun's default `idleTimeout` is ten seconds, and an app that is not printing sends nothing while the agent holds the request open regardless — so silence, not failure, was ending every stream.