### PR TITLE
refactor(agent): name what a trace should show, and let services carry their own layers

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -5,11 +5,17 @@ plane, long-polls for desired state, converges the host onto it, and reports wha
 is never sent a command. Read `reconcile/`, `volumes/topology.ts` and `network/slot.ts` first.
 
 **Written in Effect.** Every effectful path is an `Effect` with a typed error channel; anything a
-test needs to substitute is a service (`Context.Tag` or `Effect.Service`) wired in `index.ts` and
-nowhere else. State that used to be mutable class fields lives in a `Ref`. The four loops in
-`agent/` are fibers, and their retry cadence is a `Schedule` rather than a failure counter.
-Interruption is the shutdown path: `BunRuntime.runMain` cancels the fibers and scoped finalizers
-close the log sockets. Nothing stops a tenant VM, which is what keeps redeploying the agent free.
+test needs to substitute is a service (`Context.Tag` or `Effect.Service`). State that used to be
+mutable class fields lives in a `Ref`. The four loops in `agent/` are fibers, and their retry
+cadence is a `Schedule` rather than a failure counter. Interruption is the shutdown path:
+`BunRuntime.runMain` cancels the fibers and scoped finalizers close the log sockets. Nothing stops
+a tenant VM, which is what keeps redeploying the agent free.
+
+**Every service names its own requirements** in `dependencies`, so `index.ts` is a flat merge whose
+order carries nothing. A test that hands one of them a stub config takes
+`DefaultWithoutDependencies`: `Default` has already been given `AgentConfig.Default`, so a config
+provided from outside is ignored without a word, and the real one then fails at runtime on an
+environment the test never set.
 
 **Everything the host does that Bun cannot do is a subprocess** (`systemctl`, `ip`, `nft`,
 `nbd-client`, `mkfs.ext4`, `mksquashfs`, `zerofs`) rather than a library, through the
@@ -47,6 +53,9 @@ Owned by `infra/app-host/`, not fixable here.
   `table ip nibrun` and expresses isolation as `drop` rules, which are final wherever they appear;
   its `accept` rules only end its own chain, so it composes with a coexisting ruleset but cannot
   open one that is closed.
+- **A tracer.** The agent names its spans — every reconcile phase, subprocess and control-plane
+  request — and nothing collects them, so they go nowhere. Where they are exported to is a
+  deployment decision, not one the binary should hold.
 
 ## What is not tested
 

--- a/apps/agent/src/agent/desired-state.ts
+++ b/apps/agent/src/agent/desired-state.ts
@@ -25,10 +25,11 @@ export class DesiredStateCache extends Effect.Service<DesiredStateCache>()('Desi
       knownGeneration: Ref.get(generation),
       latest: Ref.get(latest),
 
-      accept: (state: HostDesiredState) =>
-        writeJsonFile({ path: config.desiredStateFile, value: state }).pipe(
-          Effect.andThen(remember(state)),
-        ),
+      accept: Effect.fn('DesiredStateCache.accept')(function* (state: HostDesiredState) {
+        yield* Effect.annotateCurrentSpan({ generation: state.generation });
+        yield* writeJsonFile({ path: config.desiredStateFile, value: state });
+        yield* remember(state);
+      }),
 
       restore: Effect.gen(function* () {
         const value = yield* readJsonFile(config.desiredStateFile).pipe(
@@ -54,4 +55,5 @@ export class DesiredStateCache extends Effect.Service<DesiredStateCache>()('Desi
       }),
     };
   }),
+  dependencies: [AgentConfig.Default],
 }) {}

--- a/apps/agent/src/agent/session.ts
+++ b/apps/agent/src/agent/session.ts
@@ -49,4 +49,5 @@ export class AgentSessionHolder extends Effect.Service<AgentSessionHolder>()('Ag
         error.isSessionExpired ? SynchronizedRef.set(cached, Option.none()) : Effect.void,
     };
   }),
+  dependencies: [AgentConfig.Default],
 }) {}

--- a/apps/agent/src/control/client.ts
+++ b/apps/agent/src/control/client.ts
@@ -94,6 +94,7 @@ export const makeControlPlaneClient = ({ baseUrl }: { baseUrl: string }) => {
             })
           : Effect.succeed(reply.data),
       ),
+      Effect.withSpan('controlPlane', { attributes: { route } }),
     );
 
   const options = (sessionToken?: SecretString) => ({
@@ -174,4 +175,4 @@ export class ControlPlane extends Context.Tag('ControlPlane')<ControlPlane, Cont
 export const layer = Layer.effect(
   ControlPlane,
   Effect.map(AgentConfig, (config) => makeControlPlaneClient({ baseUrl: config.controlPlaneUrl })),
-);
+).pipe(Layer.provide(AgentConfig.Default));

--- a/apps/agent/src/control/session.ts
+++ b/apps/agent/src/control/session.ts
@@ -38,18 +38,20 @@ const readHostId = Effect.gen(function* () {
   ) as Option.Option<HostId>;
 });
 
