### PR TITLE
refactor(logs): the agent decides when a log stream ends

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -53,15 +53,22 @@ const NO_FAILURES = 0;
 const DESIRED_STATE_FILENAME = 'desired-state.json';
 const TENANT_LOG_BUFFER_BYTES = 8_388_608;
 const LOG_RECONNECT_FLOOR_MS = 250;
-// The control plane holds this request open until the agent stops sending, so a stream that
-// ended sooner than this carried nothing and is a route answering on headers rather than an
-// upload that worked. Counting it as a failure is what keeps a misconfigured edge from becoming
-// a silent reconnect loop that never backs off and never says anything.
+// The agent ends each upload itself rather than letting one run until something kills it, so a
+// stream that ended well inside its own window ended for a reason nobody chose. Counting that as
+// a failure is what keeps a misconfigured edge from becoming a silent reconnect loop.
 const MIN_HEALTHY_LOG_STREAM_MS = 5_000;
-// Comfortably inside both the control plane's own idle timeout and the 60s an AWS load balancer
-// defaults to, because the cost of being wrong in one direction is a byte and in the other is
-// every quiet host reconnecting on a timer.
-const LOG_KEEPALIVE_INTERVAL_MS = 20_000;
+// How long one upload lasts before the agent closes it and opens the next.
+//
+// The agent ends it rather than the control plane because this request carries its data in the
+// body: whoever ends it decides what was in flight at the time, and only the sender knows when
+// nothing is. Ended at a drained queue it costs nothing, which is what makes a window this short
+// affordable — and short is what keeps a stalled upload from holding a host's output hostage.
+const LOG_STREAM_WINDOW_MS = 30_000;
+// Silence, not the window, is what an idle timer measures, and a quiet app produces plenty of it
+// inside one window. Sending an empty line more often than anything between here and the control
+// plane is willing to wait is what lets the window above be chosen for delivery reasons instead
+// of to dodge somebody's timeout.
+const LOG_KEEPALIVE_INTERVAL_MS = 10_000;
 
 export class Agent {
   readonly #config: AgentConfig;
@@ -242,6 +249,10 @@ export class Agent {
         this.#logQueue.keepalive();
       }, LOG_KEEPALIVE_INTERVAL_MS);
       keepalive.unref();
+      const window = setTimeout(() => {
+        this.#logQueue.endStream();
+      }, LOG_STREAM_WINDOW_MS);
+      window.unref();
       try {
         const session = await this.#ensureSession();
         await this.#client.streamTenantLogs({
@@ -266,13 +277,16 @@ export class Agent {
         }
         logger.warn({ message: 'tenant log stream failed', ...describeError(error) });
       } finally {
+        clearTimeout(window);
         clearInterval(keepalive);
         abort.abort();
         if (this.#logUploadAbort === abort) {
           this.#logUploadAbort = undefined;
         }
       }
