### PR TITLE
chore(api): restage pocketbase onto the kernel that can reach the host

### DIFF
--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -35,7 +35,7 @@ const VOLUME_SIZE_BYTES = 8_589_934_592;
 const POCKETBASE_PORT = 8090 as GuestPort;
 
 const DESIRED_APP = {
-  generation: 4,
+  generation: 5,
   volumes: [
     {
       volumeId: 'vol-pocketbase' as VolumeId,
@@ -48,7 +48,7 @@ const DESIRED_APP = {
     {
       instanceId: 'inst-pocketbase-1' as InstanceId,
       appId: APP_ID,
-      deploymentId: 'dep-pocketbase-2' as DeploymentId,
+      deploymentId: 'dep-pocketbase-3' as DeploymentId,
       volumeId: 'vol-pocketbase' as VolumeId,
       desiredState: 'running',
       artifact: {


### PR DESCRIPTION
Second half of #75, now safe to merge: the vsock kernel is installed on the app host (`6.1.180-6d6c45cc1031`, `CONFIG_VSOCKETS=y` confirmed on the box), and nothing has asked the instance to use it.

The running VM was staged on Aug 3, so it boots the kernel from then and its Firecracker config has no `vsock` key at all — keys are `['boot-source', 'drives', 'machine-config', 'network-interfaces']`. A host converges on desired state, so it will keep running exactly that until desired state says otherwise.

A new `deploymentId` is what says otherwise. `planInstances` sees the observed deployment differ from the desired one and returns `replace`; the reconciler stops the VM, discards its working directory, and stages it again — and staging is what writes the config that carries the vsock device. The `generation` bump is what makes the agent reconcile at all.

The tenant's data is safe across it: the stop path flushes ZeroFS before the machine ends, so the volume is sealed rather than left to whatever the periodic flush last caught.

Expect a brief interruption to the app while the VM is replaced.