### PR TITLE
feat(protocol): a directory listing has a shape

### DIFF
--- a/packages/protocol/src/domain/filesystem.ts
+++ b/packages/protocol/src/domain/filesystem.ts
@@ -1,0 +1,100 @@
+import { type TString, Type } from '@sinclair/typebox';
+import type { Brand, BrandedSchema } from '#lib/brand.ts';
+import { stringEnum } from '#lib/string-enum.ts';
+import { ByteSizeSchema, TimestampSchema } from '#lib/wire.ts';
+
+/**
+ * Domain rather than control, for the same reason a log record is: the agent reads a listing off
+ * a tenant device and the api hands it to a dashboard, so neither sends the other one as a
+ * message — but the two would drift apart silently if the shape lived in either app.
+ *
+ * A listing is one directory's children, flat. Nothing here nests, and nothing here is a tree:
+ * the wire carries what a person is looking at, and the path back to the root is the dashboard's
+ * own navigation state. That is what keeps the cost of listing a filesystem independent of how
+ * large the filesystem is.
+ */
+
+/**
+ * `other` is every symlink, socket, fifo and device node.
+ *
+ * They are named rather than hidden, because a file a tenant can see and we do not show is worse
+ * than one we decline to open — and collapsed together rather than told apart, because the only
+ * question a read-only browser asks is whether descending is meaningful. It also means nothing
+ * here has to describe a symlink target, so no listing can point out of the tenant's filesystem.
+ */
+export const FILESYSTEM_ENTRY_KINDS = ['file', 'directory', 'other'] as const;
+
+export const FilesystemEntryKindSchema = stringEnum(FILESYSTEM_ENTRY_KINDS);
+
+export type FilesystemEntryKind = (typeof FILESYSTEM_ENTRY_KINDS)[number];
+
+/**
+ * Deliberately permissive, and the asymmetry with `GuestPathSchema` below is the point: a name is
+ * reported, a path is accepted. The tenant's own binary created these, so anything ext4 allows —
+ * a leading dash, a space, a quote, a newline — has to survive being described. Refusing one here
+ * would not stop the file existing; it would only stop its owner seeing it.
+ */
+const MAX_ENTRY_NAME_LENGTH = 255;
+const ENTRY_NAME_PATTERN = '^[^/\\u0000]+$';
+
+export const FilesystemEntryNameSchema = Type.String({
+  description: 'One directory entry name, exactly as it is stored on the tenant filesystem.',
+  pattern: ENTRY_NAME_PATTERN,
+  minLength: 1,
+  maxLength: MAX_ENTRY_NAME_LENGTH,
+});
+
+/**
+ * An absolute path inside one tenant's filesystem, where its root is the volume's own root — the
+ * `data/` a tenant's binary writes to, and nothing above it.
+ *
+ * Strict where a name is permissive, because this is the direction that carries a request. `.`
+ * and `..` are excluded outright rather than resolved: a browser that never resolves a path
+ * cannot be walked out of the filesystem it was scoped to. Quotes and backslashes are excluded
+ * because the value ends up in a command string the reader's tooling tokenises the way a shell
+ * would — so a directory named `it's` can be listed by name but not descended into, which is the
+ * price of never handing that tooling a second command.
+ */
+const MAX_GUEST_PATH_LENGTH = 4096;
+const PATH_SEGMENT_CHARACTERS = '[^/\\\\"\'\\u0000-\\u001f]';
+const NOT_A_TRAVERSAL = '(?!\\.{1,2}(?:/|$))';
+const PATH_SEGMENT = `${NOT_A_TRAVERSAL}${PATH_SEGMENT_CHARACTERS}+`;
+const GUEST_PATH_PATTERN = `^/(?:${PATH_SEGMENT}(?:/${PATH_SEGMENT})*)?$`;
+
+export type GuestPath = Brand<string, 'GuestPath'>;
+
+// Branded apart from the host paths it sits beside in the agent: a device path and a path inside
+// the filesystem that device holds are both strings, and only one of them is a tenant's to name.
+export const GuestPathSchema = Type.String({
+  description: 'Absolute path within a tenant volume. No `.`, no `..`, no trailing slash.',
+  pattern: GUEST_PATH_PATTERN,
+  minLength: 1,
+  maxLength: MAX_GUEST_PATH_LENGTH,
+}) as BrandedSchema<TString, GuestPath>;
+
+export const GUEST_PATH_ROOT = '/' as GuestPath;
+
+export const FilesystemEntrySchema = Type.Object({
+  name: FilesystemEntryNameSchema,
+  kind: FilesystemEntryKindSchema,
+  sizeBytes: ByteSizeSchema,
+  modifiedAt: TimestampSchema,
+});
+
+export type FilesystemEntry = typeof FilesystemEntrySchema.static;
+
+/**
+ * `truncated` rather than a cursor, while the answer is a single read of a single directory.
+ * Paging needs a key that survives between two reads of a filesystem being written to underneath
+ * it, and there is no such key here that is not an inode — so this says plainly that there is
+ * more, instead of offering a way to walk it that would quietly skip and repeat entries.
+ */
+export const DIRECTORY_ENTRY_LIMIT = 1000;
+
+export const DirectoryListingSchema = Type.Object({
+  path: GuestPathSchema,
+  entries: Type.Array(FilesystemEntrySchema, { maxItems: DIRECTORY_ENTRY_LIMIT }),
+  truncated: Type.Boolean(),
+});
+
+export type DirectoryListing = typeof DirectoryListingSchema.static;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -99,6 +99,20 @@ export {
   ExportStateSchema,
 } from '#domain/export.ts';
 export {
+  DIRECTORY_ENTRY_LIMIT,
+  type DirectoryListing,
+  DirectoryListingSchema,
+  FILESYSTEM_ENTRY_KINDS,
+  type FilesystemEntry,
+  type FilesystemEntryKind,
+  FilesystemEntryKindSchema,
+  FilesystemEntryNameSchema,
+  FilesystemEntrySchema,
+  GUEST_PATH_ROOT,
+  type GuestPath,
+  GuestPathSchema,
+} from '#domain/filesystem.ts';
+export {
   HOST_STATES,
   type Host,
   type HostCapacity,

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -9,7 +9,11 @@ import {
   DEFAULT_RESTART_POLICY,
   type DeploymentId,
   DesiredStateResponseSchema,
+  DIRECTORY_ENTRY_LIMIT,
+  DirectoryListingSchema,
   type Filename,
+  FilesystemEntryNameSchema,
+  GuestPathSchema,
   type GuestPort,
   type HostDesiredState,
   HostDesiredStateSchema,
@@ -36,6 +40,8 @@ const TENANT_SECRET = 'sk-live-do-not-log-this' as SecretString;
 const SHA256_HEX_LENGTH = 64;
 const TRUNCATED_DIGEST_LENGTH = SHA256_HEX_LENGTH - 1;
 const OVERLONG_SECRET_LENGTH = 40_000;
+/** One past what ext4 itself stores, so the schema and the filesystem agree on the boundary. */
+const OVERLONG_ENTRY_NAME_LENGTH = 256;
 
 const hexDigest = (length: number = SHA256_HEX_LENGTH) => 'a'.repeat(length);
 
@@ -122,6 +128,93 @@ describe('branding leaves runtime validation intact', () => {
     expect(isValidMessage({ schema: FilenameSchema, value: 'nul\u0000byte' })).toBe(false);
     expect(isValidMessage({ schema: FilenameSchema, value: '' })).toBe(false);
   });
+});
+
+// A name is reported and a path is accepted, so they are validated in opposite directions. The
+// pair of suites below exist to keep that asymmetry deliberate: loosening the path or tightening
+// the name would each look like a small consistency fix in isolation.
+describe('a directory entry name describes what the tenant created', () => {
+  const accepts = (value: string) => isValidMessage({ schema: FilesystemEntryNameSchema, value });
+
+  test('anything ext4 stores survives being described', () => {
+    expect(accepts('pb_data')).toBe(true);
+    expect(accepts('.env')).toBe(true);
+    expect(accepts('-rf')).toBe(true);
+    expect(accepts("it's")).toBe(true);
+    expect(accepts('a b c.txt')).toBe(true);
+    expect(accepts('données.txt')).toBe(true);
+    expect(accepts('..')).toBe(true);
+  });
+
+  test('only what ext4 itself cannot hold is refused', () => {
+    expect(accepts('nested/path')).toBe(false);
+    expect(accepts('nul\u0000byte')).toBe(false);
+    expect(accepts('')).toBe(false);
+    expect(accepts('n'.repeat(OVERLONG_ENTRY_NAME_LENGTH))).toBe(false);
+  });
+});
+
+describe('a guest path is accepted rather than described', () => {
+  const accepts = (value: string) => isValidMessage({ schema: GuestPathSchema, value });
+
+  test('an absolute path inside the volume is addressable', () => {
+    expect(accepts('/')).toBe(true);
+    expect(accepts('/pb_data')).toBe(true);
+    expect(accepts('/pb_data/backups')).toBe(true);
+    expect(accepts('/.env')).toBe(true);
+    expect(accepts('/a b c')).toBe(true);
+  });
+
+  test('nothing that resolves out of the volume is', () => {
+    expect(accepts('/..')).toBe(false);
+    expect(accepts('/pb_data/../../etc')).toBe(false);
+    expect(accepts('/.')).toBe(false);
+    expect(accepts('/pb_data/.')).toBe(false);
+    expect(accepts('pb_data')).toBe(false);
+  });
+
+  // The value reaches `debugfs -R`, which tokenises its argument the way a shell would, so a
+  // second command must not be expressible in it.
+  test('nothing that could carry a second command is', () => {
+    expect(accepts('/pb_data" -R "rm /pb_data')).toBe(false);
+    expect(accepts("/pb_data' -R 'rm /pb_data")).toBe(false);
+    expect(accepts('/pb_data\\backups')).toBe(false);
+    expect(accepts('/pb_data\nrm /')).toBe(false);
+    expect(accepts('/nul\u0000byte')).toBe(false);
+  });
+
+  // A trailing slash and a doubled separator both name the same directory as the canonical form,
+  // so admitting them would make one directory two cache keys and two audit-log lines.
+  test('only the canonical spelling of a directory is', () => {
+    expect(accepts('/pb_data/')).toBe(false);
+    expect(accepts('//pb_data')).toBe(false);
+    expect(accepts('/pb_data//backups')).toBe(false);
+  });
+});
+
+test('a listing carries one flat directory and says when it held back', () => {
+  const entry = {
+    name: 'data.db',
+    kind: 'file',
+    sizeBytes: 4096,
+    modifiedAt: '2026-08-03T09:41:00Z',
+  };
+  expect(
+    isValidMessage({
+      schema: DirectoryListingSchema,
+      value: { path: '/pb_data', entries: [entry], truncated: false },
+    }),
+  ).toBe(true);
+  expect(
+    isValidMessage({
+      schema: DirectoryListingSchema,
+      value: {
+        path: '/pb_data',
+        entries: Array.from({ length: DIRECTORY_ENTRY_LIMIT + 1 }, () => entry),
+        truncated: true,
+      },
+    }),
+  ).toBe(false);
 });
 
 test('a guest port cannot be used where a host port belongs', () => {


### PR DESCRIPTION
A listing is one directory's children, flat — never a tree, so what it costs
to describe a filesystem does not grow with the filesystem.

Domain rather than control, for the reason a log record is: neither side sends
the other one, but the shape would drift if it lived in either app.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>