-      if (this.#running) {
+      // Reaching the end of a window is not a retry, so it does not wait: the next upload opens
+      // immediately and whatever the tenant wrote in between is already queued for it.
+      if (this.#running && failures > NO_FAILURES) {
         const retryMs = Math.max(
           LOG_RECONNECT_FLOOR_MS,
           backoffDelayMs({ attempt: failures, policy: CONTROL_PLANE_BACKOFF }),

--- a/apps/agent/src/logs/queue.test.ts
+++ b/apps/agent/src/logs/queue.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import type { AppId, DeploymentId, InstanceId, TenantLogEvent, Timestamp } from '@repo/protocol';
 import { TenantLogQueue } from '#logs/queue.ts';
 
+const AFTER_THE_STREAM_ENDED = 7;
+
 function event(sequence = 0): TenantLogEvent {
   return {
     kind: 'data',
@@ -61,9 +63,11 @@ describe('the bounded upload queue', () => {
     queue.endStream();
     expect((await ending.read()).done).toBe(true);
 
-    expect(queue.push(event(7))).toBe(true);
+    expect(queue.push(event(AFTER_THE_STREAM_ENDED))).toBe(true);
     const replacement = queue.readable().getReader();
-    expect(JSON.parse(new TextDecoder().decode((await replacement.read()).value)).sequence).toBe(7);
+    expect(JSON.parse(new TextDecoder().decode((await replacement.read()).value)).sequence).toBe(
+      AFTER_THE_STREAM_ENDED,
+    );
     await replacement.cancel();
   });
 

--- a/apps/agent/src/logs/queue.test.ts
+++ b/apps/agent/src/logs/queue.test.ts
@@ -40,6 +40,44 @@ describe('the bounded upload queue', () => {
     await reader.cancel();
   });
 
+  // The point of ending a stream rather than cutting it: an upload cut mid-flight loses whatever
+  // the request had already taken, and HTTP cannot say how much that was.
+  test('ending a stream hands over everything queued before it stops', async () => {
+    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    expect(queue.push(event(1))).toBe(true);
+    expect(queue.push(event(2))).toBe(true);
+
+    const reader = queue.readable().getReader();
+    queue.endStream();
+
+    expect(JSON.parse(new TextDecoder().decode((await reader.read()).value)).sequence).toBe(1);
+    expect(JSON.parse(new TextDecoder().decode((await reader.read()).value)).sequence).toBe(2);
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  test('an event that arrives after a stream ended waits for the one that replaces it', async () => {
+    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    const ending = queue.readable().getReader();
+    queue.endStream();
+    expect((await ending.read()).done).toBe(true);
+
+    expect(queue.push(event(7))).toBe(true);
+    const replacement = queue.readable().getReader();
+    expect(JSON.parse(new TextDecoder().decode((await replacement.read()).value)).sequence).toBe(7);
+    await replacement.cancel();
+  });
+
+  // The window fires whether or not the queue happens to be empty, and an idle host is the case
+  // where it always is.
+  test('a stream ended while nothing is queued closes rather than hanging', async () => {
+    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    const reader = queue.readable().getReader();
+    const pending = reader.read();
+    queue.endStream();
+
+    expect((await pending).done).toBe(true);
+  });
+
   test('it refuses growth past its byte limit instead of blocking the producer', () => {
     const queue = new TenantLogQueue({ maxBytes: 1 });
     expect(queue.push(event())).toBe(false);

--- a/apps/agent/src/logs/queue.ts
+++ b/apps/agent/src/logs/queue.ts
@@ -14,6 +14,7 @@ export class TenantLogQueue {
   #queuedBytes = 0;
   #waiting: WaitingReader | undefined;
   #activeToken: symbol | undefined;
+  #endingStream = false;
   #closed = false;
 
   constructor({ maxBytes }: { maxBytes: number }) {
@@ -45,6 +46,25 @@ export class TenantLogQueue {
     return this.#offer(NEWLINE);
   }
 
+  /**
+   * End the current request's body once it has taken everything queued, leaving the queue itself
+   * open for the request that replaces it.
+   *
+   * An upload cannot be cut without losing whatever the request had already taken, and HTTP has
+   * no per-chunk acknowledgement to work out how much that was. A drained queue is the one
+   * boundary where the agent knows exactly what the control plane received, so it is the only
+   * place a stream can end for free.
+   */
+  endStream(): void {
+    if (this.#waiting) {
+      const waiting = this.#waiting;
+      this.#waiting = undefined;
+      waiting.resolve(undefined);
+      return;
+    }
+    this.#endingStream = true;
+  }
+
   #offer(chunk: Uint8Array): boolean {
     if (this.#waiting) {
       const waiting = this.#waiting;
@@ -67,6 +87,7 @@ export class TenantLogQueue {
     // read. Handing the next event to that reader would deliver it nowhere.
     this.#waiting = undefined;
     this.#activeToken = token;
+    this.#endingStream = false;
     let active = true;
     return new ReadableStream<Uint8Array>({
       pull: async (controller) => {
@@ -104,7 +125,7 @@ export class TenantLogQueue {
       this.#queuedBytes -= chunk.byteLength;
       return Promise.resolve(chunk);
     }
-    if (this.#closed) {
+    if (this.#closed || this.#endingStream) {
       return Promise.resolve(undefined);
     }
     return new Promise((resolve) => {

--- a/apps/api/src/routes/internal/agent/tenant-logs/controller.ts
+++ b/apps/api/src/routes/internal/agent/tenant-logs/controller.ts
@@ -6,11 +6,15 @@ import { tenantLogEvents } from '#lib/agent/tenant-logs.ts';
 import { ProtocolHeadersSchema } from '#routes/internal/agent/model.ts';
 import { AgentServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
-// Bun closes a request that has gone ten seconds without data, and this one is quiet whenever
-// the apps on a host are: silence here is the resting state, not a stall. Raised for this
-// request alone rather than for the listener, so every other route still drops a stalled client
-// at the default. Bun's ceiling, because the floor is a host reconnecting on a timer.
-const TENANT_LOG_IDLE_TIMEOUT_SECONDS = 255;
+// Bun closes a request that has gone ten seconds without data, and this one is quiet whenever the
+// apps on a host are: silence here is the resting state, not a stall. Raised for this request
+// alone rather than for the listener, so every other route still drops a stalled client at the
+// default.
+//
+// A backstop rather than the mechanism: the agent ends each upload itself, well inside this, and
+// keeps the connection from going idle in between. What this catches is a host that stopped
+// existing without closing anything.
+const TENANT_LOG_IDLE_TIMEOUT_SECONDS = 60;
 
 // `parse: 'none'` is what makes this route possible: the default parser reads a body to its end
 // before the handler runs, and this body does not have one until the host stops sending. The


### PR DESCRIPTION
Follow-up to #72, which held each upload open for 255s. That was the wrong dial: the window was long because ending a stream cost an event, so cycles had to be rare.

An upload is not a long poll. A poll holds nothing while it waits, so either end can stop it for free. This request carries its data in the body, and HTTP has no per-chunk acknowledgement — so ending it anywhere but at a drained queue drops whatever the request had already taken.

The agent now ends each upload itself, at the one boundary where it knows what arrived: it closes the body after 30s, the control plane reads to EOF and answers, and the next one opens with nothing lost. A cycle is no longer a retry, so it neither backs off nor warns. The route's idle timeout drops from 255s to 60s, now a backstop for a host that stopped existing rather than the thing holding the stream up.