### PR TITLE
fix(infra): a package added after the fleet exists reaches it

### DIFF
--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -56,6 +56,25 @@ secret() {
     --query Parameter.Value --output text
 }
 
+# systemd-journal-upload ships this host's journal, and arrives with
+# systemd-journal-remote. user_data installs it, but user_data only ever runs on
+# a host being created — so a package added after the fleet exists reaches the
+# hosts already running it here or not at all, and enabling its unit later is
+# what fails when it has not.
+#
+# Before anything writes configuration, because the package carries its own
+# /etc/systemd/journal-upload.conf: installing it after this deploy had written
+# that file would put the two in a race decided by rpm's config handling rather
+# than by this script.
+#
+# Guarded on the unit file rather than the package, because that is the thing
+# the enable actually needs, and it makes a re-run on a healthy host a test
+# rather than a `dnf` call.
+if [ ! -f /usr/lib/systemd/system/systemd-journal-upload.service ]; then
+  log "Installing systemd-journal-remote"
+  dnf install -y systemd-journal-remote
+fi
+
 log "Ensuring the data volume is mounted"
 bash ensure_data_volume.sh zerofs
 
@@ -121,7 +140,10 @@ install_caddy() {
 install_agent() {
   local dir="$VERSIONS_DIR/agent/$AGENT_VERSION"
   mkdir -p "$dir"
-  aws s3 cp "$AGENT_URL" "$dir/nibrun-agent"
+  # `--no-progress`: SSM RunCommand truncates a command's output, and the agent is
+  # ~90 MiB, so the transfer meter alone buries everything that follows it — which
+  # is how a failure after this step comes back with no visible cause.
+  aws s3 cp --no-progress "$AGENT_URL" "$dir/nibrun-agent"
   chmod 0755 "$dir/nibrun-agent"
   mark_installed agent "$AGENT_VERSION"
 }
@@ -129,7 +151,7 @@ install_agent() {
 install_guest_image() {
   local dir="$VERSIONS_DIR/guest-image/$GUEST_IMAGE_VERSION"
   mkdir -p "$dir"
-  aws s3 cp --recursive "s3://${GUEST_IMAGES_BUCKET}/${GUEST_IMAGE_VERSION}/" "$dir/"
+  aws s3 cp --no-progress --recursive "s3://${GUEST_IMAGES_BUCKET}/${GUEST_IMAGE_VERSION}/" "$dir/"
   # Written by the publish step from the manifest's own digests, because this box
   # has no jq to read the manifest with.
   ( cd "$dir" && sha256sum -c SHA256SUMS )
@@ -371,7 +393,12 @@ fi
 # Restarted rather than reloaded: it reads its URL once, at start.
 if needs_restart journal-upload || ! systemctl is-active --quiet systemd-journal-upload.service; then
   log "Journal uploader config changed — restarting it"
-  systemctl restart systemd-journal-upload.service
+  # Tolerated rather than fatal, for the same reason it is not in the health gate
+  # below: this ships logs, and a host that cannot must still finish deploying
+  # the things that serve tenants. `set -e` would otherwise make an unreachable
+  # log store end the deploy here.
+  systemctl restart systemd-journal-upload.service ||
+    log "WARNING: the journal uploader would not start"
 fi
 
 if needs_restart agent; then
@@ -385,7 +412,7 @@ fi
 # bump reaches an app when it is next redeployed and restarts nothing now.
 
 log "Waiting for the services to settle"
-for unit in nibrun-zerofs nibrun-caddy nibrun-agent systemd-journal-upload; do
+for unit in nibrun-zerofs nibrun-caddy nibrun-agent; do
   for _ in $(seq 1 30); do
     state=$(systemctl is-active "$unit.service" || true)
     [ "$state" = "active" ] && break
@@ -398,6 +425,15 @@ for unit in nibrun-zerofs nibrun-caddy nibrun-agent systemd-journal-upload; do
     exit 1
   fi
 done
+
+# Reported, not gated. The units above serve tenants; this one only describes
+# what they did, and it reaches the log store over a port whose availability the
+# fleet's deploys should not depend on — gating here would let the log store
+# being down stop every app host from deploying.
+if [ "$(systemctl is-active systemd-journal-upload.service || true)" != "active" ]; then
+  log "WARNING: systemd-journal-upload is not active — this host is not shipping its journal"
+  systemctl status systemd-journal-upload.service --no-pager --lines 20 || true
+fi
 
 log "Active versions"
 for component in zerofs firecracker caddy agent guest-image; do


### PR DESCRIPTION
The `app-hosts` job has failed on every push since #87. This fixes that and the three other ways #87 left for the journal uploader to end a deploy, plus the reason the failure was undiagnosable.

## What broke

#87 added `systemd-journal-remote` to `app_host_user_data.sh.tftpl`. That file only runs when an instance is *created*, and the fleet's one app host predates it — so `systemd-journal-upload.service` was never installed, and enabling it ended the deploy under `set -e`.

My mistake: I verified the package exists on AL2023 and installs cleanly, but not that it would reach a host that already existed.

The deploy now installs it when the unit file is absent, guarded on the unit file rather than the package — that is what the `enable` actually needs, and it keeps a re-run on a healthy host a test rather than a `dnf` call. It runs before any configuration is written, because the package ships its own `/etc/systemd/journal-upload.conf`; installing it afterwards would have put that file and ours in a race decided by rpm's config handling rather than by the script.

## Three more of the same mistake

Reviewing the rest of #87 rather than just the first failure, the uploader could still end a deploy three other ways. All are the same error of judgement: it ships logs, and a host that cannot must still finish deploying the things that serve tenants.

- `systemctl restart systemd-journal-upload.service` was fatal under `set -e`.
- It sat in the health gate beside ZeroFS, Caddy and the agent, which do serve tenants.
- Both would have triggered on a log store that was merely unreachable, stopping every app host in the fleet from deploying.

The restart is now tolerated and the gate reports rather than fails. The unit is still enabled and started, and a host that is not shipping its journal says so.

## Why it was invisible

The job log ended at `Fetching agent <sha>`, several hundred transfer-progress lines, then `exit status 1`. SSM RunCommand truncates a command's output, and `aws s3 cp` of a ~90 MiB agent binary buries everything after it. Both large transfers now pass `--no-progress` — without this the next on-box failure is just as blind.

## What else I checked

- **`control-plane` passed** on the same run, so #88 and the `-journald.streamFields` flag added to VictoriaLogs in #87 are fine.
- **#88 touches the control plane only** — no `infra/app-host/` files.
- **The agent starts.** #85 made `AGENT_LOG_INGEST_URL` required; the deploy writes it and `LOG_INGEST_URL` was present in the failing job's environment. Confirmed `AgentConfig` loads with it and fails with a clear message without it, so the health gate will not trip on config.
- **`LogExtraFields=` needs systemd 236+**; AL2023 ships 252.

## Verified

- In an `amazonlinux:2023` container: the guard path is absent before `dnf install systemd-journal-remote` and present after, a second install is a no-op, and the packaged unit has an `[Install]` section so `enable` works.
- `bash -n`, `shellcheck`, `bun check:all` and `bun run build` pass.

## Still unverified

`systemd-journal-upload` has not run against a real journal — no Linux host here. That is now a warning rather than a deploy failure, which is the point.