-export const openSession = (inputs: { versions: HostVersions; capacity: HostCapacity }) =>
-  Effect.gen(function* () {
-    const config = yield* AgentConfig;
-    const control = yield* ControlPlane;
-    const hostId = yield* readHostId;
-    const session = yield* control.openSession({
-      ...Option.match(hostId, { onNone: () => ({}), onSome: (value) => ({ hostId: value }) }),
-      versions: inputs.versions,
-      capacity: inputs.capacity,
-    });
-    if (!Option.contains(hostId, session.hostId)) {
-      yield* writeTextFile({ path: config.hostIdFile, value: `${session.hostId}\n` });
-    }
-    return session;
+export const openSession = Effect.fn('openSession')(function* (inputs: {
+  versions: HostVersions;
+  capacity: HostCapacity;
+}) {
+  const config = yield* AgentConfig;
+  const control = yield* ControlPlane;
+  const hostId = yield* readHostId;
+  const session = yield* control.openSession({
+    ...Option.match(hostId, { onNone: () => ({}), onSome: (value) => ({ hostId: value }) }),
+    versions: inputs.versions,
+    capacity: inputs.capacity,
   });
+  if (!Option.contains(hostId, session.hostId)) {
+    yield* writeTextFile({ path: config.hostIdFile, value: `${session.hostId}\n` });
+  }
+  return session;
+});

--- a/apps/agent/src/exports/bundle.ts
+++ b/apps/agent/src/exports/bundle.ts
@@ -63,7 +63,7 @@ export function bundleBinaryName(artifact: DesiredArtifact): Either.Either<strin
  * The binary is fetched from the artifact bucket rather than lifted out of the local squashfs
  * cache, because the download proves the digest on the way past.
  */
-export const writeBundle = ({
+export const writeBundle = Effect.fn('writeBundle')(function* ({
   artifact,
   devicePath,
   stagingDir,
@@ -71,24 +71,24 @@ export const writeBundle = ({
   artifact: DesiredArtifact;
   devicePath: string;
   stagingDir: string;
-}) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const binaryName = yield* bundleBinaryName(artifact);
+}) {
+  yield* Effect.annotateCurrentSpan({ devicePath });
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const binaryName = yield* bundleBinaryName(artifact);
 
-    yield* fs.remove(stagingDir, { recursive: true, force: true });
-    yield* fs.makeDirectory(stagingDir, { recursive: true, mode: STAGING_MODE });
+  yield* fs.remove(stagingDir, { recursive: true, force: true });
+  yield* fs.makeDirectory(stagingDir, { recursive: true, mode: STAGING_MODE });
 
-    yield* dumpFilesystem({ devicePath, destination: path.join(stagingDir, DATA_DIRECTORY) });
-    yield* downloadAndVerify({ artifact, destination: path.join(stagingDir, binaryName) });
+  yield* dumpFilesystem({ devicePath, destination: path.join(stagingDir, DATA_DIRECTORY) });
+  yield* downloadAndVerify({ artifact, destination: path.join(stagingDir, binaryName) });
 
-    const bundlePath = path.join(stagingDir, BUNDLE_NAME);
-    yield* stdoutOf({
-      // Named entries rather than `.`, which would sweep the archive into itself.
-      command: ['tar', 'czf', bundlePath, '-C', stagingDir, DATA_DIRECTORY, binaryName],
-      timeout: DUMP_TIMEOUT,
-    });
-
-    return { path: bundlePath, sizeBytes: Number((yield* fs.stat(bundlePath)).size) };
+  const bundlePath = path.join(stagingDir, BUNDLE_NAME);
+  yield* stdoutOf({
+    // Named entries rather than `.`, which would sweep the archive into itself.
+    command: ['tar', 'czf', bundlePath, '-C', stagingDir, DATA_DIRECTORY, binaryName],
+    timeout: DUMP_TIMEOUT,
   });
+
+  return { path: bundlePath, sizeBytes: Number((yield* fs.stat(bundlePath)).size) };
+});

--- a/apps/agent/src/exports/manager.ts
+++ b/apps/agent/src/exports/manager.ts
@@ -38,32 +38,38 @@ export class ExportManager extends Effect.Service<ExportManager>()('ExportManage
      * truncated bundle, and the bucket's abort rule reaps it — which is why exports need no
      * delete permission.
      */
-    const upload = ({ bundlePath, objectKey }: { bundlePath: string; objectKey: string }) =>
-      Effect.gen(function* () {
-        const resolved = yield* credentials.resolve;
-        const client = new Bun.S3Client({
-          bucket: config.exportBucket,
-          region: config.awsRegion,
-          ...s3Credentials(resolved),
-        });
-        yield* Effect.tryPromise(async () => {
-          const writer = client.file(objectKey).writer({
-            partSize: UPLOAD_PART_SIZE_BYTES,
-            queueSize: UPLOAD_QUEUE_SIZE,
-            retry: UPLOAD_RETRIES,
-          });
-          for await (const chunk of Bun.file(bundlePath).stream()) {
-            writer.write(chunk);
-          }
-          await writer.end();
-        });
+    const upload = Effect.fn('ExportManager.upload')(function* ({
+      bundlePath,
+      objectKey,
+    }: {
+      bundlePath: string;
+      objectKey: string;
+    }) {
+      yield* Effect.annotateCurrentSpan({ objectKey });
+      const resolved = yield* credentials.resolve;
+      const client = new Bun.S3Client({
+        bucket: config.exportBucket,
+        region: config.awsRegion,
+        ...s3Credentials(resolved),
       });
+      yield* Effect.tryPromise(async () => {
+        const writer = client.file(objectKey).writer({
+          partSize: UPLOAD_PART_SIZE_BYTES,
+          queueSize: UPLOAD_QUEUE_SIZE,
+          retry: UPLOAD_RETRIES,
+        });
+        for await (const chunk of Bun.file(bundlePath).stream()) {
+          writer.write(chunk);
+        }
+        await writer.end();
+      });
+    });
 
     /**
      * The staging tree is a second copy of a tenant's dataset in the clear on a shared host, so
      * it is removed whether or not the upload worked.
      */
-    const write = ({
+    const write = Effect.fn('ExportManager.write')(function* ({
       desired,
       artifact,
       devicePath,
@@ -71,34 +77,35 @@ export class ExportManager extends Effect.Service<ExportManager>()('ExportManage
       desired: DesiredExport;
       artifact: DesiredArtifact;
       devicePath: string;
-    }) =>
-      Effect.gen(function* () {
-        const stagingDir = path.join(config.exportStagingDir, desired.exportId);
-        return yield* Effect.ensuring(
-          Effect.gen(function* () {
-            // Under `ignore_fsync` the guest's barriers are not durability points, so this is what
-            // turns its acknowledged writes into bytes the device will hand back.
-            yield* flush(topology.place().admin);
-            const bundle = yield* writeBundle({ artifact, devicePath, stagingDir });
-            yield* upload({ bundlePath: bundle.path, objectKey: desired.objectKey });
-            yield* Effect.logInfo('export written').pipe(
-              Effect.annotateLogs({
-                exportId: desired.exportId,
-                objectKey: desired.objectKey,
-                sizeBytes: bundle.sizeBytes,
-              }),
-            );
-            return {
+    }) {
+      yield* Effect.annotateCurrentSpan({ exportId: desired.exportId });
+      const stagingDir = path.join(config.exportStagingDir, desired.exportId);
+      return yield* Effect.ensuring(
+        Effect.gen(function* () {
+          // Under `ignore_fsync` the guest's barriers are not durability points, so this is what
+          // turns its acknowledged writes into bytes the device will hand back.
+          yield* flush(topology.place().admin);
+          const bundle = yield* writeBundle({ artifact, devicePath, stagingDir });
+          yield* upload({ bundlePath: bundle.path, objectKey: desired.objectKey });
+          yield* Effect.logInfo('export written').pipe(
+            Effect.annotateLogs({
               exportId: desired.exportId,
-              state: 'ready',
+              objectKey: desired.objectKey,
               sizeBytes: bundle.sizeBytes,
-              readyAt: yield* nowTimestamp,
-            } satisfies ReportedExport;
-          }),
-          fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),
-        );
-      });
+            }),
+          );
+          return {
+            exportId: desired.exportId,
+            state: 'ready',
+            sizeBytes: bundle.sizeBytes,
+            readyAt: yield* nowTimestamp,
+          } satisfies ReportedExport;
+        }),
+        fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),
+      );
+    });
 
     return { write };
   }),
+  dependencies: [AgentConfig.Default, ZerofsTopology.Default, AwsCredentialProvider.Default],
 }) {}

--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -4,7 +4,6 @@ import { Effect, Layer } from 'effect';
 import { DesiredStateCache } from '#agent/desired-state.ts';
 import { run } from '#agent/run.ts';
 import { AgentSessionHolder } from '#agent/session.ts';
-import { AwsCredentialProvider } from '#aws/provider.ts';
 import { AgentConfig } from '#config.ts';
 import * as ControlPlane from '#control/client.ts';
 import { ExportManager } from '#exports/manager.ts';
@@ -23,31 +22,29 @@ import { ZerofsTopology } from '#volumes/topology.ts';
 
 const platform = Layer.mergeAll(BunContext.layer, FetchHttpClient.layer);
 
-const base = Layer.mergeAll(AgentConfig.Default, Exec.layer, AgentState.layer).pipe(
-  Layer.provideMerge(platform),
-);
-
-const stores = Layer.mergeAll(
+/**
+ * Flat rather than tiered, because each service provides its own requirements. A layer named by
+ * two of them is still built once, which is what keeps one slot table, one log queue and one
+ * credential cache on a host — so the order here carries nothing.
+ */
+const agent = Layer.mergeAll(
+  AgentConfig.Default,
+  AgentState.layer,
+  Exec.layer,
+  ControlPlane.layer,
+  Artifacts.layer,
   SlotAllocator.Default,
   ZerofsTopology.Default,
-  AwsCredentialProvider.Default,
-  ControlPlane.layer,
-  TenantLogQueue.Default,
-).pipe(Layer.provideMerge(base));
-
-const managers = Layer.mergeAll(
-  Artifacts.layer,
-  TenantLogReceiver.Default,
   CaddyProxy.Default,
+  TenantLogQueue.Default,
+  TenantLogReceiver.Default,
   VolumeManager.Default,
   ExportManager.Default,
-).pipe(Layer.provideMerge(stores));
-
-const agent = Layer.mergeAll(
-  Reconciler.Default,
-  AgentSessionHolder.Default,
+  VmManager.Default,
   DesiredStateCache.Default,
-).pipe(Layer.provideMerge(VmManager.Default.pipe(Layer.provideMerge(managers))));
+  AgentSessionHolder.Default,
+  Reconciler.Default,
+).pipe(Layer.provideMerge(platform));
 
 // The agent stopping must not stop anything it started: the VMs are systemd's children, which is
 // what lets this component be redeployed as often as it changes.

--- a/apps/agent/src/lib/exec.ts
+++ b/apps/agent/src/lib/exec.ts
@@ -77,6 +77,7 @@ const execute = (request: CommandRequest) =>
       duration: request.timeout ?? DEFAULT_TIMEOUT,
       onTimeout: () => new CommandTimedOut({ command: request.command }),
     }),
+    Effect.withSpan('exec', { attributes: { command: request.command[0] } }),
   );
 
 export const layer = Layer.effect(

--- a/apps/agent/src/logs/receiver.ts
+++ b/apps/agent/src/logs/receiver.ts
@@ -141,50 +141,56 @@ export class TenantLogReceiver extends Effect.Service<TenantLogReceiver>()('Tena
         );
       });
 
