### PR TITLE
fix(ci): make the image layer cache actually apply

### DIFF
--- a/.github/actions/build-and-push-docker/action.yml
+++ b/.github/actions/build-and-push-docker/action.yml
@@ -14,9 +14,6 @@ inputs:
   dockerfile:
     description: Path to the Dockerfile.
     required: true
-  cache-scope:
-    description: GitHub Actions cache scope; keep distinct per image to avoid collisions.
-    required: true
 
 outputs:
   image-uri:
@@ -36,7 +33,12 @@ runs:
         IMAGE_TAG: ${{ inputs.image-tag }}
         BUILD_CONTEXT: ${{ inputs.context }}
         DOCKERFILE: ${{ inputs.dockerfile }}
-        CACHE_FROM: type=gha,scope=${{ inputs.cache-scope }}
-        CACHE_TO: type=gha,mode=max,scope=${{ inputs.cache-scope }}
+        # The registry cache rides on the login this build already holds.
+        # type=gha would need Actions credentials that GitHub hands to JS
+        # actions only, and buildx drops a cache it cannot authenticate
+        # silently — no warning, exit 0, every layer rebuilt. GHCR rejects
+        # buildkit's default cache manifest list, hence image-manifest.
+        CACHE_FROM: type=registry,ref=${{ inputs.image-repository }}:buildcache
+        CACHE_TO: type=registry,ref=${{ inputs.image-repository }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
         SOURCE_LABEL: https://github.com/${{ github.repository }}
       run: bun run --filter @repo/internal-scripts build-and-push-image

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,7 +62,6 @@ jobs:
           image-tag: ${{ github.sha }}
           context: ${{ matrix.context }}
           dockerfile: ${{ matrix.dockerfile }}
-          cache-scope: ${{ matrix.name }}
 
       - name: Verify the image is public
         run: bun run --filter @repo/internal-scripts verify-public-images ${{ steps.image.outputs.image-uri }}

--- a/packages/internal-scripts/src/build-and-push-image.ts
+++ b/packages/internal-scripts/src/build-and-push-image.ts
@@ -4,8 +4,7 @@ import { writeSummary } from '#shared/actions.ts';
 import { optionalEnv, requiredEnv } from '#shared/env.ts';
 import { repoRoot } from '#shared/paths.ts';
 
-const imageRepository = requiredEnv('IMAGE_REPOSITORY');
-const imageUri = `${imageRepository}:${requiredEnv('IMAGE_TAG')}`;
+const imageUri = `${requiredEnv('IMAGE_REPOSITORY')}:${requiredEnv('IMAGE_TAG')}`;
 const dockerfile = requiredEnv('DOCKERFILE');
 const buildContext = requiredEnv('BUILD_CONTEXT');
 
@@ -17,44 +16,14 @@ const cacheTo = optionalEnv('CACHE_TO');
 
 core.setOutput('image-uri', imageUri);
 
-async function gitObjectId(path: string): Promise<string> {
-  // The root tree is addressed by the empty path; `HEAD:.` is not a revision.
-  const revision = path === '.' ? 'HEAD:' : `HEAD:${path}`;
-  return (await $`git rev-parse ${revision}`.cwd(repoRoot).text()).trim();
-}
-
-async function isPublished(uri: string): Promise<boolean> {
-  return (await $`docker manifest inspect ${uri}`.quiet().nothrow()).exitCode === 0;
-}
-
-async function skipBuild(message: string): Promise<never> {
+// Tags are immutable (the commit sha), so a re-run on the same commit has
+// nothing to rebuild.
+const existing = await $`docker manifest inspect ${imageUri}`.quiet().nothrow();
+if (existing.exitCode === 0) {
+  const message = `Image ${imageUri} already exists; skipping build.`;
   core.info(message);
   await writeSummary(message);
   process.exit(0);
-}
-
-// A git object id is already a hash of the tree under it, so every input the
-// image is built from collapses into one tag that moves only when the image
-// would differ.
-const buildInputs = [
-  platform,
-  sourceLabel,
-  await gitObjectId(dockerfile),
-  await gitObjectId(buildContext),
-];
-const contentUri = `${imageRepository}:content-${Bun.SHA256.hash(buildInputs.join('\n'), 'hex')}`;
-
-// Tags are immutable (the commit sha), so a re-run on the same commit has
-// nothing to rebuild.
-if (await isPublished(imageUri)) {
-  await skipBuild(`Image ${imageUri} already exists; skipping build.`);
-}
-
-// A commit that leaves this image's inputs alone still needs a tag at its own
-// sha, which the registry copies from whichever build last produced them.
-if (await isPublished(contentUri)) {
-  await $`docker buildx imagetools create --tag ${imageUri} ${contentUri}`;
-  await skipBuild(`Image ${contentUri} is unchanged; retagged as ${imageUri} without rebuilding.`);
 }
 
 const argv = [
@@ -66,8 +35,6 @@ const argv = [
   '--push',
   '--tag',
   imageUri,
-  '--tag',
-  contentUri,
   '--label',
   `org.opencontainers.image.source=${sourceLabel}`,
   '--file',

--- a/packages/internal-scripts/src/build-and-push-image.ts
+++ b/packages/internal-scripts/src/build-and-push-image.ts
@@ -4,7 +4,8 @@ import { writeSummary } from '#shared/actions.ts';
 import { optionalEnv, requiredEnv } from '#shared/env.ts';
 import { repoRoot } from '#shared/paths.ts';
 
-const imageUri = `${requiredEnv('IMAGE_REPOSITORY')}:${requiredEnv('IMAGE_TAG')}`;
+const imageRepository = requiredEnv('IMAGE_REPOSITORY');
+const imageUri = `${imageRepository}:${requiredEnv('IMAGE_TAG')}`;
 const dockerfile = requiredEnv('DOCKERFILE');
 const buildContext = requiredEnv('BUILD_CONTEXT');
 
@@ -16,14 +17,44 @@ const cacheTo = optionalEnv('CACHE_TO');
 
 core.setOutput('image-uri', imageUri);
 
-// Tags are immutable (the commit sha), so a re-run on the same commit has
-// nothing to rebuild.
-const existing = await $`docker manifest inspect ${imageUri}`.quiet().nothrow();
-if (existing.exitCode === 0) {
-  const message = `Image ${imageUri} already exists; skipping build.`;
+async function gitObjectId(path: string): Promise<string> {
+  // The root tree is addressed by the empty path; `HEAD:.` is not a revision.
+  const revision = path === '.' ? 'HEAD:' : `HEAD:${path}`;
+  return (await $`git rev-parse ${revision}`.cwd(repoRoot).text()).trim();
+}
+
+async function isPublished(uri: string): Promise<boolean> {
+  return (await $`docker manifest inspect ${uri}`.quiet().nothrow()).exitCode === 0;
+}
+
+async function skipBuild(message: string): Promise<never> {
   core.info(message);
   await writeSummary(message);
   process.exit(0);
+}
+
+// A git object id is already a hash of the tree under it, so every input the
+// image is built from collapses into one tag that moves only when the image
+// would differ.
+const buildInputs = [
+  platform,
+  sourceLabel,
+  await gitObjectId(dockerfile),
+  await gitObjectId(buildContext),
+];
+const contentUri = `${imageRepository}:content-${Bun.SHA256.hash(buildInputs.join('\n'), 'hex')}`;
+
+// Tags are immutable (the commit sha), so a re-run on the same commit has
+// nothing to rebuild.
+if (await isPublished(imageUri)) {
+  await skipBuild(`Image ${imageUri} already exists; skipping build.`);
+}
+
+// A commit that leaves this image's inputs alone still needs a tag at its own
+// sha, which the registry copies from whichever build last produced them.
+if (await isPublished(contentUri)) {
+  await $`docker buildx imagetools create --tag ${imageUri} ${contentUri}`;
+  await skipBuild(`Image ${contentUri} is unchanged; retagged as ${imageUri} without rebuilding.`);
 }
 
 const argv = [
@@ -35,6 +66,8 @@ const argv = [
   '--push',
   '--tag',
   imageUri,
+  '--tag',
+  contentUri,
   '--label',
   `org.opencontainers.image.source=${sourceLabel}`,
   '--file',


### PR DESCRIPTION
Every push to main rebuilt both images from scratch because the layer cache was never applied.

`--cache-from type=gha` needs the Actions cache credentials, which GitHub hands to JS actions only — never to a `run:` step, which is where this build happens. buildx drops a cache it cannot authenticate silently: no warning, exit 0, every layer rebuilt. Confirmed in [run 30917189224](https://github.com/ilbertt/nibrun/actions/runs/30917189224) — no `importing cache manifest` or `exporting cache` vertex anywhere, and `apk add` / `bun install` executing on every run — and reproduced locally, where the same flags no-op without the token and configure the exporter with it.

A registry cache needs only the GHCR login the build already holds, so the ref comes from the image repository and `cache-scope` has nothing left to name.

The existing `docker manifest inspect` skip is untouched, and so is the deploy wiring.

Verified against a local registry: the cache round-trips on a fresh builder (`apk add` → `CACHED`), and a missing cache tag on the first run is non-fatal.

> [!NOTE]
> `onfabric/company-brain` builds the same way from a `run:` step with `type=gha`, and nothing there exposes the runtime token either — its cache is silently inert too.