### PR TITLE
refactor(agent): one way to define a service

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -6,15 +6,23 @@ is never sent a command. Read `lib/reconcile/`, `lib/volumes/topology.ts` and
 `lib/network/slot.ts` first.
 
 **Written in Effect.** Every effectful path is an `Effect` with a typed error channel; anything a
-test needs to substitute is a service (`Context.Tag` or `Effect.Service`). State that used to be
+test needs to substitute is a service. State that used to be
 mutable class fields lives in a `Ref`. The four loops in `lib/agent/` are fibers, and their retry
 cadence is a `Schedule` rather than a failure counter. Interruption is the shutdown path:
 `BunRuntime.runMain` cancels the fibers and scoped finalizers close the log sockets. Nothing stops
 a tenant VM, which is what keeps redeploying the agent free.
 
+**A service is an `Effect.Service`, and there is no second way to define one.** `Context.Tag` with
+a hand-written `Layer` is the primitive underneath it, not an alternative style: reaching for it
+gives a service that is provided as `layer` while its neighbours are provided as `Default`, and
+that inconsistency spreads to whatever is written next to it. A test substitutes a service through
+the generated `make` — `Layer.succeed(CommandRunner, CommandRunner.make({ run }))`. If something
+does not deserve a service, it is plain functions taking what they need from context, as
+`lib/vm/systemd.ts` is.
+
 **Every service lives in `services/`, one per file**, named for the service it exports — the
 kebab-case of the identifier plus `.service.ts`, so `VolumeManager` is
-`volume-manager.service.ts`. A `.service.ts` module holds the service and its layer and nothing
+`volume-manager.service.ts`. A `.service.ts` module holds the service and nothing
 else; pure functions, error classes and host mechanics stay in the domain folder they belong to.
 `apps/api/src/services/` is the same shape, so the two apps read the same way.
 

--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -5,14 +5,14 @@ import { run } from '#lib/agent/run.ts';
 import { AgentLogger } from '#lib/logger.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
-import * as AgentState from '#services/agent-state.service.ts';
-import * as Artifacts from '#services/artifact-store.service.ts';
+import { AgentState } from '#services/agent-state.service.ts';
+import { ArtifactStore } from '#services/artifact-store.service.ts';
 import { CaddyProxy } from '#services/caddy-proxy.service.ts';
-import * as Exec from '#services/command-runner.service.ts';
-import * as ControlPlane from '#services/control-plane.service.ts';
+import { CommandRunner } from '#services/command-runner.service.ts';
+import { ControlPlane } from '#services/control-plane.service.ts';
 import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
 import { ExportManager } from '#services/export-manager.service.ts';