-    const detach = (instanceId: InstanceId) =>
-      Effect.gen(function* () {
-        const attachment = (yield* Ref.get(attachments)).get(instanceId);
-        if (!attachment) {
-          return;
-        }
-        yield* Ref.update(attachments, (current) => {
-          const next = new Map(current);
-          next.delete(instanceId);
-          return next;
-        });
-        yield* Scope.close(attachment.scope, Exit.void);
-        yield* fs.remove(attachment.socketPath, { force: true });
+    const detach = Effect.fn('TenantLogReceiver.detach')(function* (instanceId: InstanceId) {
+      yield* Effect.annotateCurrentSpan({ instanceId });
+      const attachment = (yield* Ref.get(attachments)).get(instanceId);
+      if (!attachment) {
+        return;
+      }
+      yield* Ref.update(attachments, (current) => {
+        const next = new Map(current);
+        next.delete(instanceId);
+        return next;
       });
+      yield* Scope.close(attachment.scope, Exit.void);
+      yield* fs.remove(attachment.socketPath, { force: true });
+    });
 
-    const attach = ({ source, socketPath }: { source: TenantLogSource; socketPath: string }) =>
-      Effect.gen(function* () {
-        const current = yield* Ref.get(attachments);
-        const existing = current.get(source.instanceId);
-        if (existing?.socketPath === socketPath) {
-          return yield* Ref.set(existing.source, source);
+    const attach = Effect.fn('TenantLogReceiver.attach')(function* ({
+      source,
+      socketPath,
+    }: {
+      source: TenantLogSource;
+      socketPath: string;
+    }) {
+      yield* Effect.annotateCurrentSpan({ instanceId: source.instanceId, appId: source.appId });
+      const current = yield* Ref.get(attachments);
+      const existing = current.get(source.instanceId);
+      if (existing?.socketPath === socketPath) {
+        return yield* Ref.set(existing.source, source);
+      }
+      for (const [instanceId, attached] of current) {
+        if (instanceId === source.instanceId || attached.socketPath === socketPath) {
+          yield* detach(instanceId);
         }
-        for (const [instanceId, attached] of current) {
-          if (instanceId === source.instanceId || attached.socketPath === socketPath) {
-            yield* detach(instanceId);
-          }
-        }
+      }
 
-        yield* fs.makeDirectory(path.dirname(socketPath), { recursive: true });
-        yield* fs.remove(socketPath, { force: true });
+      yield* fs.makeDirectory(path.dirname(socketPath), { recursive: true });
+      yield* fs.remove(socketPath, { force: true });
 
-        const scope = yield* Scope.make();
-        const attachment: Attachment = {
-          sourceId: yield* Effect.sync(() => crypto.randomUUID()),
-          socketPath,
-          source: yield* Ref.make(source),
-          sequence: yield* Ref.make(0),
-          scope,
-        };
-        yield* Scope.extend(serve({ attachment }), scope).pipe(
-          Effect.onError(() => Scope.close(scope, Exit.void)),
-        );
-        yield* Ref.update(attachments, (all) => new Map(all).set(source.instanceId, attachment));
-      });
+      const scope = yield* Scope.make();
+      const attachment: Attachment = {
+        sourceId: yield* Effect.sync(() => crypto.randomUUID()),
+        socketPath,
+        source: yield* Ref.make(source),
+        sequence: yield* Ref.make(0),
+        scope,
+      };
+      yield* Scope.extend(serve({ attachment }), scope).pipe(
+        Effect.onError(() => Scope.close(scope, Exit.void)),
+      );
+      yield* Ref.update(attachments, (all) => new Map(all).set(source.instanceId, attachment));
+    });
 
     yield* Effect.addFinalizer(() =>
       Effect.flatMap(Ref.get(attachments), (all) =>
@@ -194,4 +200,5 @@ export class TenantLogReceiver extends Effect.Service<TenantLogReceiver>()('Tena
 
     return { attach, detach };
   }),
+  dependencies: [TenantLogQueue.Default],
 }) {}

--- a/apps/agent/src/network/allocator.ts
+++ b/apps/agent/src/network/allocator.ts
@@ -102,4 +102,5 @@ export class SlotAllocator extends Effect.Service<SlotAllocator>()('SlotAllocato
       ),
     };
   }),
+  dependencies: [AgentConfig.Default],
 }) {}

--- a/apps/agent/src/network/tap.ts
+++ b/apps/agent/src/network/tap.ts
@@ -30,25 +30,25 @@ export type TapInterface = {
   readonly subnetPrefixLength: number;
 };
 
-export const ensureTap = (tap: TapInterface) =>
-  Effect.gen(function* () {
-    const existing = yield* listTapNames;
-    if (!existing.includes(tap.tapName)) {
-      yield* stdoutOf({ command: [IP, 'tuntap', 'add', 'dev', tap.tapName, 'mode', 'tap'] });
-    }
-    // `replace` rather than `add`, so a converged host re-runs this to no effect.
-    yield* stdoutOf({
-      command: [
-        IP,
-        'addr',
-        'replace',
-        `${tap.hostIpv4}/${tap.subnetPrefixLength}`,
-        'dev',
-        tap.tapName,
-      ],
-    });
-    yield* stdoutOf({ command: [IP, 'link', 'set', 'dev', tap.tapName, 'up'] });
-    // Without this the kernel drops replies to the forwarded 127.0.0.1 port as martian, before
-    // the nftables SNAT can rewrite them — and the local proxy reaches every app that way.
-    yield* stdoutOf({ command: [SYSCTL, '-w', `net.ipv4.conf.${tap.tapName}.route_localnet=1`] });
+export const ensureTap = Effect.fn('ensureTap')(function* (tap: TapInterface) {
+  yield* Effect.annotateCurrentSpan({ tapName: tap.tapName });
+  const existing = yield* listTapNames;
+  if (!existing.includes(tap.tapName)) {
+    yield* stdoutOf({ command: [IP, 'tuntap', 'add', 'dev', tap.tapName, 'mode', 'tap'] });
+  }
+  // `replace` rather than `add`, so a converged host re-runs this to no effect.
+  yield* stdoutOf({
+    command: [
+      IP,
+      'addr',
+      'replace',
+      `${tap.hostIpv4}/${tap.subnetPrefixLength}`,
+      'dev',
+      tap.tapName,
+    ],
   });
+  yield* stdoutOf({ command: [IP, 'link', 'set', 'dev', tap.tapName, 'up'] });
+  // Without this the kernel drops replies to the forwarded 127.0.0.1 port as martian, before
+  // the nftables SNAT can rewrite them — and the local proxy reaches every app that way.
+  yield* stdoutOf({ command: [SYSCTL, '-w', `net.ipv4.conf.${tap.tapName}.route_localnet=1`] });
+});

--- a/apps/agent/src/proxy/caddy.ts
+++ b/apps/agent/src/proxy/caddy.ts
@@ -23,21 +23,21 @@ export class CaddyProxy extends Effect.Service<CaddyProxy>()('CaddyProxy', {
     const applied = yield* Ref.make(Option.none<string>());
 
     return {
-      apply: (routes: readonly RouteTarget[]) =>
-        Effect.gen(function* () {
-          const sites = renderAppSites(routes);
-          if (Option.getOrUndefined(yield* Ref.get(applied)) === sites) {
-            return;
-          }
-          yield* writeTextFile({
-            path: config.caddySitesFile,
-            value: sites,
-            mode: SITE_FILE_MODE,
-          });
-          // Reloaded, not restarted: one app's route must not interrupt the others.
-          yield* stdoutOf({ command: [SYSTEMCTL, 'reload', CADDY_UNIT] });
-          yield* Ref.set(applied, Option.some(sites));
-        }),
+      apply: Effect.fn('CaddyProxy.apply')(function* (routes: readonly RouteTarget[]) {
+        const sites = renderAppSites(routes);
+        if (Option.getOrUndefined(yield* Ref.get(applied)) === sites) {
+          return;
+        }
+        yield* writeTextFile({
+          path: config.caddySitesFile,
+          value: sites,
+          mode: SITE_FILE_MODE,
+        });
+        // Reloaded, not restarted: one app's route must not interrupt the others.
+        yield* stdoutOf({ command: [SYSTEMCTL, 'reload', CADDY_UNIT] });
+        yield* Ref.set(applied, Option.some(sites));
+      }),
     };
   }),
+  dependencies: [AgentConfig.Default],
 }) {}

--- a/apps/agent/src/reconcile/checkpoints.ts
+++ b/apps/agent/src/reconcile/checkpoints.ts
@@ -11,41 +11,41 @@ type Applicable = Extract<CheckpointPlan, { action: 'create' | 'delete' }>;
 
 /** `CreateCheckpoint` takes the flush barrier itself, so an extra flush here would be a redundant
  * round trip against a guarantee the RPC already makes. */
