### PR TITLE
chore(infra): adopt the guest image that can carry tenant output

### DIFF
--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -16,5 +16,5 @@
     "url": "https://github.com/caddyserver/caddy/releases/download/v2.11.4/caddy_2.11.4_linux_amd64.tar.gz",
     "sha256": "527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9"
   },
-  "guestImage": "6.1.180-ba5084da9128"
+  "guestImage": "6.1.180-6d6c45cc1031"
 }


### PR DESCRIPTION
**This is why no tenant logs are arriving.** Not the VM, and not the transport — that part works.

#59 added `CONFIG_VSOCKETS` to `infra/guest-image/kernel/nibrun.config`. The guest image version is a digest of every build input, so that published a new image, `6.1.180-6d6c45cc1031`. Publishing is not adopting: the pin in this file was never moved, so hosts have gone on installing `6.1.180-ba5084da9128`, whose kernel has no AF_VSOCK. The guest cannot open the socket the runtime asks for, and everything a tenant writes is counted into `dropped_bytes` and dropped.

Meanwhile the pipe above it is healthy — the control plane is answering `POST /internal/agent/tenant-logs 204 (30001ms)` on a clean 30-second cycle, with `accepted: 0` every time.

Adoption only, on purpose. The running instance was staged on Aug 3 and its Firecracker config has no `vsock` key at all, so it keeps the old kernel until something re-stages it. That is a second commit, once this one is on the box: `control-plane` and `app-hosts` deploy in parallel, so a replace triggered in the same run could win the race and re-stage onto the very kernel this replaces.