### PR TITLE
feat(logs): the app host ships its own journal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,12 @@ services:
     command:
       - -retentionPeriod=${VICTORIALOGS_RETENTION_PERIOD}
       - -storageDataPath=/victoria-logs-data
+      # Overrides the journald default of `_HOSTNAME,_SYSTEMD_UNIT`, which would
+      # be a stream per microVM on this fleet: `nibrun-vm@<instanceId>.service`
+      # is one unit per instance, and instances are minted on every deploy. Host
+      # and service are stable, so they key the stream; the unit stays an
+      # ordinary indexed field and is no less filterable for it.
+      - -journald.streamFields=_HOSTNAME,SOURCE
     volumes:
       - victorialogs-data:/victoria-logs-data
     # Loopback only, for the built-in UI at /select/vmui — same reasoning as

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -225,6 +225,19 @@ EOF
 chmod 0644 "$NIBRUN_DIR/bundle/versions.json.new"
 changed_file "$NIBRUN_DIR/bundle/versions.json" && NEEDS_RESTART+=(agent) || true
 
+# Ships this host's journal to the log store. systemd-journal-upload appends
+# `/upload` to this URL, which is exactly the path VictoriaLogs serves its
+# journald endpoint on — so the URL names the endpoint and the tool completes it.
+#
+# Holds no secret: the port admits app hosts by security group and nothing else,
+# so 0644 rather than the 0600 the umask above would otherwise give it.
+cat > /etc/systemd/journal-upload.conf.new <<EOF
+[Upload]
+URL=${LOG_INGEST_URL}/insert/journald
+EOF
+chmod 0644 /etc/systemd/journal-upload.conf.new
+changed_file /etc/systemd/journal-upload.conf && NEEDS_RESTART+=(journal-upload) || true
+
 cp zerofs/config.toml /etc/zerofs/config.toml.new
 # Read by ZeroFS itself, which runs as its own user, so it cannot inherit the
 # 0600 the umask above gives the secrets around it. It holds no secret: every
@@ -305,7 +318,7 @@ if [ "$units_changed" = "1" ]; then
 fi
 
 systemctl enable nibrun-zerofs.service nibrun-zerofs-mount.service \
-  nibrun-caddy.service nibrun-agent.service >/dev/null
+  nibrun-caddy.service nibrun-agent.service systemd-journal-upload.service >/dev/null
 
 # --- Restarting --------------------------------------------------------------
 #
@@ -355,6 +368,12 @@ elif needs_reload caddy; then
   systemctl reload nibrun-caddy.service
 fi
 
+# Restarted rather than reloaded: it reads its URL once, at start.
+if needs_restart journal-upload || ! systemctl is-active --quiet systemd-journal-upload.service; then
+  log "Journal uploader config changed — restarting it"
+  systemctl restart systemd-journal-upload.service
+fi
+
 if needs_restart agent; then
   log "Agent changed — restarting it, leaving tenant microVMs running"
   systemctl restart nibrun-agent.service
@@ -366,7 +385,7 @@ fi
 # bump reaches an app when it is next redeployed and restarts nothing now.
 
 log "Waiting for the services to settle"
-for unit in nibrun-zerofs nibrun-caddy nibrun-agent; do
+for unit in nibrun-zerofs nibrun-caddy nibrun-agent systemd-journal-upload; do
   for _ in $(seq 1 30); do
     state=$(systemctl is-active "$unit.service" || true)
     [ "$state" = "active" ] && break

--- a/infra/app-host/systemd/nibrun-agent.service
+++ b/infra/app-host/systemd/nibrun-agent.service
@@ -34,5 +34,11 @@ RuntimeDirectoryPreserve=yes
 # removed, which is why nothing on this host is containerised.
 NoNewPrivileges=false
 
+# What this unit is called in the log store. journald attaches this to every
+# entry the unit writes, and systemd requires the field name to be uppercase —
+# which is why the agent spells it the same way on tenant output. One `SOURCE`
+# then answers "which service wrote this" for everything on the fleet.
+LogExtraFields=SOURCE=agent
+
 [Install]
 WantedBy=multi-user.target

--- a/infra/app-host/systemd/nibrun-caddy.service
+++ b/infra/app-host/systemd/nibrun-caddy.service
@@ -43,5 +43,11 @@ RestrictRealtime=true
 RestrictSUIDSGID=true
 LockPersonality=true
 
+# What this unit is called in the log store. journald attaches this to every
+# entry the unit writes, and systemd requires the field name to be uppercase —
+# which is why the agent spells it the same way on tenant output. One `SOURCE`
+# then answers "which service wrote this" for everything on the fleet.
+LogExtraFields=SOURCE=caddy
+
 [Install]
 WantedBy=multi-user.target

--- a/infra/app-host/systemd/nibrun-vm@.service
+++ b/infra/app-host/systemd/nibrun-vm@.service
@@ -40,3 +40,9 @@ TimeoutStopSec=30
 # down cleanly first. That is survivable only because the agent flushes ZeroFS
 # before stopping a VM, which is the step that turns acknowledged writes durable
 # when `ignore_fsync` has made the guest's own fsync a no-op.
+
+# What this unit is called in the log store. journald attaches this to every
+# entry the unit writes, and systemd requires the field name to be uppercase —
+# which is why the agent spells it the same way on tenant output. One `SOURCE`
+# then answers "which service wrote this" for everything on the fleet.
+LogExtraFields=SOURCE=firecracker

