### PR TITLE
fix: a quiet tenant reconnects its log stream

### DIFF
--- a/apps/runtime/src/guest-logs.c
+++ b/apps/runtime/src/guest-logs.c
@@ -183,6 +183,22 @@ static void forward_output(void *context, enum tenant_output_stream stream, cons
   }
 }
 
+/* A host that goes away leaves this side looking connected: nothing fails until something is
+ * written, and a tenant that is not printing never writes. So the connection is asked about
+ * rather than waited on — a peek costs one syscall and turns the agent restarting into something
+ * the guest notices before it has anything to say, instead of a first line lost proving it. */
+static void service_connection(void *context) {
+  struct guest_log_forwarder *forwarder = context;
+  if (forwarder->connection_state == CONNECTION_CONNECTED) {
+    unsigned char probe;
+    ssize_t seen = recv(forwarder->descriptor, &probe, sizeof(probe), MSG_DONTWAIT | MSG_PEEK);
+    if (seen == 0 || (seen < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+      disconnect(forwarder);
+    }
+  }
+  connection_ready(forwarder);
+}
+
 void guest_logs_init(struct guest_log_forwarder *forwarder) {
   *forwarder = (struct guest_log_forwarder){
       .descriptor = -1,
@@ -200,5 +216,6 @@ void guest_logs_close(struct guest_log_forwarder *forwarder) {
 }
 
 struct tenant_output guest_logs_tenant_output(struct guest_log_forwarder *forwarder) {
-  return (struct tenant_output){.write = forward_output, .context = forwarder};
+  return (struct tenant_output){
+      .write = forward_output, .service = service_connection, .context = forwarder};
 }

--- a/apps/runtime/src/supervise.c
+++ b/apps/runtime/src/supervise.c
@@ -21,6 +21,10 @@
 #define TENANT_SPAWN_EXIT_CODE 126
 #define SIGKILL_GRACE_MS 2000
 #define OUTPUT_CHUNK_BYTES 4096
+/* How long the supervisor may sit in poll before giving the output sink a turn. A tenant that
+ * prints nothing for hours is ordinary, and it is exactly the tenant whose sink can lose its far
+ * end without anything here noticing. One wakeup a second buys that back for a syscall. */
+#define OUTPUT_SERVICE_INTERVAL_MS 1000
 
 /* Blocked rather than handled, and waited on synchronously: there is no signal
  * handler, so there is no async-signal-safety to get wrong, and a signal that
@@ -208,7 +212,7 @@ static struct wait_result wait_for_tenant(pid_t tenant, uint32_t grace_ms, int s
         {.fd = stderr_descriptor, .events = POLLIN},
     };
     int ready = poll(polled, sizeof(polled) / sizeof(polled[0]),
-                     phase == PHASE_RUNNING ? -1 : remaining_ms(deadline_ms));
+                     phase == PHASE_RUNNING ? OUTPUT_SERVICE_INTERVAL_MS : remaining_ms(deadline_ms));
     if (ready < 0 && errno == EINTR) {
       continue;
     }
@@ -221,6 +225,14 @@ static struct wait_result wait_for_tenant(pid_t tenant, uint32_t grace_ms, int s
     }
 
     if (ready == 0) {
+      /* Nothing happened, which while the tenant is running is not a deadline but the quiet the
+       * sink needs a turn in. */
+      if (phase == PHASE_RUNNING) {
+        if (output->service != NULL) {
+          output->service(output->context);
+        }
+        continue;
+      }
       if (phase == PHASE_TERM_SENT) {
         log_line("the tenant is still running %ums after SIGTERM; killing it", grace_ms);
         signal_tenant(tenant, SIGKILL);

--- a/apps/runtime/src/supervise.h
+++ b/apps/runtime/src/supervise.h
@@ -25,6 +25,9 @@ enum tenant_output_stream {
 struct tenant_output {
   void (*write)(void *context, enum tenant_output_stream stream, const unsigned char *bytes,
                 size_t length);
+  /* Called while the tenant is quiet. Nothing else runs then, and a sink whose far end has gone
+   * away has no way to find that out from a tenant that is not printing. */
+  void (*service)(void *context);
   void *context;
 };
 

--- a/apps/runtime/tests/test-supervise.c
+++ b/apps/runtime/tests/test-supervise.c
@@ -335,6 +335,31 @@ static void stdout_and_stderr_are_separate_streams(void) {
   EXPECT(!file_contains(stderr_path, "from stdout\n"));
 }
 
+static void count_service(void *context) {
+  int descriptor = open((const char *)context, O_WRONLY | O_APPEND);
+  if (descriptor < 0 || write(descriptor, "x", 1) != 1) {
+    _exit(1);
+  }
+  close(descriptor);
+}
+
+/* A tenant that prints nothing is the whole problem: it is the one case where no write can
+ * discover that the sink's far end has gone, so the supervisor has to hand it a turn unasked. */
+static void a_quiet_tenant_still_gets_the_sink_serviced(void) {
+  char ticks_path[128];
+  snprintf(ticks_path, sizeof(ticks_path), "%s", scratch_file("service-ticks"));
+  char *environment[] = {"FAKE_MODE=stay", "FAKE_RECORD=/tmp/unused", "FAKE_DURATION_MS=3500",
+                         NULL};
+  struct restart_policy policy = {
+      .max_restarts = 0, .initial_backoff_ms = 0, .max_backoff_ms = 0, .backoff_factor = 1,
+      .reset_after_ms = 60000};
+  struct supervisor supervisor = supervisor_for(environment, &policy, 1000);
+  supervisor.output = (struct tenant_output){.service = count_service, .context = ticks_path};
+
+  EXPECT(wait_for_supervisor(start_supervisor(&supervisor)) == SUPERVISE_RESTART_BUDGET_EXHAUSTED);
+  EXPECT(file_contains(ticks_path, "xx"));
+}
+
 int main(void) {
   backoff_grows_then_stops_growing();
   a_crashing_tenant_exhausts_its_budget();
@@ -344,5 +369,6 @@ int main(void) {
   orphans_are_reaped();
   the_tenant_runs_unprivileged_in_its_own_directory();
   stdout_and_stderr_are_separate_streams();
+  a_quiet_tenant_still_gets_the_sink_serviced();
   return EXPECT_REPORT("supervise");
 }

--- a/infra/app-host/systemd/nibrun-agent.service
+++ b/infra/app-host/systemd/nibrun-agent.service
@@ -23,6 +23,11 @@ RestartSec=5s
 
 StateDirectory=nibrun
 RuntimeDirectory=nibrun
+# systemd removes a RuntimeDirectory when its unit stops, and what lives in this one belongs to
+# the microVMs rather than to the agent: each Firecracker holds its API socket there and keeps
+# running across an agent restart. Removing it takes away the only handle on a VM that outlived
+# the agent, which is precisely the case the VMs are parented to init to survive.
+RuntimeDirectoryPreserve=yes
 
 # It creates tap devices, writes firewall rules and starts microVM units, so it
 # runs as root. Containerising it would hand back every privilege the container


### PR DESCRIPTION
Found by trying to watch #77 work: logging was dead again, one deploy after it started working.

**The guest only tried to connect when the tenant printed.** `forward_output` is the only caller of `connection_ready`, so an app with nothing to say never retries. The agent restarted for #77's deploy, which broke the guest's connection, and PocketBase has been silent since — two `LISTEN` sockets and no `ESTAB`. The recovery was lossy too: the first line the tenant eventually writes starts a non-blocking connect that cannot finish inside that call, so that line goes to `dropped_bytes` and is reported as a gap.

**A retry alone would not have been enough.** A peer that goes away leaves this side reading `CONNECTION_CONNECTED` until a write fails on it. So the supervisor now gives the sink a turn once a second — a bounded `poll` timeout while the tenant runs — and the sink peeks at its own socket to find out whether anyone is still there.

**The agent's unit was taking the other half.** `RuntimeDirectory=nibrun` is removed by systemd when the unit stops, and `/run/nibrun` holds one Firecracker API socket per running microVM. VMs are parented to init specifically so an agent restart is a non-event for them, and this was deleting the only handle on every VM that outlived it — `/run/nibrun` is empty right now while a VM from 16:48 is still running. `RuntimeDirectoryPreserve=yes`.

Costs one `poll` wakeup and one `recv` per second in PID 1. Measured RSS moved 1336 KiB → 1352 KiB.

Verified the new test catches it: restore the infinite `poll` timeout and `a_quiet_tenant_still_gets_the_sink_serviced` fails on the missing ticks.