### PR TITLE
chore(infra): adopt the guest image whose runtime reconnects

### DIFF
--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -16,5 +16,5 @@
     "url": "https://github.com/caddyserver/caddy/releases/download/v2.11.4/caddy_2.11.4_linux_amd64.tar.gz",
     "sha256": "527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9"
   },
-  "guestImage": "6.1.180-6d6c45cc1031"
+  "guestImage": "6.1.180-26eb600e8e86"
 }


### PR DESCRIPTION
#79 taught the guest runtime to notice the host going away. It changed `supervise.c` and `guest-logs.c`, so it changed the image inputs, so CI published `6.1.180-26eb600e8e86` — and left the pin on `6.1.180-6d6c45cc1031`, which is the image without the fix. Publishing is not adopting.

Confirmed on the app host after #79 deployed: `versions.json` still reads `6d6c45cc1031`, and the guest still has no log connection — two `LISTEN` sockets and no `ESTAB`.

The other half of #79 did land: `RuntimeDirectoryPreserve=yes` is in effect, and `/run/nibrun` kept its 17:09 mtime through the 19:19 agent restart instead of being deleted and recreated.

Adoption only. The running instance predates all of this and has no log connection, so it stays that way until it is restarted onto this image — which is the step after this one.