### PR TITLE
fix(infra): the journal uploader survives an unreachable store

### DIFF
--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -335,6 +335,14 @@ for unit in systemd/*.service; do
   cp "$unit" "/etc/systemd/system/$(basename "$unit").new"
   changed_file "/etc/systemd/system/$(basename "$unit")" && units_changed=1 || true
 done
+
+# The uploader's unit belongs to systemd rather than to us, so what we have to
+# say about it goes in a drop-in beside it instead of replacing it.
+journal_upload_dropin=/etc/systemd/system/systemd-journal-upload.service.d
+mkdir -p "$journal_upload_dropin"
+cp systemd/systemd-journal-upload.service.d/nibrun.conf "$journal_upload_dropin/nibrun.conf.new"
+changed_file "$journal_upload_dropin/nibrun.conf" && units_changed=1 || true
+
 if [ "$units_changed" = "1" ]; then
   systemctl daemon-reload
 fi
@@ -393,6 +401,11 @@ fi
 # Restarted rather than reloaded: it reads its URL once, at start.
 if needs_restart journal-upload || ! systemctl is-active --quiet systemd-journal-upload.service; then
   log "Journal uploader config changed — restarting it"
+  # A unit that exhausted its start limit refuses to restart until the failure is
+  # cleared, so without this a host that gave up while the store was unreachable
+  # stays down through every deploy that follows. The drop-in above stops it
+  # latching in the first place; this recovers the hosts that already have.
+  systemctl reset-failed systemd-journal-upload.service || true
   # Tolerated rather than fatal, for the same reason it is not in the health gate
   # below: this ships logs, and a host that cannot must still finish deploying
   # the things that serve tenants. `set -e` would otherwise make an unreachable

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -401,11 +401,6 @@ fi
 # Restarted rather than reloaded: it reads its URL once, at start.
 if needs_restart journal-upload || ! systemctl is-active --quiet systemd-journal-upload.service; then
   log "Journal uploader config changed — restarting it"
-  # A unit that exhausted its start limit refuses to restart until the failure is
-  # cleared, so without this a host that gave up while the store was unreachable
-  # stays down through every deploy that follows. The drop-in above stops it
-  # latching in the first place; this recovers the hosts that already have.
-  systemctl reset-failed systemd-journal-upload.service || true
   # Tolerated rather than fatal, for the same reason it is not in the health gate
   # below: this ships logs, and a host that cannot must still finish deploying
   # the things that serve tenants. `set -e` would otherwise make an unreachable

--- a/infra/app-host/systemd/systemd-journal-upload.service.d/nibrun.conf
+++ b/infra/app-host/systemd/systemd-journal-upload.service.d/nibrun.conf
@@ -1,0 +1,13 @@
+# The uploader exits whenever the log store is unreachable, and the unit systemd
+# ships restarts it with a backoff that grows to a minute (RestartSteps=10,
+# RestartMaxDelaySec=60). But the first restarts are 100ms apart, so the default
+# start limit — five within ten seconds — is spent long before that backoff
+# engages, and the unit latches into `failed` and stays there. A store that is
+# briefly unreachable then stops this host shipping its journal permanently,
+# until someone runs `reset-failed` by hand.
+#
+# Disabling the limit lets the backoff it already has do the job it was written
+# for. There is no reason to give up: the journal is durable and the uploader
+# resumes from its own cursor, so an outage costs a delay rather than the logs.
+[Unit]
+StartLimitIntervalSec=0


### PR DESCRIPTION
`systemd-journal-upload` exits whenever the log store is unreachable. The unit systemd ships restarts it with a backoff that grows to a minute (`RestartSteps=10`, `RestartMaxDelaySec=60`) — but the first restarts are 100ms apart, so the default start limit of five in ten seconds is spent long before that backoff engages, and the unit latches into `failed` permanently.

That is what kept the fleet silent even after #92 bound the ingest port: the uploader had already given up at 09:08, and a plain `systemctl restart` cannot clear a latched start limit, so the deploy's own restart was a no-op every time.

- A drop-in disables the start limit, letting the backoff the unit already has do its job. Giving up is never right here: the journal is durable and the uploader resumes from its own cursor, so an outage costs a delay rather than the logs.
- The deploy `reset-failed`s before restarting, so a host that already latched recovers on its next deploy instead of needing a hand.

## Verified

- `systemd-analyze verify` accepts the drop-in (the two warnings it prints are about the shipped unit's `RestartSteps`/`RestartMaxDelaySec`, unknown to that container's older systemd — the box honours them)
- the bundle already ships it: `BUNDLE_DIRECTORIES` tars `systemd` recursively, confirmed by listing the tar
- `shellcheck`, `bun check:all`