### PR TITLE
fix(agent): a failed upload keeps what it was carrying

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -52,6 +52,12 @@ const NO_FAILURES = 0;
 
 const DESIRED_STATE_FILENAME = 'desired-state.json';
 const TENANT_LOG_BUFFER_BYTES = 8_388_608;
+// How much one upload may carry before it ends and asks to be confirmed.
+//
+// What a request has taken is held here until the control plane answers, so this is the memory a
+// failure is allowed to be worth — small beside the buffer above, and large beside anything a
+// tenant produces between two answers. A quiet host never reaches it and cycles on time instead.
+const TENANT_LOG_IN_FLIGHT_BYTES = 1_048_576;
 const LOG_RECONNECT_FLOOR_MS = 250;
 // The agent ends each upload itself rather than letting one run until something kills it, so a
 // stream that ended well inside its own window ended for a reason nobody chose. Counting that as
@@ -136,7 +142,10 @@ export class Agent {
     const allocator = SlotAllocator.fromRecords(
       readSlotRecords(await readJsonFile({ path: config.slotsFile })),
     );
-    const logQueue = new TenantLogQueue({ maxBytes: TENANT_LOG_BUFFER_BYTES });
+    const logQueue = new TenantLogQueue({
+      maxBytes: TENANT_LOG_BUFFER_BYTES,
+      maxInFlightBytes: TENANT_LOG_IN_FLIGHT_BYTES,
+    });
     let droppedLogEvents = 0;
     const logs = new TenantLogReceiver({
       publish: (event) => {
@@ -265,6 +274,7 @@ export class Agent {
           failures += FIRST_FAILURE;
           logger.warn({ message: 'tenant log stream ended without carrying anything', elapsedMs });
         } else {
+          this.#logQueue.acknowledge();
           failures = NO_FAILURES;
         }
       } catch (error) {

--- a/apps/agent/src/logs/queue.test.ts
+++ b/apps/agent/src/logs/queue.test.ts
@@ -3,6 +3,18 @@ import type { AppId, DeploymentId, InstanceId, TenantLogEvent, Timestamp } from 
 import { TenantLogQueue } from '#logs/queue.ts';
 
 const AFTER_THE_STREAM_ENDED = 7;
+// Larger than any test puts through it, for the limit a given test is not about.
+const LARGE = 1_048_576;
+
+function limits() {
+  return { maxBytes: LARGE, maxInFlightBytes: LARGE };
+}
+
+// Sized from the encoding rather than guessed, so a field added to the event does not silently
+// turn a limit of three events into a limit of two.
+function oneEvent(): number {
+  return new TextEncoder().encode(`${JSON.stringify(event())}\n`).byteLength;
+}
 
 function event(sequence = 0): TenantLogEvent {
   return {
@@ -20,7 +32,7 @@ function event(sequence = 0): TenantLogEvent {
 
 describe('the bounded upload queue', () => {
   test('it emits one complete NDJSON event at a time', async () => {
-    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    const queue = new TenantLogQueue(limits());
     expect(queue.push(event())).toBe(true);
 
     const reader = queue.readable().getReader();
@@ -33,7 +45,7 @@ describe('the bounded upload queue', () => {
   // A host whose apps are quiet still has to hold the request open, and every timeout between
   // here and the control plane counts silence as a dead connection.
   test('a keepalive is an empty line, so it carries no event', async () => {
-    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    const queue = new TenantLogQueue(limits());
     expect(queue.keepalive()).toBe(true);
 
     const reader = queue.readable().getReader();
@@ -45,7 +57,7 @@ describe('the bounded upload queue', () => {
   // The point of ending a stream rather than cutting it: an upload cut mid-flight loses whatever
   // the request had already taken, and HTTP cannot say how much that was.
   test('ending a stream hands over everything queued before it stops', async () => {
-    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    const queue = new TenantLogQueue(limits());
     expect(queue.push(event(1))).toBe(true);
     expect(queue.push(event(2))).toBe(true);
 
@@ -58,7 +70,7 @@ describe('the bounded upload queue', () => {
   });
 
   test('an event that arrives after a stream ended waits for the one that replaces it', async () => {
-    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    const queue = new TenantLogQueue(limits());
     const ending = queue.readable().getReader();
     queue.endStream();
     expect((await ending.read()).done).toBe(true);
@@ -74,7 +86,7 @@ describe('the bounded upload queue', () => {
   // The window fires whether or not the queue happens to be empty, and an idle host is the case
   // where it always is.
   test('a stream ended while nothing is queued closes rather than hanging', async () => {
-    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    const queue = new TenantLogQueue(limits());
     const reader = queue.readable().getReader();
     const pending = reader.read();
     queue.endStream();
@@ -82,15 +94,80 @@ describe('the bounded upload queue', () => {
     expect((await pending).done).toBe(true);
   });
 
+  // The whole point of holding copies: a request that dies takes nothing with it.
+  test('an upload that is never confirmed hands its events to the next one', async () => {
+    const queue = new TenantLogQueue(limits());
+    expect(queue.push(event(1))).toBe(true);
+    expect(queue.push(event(2))).toBe(true);
+
+    const failed = queue.readable().getReader();
+    expect(JSON.parse(new TextDecoder().decode((await failed.read()).value)).sequence).toBe(1);
+    expect(JSON.parse(new TextDecoder().decode((await failed.read()).value)).sequence).toBe(2);
+    await failed.cancel();
+
+    const replacement = queue.readable().getReader();
+    expect(JSON.parse(new TextDecoder().decode((await replacement.read()).value)).sequence).toBe(1);
+    expect(JSON.parse(new TextDecoder().decode((await replacement.read()).value)).sequence).toBe(2);
+    await replacement.cancel();
+  });
+
+  test('a confirmed upload does not hand them over again', async () => {
+    const queue = new TenantLogQueue(limits());
+    expect(queue.push(event(1))).toBe(true);
+
+    const delivered = queue.readable().getReader();
+    expect(JSON.parse(new TextDecoder().decode((await delivered.read()).value)).sequence).toBe(1);
+    queue.acknowledge();
+    await delivered.cancel();
+
+    const replacement = queue.readable().getReader();
+    const pending = replacement.read();
+    queue.endStream();
+    expect((await pending).done).toBe(true);
+  });
+
+  // Copies are held until they are confirmed, so a request that is never confirmed must not be
+  // able to hold more of this host's memory than the buffer it was drawn from.
+  test('what is held for an unconfirmed upload answers to the same byte limit', async () => {
+    const queue = new TenantLogQueue({ maxBytes: oneEvent() * 2, maxInFlightBytes: LARGE });
+    expect(queue.push(event(1))).toBe(true);
+    expect(queue.push(event(2))).toBe(true);
+
+    const reader = queue.readable().getReader();
+    await reader.read();
+    await reader.read();
+
+    // Both are in flight rather than queued, and the budget has not reopened because of it.
+    expect(queue.push(event())).toBe(false);
+    queue.acknowledge();
+    expect(queue.push(event())).toBe(true);
+    await reader.cancel();
+  });
+
+  test('an upload ends once it is carrying its limit, leaving the rest queued', async () => {
+    const queue = new TenantLogQueue({ maxBytes: LARGE, maxInFlightBytes: oneEvent() });
+    expect(queue.push(event(1))).toBe(true);
+    expect(queue.push(event(2))).toBe(true);
+
+    const first = queue.readable().getReader();
+    expect(JSON.parse(new TextDecoder().decode((await first.read()).value)).sequence).toBe(1);
+    expect((await first.read()).done).toBe(true);
+    queue.acknowledge();
+
+    const second = queue.readable().getReader();
+    expect(JSON.parse(new TextDecoder().decode((await second.read()).value)).sequence).toBe(2);
+    await second.cancel();
+  });
+
   test('it refuses growth past its byte limit instead of blocking the producer', () => {
-    const queue = new TenantLogQueue({ maxBytes: 1 });
+    const queue = new TenantLogQueue({ maxBytes: 1, maxInFlightBytes: LARGE });
     expect(queue.push(event())).toBe(false);
   });
 
   // A control plane that answers before the body ends leaves the request stream uncancelled, so
   // the reader it was draining stays pending. Whatever arrives next belongs to the reconnect.
   test('a reader the control plane abandoned does not swallow the next event', async () => {
-    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    const queue = new TenantLogQueue(limits());
     const abandoned = queue.readable().getReader();
     const neverDelivered = abandoned.read();
 
@@ -104,7 +181,7 @@ describe('the bounded upload queue', () => {
   });
 
   test('canceling one HTTP request leaves later events for its replacement', async () => {
-    const queue = new TenantLogQueue({ maxBytes: 4096 });
+    const queue = new TenantLogQueue(limits());
     const first = queue.readable().getReader();
     const pending = first.read();
     await first.cancel();

--- a/apps/agent/src/logs/queue.ts
+++ b/apps/agent/src/logs/queue.ts
@@ -9,16 +9,20 @@ type WaitingReader = {
 
 export class TenantLogQueue {
   readonly #maxBytes: number;
+  readonly #maxInFlightBytes: number;
   readonly #encoder = new TextEncoder();
-  readonly #chunks: Uint8Array[] = [];
-  #queuedBytes = 0;
+  #chunks: Uint8Array[] = [];
+  #inFlight: Uint8Array[] = [];
+  #inFlightBytes = 0;
+  #retainedBytes = 0;
   #waiting: WaitingReader | undefined;
   #activeToken: symbol | undefined;
   #endingStream = false;
   #closed = false;
 
-  constructor({ maxBytes }: { maxBytes: number }) {
+  constructor({ maxBytes, maxInFlightBytes }: { maxBytes: number; maxInFlightBytes: number }) {
     this.#maxBytes = maxBytes;
+    this.#maxInFlightBytes = maxInFlightBytes;
   }
 
   push(event: TenantLogEvent): boolean {
@@ -65,23 +69,49 @@ export class TenantLogQueue {
     this.#endingStream = true;
   }
 
+  /**
+   * The control plane answered, so what this request carried is somewhere other than here and the
+   * copies held for it can go.
+   *
+   * Only ever called for a request that ran long enough to have been read. A reply that arrives
+   * too quickly to have consumed a body is the one success that proves nothing, and keeping the
+   * copies through it costs a duplicate where believing it would cost the events.
+   */
+  acknowledge(): void {
+    this.#retainedBytes -= this.#inFlightBytes;
+    this.#inFlight = [];
+    this.#inFlightBytes = 0;
+  }
+
   #offer(chunk: Uint8Array): boolean {
+    // In-flight bytes are counted here too. They are copies this host is holding until they are
+    // confirmed, which is the same memory as a queued event and has to answer to the same limit —
+    // a budget that only counted what had not been sent yet would be a budget for half the bytes.
+    if (this.#retainedBytes + chunk.byteLength > this.#maxBytes) {
+      return false;
+    }
+    this.#retainedBytes += chunk.byteLength;
     if (this.#waiting) {
       const waiting = this.#waiting;
       this.#waiting = undefined;
+      if (this.#inFlightBytes >= this.#maxInFlightBytes) {
+        this.#chunks.push(chunk);
+        waiting.resolve(undefined);
+        return true;
+      }
+      this.#holdInFlight(chunk);
       waiting.resolve(chunk);
       return true;
     }
-    if (this.#queuedBytes + chunk.byteLength > this.#maxBytes) {
-      return false;
-    }
     this.#chunks.push(chunk);
-    this.#queuedBytes += chunk.byteLength;
     return true;
   }
 
   readable(): ReadableStream<Uint8Array> {
     const token = Symbol('tenant log reader');
+    // Whatever the request this replaces had taken was never confirmed, so it is still owed. A
+    // new stream superseding an old one is exactly the case where those bytes have to go back.
+    this.#recover();
     // A control plane that answers before the body ends completes the fetch without cancelling
     // the stream it was reading, so the request this one replaces can still be holding a pending
     // read. Handing the next event to that reader would deliver it nowhere.
@@ -114,15 +144,35 @@ export class TenantLogQueue {
     this.#waiting = undefined;
   }
 
+  #holdInFlight(chunk: Uint8Array): void {
+    this.#inFlight.push(chunk);
+    this.#inFlightBytes += chunk.byteLength;
+  }
+
+  #recover(): void {
+    if (this.#inFlightBytes === 0) {
+      return;
+    }
+    this.#chunks = this.#inFlight.concat(this.#chunks);
+    this.#inFlight = [];
+    this.#inFlightBytes = 0;
+  }
+
   #take(token: symbol): Promise<Uint8Array | undefined> {
     // Checked before the queue is touched: a superseded reader whose pull lands late would
     // otherwise take a chunk into a request nothing is sending any more.
     if (token !== this.#activeToken) {
       return Promise.resolve(undefined);
     }
+    // A window ends on what it is carrying as well as on how long it has been open. Held copies
+    // are only released by an answer, so how much one request may take is how much this host is
+    // willing to hold — and a talkative tenant reaches that long before thirty seconds.
+    if (this.#inFlightBytes >= this.#maxInFlightBytes) {
+      return Promise.resolve(undefined);
+    }
     const chunk = this.#chunks.shift();
     if (chunk) {
-      this.#queuedBytes -= chunk.byteLength;
+      this.#holdInFlight(chunk);
       return Promise.resolve(chunk);
     }
     if (this.#closed || this.#endingStream) {


### PR DESCRIPTION
An event handed to a request was gone from the queue the moment it was written, so a request that died took its contents with it — and nobody knew. The agent logged that a *stream* failed, never that it had been carrying anything.

That is what lost three of PocketBase's startup lines this afternoon: the #76 deploy replaced the API container at 16:42:29, two seconds before the VM booted. Caddy held the agent's request for its full 30 seconds against a dead backend connection, then answered 502. Everything written into that window went with it.

Events are now held until the control plane answers, and handed to the next request when it doesn't.

Holding costs memory, so two limits meet:

- **in-flight bytes count against the same 8 MiB budget as queued ones.** A copy held for an unconfirmed request is the same memory as an event nobody has sent yet; a budget covering only one of them is a budget for half the bytes.
- **a request ends on what it is carrying as well as on how long it has been open** — 1 MiB or 30s, whichever comes first. An answer is the only thing that frees a copy, so how much one request may take is how much the host is willing to hold. A quiet host never reaches it and keeps cycling on time; a chatty one cycles more often, which is affordable because a clean cycle is already free.

A reply too quick to have read a body doesn't count as an answer, so those copies are kept. Believing it would cost the events; disbelieving it costs a duplicate, and `sourceId` + `sequence` are exactly what a consumer dedupes on.