-const applyOne = (action: Applicable) =>
-  Effect.gen(function* () {
-    const topology = yield* ZerofsTopology;
-    const { checkpointId, volumeId } = action.desired;
-    const target = topology.place().admin;
+const applyOne = Effect.fn('applyCheckpoint')(function* (action: Applicable) {
+  const topology = yield* ZerofsTopology;
+  const { checkpointId, volumeId } = action.desired;
+  yield* Effect.annotateCurrentSpan({ checkpointId, volumeId });
+  const target = topology.place().admin;
 
-    return yield* Effect.gen(function* () {
-      const existing = new Set(yield* listCheckpoints(target));
-      if (action.action === 'create') {
-        if (!existing.has(checkpointId)) {
-          yield* createCheckpoint({ target, checkpointId });
-        }
-        return {
-          checkpointId,
-          volumeId,
-          state: 'ready',
-          reference: checkpointId,
-          readyAt: yield* nowTimestamp,
-        } satisfies ReportedCheckpoint;
+  return yield* Effect.gen(function* () {
+    const existing = new Set(yield* listCheckpoints(target));
+    if (action.action === 'create') {
+      if (!existing.has(checkpointId)) {
+        yield* createCheckpoint({ target, checkpointId });
       }
-      if (existing.has(checkpointId)) {
-        yield* deleteCheckpoint({ target, checkpointId });
-      }
-      return { checkpointId, volumeId, state: 'pending' } satisfies ReportedCheckpoint;
-    }).pipe(
-      Effect.catchAll((error) =>
-        Effect.succeed({
-          checkpointId,
-          volumeId,
-          state: 'failed',
-          message: reportedMessage(error),
-        } satisfies ReportedCheckpoint),
-      ),
-    );
-  });
+      return {
+        checkpointId,
+        volumeId,
+        state: 'ready',
+        reference: checkpointId,
+        readyAt: yield* nowTimestamp,
+      } satisfies ReportedCheckpoint;
+    }
+    if (existing.has(checkpointId)) {
+      yield* deleteCheckpoint({ target, checkpointId });
+    }
+    return { checkpointId, volumeId, state: 'pending' } satisfies ReportedCheckpoint;
+  }).pipe(
+    Effect.catchAll((error) =>
+      Effect.succeed({
+        checkpointId,
+        volumeId,
+        state: 'failed',
+        message: reportedMessage(error),
+      } satisfies ReportedCheckpoint),
+    ),
+  );
+});
 
 /** Listing costs an RPC round trip, and almost every reconcile has no checkpoint to converge. */
 export const applyCheckpoints = ({

--- a/apps/agent/src/reconcile/instances.ts
+++ b/apps/agent/src/reconcile/instances.ts
@@ -35,18 +35,24 @@ const flushEverything = Effect.gen(function* () {
   );
 });
 
-export const stopInstance = ({ instanceId, reason }: { instanceId: InstanceId; reason: string }) =>
-  Effect.gen(function* () {
-    const vms = yield* VmManager;
-    yield* setState({ instanceId, state: 'stopping', stopRequested: true });
-    yield* flushEverything;
-    yield* vms.stop(instanceId).pipe(
-      Effect.andThen(Effect.logInfo('instance stopped')),
-      Effect.catchAll((error) => Effect.logError('instance stop failed', error)),
-      Effect.annotateLogs({ instanceId, reason }),
-    );
-    yield* setState({ instanceId, state: 'stopped' });
-  });
+export const stopInstance = Effect.fn('stopInstance')(function* ({
+  instanceId,
+  reason,
+}: {
+  instanceId: InstanceId;
+  reason: string;
+}) {
+  yield* Effect.annotateCurrentSpan({ instanceId, reason });
+  const vms = yield* VmManager;
+  yield* setState({ instanceId, state: 'stopping', stopRequested: true });
+  yield* flushEverything;
+  yield* vms.stop(instanceId).pipe(
+    Effect.andThen(Effect.logInfo('instance stopped')),
+    Effect.catchAll((error) => Effect.logError('instance stop failed', error)),
+    Effect.annotateLogs({ instanceId, reason }),
+  );
+  yield* setState({ instanceId, state: 'stopped' });
+});
 
 const setState = ({
   instanceId,
@@ -85,84 +91,84 @@ const isStartable = ({
   );
 };
 
-export const startInstance = (desired: DesiredInstance) =>
-  Effect.gen(function* () {
-    const allocator = yield* SlotAllocator;
-    const vms = yield* VmManager;
-    const nowMs = yield* Clock.currentTimeMillis;
-    const existing = (yield* State.snapshot).records.get(desired.instanceId);
-    if (!isStartable({ existing, nowMs, desired })) {
-      return;
-    }
+export const startInstance = Effect.fn('startInstance')(function* (desired: DesiredInstance) {
+  yield* Effect.annotateCurrentSpan({ instanceId: desired.instanceId, appId: desired.appId });
+  const allocator = yield* SlotAllocator;
+  const vms = yield* VmManager;
+  const nowMs = yield* Clock.currentTimeMillis;
+  const existing = (yield* State.snapshot).records.get(desired.instanceId);
+  if (!isStartable({ existing, nowMs, desired })) {
+    return;
+  }
 
-    const slot = yield* allocator.allocate(desired.appId);
-    const attempted: InstanceRecord = {
-      ...(existing ??
-        newInstanceRecord({
-          instanceId: desired.instanceId,
-          appId: desired.appId,
-          deploymentId: desired.deploymentId,
-          volumeId: desired.volumeId,
-          hostnames: desired.hostnames,
-          hostPort: slot.hostPort,
-          guestPort: desired.config.guestPort,
-          guestIpv4: slot.guestIpv4,
-          artifactDigest: desired.artifact.digest,
-          state: 'pending',
+  const slot = yield* allocator.allocate(desired.appId);
+  const attempted: InstanceRecord = {
+    ...(existing ??
+      newInstanceRecord({
+        instanceId: desired.instanceId,
+        appId: desired.appId,
+        deploymentId: desired.deploymentId,
+        volumeId: desired.volumeId,
+        hostnames: desired.hostnames,
+        hostPort: slot.hostPort,
+        guestPort: desired.config.guestPort,
+        guestIpv4: slot.guestIpv4,
+        artifactDigest: desired.artifact.digest,
+        state: 'pending',
+        health: initialTracker(),
+        healthCheck: desired.config.healthCheck,
+        resources: desired.config.resources,
+        desiredRunning: true,
+      })),
+    startAttempts: nextAttemptWindow({
+      window: existing?.startAttempts ?? { attempts: 0 },
+      nowMs,
+      resetAfterMs: desired.config.restartPolicy.resetAfterMs,
+    }),
+  };
+  yield* State.putRecord(attempted);
+
+  yield* Effect.matchEffect(vms.boot({ desired, slot, dataDevicePath: slot.nbdDevicePath }), {
+    onSuccess: () =>
+      Effect.gen(function* () {
+        yield* State.putRecord({
+          ...attempted,
+          startedAt: yield* nowTimestamp,
+          state: 'starting',
+          stopRequested: false,
           health: initialTracker(),
-          healthCheck: desired.config.healthCheck,
-          resources: desired.config.resources,
-          desiredRunning: true,
-        })),
-      startAttempts: nextAttemptWindow({
-        window: existing?.startAttempts ?? { attempts: 0 },
-        nowMs,
-        resetAfterMs: desired.config.restartPolicy.resetAfterMs,
+          restartCount: attempted.restartCount + (existing ? ONE_RESTART : NO_RESTART),
+          message: undefined,
+        });
+        yield* State.modify((current) => {
+          const nextProbeAtMs = new Map(current.nextProbeAtMs);
+          nextProbeAtMs.delete(desired.instanceId);
+          return { ...current, nextProbeAtMs };
+        });
+        yield* Effect.logInfo('instance started').pipe(
+          Effect.annotateLogs({
+            instanceId: desired.instanceId,
+            hostPort: attempted.hostPort,
+            guestIpv4: attempted.guestIpv4,
+          }),
+        );
       }),
-    };
-    yield* State.putRecord(attempted);
-
-    yield* Effect.matchEffect(vms.boot({ desired, slot, dataDevicePath: slot.nbdDevicePath }), {
-      onSuccess: () =>
-        Effect.gen(function* () {
-          yield* State.putRecord({
-            ...attempted,
-            startedAt: yield* nowTimestamp,
-            state: 'starting',
-            stopRequested: false,
-            health: initialTracker(),
-            restartCount: attempted.restartCount + (existing ? ONE_RESTART : NO_RESTART),
-            message: undefined,
-          });
-          yield* State.modify((current) => {
-            const nextProbeAtMs = new Map(current.nextProbeAtMs);
-            nextProbeAtMs.delete(desired.instanceId);
-            return { ...current, nextProbeAtMs };
-          });
-          yield* Effect.logInfo('instance started').pipe(
-            Effect.annotateLogs({
-              instanceId: desired.instanceId,
-              hostPort: attempted.hostPort,
-              guestIpv4: attempted.guestIpv4,
-            }),
-          );
-        }),
-      onFailure: (error) =>
-        Effect.gen(function* () {
-          yield* State.putRecord({
-            ...attempted,
-            state: 'failed',
-            message: reportedMessage(error),
-          });
-          yield* Effect.logError('instance start failed', error).pipe(
-            Effect.annotateLogs({
-              instanceId: desired.instanceId,
-              attempt: attempted.startAttempts.attempts,
-            }),
-          );
-        }),
-    });
+    onFailure: (error) =>
+      Effect.gen(function* () {
+        yield* State.putRecord({
+          ...attempted,
+          state: 'failed',
+          message: reportedMessage(error),
+        });
+        yield* Effect.logError('instance start failed', error).pipe(
+          Effect.annotateLogs({
+            instanceId: desired.instanceId,
+            attempt: attempted.startAttempts.attempts,
+          }),
+        );
+      }),
   });
+});
 
 const probed = ({ record, nowMs }: { record: InstanceRecord; nowMs: number }) =>
   Effect.gen(function* () {

--- a/apps/agent/src/reconcile/reconciler.ts
+++ b/apps/agent/src/reconcile/reconciler.ts
@@ -47,7 +47,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
           exports: exports.length,
         }),
       );
-    });
+    }).pipe(Effect.withSpan('Reconciler.load'));
 
     /**
      * The union of what systemd knows and what this agent has notes on: a unit with no note is an
@@ -94,7 +94,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
           written: report.state === 'ready',
         })),
       } satisfies ObservedState;
-    });
+    }).pipe(Effect.withSpan('Reconciler.observe'));
 
     const persist = Effect.gen(function* () {
       const current = yield* State.snapshot;
@@ -184,38 +184,38 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
         );
       });
 
-    const reconcile = (desired: HostDesiredState) =>
-      Effect.gen(function* () {
-        const observed = yield* observe;
-        const plan = planReconcile({ desired, observed });
-        yield* State.modify((current) => ({
-          ...current,
-          deferredWork: hasDeferredWork(plan),
-        }));
-        yield* syncDesired(desired);
+    const reconcile = Effect.fn('Reconciler.reconcile')(function* (desired: HostDesiredState) {
+      yield* Effect.annotateCurrentSpan({ generation: desired.generation });
+      const observed = yield* observe;
+      const plan = planReconcile({ desired, observed });
+      yield* State.modify((current) => ({
+        ...current,
+        deferredWork: hasDeferredWork(plan),
+      }));
+      yield* syncDesired(desired);
 
-        yield* applyStops(plan);
-        yield* applyVolumes({ plan, observed });
-        // Before anything boots: nothing persists the ruleset across a reboot, so a host that
-        // started its VMs first would serve tenants through a kernel with no `nibrun` table.
-        yield* applyNetwork;
-        yield* applyStarts(plan);
-        yield* applyCheckpoints({ plan, desired });
-        // After starts, so an export never competes with a boot for the device it reads, and
-        // before teardowns, so a volume marked absent this generation is still there to read.
-        yield* applyExports({ plan, desired });
-        yield* applyTeardowns(plan);
-        // Again, because the instances started above are the ones whose forwards this renders.
-        yield* applyNetwork;
-        yield* applyRoutes;
-        yield* persist;
+      yield* applyStops(plan).pipe(Effect.withSpan('reconcile.stops'));
+      yield* applyVolumes({ plan, observed }).pipe(Effect.withSpan('reconcile.volumes'));
+      // Before anything boots: nothing persists the ruleset across a reboot, so a host that
+      // started its VMs first would serve tenants through a kernel with no `nibrun` table.
+      yield* applyNetwork.pipe(Effect.withSpan('reconcile.network'));
+      yield* applyStarts(plan).pipe(Effect.withSpan('reconcile.starts'));
+      yield* applyCheckpoints({ plan, desired }).pipe(Effect.withSpan('reconcile.checkpoints'));
+      // After starts, so an export never competes with a boot for the device it reads, and
+      // before teardowns, so a volume marked absent this generation is still there to read.
+      yield* applyExports({ plan, desired }).pipe(Effect.withSpan('reconcile.exports'));
+      yield* applyTeardowns(plan).pipe(Effect.withSpan('reconcile.teardowns'));
+      // Again, because the instances started above are the ones whose forwards this renders.
+      yield* applyNetwork.pipe(Effect.withSpan('reconcile.network'));
+      yield* applyRoutes.pipe(Effect.withSpan('reconcile.routes'));
+      yield* persist.pipe(Effect.withSpan('reconcile.persist'));
 
-        yield* State.modify((current) => ({
-          ...current,
-          observedGeneration: desired.generation,
-          converged: true,
-        }));
-      });
+      yield* State.modify((current) => ({
+        ...current,
+        observedGeneration: desired.generation,
+        converged: true,
+      }));
+    });
 
     return {
       load,
@@ -223,7 +223,17 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       reconcile,
       // An instance becomes routable here rather than in reconcile: the probe is what tells a
       // booted VM from one whose tenant has answered.
-      refresh: refreshStates.pipe(Effect.andThen(applyRoutes), Effect.andThen(persist)),
+      refresh: refreshStates.pipe(
+        Effect.andThen(applyRoutes),
+        Effect.andThen(persist),
+        Effect.withSpan('Reconciler.refresh'),
+      ),
     };
   }),
+  dependencies: [
+    AgentConfig.Default,
+    SlotAllocator.Default,
+    VolumeManager.Default,
+    VmManager.Default,
+  ],
 }) {}

--- a/apps/agent/src/vm/artifacts.ts
+++ b/apps/agent/src/vm/artifacts.ts
@@ -74,7 +74,7 @@ export const layer = Layer.effect(
         ),
     };
   }),
-);
+).pipe(Layer.provide([AgentConfig.Default, AwsCredentialProvider.Default]));
 
 /** Content-addressed, so a redeploy of a known digest costs nothing and two apps share one image. */
 export const artifactImagePath = ({
@@ -91,87 +91,92 @@ export const artifactImagePath = ({
  * Hashed during the transfer rather than after it, so the bytes are never read twice and the
  * file is only moved into the content-addressed cache once it is proven to be what it claims.
  */
-export const downloadAndVerify = ({
+export const downloadAndVerify = Effect.fn('downloadAndVerify')(function* ({
   artifact,
   destination,
 }: {
   artifact: DesiredArtifact;
   destination: string;
-}) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const store = yield* ArtifactStore;
-    const hasher = yield* Effect.sync(() => new Bun.CryptoHasher(DIGEST_ALGORITHM));
-    const written = yield* Ref.make(0);
-
-    yield* Stream.unwrap(
-      Effect.map(store.open(artifact.objectKey), (readable) =>
-        Stream.fromReadableStream({
-          evaluate: () => readable,
-          onError: (cause) => new ArtifactTransferError({ cause }),
-        }),
-      ),
-    ).pipe(
-      Stream.tap((chunk) =>
-        Effect.zipRight(
-          Effect.sync(() => hasher.update(chunk)),
-          Ref.update(written, (total) => total + chunk.byteLength),
-        ),
-      ),
-      Stream.run(fs.sink(destination)),
-      Effect.onError(() => fs.remove(destination, { force: true }).pipe(Effect.ignore)),
-    );
-
-    const actual = yield* Effect.sync(() => hasher.digest(HEX_ENCODING));
-    const size = yield* Ref.get(written);
-    const mismatch =
-      actual !== artifact.digest
-        ? new DigestMismatch({ expected: artifact.digest, actual })
-        : size !== artifact.sizeBytes
-          ? new ArtifactSizeMismatch({ expected: artifact.sizeBytes, actual: size })
-          : undefined;
-    if (mismatch) {
-      yield* fs.remove(destination, { force: true }).pipe(Effect.ignore);
-      return yield* mismatch;
-    }
+}) {
+  yield* Effect.annotateCurrentSpan({
+    objectKey: artifact.objectKey,
+    digest: artifact.digest,
   });
+  const fs = yield* FileSystem.FileSystem;
+  const store = yield* ArtifactStore;
+  const hasher = yield* Effect.sync(() => new Bun.CryptoHasher(DIGEST_ALGORITHM));
+  const written = yield* Ref.make(0);
+
+  yield* Stream.unwrap(
+    Effect.map(store.open(artifact.objectKey), (readable) =>
+      Stream.fromReadableStream({
+        evaluate: () => readable,
+        onError: (cause) => new ArtifactTransferError({ cause }),
+      }),
+    ),
+  ).pipe(
+    Stream.tap((chunk) =>
+      Effect.zipRight(
+        Effect.sync(() => hasher.update(chunk)),
+        Ref.update(written, (total) => total + chunk.byteLength),
+      ),
+    ),
+    Stream.run(fs.sink(destination)),
+    Effect.onError(() => fs.remove(destination, { force: true }).pipe(Effect.ignore)),
+  );
+
+  const actual = yield* Effect.sync(() => hasher.digest(HEX_ENCODING));
+  const size = yield* Ref.get(written);
+  const mismatch =
+    actual !== artifact.digest
+      ? new DigestMismatch({ expected: artifact.digest, actual })
+      : size !== artifact.sizeBytes
+        ? new ArtifactSizeMismatch({ expected: artifact.sizeBytes, actual: size })
+        : undefined;
+  if (mismatch) {
+    yield* fs.remove(destination, { force: true }).pipe(Effect.ignore);
+    return yield* mismatch;
+  }
+});
 
 /** The read-only squashfs the guest attaches as `vdb`, built if this host has not seen the digest. */
-export const ensureArtifactImage = (artifact: DesiredArtifact) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const config = yield* AgentConfig;
-    const cacheDir = config.artifactCacheDir;
-    const imagePath = artifactImagePath({ cacheDir, digest: artifact.digest, path });
-    if (yield* fs.exists(imagePath)) {
-      return imagePath;
-    }
+export const ensureArtifactImage = Effect.fn('ensureArtifactImage')(function* (
+  artifact: DesiredArtifact,
+) {
+  yield* Effect.annotateCurrentSpan({ digest: artifact.digest });
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const config = yield* AgentConfig;
+  const cacheDir = config.artifactCacheDir;
+  const imagePath = artifactImagePath({ cacheDir, digest: artifact.digest, path });
+  if (yield* fs.exists(imagePath)) {
+    return imagePath;
+  }
 
-    const stagingDir = path.join(cacheDir, `.staging-${artifact.digest}`);
-    const stagedImage = `${stagingDir}.squashfs`;
-    return yield* Effect.acquireUseRelease(
-      fs
-        .remove(stagingDir, { recursive: true, force: true })
-        .pipe(
-          Effect.andThen(fs.makeDirectory(stagingDir, { recursive: true, mode: CACHE_DIR_MODE })),
-        ),
-      () =>
-        Effect.gen(function* () {
-          const binaryPath = path.join(stagingDir, GUEST_BINARY_NAME);
-          yield* downloadAndVerify({ artifact, destination: binaryPath });
-          yield* fs.chmod(binaryPath, BINARY_MODE);
-          yield* fs.remove(stagedImage, { force: true });
-          yield* stdoutOf({
-            command: ['mksquashfs', stagingDir, stagedImage, '-no-progress', '-noappend'],
-          });
-          yield* fs.makeDirectory(path.dirname(imagePath), {
-            recursive: true,
-            mode: CACHE_DIR_MODE,
-          });
-          yield* fs.rename(stagedImage, imagePath);
-          return imagePath;
-        }),
-      () => fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),
-    );
-  });
+  const stagingDir = path.join(cacheDir, `.staging-${artifact.digest}`);
+  const stagedImage = `${stagingDir}.squashfs`;
+  return yield* Effect.acquireUseRelease(
+    fs
+      .remove(stagingDir, { recursive: true, force: true })
+      .pipe(
+        Effect.andThen(fs.makeDirectory(stagingDir, { recursive: true, mode: CACHE_DIR_MODE })),
+      ),
+    () =>
+      Effect.gen(function* () {
+        const binaryPath = path.join(stagingDir, GUEST_BINARY_NAME);
+        yield* downloadAndVerify({ artifact, destination: binaryPath });
+        yield* fs.chmod(binaryPath, BINARY_MODE);
+        yield* fs.remove(stagedImage, { force: true });
+        yield* stdoutOf({
+          command: ['mksquashfs', stagingDir, stagedImage, '-no-progress', '-noappend'],
+        });
+        yield* fs.makeDirectory(path.dirname(imagePath), {
+          recursive: true,
+          mode: CACHE_DIR_MODE,
+        });
+        yield* fs.rename(stagedImage, imagePath);
+        return imagePath;
+      }),
+    () => fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),
+  );
+});

--- a/apps/agent/src/vm/manager.ts
+++ b/apps/agent/src/vm/manager.ts
@@ -10,7 +10,7 @@ import {
 } from '#logs/receiver.ts';
 import type { AppSlot } from '#network/slot.ts';
 import { ensureTap } from '#network/tap.ts';
-import { ensureArtifactImage } from '#vm/artifacts.ts';
+import * as Artifacts from '#vm/artifacts.ts';
 import { renderFirecrackerConfig } from '#vm/firecracker-config.ts';
 import { buildInstanceConfigImage } from '#vm/instance-env.ts';
 import * as Systemd from '#vm/systemd.ts';
@@ -35,7 +35,7 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
      * The agent never becomes the VM's parent: it stages the files, asks init to start the unit,
      * and stops caring.
      */
-    const boot = ({
+    const boot = Effect.fn('VmManager.boot')(function* ({
       desired,
       slot,
       dataDevicePath,
@@ -43,73 +43,78 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       desired: DesiredInstance;
       slot: AppSlot;
       dataDevicePath: string;
-    }) =>
-      Effect.gen(function* () {
-        const artifactImagePath = yield* ensureArtifactImage(desired.artifact);
-        yield* ensureTap({
-          tapName: slot.tapName,
-          hostIpv4: slot.hostIpv4,
-          subnetPrefixLength: slot.subnetPrefixLength,
-        });
-
-        const directory = workingDir(desired.instanceId);
-        yield* fs.makeDirectory(directory, { recursive: true, mode: VM_DIR_MODE });
-        const instanceConfigImagePath = yield* buildInstanceConfigImage({
-          workingDir: directory,
-          guestPort: desired.config.guestPort,
-          args: desired.config.args,
-          environment: desired.config.environment,
-          restartPolicy: desired.config.restartPolicy,
-          dnsServers: config.guestDnsServers,
-        });
-
-        yield* writeJsonFile({
-          path: path.join(directory, FIRECRACKER_CONFIG_FILENAME),
-          value: renderFirecrackerConfig({
-            resources: desired.config.resources,
-            paths: {
-              kernelPath: path.join(config.guestImageDir, GUEST_KERNEL_FILENAME),
-              rootfsPath: path.join(config.guestImageDir, GUEST_ROOTFS_FILENAME),
-              artifactImagePath,
-              instanceConfigImagePath,
-              dataDevicePath,
-            },
-            network: {
-              tapName: slot.tapName,
-              guestMac: slot.guestMac,
-              guestIpv4: slot.guestIpv4,
-              hostIpv4: slot.hostIpv4,
-              subnetPrefixLength: slot.subnetPrefixLength,
-            },
-            vsock: {
-              guestCid: FIRST_GUEST_CID + slot.slot,
-              path: TENANT_LOG_VSOCK_FILENAME,
-            },
-          }),
-        });
-
-        yield* logs.attach({
-          source: {
-            instanceId: desired.instanceId,
-            appId: desired.appId,
-            deploymentId: desired.deploymentId,
-          },
-          socketPath: tenantLogSocketPath({ workingDir: directory }),
-        });
-        yield* Effect.onError(Systemd.start(desired.instanceId), () =>
-          Effect.ignore(logs.detach(desired.instanceId)),
-        );
+    }) {
+      yield* Effect.annotateCurrentSpan({
+        instanceId: desired.instanceId,
+        appId: desired.appId,
       });
+      const artifactImagePath = yield* Artifacts.ensureArtifactImage(desired.artifact);
+      yield* ensureTap({
+        tapName: slot.tapName,
+        hostIpv4: slot.hostIpv4,
+        subnetPrefixLength: slot.subnetPrefixLength,
+      });
+
+      const directory = workingDir(desired.instanceId);
+      yield* fs.makeDirectory(directory, { recursive: true, mode: VM_DIR_MODE });
+      const instanceConfigImagePath = yield* buildInstanceConfigImage({
+        workingDir: directory,
+        guestPort: desired.config.guestPort,
+        args: desired.config.args,
+        environment: desired.config.environment,
+        restartPolicy: desired.config.restartPolicy,
+        dnsServers: config.guestDnsServers,
+      });
+
+      yield* writeJsonFile({
+        path: path.join(directory, FIRECRACKER_CONFIG_FILENAME),
+        value: renderFirecrackerConfig({
+          resources: desired.config.resources,
+          paths: {
+            kernelPath: path.join(config.guestImageDir, GUEST_KERNEL_FILENAME),
+            rootfsPath: path.join(config.guestImageDir, GUEST_ROOTFS_FILENAME),
+            artifactImagePath,
+            instanceConfigImagePath,
+            dataDevicePath,
+          },
+          network: {
+            tapName: slot.tapName,
+            guestMac: slot.guestMac,
+            guestIpv4: slot.guestIpv4,
+            hostIpv4: slot.hostIpv4,
+            subnetPrefixLength: slot.subnetPrefixLength,
+          },
+          vsock: {
+            guestCid: FIRST_GUEST_CID + slot.slot,
+            path: TENANT_LOG_VSOCK_FILENAME,
+          },
+        }),
+      });
+
+      yield* logs.attach({
+        source: {
+          instanceId: desired.instanceId,
+          appId: desired.appId,
+          deploymentId: desired.deploymentId,
+        },
+        socketPath: tenantLogSocketPath({ workingDir: directory }),
+      });
+      yield* Effect.onError(Systemd.start(desired.instanceId), () =>
+        Effect.ignore(logs.detach(desired.instanceId)),
+      );
+    });
 
     return {
       workingDir,
       boot,
       stop: Systemd.stop,
-      discard: (instanceId: InstanceId) =>
-        Systemd.forget(instanceId).pipe(
-          Effect.andThen(logs.detach(instanceId)),
-          Effect.andThen(fs.remove(workingDir(instanceId), { recursive: true, force: true })),
-        ),
+      discard: Effect.fn('VmManager.discard')(function* (instanceId: InstanceId) {
+        yield* Effect.annotateCurrentSpan({ instanceId });
+        yield* Systemd.forget(instanceId);
+        yield* logs.detach(instanceId);
+        yield* fs.remove(workingDir(instanceId), { recursive: true, force: true });
+      }),
     };
   }),
+  dependencies: [AgentConfig.Default, TenantLogReceiver.Default],
 }) {}

--- a/apps/agent/src/vm/systemd.ts
+++ b/apps/agent/src/vm/systemd.ts
@@ -54,36 +54,41 @@ export const listInstanceIds = stdoutOf({
       .map(instanceIdFromUnit)
       .filter((id): id is InstanceId => id !== undefined),
   ),
+  Effect.withSpan('systemd.listInstanceIds'),
 );
 
-export const statuses = (instanceIds: readonly InstanceId[]) =>
-  Effect.gen(function* () {
-    if (instanceIds.length === 0) {
-      return new Map<InstanceId, UnitStatus>();
-    }
-    const result = yield* run({
-      command: [
-        SYSTEMCTL,
-        'show',
-        ...instanceIds.map(vmUnitName),
-        `--property=${SHOWN_PROPERTIES.join(',')}`,
-      ],
-    });
-    const blocks = parsePropertyBlocks(result.stdout);
-    return new Map(
-      [...instanceIds.entries()].map(([index, instanceId]) => [
-        instanceId,
-        unitStatusFrom(blocks[index] ?? { LoadState: 'not-found', ActiveState: 'inactive' }),
-      ]),
-    );
+export const statuses = Effect.fn('systemd.statuses')(function* (
+  instanceIds: readonly InstanceId[],
+) {
+  if (instanceIds.length === 0) {
+    return new Map<InstanceId, UnitStatus>();
+  }
+  const result = yield* run({
+    command: [
+      SYSTEMCTL,
+      'show',
+      ...instanceIds.map(vmUnitName),
+      `--property=${SHOWN_PROPERTIES.join(',')}`,
+    ],
   });
+  const blocks = parsePropertyBlocks(result.stdout);
+  return new Map(
+    [...instanceIds.entries()].map(([index, instanceId]) => [
+      instanceId,
+      unitStatusFrom(blocks[index] ?? { LoadState: 'not-found', ActiveState: 'inactive' }),
+    ]),
+  );
+});
 
-export const start = (instanceId: InstanceId) =>
-  stdoutOf({ command: [SYSTEMCTL, 'start', vmUnitName(instanceId)] });
+export const start = Effect.fn('systemd.start')((instanceId: InstanceId) =>
+  stdoutOf({ command: [SYSTEMCTL, 'start', vmUnitName(instanceId)] }),
+);
 
-export const stop = (instanceId: InstanceId) =>
-  stdoutOf({ command: [SYSTEMCTL, 'stop', vmUnitName(instanceId)] });
+export const stop = Effect.fn('systemd.stop')((instanceId: InstanceId) =>
+  stdoutOf({ command: [SYSTEMCTL, 'stop', vmUnitName(instanceId)] }),
+);
 
 /** An exited template instance stays loaded and failed until reset, and would linger in every enumeration. */
-export const forget = (instanceId: InstanceId) =>
-  run({ command: [SYSTEMCTL, 'reset-failed', vmUnitName(instanceId)] });
+export const forget = Effect.fn('systemd.forget')((instanceId: InstanceId) =>
+  run({ command: [SYSTEMCTL, 'reset-failed', vmUnitName(instanceId)] }),
+);

--- a/apps/agent/src/volumes/device-file.ts
+++ b/apps/agent/src/volumes/device-file.ts
@@ -45,25 +45,30 @@ export const readDeviceFileSize = (path: string) =>
  * Growing preserves the data and shrinking discards everything past the new size, so a smaller
  * desired size is refused: truncating a tenant's filesystem is not a way to discover a bug.
  */
-export const ensureDeviceFile = ({ path, sizeBytes }: { path: string; sizeBytes: number }) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const pathService = yield* Path.Path;
-    const target = alignToSector(sizeBytes);
-    const current = yield* readDeviceFileSize(path);
+export const ensureDeviceFile = Effect.fn('ensureDeviceFile')(function* ({
+  path,
+  sizeBytes,
+}: {
+  path: string;
+  sizeBytes: number;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const target = alignToSector(sizeBytes);
+  const current = yield* readDeviceFileSize(path);
 
-    if (Option.isSome(current)) {
-      if (current.value > target) {
-        return yield* new VolumeShrinkRefused({ current: current.value, requested: target });
-      }
-      if (current.value === target) {
-        return target;
-      }
+  if (Option.isSome(current)) {
+    if (current.value > target) {
+      return yield* new VolumeShrinkRefused({ current: current.value, requested: target });
     }
+    if (current.value === target) {
+      return target;
+    }
+  }
 
-    yield* fs.makeDirectory(pathService.dirname(path), { recursive: true });
-    yield* Effect.scoped(
-      Effect.flatMap(fs.open(path, { flag: 'a' }), (file) => file.truncate(target)),
-    );
-    return target;
-  });
+  yield* fs.makeDirectory(pathService.dirname(path), { recursive: true });
+  yield* Effect.scoped(
+    Effect.flatMap(fs.open(path, { flag: 'a' }), (file) => file.truncate(target)),
+  );
+  return target;
+});

--- a/apps/agent/src/volumes/ext4.ts
+++ b/apps/agent/src/volumes/ext4.ts
@@ -37,11 +37,11 @@ export const isFormatted = (devicePath: string) =>
   });
 
 /** Writing a filesystem is not parsing one, so this stays on the host and the guest only mounts. */
-export const formatOnce = (devicePath: string) =>
-  Effect.gen(function* () {
-    if (yield* isFormatted(devicePath)) {
-      return false;
-    }
-    yield* stdoutOf({ command: ['mkfs.ext4', '-q', '-L', FILESYSTEM_LABEL, devicePath] });
-    return true;
-  });
+export const formatOnce = Effect.fn('formatOnce')(function* (devicePath: string) {
+  yield* Effect.annotateCurrentSpan({ devicePath });
+  if (yield* isFormatted(devicePath)) {
+    return false;
+  }
+  yield* stdoutOf({ command: ['mkfs.ext4', '-q', '-L', FILESYSTEM_LABEL, devicePath] });
+  return true;
+});

--- a/apps/agent/src/volumes/manager.ts
+++ b/apps/agent/src/volumes/manager.ts
@@ -81,84 +81,87 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
       });
 
     /** The truth a restarted agent converges against: what ZeroFS is exporting, not what it remembers. */