-import * as LogStore from '#services/log-store.service.ts';
+import { LogStore } from '#services/log-store.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { TenantLogQueue } from '#services/tenant-log-queue.service.ts';
@@ -30,11 +30,11 @@ const platform = Layer.mergeAll(BunContext.layer, FetchHttpClient.layer);
  */
 const agent = Layer.mergeAll(
   AgentConfig.Default,
-  AgentState.layer,
-  Exec.layer,
-  ControlPlane.layer,
-  LogStore.layer,
-  Artifacts.layer,
+  AgentState.Default,
+  CommandRunner.Default,
+  ControlPlane.Default,
+  LogStore.Default,
+  ArtifactStore.Default,
   SlotAllocator.Default,
   ZerofsTopology.Default,
   CaddyProxy.Default,

--- a/apps/agent/src/lib/agent/poll.ts
+++ b/apps/agent/src/lib/agent/poll.ts
@@ -3,8 +3,8 @@ import { Duration, Effect, Option } from 'effect';
 import { CONTROL_PLANE_BACKOFF } from '#lib/agent/backoff.ts';
 import { supervised } from '#lib/agent/loop.ts';
 import type { ProtocolMismatch } from '#lib/protocol.ts';
-import * as State from '#lib/reconcile/state.ts';
 import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { ControlPlane } from '#services/control-plane.service.ts';
 import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
@@ -48,7 +48,7 @@ export const pollLoop = Effect.gen(function* () {
       // Only a new generation re-runs a reconcile, and work the last one deferred does not change
       // it — so a volume waiting on an instance to stop would otherwise never be carried.
       const latest = yield* cache.latest;
-      if ((yield* State.snapshot).deferredWork && Option.isSome(latest)) {
+      if ((yield* AgentState.snapshot).deferredWork && Option.isSome(latest)) {
         yield* reconcileSafely(latest.value);
       }
     }

--- a/apps/agent/src/lib/agent/report.ts
+++ b/apps/agent/src/lib/agent/report.ts
@@ -2,7 +2,6 @@ import { Duration, Effect } from 'effect';
 import { CONTROL_PLANE_BACKOFF } from '#lib/agent/backoff.ts';
 import { supervised } from '#lib/agent/loop.ts';
 import { nowTimestamp } from '#lib/clock.ts';
-import * as State from '#lib/reconcile/state.ts';
 import { buildReportedState } from '#lib/report/build-report.ts';
 import {
   allocatableCapacity,
@@ -11,6 +10,7 @@ import {
 } from '#lib/report/capacity.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { ControlPlane } from '#services/control-plane.service.ts';
 
 const report = Effect.gen(function* () {
@@ -19,7 +19,7 @@ const report = Effect.gen(function* () {
   const sessions = yield* AgentSessionHolder;
 
   const session = yield* sessions.current;
-  const current = yield* State.snapshot;
+  const current = yield* AgentState.snapshot;
   const records = [...current.records.values()];
   const capacity = yield* readHostCapacity(config.stateDir);
 

--- a/apps/agent/src/lib/agent/run.ts
+++ b/apps/agent/src/lib/agent/run.ts
@@ -4,8 +4,8 @@ import { pollLoop, reconcileSafely } from '#lib/agent/poll.ts';
 import { reportLoop } from '#lib/agent/report.ts';
 import { statusLoop } from '#lib/agent/status.ts';
 import { tenantLogSocketPath } from '#lib/logs/vsock.ts';
-import * as State from '#lib/reconcile/state.ts';
 import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
 import { TenantLogReceiver } from '#services/tenant-log-receiver.service.ts';
@@ -15,7 +15,7 @@ const restoreLogReceivers = Effect.gen(function* () {
   const vms = yield* VmManager;
   const receiver = yield* TenantLogReceiver;
   yield* Effect.forEach(
-    yield* State.records,
+    yield* AgentState.records,
     (record) =>
       receiver
         .attach({

--- a/apps/agent/src/lib/reconcile/checkpoints.ts
+++ b/apps/agent/src/lib/reconcile/checkpoints.ts
@@ -3,8 +3,8 @@ import { Effect } from 'effect';
 import { nowTimestamp } from '#lib/clock.ts';
 import { reportedMessage } from '#lib/failure.ts';
 import type { CheckpointPlan, ReconcilePlan } from '#lib/reconcile/plan.ts';
-import * as State from '#lib/reconcile/state.ts';
 import { createCheckpoint, deleteCheckpoint, listCheckpoints } from '#lib/volumes/zerofs.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
 
 type Applicable = Extract<CheckpointPlan, { action: 'create' | 'delete' }>;
@@ -61,5 +61,5 @@ export const applyCheckpoints = ({
         ? []
         : plan.checkpoints.filter((action): action is Applicable => action.action !== 'none');
     const checkpointReports = yield* Effect.forEach(applicable, applyOne);
-    yield* State.modify((current) => ({ ...current, checkpointReports }));
+    yield* AgentState.modify((current) => ({ ...current, checkpointReports }));
   });

--- a/apps/agent/src/lib/reconcile/exports.ts
+++ b/apps/agent/src/lib/reconcile/exports.ts
@@ -2,18 +2,18 @@ import type { ExportId, HostDesiredState, ReportedExport } from '@repo/protocol'
 import { Effect, Option } from 'effect';
 import { reportedMessage } from '#lib/failure.ts';
 import type { ExportPlan, ReconcilePlan } from '#lib/reconcile/plan.ts';
-import * as State from '#lib/reconcile/state.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { ExportManager } from '#services/export-manager.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 
 const setReport = (report: ReportedExport) =>
-  State.modify((current) => ({
+  AgentState.modify((current) => ({
     ...current,
     exportReports: new Map(current.exportReports).set(report.exportId, report),
   }));
 
 const forget = (exportId: ExportId) =>
-  State.modify((current) => {
+  AgentState.modify((current) => {
     const exportReports = new Map(current.exportReports);
     exportReports.delete(exportId);
     return { ...current, exportReports };

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -5,11 +5,11 @@ import { nowTimestamp } from '#lib/clock.ts';
 import { reportedMessage } from '#lib/failure.ts';
 import { probeInstance } from '#lib/health/probe.ts';
 import { applyProbe, evaluateInstanceState, initialTracker } from '#lib/health/state.ts';
-import * as State from '#lib/reconcile/state.ts';
 import { type InstanceRecord, newInstanceRecord } from '#lib/report/instance-record.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { UNKNOWN_UNIT } from '#lib/vm/unit-status.ts';
 import { flush } from '#lib/volumes/zerofs.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { VmManager } from '#services/vm-manager.service.ts';
 import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
@@ -63,7 +63,7 @@ const setState = ({
   state: InstanceState;
   stopRequested?: boolean;
 }) =>
-  State.updateRecord({
+  AgentState.updateRecord({
     instanceId,
     change: (record) => ({
       ...record,
@@ -96,7 +96,7 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
   const allocator = yield* SlotAllocator;
   const vms = yield* VmManager;
   const nowMs = yield* Clock.currentTimeMillis;
-  const existing = (yield* State.snapshot).records.get(desired.instanceId);
+  const existing = (yield* AgentState.snapshot).records.get(desired.instanceId);
   if (!isStartable({ existing, nowMs, desired })) {
     return;
   }
@@ -126,12 +126,12 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
       resetAfterMs: desired.config.restartPolicy.resetAfterMs,
     }),
   };
-  yield* State.putRecord(attempted);
+  yield* AgentState.putRecord(attempted);
 
   yield* Effect.matchEffect(vms.boot({ desired, slot, dataDevicePath: slot.nbdDevicePath }), {
     onSuccess: () =>
       Effect.gen(function* () {
-        yield* State.putRecord({
+        yield* AgentState.putRecord({
           ...attempted,
           startedAt: yield* nowTimestamp,
           state: 'starting',
@@ -140,7 +140,7 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
           restartCount: attempted.restartCount + (existing ? ONE_RESTART : NO_RESTART),
           message: undefined,
         });
-        yield* State.modify((current) => {
+        yield* AgentState.modify((current) => {
           const nextProbeAtMs = new Map(current.nextProbeAtMs);
           nextProbeAtMs.delete(desired.instanceId);
           return { ...current, nextProbeAtMs };
@@ -155,7 +155,7 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
       }),
     onFailure: (error) =>
       Effect.gen(function* () {
-        yield* State.putRecord({
+        yield* AgentState.putRecord({
           ...attempted,
           state: 'failed',
           message: reportedMessage(error),
@@ -177,7 +177,7 @@ const probed = ({ record, nowMs }: { record: InstanceRecord; nowMs: number }) =>
       guestPort: record.guestPort,
       healthCheck: record.healthCheck,
     });
-    yield* State.modify((current) => ({
+    yield* AgentState.modify((current) => ({
       ...current,
       nextProbeAtMs: new Map(current.nextProbeAtMs).set(
         record.instanceId,
@@ -194,7 +194,7 @@ const probed = ({ record, nowMs }: { record: InstanceRecord; nowMs: number }) =>
 
 /** Probes the tenants that are due, then settles each state from systemd and the probe together. */
 export const refreshStates = Effect.gen(function* () {
-  const current = yield* State.snapshot;
+  const current = yield* AgentState.snapshot;
   const statuses = yield* Systemd.statuses([...current.records.keys()]);
   const nowMs = yield* Clock.currentTimeMillis;
 
@@ -217,7 +217,7 @@ export const refreshStates = Effect.gen(function* () {
         });
 
         const changed = state !== record.state;
-        yield* State.putRecord({
+        yield* AgentState.putRecord({
           ...record,
           health,
           state,

--- a/apps/agent/src/lib/reconcile/network.ts
+++ b/apps/agent/src/lib/reconcile/network.ts
@@ -1,13 +1,13 @@
 import { Effect, Option } from 'effect';
 import type { ForwardedInstance } from '#lib/network/firewall.ts';
 import { applyRuleset } from '#lib/network/nftables.ts';
-import * as State from '#lib/reconcile/state.ts';
 import { renderableRoutes } from '#lib/report/routes.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { CaddyProxy } from '#services/caddy-proxy.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 
-export const routes = Effect.map(State.records, renderableRoutes);
+export const routes = Effect.map(AgentState.records, renderableRoutes);
 
 export const applyRoutes = Effect.gen(function* () {
   const proxy = yield* CaddyProxy;
@@ -18,7 +18,7 @@ export const applyRoutes = Effect.gen(function* () {
 
 const forwards = Effect.gen(function* () {
   const allocator = yield* SlotAllocator;
-  const all = yield* State.records;
+  const all = yield* AgentState.records;
   const forwarded: ForwardedInstance[] = [];
   for (const record of all) {
     const slot = yield* allocator.lookup(record.appId);
@@ -47,9 +47,9 @@ export const applyNetwork = Effect.gen(function* () {
     controlPlaneCidrsV6: config.controlPlaneCidrsV6,
     guestDnsServers: config.guestDnsServers,
   }).pipe(
-    Effect.andThen(State.modify((current) => ({ ...current, isolated: true }))),
+    Effect.andThen(AgentState.modify((current) => ({ ...current, isolated: true }))),
     Effect.catchAll((error) =>
-      State.modify((current) => ({ ...current, isolated: false })).pipe(
+      AgentState.modify((current) => ({ ...current, isolated: false })).pipe(
         Effect.andThen(Effect.logError('firewall apply failed', error)),
       ),
     ),

--- a/apps/agent/src/lib/reconcile/state.ts
+++ b/apps/agent/src/lib/reconcile/state.ts
@@ -1,46 +1,4 @@
-import type { AppId, InstanceId, ReportedVolume, VolumeId } from '@repo/protocol';
-import { Effect, Ref } from 'effect';
-import type { InstanceRecord } from '#lib/report/instance-record.ts';
-import { type AgentSnapshot, AgentState } from '#services/agent-state.service.ts';
-
-export const snapshot = Effect.flatMap(AgentState, Ref.get);
-
-export const modify = (change: (current: AgentSnapshot) => AgentSnapshot) =>
-  Effect.flatMap(AgentState, (state) => Ref.update(state, change));
-
-export const records = Effect.map(snapshot, (current) => [...current.records.values()]);
-
-export const putRecord = (record: InstanceRecord) =>
-  modify((current) => ({
-    ...current,
-    records: new Map(current.records).set(record.instanceId, record),
-  }));
-
-export const updateRecord = ({
-  instanceId,
-  change,
-}: {
-  instanceId: InstanceId;
-  change: (record: InstanceRecord) => InstanceRecord;
-}) =>
-  modify((current) => {
-    const record = current.records.get(instanceId);
-    return record
-      ? { ...current, records: new Map(current.records).set(instanceId, change(record)) }
-      : current;
-  });
-
-export const dropRecord = (instanceId: InstanceId) =>
-  modify((current) => {
-    const records_ = new Map(current.records);
-    records_.delete(instanceId);
-    return { ...current, records: records_ };
-  });
-
-export const appIdByVolume = Effect.map(
-  records,
-  (all) => new Map<VolumeId, AppId>(all.map((record) => [record.volumeId, record.appId])),
-);
+import type { ReportedVolume } from '@repo/protocol';
 
 /** Rebuilt from what a reconcile found rather than added to, so what just happened to a volume wins. */
 export function mergeVolumeReports({

--- a/apps/agent/src/lib/reconcile/volumes.ts
+++ b/apps/agent/src/lib/reconcile/volumes.ts
@@ -2,8 +2,9 @@ import type { DesiredVolume, ReportedVolume } from '@repo/protocol';
 import { Effect } from 'effect';
 import { reportedMessage } from '#lib/failure.ts';
 import type { ObservedState, ReconcilePlan } from '#lib/reconcile/plan.ts';
-import * as State from '#lib/reconcile/state.ts';
+import { mergeVolumeReports } from '#lib/reconcile/state.ts';
 import { toReportedVolume } from '#lib/volumes/manager.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { VolumeManager } from '#services/volume-manager.service.ts';
 
 const provision = (desired: DesiredVolume) =>
@@ -46,9 +47,9 @@ export const applyVolumes = ({
         );
       }
     }
-    yield* State.modify((current) => ({
+    yield* AgentState.modify((current) => ({
       ...current,
-      volumeReports: State.mergeVolumeReports({
+      volumeReports: mergeVolumeReports({
         existing: observed.volumes.map(toReportedVolume),
         updates,
       }),
@@ -64,9 +65,9 @@ export const applyTeardowns = (plan: ReconcilePlan) =>
       }
       yield* volumes.teardown(action.desired).pipe(
         Effect.flatMap((report) =>
-          State.modify((current) => ({
+          AgentState.modify((current) => ({
             ...current,
-            volumeReports: State.mergeVolumeReports({
+            volumeReports: mergeVolumeReports({
               existing: current.volumeReports,
               updates: [report],
             }),

--- a/apps/agent/src/services/agent-state.service.ts
+++ b/apps/agent/src/services/agent-state.service.ts
@@ -1,11 +1,13 @@
 import type {
+  AppId,
   ExportId,
   InstanceId,
   ReportedCheckpoint,
   ReportedExport,
   ReportedVolume,
+  VolumeId,
 } from '@repo/protocol';
-import { Context, Layer, Ref } from 'effect';
+import { Effect, Ref } from 'effect';
 import type { InstanceRecord } from '#lib/report/instance-record.ts';
 
 const NO_GENERATION = 0;
@@ -36,6 +38,52 @@ const EMPTY: AgentSnapshot = {
   isolated: false,
 };
 
-export class AgentState extends Context.Tag('AgentState')<AgentState, Ref.Ref<AgentSnapshot>>() {}
+/** The Ref never leaves: every read and every transition is a member, so there is one writer. */
+export class AgentState extends Effect.Service<AgentState>()('AgentState', {
+  accessors: true,
+  effect: Effect.gen(function* () {
+    const state = yield* Ref.make(EMPTY);
 
-export const layer = Layer.effect(AgentState, Ref.make(EMPTY));
+    const modify = (change: (current: AgentSnapshot) => AgentSnapshot) => Ref.update(state, change);
+    const snapshot = Ref.get(state);
+    const records = Effect.map(snapshot, (current) => [...current.records.values()]);
+
+    return {
+      snapshot,
+      modify,
+      records,
+
+      putRecord: (record: InstanceRecord) =>
+        modify((current) => ({
+          ...current,
+          records: new Map(current.records).set(record.instanceId, record),
+        })),
+
+      updateRecord: ({
+        instanceId,
+        change,
+      }: {
+        instanceId: InstanceId;
+        change: (record: InstanceRecord) => InstanceRecord;
+      }) =>
+        modify((current) => {
+          const record = current.records.get(instanceId);
+          return record
+            ? { ...current, records: new Map(current.records).set(instanceId, change(record)) }
+            : current;
+        }),
+
+      dropRecord: (instanceId: InstanceId) =>
+        modify((current) => {
+          const remaining = new Map(current.records);
+          remaining.delete(instanceId);
+          return { ...current, records: remaining };
+        }),
+
+      appIdByVolume: Effect.map(
+        records,
+        (all) => new Map<VolumeId, AppId>(all.map((record) => [record.volumeId, record.appId])),
+      ),
+    };
+  }),
+}) {}

--- a/apps/agent/src/services/artifact-store.service.ts
+++ b/apps/agent/src/services/artifact-store.service.ts
@@ -1,4 +1,4 @@
-import { Context, Data, Effect, Layer } from 'effect';
+import { Data, Effect } from 'effect';
 import { s3Credentials } from '#lib/aws/credentials.ts';
 import { describe } from '#lib/failure.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
@@ -12,22 +12,12 @@ export class ArtifactTransferError extends Data.TaggedError('ArtifactTransferErr
   }
 }
 
-export class ArtifactStore extends Context.Tag('ArtifactStore')<
-  ArtifactStore,
-  {
-    readonly open: (
-      objectKey: string,
-    ) => Effect.Effect<ReadableStream<Uint8Array>, ArtifactTransferError>;
-  }
->() {}
-
-export const layer = Layer.effect(
-  ArtifactStore,
-  Effect.gen(function* () {
+export class ArtifactStore extends Effect.Service<ArtifactStore>()('ArtifactStore', {
+  effect: Effect.gen(function* () {
     const config = yield* AgentConfig;
     const credentials = yield* AwsCredentialProvider;
     return {
-      open: (objectKey: string) =>
+      open: (objectKey: string): Effect.Effect<ReadableStream<Uint8Array>, ArtifactTransferError> =>
         credentials.resolve.pipe(
           Effect.flatMap((resolved) =>
             Effect.try(
@@ -45,4 +35,5 @@ export const layer = Layer.effect(
         ),
     };
   }),
-).pipe(Layer.provide([AgentConfig.Default, AwsCredentialProvider.Default]));
+  dependencies: [AgentConfig.Default, AwsCredentialProvider.Default],
+}) {}

--- a/apps/agent/src/services/command-runner.service.ts
+++ b/apps/agent/src/services/command-runner.service.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandExecutor } from '@effect/platform';
 import type { PlatformError } from '@effect/platform/Error';
-import { Context, Duration, Effect, Layer, Stream } from 'effect';
+import { Duration, Effect, Stream } from 'effect';
 import {
   type CommandError,
   CommandFailed,
@@ -11,11 +11,6 @@ import {
 
 const DEFAULT_TIMEOUT = Duration.minutes(2);
 const SUCCESS = 0;
-
-export class CommandRunner extends Context.Tag('CommandRunner')<
-  CommandRunner,
-  { readonly run: (request: CommandRequest) => Effect.Effect<CommandResult, CommandError> }
->() {}
 
 export const run = (request: CommandRequest) =>
   Effect.flatMap(CommandRunner, (runner) => runner.run(request));
@@ -52,9 +47,9 @@ const execute = (request: CommandRequest) =>
     Effect.withSpan('exec', { attributes: { command: request.command[0] } }),
   );
 
-export const layer = Layer.effect(
-  CommandRunner,
-  Effect.map(Effect.context<CommandExecutor.CommandExecutor>(), (context) => ({
-    run: (request: CommandRequest) => Effect.provide(execute(request), context),
+export class CommandRunner extends Effect.Service<CommandRunner>()('CommandRunner', {
+  effect: Effect.map(Effect.context<CommandExecutor.CommandExecutor>(), (context) => ({
+    run: (request: CommandRequest): Effect.Effect<CommandResult, CommandError> =>
+      Effect.provide(execute(request), context),
   })),
-);
+}) {}

--- a/apps/agent/src/services/control-plane.service.ts
+++ b/apps/agent/src/services/control-plane.service.ts
@@ -1,10 +1,10 @@
-import { Context, Effect, Layer } from 'effect';
-import { type ControlPlaneClient, makeControlPlaneClient } from '#lib/control/client.ts';
+import { Effect } from 'effect';
+import { makeControlPlaneClient } from '#lib/control/client.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 
-export class ControlPlane extends Context.Tag('ControlPlane')<ControlPlane, ControlPlaneClient>() {}
-
-export const layer = Layer.effect(
-  ControlPlane,
-  Effect.map(AgentConfig, (config) => makeControlPlaneClient({ baseUrl: config.controlPlaneUrl })),
-).pipe(Layer.provide(AgentConfig.Default));
+export class ControlPlane extends Effect.Service<ControlPlane>()('ControlPlane', {
+  effect: Effect.map(AgentConfig, (config) =>
+    makeControlPlaneClient({ baseUrl: config.controlPlaneUrl }),
+  ),
+  dependencies: [AgentConfig.Default],
+}) {}

--- a/apps/agent/src/services/log-store.service.ts
+++ b/apps/agent/src/services/log-store.service.ts
@@ -1,10 +1,8 @@
-import { Context, Effect, Layer } from 'effect';
-import { type LogStoreClient, makeLogStoreClient } from '#lib/logs/store-client.ts';
+import { Effect } from 'effect';
+import { makeLogStoreClient } from '#lib/logs/store-client.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 
-export class LogStore extends Context.Tag('LogStore')<LogStore, LogStoreClient>() {}
-
-export const layer = Layer.effect(
-  LogStore,
-  Effect.map(AgentConfig, (config) => makeLogStoreClient({ baseUrl: config.logIngestUrl })),
-).pipe(Layer.provide(AgentConfig.Default));
+export class LogStore extends Effect.Service<LogStore>()('LogStore', {
+  effect: Effect.map(AgentConfig, (config) => makeLogStoreClient({ baseUrl: config.logIngestUrl })),
+  dependencies: [AgentConfig.Default],
+}) {}

--- a/apps/agent/src/services/reconciler.service.ts
+++ b/apps/agent/src/services/reconciler.service.ts
@@ -7,12 +7,12 @@ import { applyExports } from '#lib/reconcile/exports.ts';
 import { refreshStates, startInstance, stopInstance } from '#lib/reconcile/instances.ts';
 import { applyNetwork, applyRoutes } from '#lib/reconcile/network.ts';
 import { hasDeferredWork, type ObservedState, planReconcile } from '#lib/reconcile/plan.ts';
-import * as State from '#lib/reconcile/state.ts';
 import { applyTeardowns, applyVolumes } from '#lib/reconcile/volumes.ts';
 import { readInstanceRecords } from '#lib/report/instance-record.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { UNKNOWN_UNIT } from '#lib/vm/unit-status.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { VmManager } from '#services/vm-manager.service.ts';
 import { VolumeManager } from '#services/volume-manager.service.ts';
@@ -35,7 +35,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       const exports = readExportReports(
         Option.getOrUndefined(yield* readJsonFile(config.exportsFile)),
       );
-      yield* State.modify((current) => ({
+      yield* AgentState.modify((current) => ({
         ...current,
         records: new Map(instances.map((record) => [record.instanceId, record])),
         exportReports: new Map(exports.map((report) => [report.exportId, report])),
@@ -54,7 +54,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
      * orphan to stop, and a note with no unit is an instance that is gone.
      */
     const observe = Effect.gen(function* () {
-      const current = yield* State.snapshot;
+      const current = yield* AgentState.snapshot;
       const unitIds = yield* Systemd.listInstanceIds.pipe(Effect.orElseSucceed(() => []));
       const ids = [...new Set([...unitIds, ...current.records.keys()])];
       const statuses = yield* Systemd.statuses(ids).pipe(
@@ -86,7 +86,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
           };
         }),
         volumes: yield* volumes
-          .observe(yield* State.appIdByVolume)
+          .observe(yield* AgentState.appIdByVolume)
           .pipe(Effect.orElseSucceed(() => [])),
         checkpoints: [],
         exports: [...current.exportReports.values()].map((report) => ({
@@ -97,7 +97,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
     }).pipe(Effect.withSpan('Reconciler.observe'));
 
     const persist = Effect.gen(function* () {
-      const current = yield* State.snapshot;
+      const current = yield* AgentState.snapshot;
       yield* allocator.persist;
       yield* writeJsonFile({
         path: config.instancesFile,
@@ -117,7 +117,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       Effect.forEach(
         desired.instances,
         (wanted) =>
-          State.updateRecord({
+          AgentState.updateRecord({
             instanceId: wanted.instanceId,
             change: (record) => ({
               ...record,
@@ -144,13 +144,13 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
               reason: 'superseded',
             }).pipe(
               Effect.andThen(vms.discard(action.desired.instanceId)),
-              Effect.andThen(State.dropRecord(action.desired.instanceId)),
+              Effect.andThen(AgentState.dropRecord(action.desired.instanceId)),
             );
           }
           if (action.action === 'forget') {
             return vms
               .discard(action.instanceId)
-              .pipe(Effect.andThen(State.dropRecord(action.instanceId)));
+              .pipe(Effect.andThen(AgentState.dropRecord(action.instanceId)));
           }
           return Effect.void;
         },
@@ -169,7 +169,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
         if (starts.length === 0) {
           return;
         }
-        if (!(yield* State.snapshot).isolated) {
+        if (!(yield* AgentState.snapshot).isolated) {
           return yield* Effect.logError(
             'instance starts refused: isolation ruleset not applied',
           ).pipe(Effect.annotateLogs({ refused: starts.length }));
@@ -188,7 +188,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       yield* Effect.annotateCurrentSpan({ generation: desired.generation });
       const observed = yield* observe;
       const plan = planReconcile({ desired, observed });
-      yield* State.modify((current) => ({
+      yield* AgentState.modify((current) => ({
         ...current,
         deferredWork: hasDeferredWork(plan),
       }));
@@ -210,7 +210,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       yield* applyRoutes.pipe(Effect.withSpan('reconcile.routes'));
       yield* persist.pipe(Effect.withSpan('reconcile.persist'));
 
-      yield* State.modify((current) => ({
+      yield* AgentState.modify((current) => ({
         ...current,
         observedGeneration: desired.generation,
         converged: true,

--- a/apps/agent/tests/support/artifacts.ts
+++ b/apps/agent/tests/support/artifacts.ts
@@ -9,18 +9,21 @@ export const ARTIFACT_DIGEST = new Bun.CryptoHasher('sha256')
 
 /** The artifact bucket as the chunks the transfer is meant to see, in the order it sees them. */
 export function artifactStore(chunks: readonly Uint8Array[] = [ARTIFACT_BYTES]) {
-  return Layer.succeed(ArtifactStore, {
-    open: () =>
-      Effect.sync(
-        () =>
-          new ReadableStream<Uint8Array>({
-            start(controller) {
-              for (const chunk of chunks) {
-                controller.enqueue(chunk);
-              }
-              controller.close();
-            },
-          }),
-      ),
-  });
+  return Layer.succeed(
+    ArtifactStore,
+    ArtifactStore.make({
+      open: () =>
+        Effect.sync(
+          () =>
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                for (const chunk of chunks) {
+                  controller.enqueue(chunk);
+                }
+                controller.close();
+              },
+            }),
+        ),
+    }),
+  );
 }

--- a/apps/agent/tests/support/commands.ts
+++ b/apps/agent/tests/support/commands.ts
@@ -14,11 +14,14 @@ export function recordingCommands(
     succeeding(),
 ) {
   const commands: CommandRequest[] = [];
-  const layer = Layer.succeed(CommandRunner, {
-    run: (request) => {
-      commands.push(request);
-      return answer(request);
-    },
-  });
+  const layer = Layer.succeed(
+    CommandRunner,
+    CommandRunner.make({
+      run: (request) => {
+        commands.push(request);
+        return answer(request);
+      },
+    }),
+  );
   return { commands, layer, executables: () => commands.map(({ command }) => command[0]) };
 }


### PR DESCRIPTION
Five of the eighteen services were a `Context.Tag` with a hand-written layer rather than an `Effect.Service`, so `index.ts` read as `Default` beside `layer` and three call sites needed a namespace import. The newest of the five copied the pattern it found beside it.

All eighteen are `Effect.Service` now. A test substitutes one through the generated `make`.

`AgentState` got more than a mechanical swap: it kept a raw `Ref` behind its tag and its transitions in a separate file to dodge an import cycle. Those transitions are its members now, so nothing outside the service touches the `Ref`.

No behaviour change — 205 tests pass asserting the same things.