--- a/infra/app-host/systemd/nibrun-zerofs.service
+++ b/infra/app-host/systemd/nibrun-zerofs.service
@@ -44,5 +44,11 @@ LockPersonality=true
 # the data volume rather than under CacheDirectory.
 ReadWritePaths=/data/zerofs
 
+# What this unit is called in the log store. journald attaches this to every
+# entry the unit writes, and systemd requires the field name to be uppercase —
+# which is why the agent spells it the same way on tenant output. One `SOURCE`
+# then answers "which service wrote this" for everything on the fleet.
+LogExtraFields=SOURCE=zerofs
+
 [Install]
 WantedBy=multi-user.target

--- a/infra/terraform/app_host_user_data.sh.tftpl
+++ b/infra/terraform/app_host_user_data.sh.tftpl
@@ -14,16 +14,21 @@ dnf update -y
 # No Docker: everything this host runs is a versioned binary the deploy fetches
 # from S3 and starts under systemd.
 #
-#   unzip           the deploy installs the AWS CLI with it
-#   fuse3           ZeroFS serves the host's own view over 9P through a FUSE client
-#   nftables        guest isolation and the forward to a tenant's port
-#   nbd             attaches a tenant's disk, which ZeroFS serves over NBD
-#   squashfs-tools  builds the read-only config drive handed to a microVM
+#   unzip                   the deploy installs the AWS CLI with it
+#   fuse3                   ZeroFS serves the host's own view over 9P through a FUSE client
+#   nftables                guest isolation and the forward to a tenant's port
+#   nbd                     attaches a tenant's disk, which ZeroFS serves over NBD
+#   squashfs-tools          builds the read-only config drive handed to a microVM
+#   systemd-journal-remote  ships this host's journal to the log store
 #
 # The agent runs none of these until it has work, so a missing one surfaces when
 # an app is placed here rather than at boot — hence installing them together, up
 # front, rather than discovering them one replaced instance at a time.
-dnf install -y unzip fuse3 nftables nbd squashfs-tools
+#
+# systemd-journal-remote is the exception: it carries systemd-journal-upload,
+# which the deploy points at the log store. Part of systemd rather than a binary
+# of its own, so nothing here has to be pinned, fetched or kept current.
+dnf install -y unzip fuse3 nftables nbd squashfs-tools systemd-journal-remote
 
 # Not guaranteed on minimal AL2023, and the deploy script needs it.
 if ! command -v aws >/dev/null 2>&1; then


### PR DESCRIPTION
Stacked on #85 — that PR ships tenant output; this one ships everything else on an app host.

The agent, Firecracker, ZeroFS, the app proxy and the box itself all log to journald, where they stay: reachable only over an SSM session. This sends them to the store.

## No new binary

`systemd-journal-upload` is part of systemd, and VictoriaLogs serves its protocol natively at `/insert/journald`. So the collector is a package (`systemd-journal-remote`, confirmed present on AL2023) and a two-line config file — nothing pinned in `versions.json`, nothing to fetch, nothing to keep current. It resumes from its own state file across a restart.

I did look at Vector, which would have been one more pinned binary. It is only needed if you have to rewrite field names on the way through, and the `SOURCE` decision in #85 removes that need.

## One field answers "which service"

Each of our units gains `LogExtraFields=SOURCE=<name>`, which journald attaches to every entry it writes. That is the same field, spelled the same way, that the agent stamps on tenant output — so:

```
SOURCE:agent        the host agent
SOURCE:firecracker  the hypervisor, any microVM
SOURCE:tenant       what an app printed
SOURCE:zerofs       the storage layer
SOURCE:caddy        the user-app proxy
```

Untagged units (sshd, cloud-init, the kernel) carry no `SOURCE` and group by host — verified they still ingest.

## The default that would have bitten

`-journald.streamFields=_HOSTNAME,SOURCE` replaces VictoriaLogs' journald default of `_HOSTNAME,_SYSTEMD_UNIT`. On this fleet `nibrun-vm@<instanceId>.service` is one unit per microVM, and instances are minted on every deploy — so the default would mint a stream per instance, forever. That is the same cardinality trap that ruled out Loki in #80.

Host and service are stable and key the stream; the unit stays an ordinary indexed field and is no less filterable for it.

## On filtering by app

Tenant records already carry `appId` as a stream field, so `SOURCE:tenant AND appId:<id>` is the query and the api adds it after checking ownership.

Firecracker's records cannot carry one: the unit file is templated across every instance on the host, so there is no place to put an app id that is known per instance. The unit name carries the instance id instead, and the api resolves app → instances against Postgres — the same place it already decides who may ask. That is the query-route PR.

## Verified locally

- Journal export format through Caddy's ingest listener → `200`, and `/select/*` on that port still `404`s.
- `SOURCE:agent` returns the agent's entries; `_stream` is `{SOURCE,_HOSTNAME}` — no per-VM streams.
- `level` is derived from `PRIORITY` by the store, so `level:error` works without anything mapping it.
- `SOURCE:firecracker AND _SYSTEMD_UNIT:"nibrun-vm@inst-7.service"` narrows to one instance.
- An entry from an untagged unit ingests and groups by host.
- `bun check:all`, `bun run build`, `terraform fmt -check`, `terraform validate` and `shellcheck` all pass.

## Not verified

`systemd-journal-upload` itself has not run against a real journal — this was written on macOS. What is verified is the wire format it sends and the endpoint that receives it. The package, the unit and the config path were confirmed in an `amazonlinux:2023` container.

## Not in this PR

The api's query route, which is where app-scoped retrieval and ownership checks land.