-    const observe = (appIdByVolume: ReadonlyMap<VolumeId, AppId>) =>
-      Effect.forEach(topology.all, (filesystem) =>
-        Effect.gen(function* () {
-          const directory = path.join(filesystem.mountPath, NBD_DIRECTORY);
-          const names = yield* fs.readDirectory(directory).pipe(
-            Effect.tapError((error) =>
-              Effect.logWarning('zerofs nbd directory unreadable', error).pipe(
-                Effect.annotateLogs({ directory }),
+    const observe = Effect.fn('VolumeManager.observe')(
+      (appIdByVolume: ReadonlyMap<VolumeId, AppId>) =>
+        Effect.forEach(topology.all, (filesystem) =>
+          Effect.gen(function* () {
+            const directory = path.join(filesystem.mountPath, NBD_DIRECTORY);
+            const names = yield* fs.readDirectory(directory).pipe(
+              Effect.tapError((error) =>
+                Effect.logWarning('zerofs nbd directory unreadable', error).pipe(
+                  Effect.annotateLogs({ directory }),
+                ),
               ),
-            ),
-            Effect.orElseSucceed(() => [] as string[]),
-          );
-          const observed = yield* Effect.forEach(names, (name) =>
-            Effect.flatMap(slotFor({ volumeId: name as VolumeId, appIdByVolume }), (slot) =>
-              observeFile({ filesystem, volumeId: name as VolumeId, slot }),
-            ),
-          );
-          return Arr.getSomes(observed);
-        }),
-      ).pipe(Effect.map((byFilesystem) => byFilesystem.flat()));
+              Effect.orElseSucceed(() => [] as string[]),
+            );
+            const observed = yield* Effect.forEach(names, (name) =>
+              Effect.flatMap(slotFor({ volumeId: name as VolumeId, appIdByVolume }), (slot) =>
+                observeFile({ filesystem, volumeId: name as VolumeId, slot }),
+              ),
+            );
+            return Arr.getSomes(observed);
+          }),
+        ).pipe(Effect.map((byFilesystem) => byFilesystem.flat())),
+    );
 
-    const provision = (desired: DesiredVolume) =>
-      Effect.gen(function* () {
-        const filesystem = topology.place();
-        const slot = yield* allocator.allocate(desired.appId);
-        const sizeBytes = yield* ensureDeviceFile({
-          path: devicePathFor({ mount: filesystem.mountPath, volumeId: desired.volumeId, path }),
-          sizeBytes: desired.sizeBytes,
-        });
-
-        if (!(yield* isAttached(slot.nbdDevicePath))) {
-          yield* attach({
-            socketPath: filesystem.nbdSocketPath,
-            devicePath: slot.nbdDevicePath,
-            volumeId: desired.volumeId,
-          });
-        }
-
-        if (yield* formatOnce(slot.nbdDevicePath)) {
-          yield* Effect.logInfo('volume formatted').pipe(
-            Effect.annotateLogs({ volumeId: desired.volumeId, device: slot.nbdDevicePath }),
-          );
-        }
-
-        return {
-          volumeId: desired.volumeId,
-          state: 'ready',
-          sizeBytes,
-          devicePath: slot.nbdDevicePath,
-          storagePrefix: filesystem.storagePrefix,
-        } satisfies ReportedVolume;
+    const provision = Effect.fn('VolumeManager.provision')(function* (desired: DesiredVolume) {
+      yield* Effect.annotateCurrentSpan({ volumeId: desired.volumeId, appId: desired.appId });
+      const filesystem = topology.place();
+      const slot = yield* allocator.allocate(desired.appId);
+      const sizeBytes = yield* ensureDeviceFile({
+        path: devicePathFor({ mount: filesystem.mountPath, volumeId: desired.volumeId, path }),
+        sizeBytes: desired.sizeBytes,
       });
+
+      if (!(yield* isAttached(slot.nbdDevicePath))) {
+        yield* attach({
+          socketPath: filesystem.nbdSocketPath,
+          devicePath: slot.nbdDevicePath,
+          volumeId: desired.volumeId,
+        });
+      }
+
+      if (yield* formatOnce(slot.nbdDevicePath)) {
+        yield* Effect.logInfo('volume formatted').pipe(
+          Effect.annotateLogs({ volumeId: desired.volumeId, device: slot.nbdDevicePath }),
+        );
+      }
+
+      return {
+        volumeId: desired.volumeId,
+        state: 'ready',
+        sizeBytes,
+        devicePath: slot.nbdDevicePath,
+        storagePrefix: filesystem.storagePrefix,
+      } satisfies ReportedVolume;
+    });
 
     /**
      * The only path that destroys tenant data, and it runs only for an explicit `absent`. The
      * flush first, so the detach happens at a durability point rather than dropping whatever the
      * periodic flush had not yet uploaded.
      */
-    const teardown = (desired: DesiredVolume) =>
-      Effect.gen(function* () {
-        const filesystem = topology.place();
-        const slot = yield* allocator.lookup(desired.appId);
-        yield* flush(filesystem.admin);
-        if (Option.isSome(slot)) {
-          yield* detach(slot.value.nbdDevicePath);
-        }
-        yield* fs.remove(
-          devicePathFor({ mount: filesystem.mountPath, volumeId: desired.volumeId, path }),
-          { force: true },
-        );
-        yield* allocator.release(desired.appId);
-        return {
-          volumeId: desired.volumeId,
-          state: 'deleting',
-          sizeBytes: EMPTY_SIZE,
-        } satisfies ReportedVolume;
-      });
+    const teardown = Effect.fn('VolumeManager.teardown')(function* (desired: DesiredVolume) {
+      yield* Effect.annotateCurrentSpan({ volumeId: desired.volumeId, appId: desired.appId });
+      const filesystem = topology.place();
+      const slot = yield* allocator.lookup(desired.appId);
+      yield* flush(filesystem.admin);
+      if (Option.isSome(slot)) {
+        yield* detach(slot.value.nbdDevicePath);
+      }
+      yield* fs.remove(
+        devicePathFor({ mount: filesystem.mountPath, volumeId: desired.volumeId, path }),
+        { force: true },
+      );
+      yield* allocator.release(desired.appId);
+      return {
+        volumeId: desired.volumeId,
+        state: 'deleting',
+        sizeBytes: EMPTY_SIZE,
+      } satisfies ReportedVolume;
+    });
 
     return { observe, provision, teardown };
   }),
+  dependencies: [ZerofsTopology.Default, SlotAllocator.Default],
 }) {}

