### PR TITLE
feat(api): the api knows where the log store is

### DIFF
--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -7,6 +7,7 @@ interface CustomProcessEnv {
   readonly GITHUB_CLIENT_ID: string;
   readonly GITHUB_CLIENT_SECRET: string;
   readonly S3_ENDPOINT: string;
+  readonly VICTORIALOGS_ENDPOINT: string;
   readonly ARTIFACTS_BUCKET: string;
   readonly S3_ACCESS_KEY_ID: string;
   readonly S3_SECRET_ACCESS_KEY: string;
@@ -41,6 +42,7 @@ type Env = {
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;
   S3_ENDPOINT: URL;
+  VICTORIALOGS_ENDPOINT: URL;
   ARTIFACTS_BUCKET: string;
   S3_ACCESS_KEY_ID: string;
   S3_SECRET_ACCESS_KEY: string;
@@ -55,6 +57,7 @@ function loadEnv(): Env {
     GITHUB_CLIENT_ID: required('GITHUB_CLIENT_ID'),
     GITHUB_CLIENT_SECRET: required('GITHUB_CLIENT_SECRET'),
     S3_ENDPOINT: new URL(required('S3_ENDPOINT')),
+    VICTORIALOGS_ENDPOINT: new URL(required('VICTORIALOGS_ENDPOINT')),
     ARTIFACTS_BUCKET: required('ARTIFACTS_BUCKET'),
     S3_ACCESS_KEY_ID: required('S3_ACCESS_KEY_ID'),
     S3_SECRET_ACCESS_KEY: required('S3_SECRET_ACCESS_KEY'),

--- a/apps/api/src/routes/internal/agent/controller.test.ts
+++ b/apps/api/src/routes/internal/agent/controller.test.ts
@@ -29,6 +29,7 @@ const REQUIRED_ENV = {
   GITHUB_CLIENT_ID: 'test',
   GITHUB_CLIENT_SECRET: 'test',
   S3_ENDPOINT: 'http://127.0.0.1:1',
+  VICTORIALOGS_ENDPOINT: 'http://127.0.0.1:1',
   ARTIFACTS_BUCKET: 'test',
   S3_ACCESS_KEY_ID: 'test',
   S3_SECRET_ACCESS_KEY: 'test',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,15 @@ services:
       - GITHUB_CLIENT_ID=${API_GITHUB_CLIENT_ID}
       - GITHUB_CLIENT_SECRET=${API_GITHUB_CLIENT_SECRET}
       - S3_ENDPOINT=http://minio:9000
+      # Reads only. Writes arrive from the fleet through Caddy's ingest listener,
+      # and the api is what decides who may see an app — so this is the one thing
+      # on the compose network that queries the store, and nothing queries it
+      # from outside.
+      #
+      # Not in .env: unlike S3, the log store runs in this stack in production
+      # too, at the same name and port, so there is no deployment for this to
+      # vary by.
+      - VICTORIALOGS_ENDPOINT=http://victorialogs:9428
       - ARTIFACTS_BUCKET=${ARTIFACTS_BUCKET}
       - AGENT_BOOTSTRAP_TOKEN=${AGENT_BOOTSTRAP_TOKEN}
       - S3_ACCESS_KEY_ID=${API_S3_ACCESS_KEY_ID}


### PR DESCRIPTION
The address the query route will need, read at startup like every other one the api holds.

## On the name

You asked for `API_VICTORIALOGS_ENDPOINT`; I used `VICTORIALOGS_ENDPOINT`, because that is what the api actually reads for everything else. The container takes `S3_ENDPOINT` and `DATABASE_URL` unprefixed — the `API_` prefix belongs to `.env`, which `.env.example` describes as namespacing the deployment's own values, and `docker-compose.yml` maps those onto the names the image expects.

Say the word and I will rename it.

## Why it is not in .env

`.env.example` reserves itself for what varies per deployment, and says internal service URLs live in `docker-compose.yml`. `S3_ENDPOINT` is hardcoded there for local and overridden in prod only because production uses real S3.

The log store has no equivalent: it runs in this compose stack in production too, under the same service name on the same port. There is no deployment for it to vary by, so hardcoding it is the honest description.

The api also has no dev script — it only ever runs inside the stack — so there is no host-side invocation that would need `localhost`.

## Required, not defaulted

An api that started without it would answer every log query with a connection error to localhost. Refusing to start is the better way to find that out, and matches how `S3_ENDPOINT` is treated.

## No depends_on

Deliberate. The api does not need the store to start, and VictoriaLogs has no healthcheck to wait on (scratch image, no shell). Ordering the api behind it would couple the control plane's startup to its log store for nothing.

## Verified

- `VICTORIALOGS_ENDPOINT: http://victorialogs:9428` renders in the prod compose config.
- The name resolves and answers on the compose network: `/health` and `/select/logsql/query` both return 200 from another container.
- `bun check:all` and `bun run build` pass. The api's route test needed the new variable in its `REQUIRED_ENV`, which is the check doing its job.

## Next

The query route itself: resolve app → ownership, then filter `SOURCE:tenant AND appId:<id>`, plus `_SYSTEMD_UNIT` for the Firecracker records belonging to that app's instances.