### PR TITLE
fix(infra): the log ingest listener actually listens

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -43,10 +43,12 @@ services:
     restart: always
     ports:
       - "443:443"
-      # Admitted from the app hosts' security group only; see infra/caddy/Caddyfile.
-      # On every interface like 443 above: the security group is the boundary, and
-      # AWS enforces it before a packet reaches the instance.
+      # Both admitted from the app hosts' security group only; see
+      # infra/caddy/Caddyfile. On every interface like 443 above: the security
+      # group is the boundary, and AWS enforces it before a packet reaches the
+      # instance.
       - "${INTERNAL_PORT}:${INTERNAL_PORT}"
+      - "${LOG_INGEST_PORT}:${LOG_INGEST_PORT}"
     healthcheck:
       test:
         ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:2019/config/ || exit 1"]
@@ -63,6 +65,11 @@ services:
       # in rather than mounted because basic_auth takes the hash inline.
       - VICTORIALOGS_PASSWORD_HASH
       - INTERNAL_PORT
+      # Without this the Caddyfile's `:{$LOG_INGEST_PORT}` site address expands
+      # to a bare `:`, which Caddy drops silently rather than refusing — the
+      # listener simply does not exist and every shipper on the fleet gets a
+      # connection refused.
+      - LOG_INGEST_PORT
     volumes:
       - ./caddy:/etc/caddy:ro
     networks:

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -122,6 +122,15 @@ https://{$VICTORIALOGS_HOSTNAME} {
 		admin {$VICTORIALOGS_PASSWORD_HASH}
 	}
 
+	# Nothing is served at the bare hostname — the allowlist below starts at
+	# /select — so this is what makes typing the hostname land on the dashboard
+	# rather than a 404. A redirect, not a proxy: it publishes no new path.
+	# Temporary, so the destination can move without browsers having cached it.
+	@root path /
+	handle @root {
+		redir * /select/vmui/
+	}
+
 	# vmui is served from /select/vmui/ and loads every asset relative to it, and
 	# its queries are /select/logsql/*. So this is the whole dashboard and nothing
 	# else: /insert stays reachable only on the ingest listener above, and the


### PR DESCRIPTION
The store was empty because nothing could reach it.

`infra/caddy/Caddyfile` has had a `:{$LOG_INGEST_PORT}` site since #80, but `docker-compose.prod.yml` never published that port and never passed the variable into the container. With it unset the site address expands to a bare `:`, and Caddy drops that silently — `caddy adapt` exits 0 and simply emits no such server. The running edge had only `:443` and `:19080`, so `systemd-journal-upload` was in a restart loop on `Could not connect to server` and the agent's tenant writes had nowhere to go.

The security group was correct all along; only the bind was missing.

Also redirects the dashboard's bare hostname to `/select/vmui/`, which 404'd.

## Verified

Against the real Caddyfile, with a stand-in origin-pull CA:

- with the variable unset, `caddy adapt` exits 0 and emits `:19080` and `:443` only — reproducing production
- with it set, all three listeners appear
- a journal-export-format entry POSTed to `:19081/insert/journald/upload` returns 200 and comes back as `SOURCE:agent`, `level:info`, `_stream` `{SOURCE,_HOSTNAME}` — the cardinality shape #87 designed for
- `/select/*` on the ingest port still 404s
- `/` on the dashboard redirects to `/select/vmui/`; unauthenticated it is still 401, and `/metrics`, `/flags` and `/insert/*` still 404