--- a/apps/agent/src/volumes/nbd.ts
+++ b/apps/agent/src/volumes/nbd.ts
@@ -18,31 +18,35 @@ export const isAttached = (devicePath: string) =>
   );
 
 /** `-persist` reconnects on its own, which keeps a ZeroFS restart a stall rather than an I/O error. */
-export const attach = ({
-  socketPath,
-  devicePath,
-  volumeId,
-}: {
-  socketPath: string;
-  devicePath: string;
-  volumeId: VolumeId;
-}) =>
-  stdoutOf({
-    command: [
-      NBD_CLIENT,
-      '-unix',
-      socketPath,
-      devicePath,
-      '-N',
-      volumeId,
-      '-persist',
-      '-timeout',
-      String(NBD_TIMEOUT_SECONDS),
-      '-connections',
-      String(NBD_CONNECTIONS),
-      '-block-size',
-      String(NBD_BLOCK_SIZE_BYTES),
-    ],
-  });
+export const attach = Effect.fn('nbd.attach')(
+  ({
+    socketPath,
+    devicePath,
+    volumeId,
+  }: {
+    socketPath: string;
+    devicePath: string;
+    volumeId: VolumeId;
+  }) =>
+    stdoutOf({
+      command: [
+        NBD_CLIENT,
+        '-unix',
+        socketPath,
+        devicePath,
+        '-N',
+        volumeId,
+        '-persist',
+        '-timeout',
+        String(NBD_TIMEOUT_SECONDS),
+        '-connections',
+        String(NBD_CONNECTIONS),
+        '-block-size',
+        String(NBD_BLOCK_SIZE_BYTES),
+      ],
+    }),
+);
 
-export const detach = (devicePath: string) => run({ command: [NBD_CLIENT, '-d', devicePath] });
+export const detach = Effect.fn('nbd.detach')((devicePath: string) =>
+  run({ command: [NBD_CLIENT, '-d', devicePath] }),
+);

--- a/apps/agent/src/volumes/topology.ts
+++ b/apps/agent/src/volumes/topology.ts
@@ -40,4 +40,5 @@ export class ZerofsTopology extends Effect.Service<ZerofsTopology>()('ZerofsTopo
     ];
     return { place: () => filesystems[0], all: filesystems };
   }),
+  dependencies: [AgentConfig.Default],
 }) {}

--- a/apps/agent/src/volumes/zerofs.ts
+++ b/apps/agent/src/volumes/zerofs.ts
@@ -16,32 +16,27 @@ const admin = ({ target, args }: { target: ZerofsAdmin; args: readonly string[] 
   stdoutOf({ command: [target.binary, ...args, '-c', target.configFile] });
 
 /** With `ignore_fsync` the guest's own flushes are a no-op, so this is what makes writes durable. */
-export const flush = (target: ZerofsAdmin) => admin({ target, args: ['flush'] });
+export const flush = Effect.fn('zerofs.flush')((target: ZerofsAdmin) =>
+  admin({ target, args: ['flush'] }),
+);
 
-export const createCheckpoint = ({
-  target,
-  checkpointId,
-}: {
-  target: ZerofsAdmin;
-  checkpointId: CheckpointId;
-}) =>
-  stdoutOf({
-    command: [target.binary, 'checkpoint', 'create', '-c', target.configFile, checkpointId],
-  });
+export const createCheckpoint = Effect.fn('zerofs.createCheckpoint')(
+  ({ target, checkpointId }: { target: ZerofsAdmin; checkpointId: CheckpointId }) =>
+    stdoutOf({
+      command: [target.binary, 'checkpoint', 'create', '-c', target.configFile, checkpointId],
+    }),
+);
 
-export const deleteCheckpoint = ({
-  target,
-  checkpointId,
-}: {
-  target: ZerofsAdmin;
-  checkpointId: CheckpointId;
-}) =>
-  stdoutOf({
-    command: [target.binary, 'checkpoint', 'delete', '-c', target.configFile, checkpointId],
-  });
+export const deleteCheckpoint = Effect.fn('zerofs.deleteCheckpoint')(
+  ({ target, checkpointId }: { target: ZerofsAdmin; checkpointId: CheckpointId }) =>
+    stdoutOf({
+      command: [target.binary, 'checkpoint', 'delete', '-c', target.configFile, checkpointId],
+    }),
+);
 
-export const listCheckpoints = (target: ZerofsAdmin) =>
-  Effect.map(admin({ target, args: ['checkpoint', 'list'] }), parseCheckpointNames);
+export const listCheckpoints = Effect.fn('zerofs.listCheckpoints')((target: ZerofsAdmin) =>
+  Effect.map(admin({ target, args: ['checkpoint', 'list'] }), parseCheckpointNames),
+);
 
 export function parseCheckpointNames(output: string): string[] {
   return output

--- a/apps/agent/tests/logs/receiver.test.ts
+++ b/apps/agent/tests/logs/receiver.test.ts
@@ -15,8 +15,11 @@ const DROPPED_BYTES = 17n;
 const MAX_GUEST_CONNECTIONS = 4;
 const SETTLE_MS = 50;
 
+// The receiver publishes to the queue this drains: naming one layer twice still builds it once.
 const run = provided(
-  TenantLogReceiver.Default.pipe(Layer.provideMerge(Layer.merge(TenantLogQueue.Default, platform))),
+  Layer.mergeAll(TenantLogReceiver.Default, TenantLogQueue.Default).pipe(
+    Layer.provideMerge(platform),
+  ),
 );
 
 async function connect(socketPath: string): Promise<Socket> {

--- a/apps/agent/tests/network/allocator.test.ts
+++ b/apps/agent/tests/network/allocator.test.ts
@@ -19,7 +19,9 @@ const BEYOND_THE_LAST_SLOT = 1_000;
 const everySlot = [...Array(SLOT_COUNT).keys()];
 
 const run = provided(
-  SlotAllocator.Default.pipe(Layer.provide(Layer.merge(agentConfig(), platform))),
+  SlotAllocator.DefaultWithoutDependencies.pipe(
+    Layer.provide(Layer.merge(agentConfig(), platform)),
+  ),
 );
 
 function app(name: string | number) {

--- a/apps/agent/tests/volumes/topology.test.ts
+++ b/apps/agent/tests/volumes/topology.test.ts
@@ -5,7 +5,10 @@ import { ZerofsTopology } from '#volumes/topology.ts';
 
 function topology() {
   return Effect.runSync(
-    Effect.provide(ZerofsTopology, ZerofsTopology.Default.pipe(Layer.provide(agentConfig()))),
+    Effect.provide(
+      ZerofsTopology,
+      ZerofsTopology.DefaultWithoutDependencies.pipe(Layer.provide(agentConfig())),
+    ),
   );
 }
 


### PR DESCRIPTION
Stacked on #78.

Two things the agent had no way to express: what an operation is called when it shows up in a stack trace or a span, and what a service needs to be built. Spans are inert until a tracer is configured — wiring one is out of scope.