### PR TITLE
feat(agent): the agent reads one tenant directory

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -12,6 +12,7 @@ import { CommandRunner } from '#services/command-runner.service.ts';
 import { ControlPlane } from '#services/control-plane.service.ts';
 import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
 import { ExportManager } from '#services/export-manager.service.ts';
+import { FilesystemReader } from '#services/filesystem-reader.service.ts';
 import { LogStore } from '#services/log-store.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
@@ -42,6 +43,7 @@ const agent = Layer.mergeAll(
   TenantLogReceiver.Default,
   VolumeManager.Default,
   ExportManager.Default,
+  FilesystemReader.Default,
   VmManager.Default,
   DesiredStateCache.Default,
   AgentSessionHolder.Default,

--- a/apps/agent/src/lib/exec.ts
+++ b/apps/agent/src/lib/exec.ts
@@ -7,6 +7,8 @@ export type CommandRequest = {
   readonly command: CommandLine;
   readonly stdin?: string;
   readonly timeout?: Duration.DurationInput;
+  /** Merged over the agent's own environment, so a caller pins a variable without dropping PATH. */
+  readonly env?: Readonly<Record<string, string>>;
 };
 
 export type CommandResult = {

--- a/apps/agent/src/lib/filesystem/debugfs.ts
+++ b/apps/agent/src/lib/filesystem/debugfs.ts
@@ -1,0 +1,187 @@
+import {
+  DIRECTORY_ENTRY_LIMIT,
+  type DirectoryListing,
+  type FilesystemEntry,
+  type FilesystemEntryKind,
+  type GuestPath,
+  GuestPathSchema,
+  isValidMessage,
+  type Timestamp,
+} from '@repo/protocol';
+import { Data, Either } from 'effect';
+import type { CommandLine } from '#lib/exec.ts';
+
+/**
+ * Reading a tenant filesystem with `debugfs`, which walks inodes in userspace — the same reason
+ * the export path uses it. The host never asks its kernel to interpret tenant-controlled
+ * metadata, and no `-w` appears below, so the device is opened read-only.
+ *
+ * What this cannot be is exact. The guest holds the same filesystem mounted read-write, and with
+ * `ignore_fsync` its writes only reach the device on ZeroFS's flush interval, so a listing lags
+ * reality by roughly the flush interval plus the guest's own journal commit. Forcing a flush
+ * first would make it exact and would also stall every other tenant sharing that ZeroFS, which
+ * is a poor trade for a directory listing somebody is scrolling.
+ */
+
+/**
+ * `debugfs -l` renders mtimes through `strftime("%d-%b-%Y %H:%M", localtime(...))`, so the host's
+ * zone decides the instant and the locale decides the month name. Both are pinned here rather
+ * than guessed at on the way back in.
+ */
+export const LISTING_ENVIRONMENT: Readonly<Record<string, string>> = { TZ: 'UTC', LC_ALL: 'C' };
+
+const MONTH_NUMBERS: Readonly<Record<string, string>> = {
+  Jan: '01',
+  Feb: '02',
+  Mar: '03',
+  Apr: '04',
+  May: '05',
+  Jun: '06',
+  Jul: '07',
+  Aug: '08',
+  Sep: '09',
+  Oct: '10',
+  Nov: '11',
+  Dec: '12',
+};
+
+const OCTAL = 8;
+const DECIMAL = 10;
+const TWO_DIGITS = 2;
+
+const FILE_TYPE_MASK = 0o170000;
+const DIRECTORY_MODE = 0o040000;
+const REGULAR_FILE_MODE = 0o100000;
+
+/** `.` and `..` are the filesystem's own bookkeeping; upward navigation is the dashboard's. */
+const SELF_AND_PARENT = new Set(['.', '..']);
+
+export class UnsafeGuestPath extends Data.TaggedError('UnsafeGuestPath')<{
+  readonly reason: string;
+}> {
+  override get message() {
+    return `a path this host will not read was requested: ${this.reason}`;
+  }
+}
+
+export class UnreadableDirectory extends Data.TaggedError('UnreadableDirectory')<{
+  readonly devicePath: string;
+}> {
+  /** Names the device and never the path, which is the tenant's to know and not an operator's. */
+  override get message() {
+    return `no directory could be read from ${this.devicePath}`;
+  }
+}
+
+/**
+ * Re-checked here rather than trusted from the wire, exactly as an artifact filename is: the
+ * value becomes part of a command string `debugfs` tokenises the way a shell would, so a peer
+ * that did not honour the schema must not be able to append a second command.
+ */
+export function listingCommand({
+  devicePath,
+  path,
+}: {
+  devicePath: string;
+  path: GuestPath;
+}): Either.Either<CommandLine, UnsafeGuestPath> {
+  if (!isValidMessage({ schema: GuestPathSchema, value: path })) {
+    return Either.left(new UnsafeGuestPath({ reason: 'it is not an absolute in-volume path' }));
+  }
+  return Either.right(['debugfs', '-R', `ls -l "${path}"`, devicePath]);
+}
+
+function kindFor(mode: number): FilesystemEntryKind {
+  const type = mode & FILE_TYPE_MASK;
+  if (type === DIRECTORY_MODE) {
+    return 'directory';
+  }
+  return type === REGULAR_FILE_MODE ? 'file' : 'other';
+}
+
+function timestampFrom({ date, time }: { date: string; time: string }): Timestamp | undefined {
+  const [day, month, year] = date.split('-');
+  const [hour, minute] = time.split(':');
+  const monthNumber = month ? MONTH_NUMBERS[month] : undefined;
+  if (!(day && monthNumber && year && hour && minute)) {
+    return undefined;
+  }
+  const paddedDay = day.padStart(TWO_DIGITS, '0');
+  const paddedHour = hour.padStart(TWO_DIGITS, '0');
+  return `${year}-${monthNumber}-${paddedDay}T${paddedHour}:${minute}:00Z` as Timestamp;
+}
+
+/**
+ * Anchored on the date rather than on a fixed column count: the `(filetype)` column `ls -l` emits
+ * between the mode and the owner is not present in every e2fsprogs, and the entry name is
+ * whatever follows the time — including spaces, quotes and dashes, none of which a tenant needs
+ * our permission to use.
+ */
+const ENTRY_PATTERN = /^(.*?)\s(\d{1,2}-[A-Za-z]{3}-\d{4})\s+(\d{1,2}:\d{2})\s(.*)$/;
+
+type ParsedEntry = { readonly name: string; readonly entry: FilesystemEntry };
+
+function parseEntry(line: string): ParsedEntry | undefined {
+  const matched = ENTRY_PATTERN.exec(line);
+  if (!matched) {
+    return undefined;
+  }
+  const [, columns = '', date = '', time = '', name = ''] = matched;
+  const numbers = columns.trim().split(/\s+/);
+  // Inode first, mode second, size last. Between them sit owner, group and possibly a file-type
+  // column, none of which a read-only browser has a use for.
+  const mode = numbers[1];
+  const size = numbers.at(-1);
+  const modifiedAt = timestampFrom({ date, time });
+  if (!(mode && size && modifiedAt) || name.length === 0) {
+    return undefined;
+  }
+  const parsedMode = Number.parseInt(mode, OCTAL);
+  const parsedSize = Number.parseInt(size, DECIMAL);
+  if (Number.isNaN(parsedMode) || Number.isNaN(parsedSize)) {
+    return undefined;
+  }
+  return {
+    name,
+    entry: { name, kind: kindFor(parsedMode), sizeBytes: parsedSize, modifiedAt },
+  };
+}
+
+/**
+ * `debugfs` reports a failed read on stderr and still exits 0, so the output is the only thing
+ * that can say whether it worked. Every ext4 directory holds `.`, which makes its absence a
+ * far sharper signal than emptiness — an unreadable device and a directory a tenant emptied
+ * both produce no entries, and only one of them is a failure.
+ *
+ * A line that does not parse is dropped rather than failing the read: a filename containing a
+ * newline arrives as fragments, and one such file must not blank the directory holding it.
+ */
+export function parseListing({
+  output,
+  path,
+}: {
+  output: string;
+  path: GuestPath;
+}): Either.Either<DirectoryListing, 'no-directory'> {
+  const entries: FilesystemEntry[] = [];
+  let sawSelf = false;
+  let truncated = false;
+
+  for (const line of output.split('\n')) {
+    const parsed = parseEntry(line);
+    if (!parsed) {
+      continue;
+    }
+    if (SELF_AND_PARENT.has(parsed.name)) {
+      sawSelf ||= parsed.name === '.';
+      continue;
+    }
+    if (entries.length === DIRECTORY_ENTRY_LIMIT) {
+      truncated = true;
+      break;
+    }
+    entries.push(parsed.entry);
+  }
+
+  return sawSelf ? Either.right({ path, entries, truncated }) : Either.left('no-directory');
+}

--- a/apps/agent/src/services/command-runner.service.ts
+++ b/apps/agent/src/services/command-runner.service.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandExecutor } from '@effect/platform';
 import type { PlatformError } from '@effect/platform/Error';
-import { Duration, Effect, Stream } from 'effect';
+import { Duration, Effect, identity, Stream } from 'effect';
 import {
   type CommandError,
   CommandFailed,
@@ -22,8 +22,8 @@ export const stdoutOf = (request: CommandRequest) =>
       : new CommandFailed({ command: request.command, result }),
   );
 
-const build = ({ command: [executable, ...args], stdin }: CommandRequest) => {
-  const command = Command.make(executable, ...args);
+const build = ({ command: [executable, ...args], stdin, env }: CommandRequest) => {
+  const command = Command.make(executable, ...args).pipe(env ? Command.env(env) : identity);
   return stdin === undefined ? command : Command.feed(command, stdin);
 };
 

--- a/apps/agent/src/services/filesystem-reader.service.ts
+++ b/apps/agent/src/services/filesystem-reader.service.ts
@@ -1,0 +1,68 @@
+import type { AppId, DirectoryListing, GuestPath } from '@repo/protocol';
+import { Data, Duration, Effect, Either, Option } from 'effect';
+import {
+  LISTING_ENVIRONMENT,
+  listingCommand,
+  parseListing,
+  UnreadableDirectory,
+} from '#lib/filesystem/debugfs.ts';
+import { stdoutOf } from '#services/command-runner.service.ts';
+import { SlotAllocator } from '#services/slot-allocator.service.ts';
+
+/**
+ * Bounded well below the export path's hour: a listing is read while somebody waits for it, and
+ * a directory large enough to take longer than this is one the entry limit would truncate anyway.
+ */
+const LISTING_TIMEOUT_SECONDS = 20;
+const LISTING_TIMEOUT = Duration.seconds(LISTING_TIMEOUT_SECONDS);
+
+export class NoDeviceForApp extends Data.TaggedError('NoDeviceForApp')<{
+  readonly appId: AppId;
+}> {
+  override get message() {
+    return `no device is attached on this host for ${this.appId}`;
+  }
+}
+
+/**
+ * Reads one directory out of one tenant's filesystem.
+ *
+ * The slot lookup is what scopes it: an app resolves to the single device this host attached for
+ * it, so a path is only ever resolved against the filesystem its own app owns. Nothing here takes
+ * a device path from a caller.
+ */
+export class FilesystemReader extends Effect.Service<FilesystemReader>()('FilesystemReader', {
+  effect: Effect.gen(function* () {
+    const allocator = yield* SlotAllocator;
+
+    const list = Effect.fn('FilesystemReader.list')(function* ({
+      appId,
+      path,
+    }: {
+      appId: AppId;
+      path: GuestPath;
+    }) {
+      yield* Effect.annotateCurrentSpan({ appId, path });
+      const slot = yield* allocator.lookup(appId);
+      if (Option.isNone(slot)) {
+        return yield* new NoDeviceForApp({ appId });
+      }
+
+      const { nbdDevicePath } = slot.value;
+      const command = yield* listingCommand({ devicePath: nbdDevicePath, path });
+      const output = yield* stdoutOf({
+        command,
+        timeout: LISTING_TIMEOUT,
+        env: LISTING_ENVIRONMENT,
+      });
+
+      const listing = parseListing({ output, path });
+      return Either.isLeft(listing)
+        ? yield* new UnreadableDirectory({ devicePath: nbdDevicePath })
+        : (listing.right satisfies DirectoryListing);
+    });
+
+    return { list };
+  }),
+  dependencies: [SlotAllocator.Default],
+}) {}

--- a/apps/agent/tests/lib/failure.test.ts
+++ b/apps/agent/tests/lib/failure.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import type { Sha256Digest } from '@repo/protocol';
+import type { AppId, Sha256Digest } from '@repo/protocol';
 import { InstanceCredentialsError } from '#lib/aws/credentials.ts';
 import { ControlPlaneError } from '#lib/control/client.ts';
 import { CommandFailed, CommandTimedOut } from '#lib/exec.ts';
 import { EmptyDump, UnsafeFilename } from '#lib/exports/bundle.ts';
 import { reportedMessage } from '#lib/failure.ts';
+import { UnreadableDirectory, UnsafeGuestPath } from '#lib/filesystem/debugfs.ts';
 import { MalformedJsonError } from '#lib/json-store.ts';
 import { InvalidGuestLogFrame } from '#lib/logs/guest-protocol.ts';
 import { SlotExhausted } from '#lib/network/allocator.ts';
@@ -14,6 +15,7 @@ import { ArtifactSizeMismatch, DigestMismatch } from '#lib/vm/artifacts.ts';
 import { UnrepresentableEnvironment } from '#lib/vm/instance-env.ts';
 import { VolumeShrinkRefused } from '#lib/volumes/device-file.ts';
 import { ArtifactTransferError } from '#services/artifact-store.service.ts';
+import { NoDeviceForApp } from '#services/filesystem-reader.service.ts';
 
 const DIGEST_HEX_LENGTH = 64;
 const HTTP_UNAUTHORIZED = 401;
@@ -42,6 +44,9 @@ const everyFailure = [
   new VolumeShrinkRefused({ current: OTHER_SIZE, requested: SOME_SIZE }),
   new ControlPlaneError({ status: HTTP_UNAUTHORIZED, route: '/desired-state', body: 'expired' }),
   new ProtocolMismatch({ issues: [] }),
+  new UnsafeGuestPath({ reason: 'it is not an absolute in-volume path' }),
+  new UnreadableDirectory({ devicePath: '/dev/nbd7' }),
+  new NoDeviceForApp({ appId: 'app-pocketbase' as AppId }),
 ];
 
 // The message is what a report carries to the control plane, and from there to whoever is

--- a/apps/agent/tests/lib/filesystem/debugfs.test.ts
+++ b/apps/agent/tests/lib/filesystem/debugfs.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'bun:test';
+import { DIRECTORY_ENTRY_LIMIT, type GuestPath, type Timestamp } from '@repo/protocol';
+import { Either } from 'effect';
+import { listingCommand, parseListing } from '#lib/filesystem/debugfs.ts';
+
+const DEVICE = '/dev/nbd7';
+const ROOT = '/' as GuestPath;
+
+// Captured from `debugfs -R "ls -l /" <device>`: inode, mode, an e2fsprogs-dependent file-type
+// column, owner, group, size, then the date, time and name.
+const LISTING = [
+  '      2  40755 (2)      0      0    4096 15-Jan-2026 10:23 .',
+  '      2  40755 (2)      0      0    4096 15-Jan-2026 10:23 ..',
+  '     12  40755 (2)      0      0    4096  4-Feb-2026 09:05 pb_data',
+  '     13 100644 (1)      0      0   32768 15-Jan-2026 10:24 data.db',
+  '     14 120777 (7)      0      0      11 15-Jan-2026 10:24 latest.db',
+  '',
+].join('\n');
+
+function listingOf(output: string) {
+  return parseListing({ output, path: ROOT });
+}
+
+function entriesOf(output: string) {
+  const listing = listingOf(output);
+  if (Either.isLeft(listing)) {
+    throw new Error('expected a readable directory');
+  }
+  return listing.right;
+}
+
+function at(value: string): Timestamp {
+  return value as Timestamp;
+}
+
+describe('a directory is read off the columns debugfs prints', () => {
+  test('each entry carries what a browser needs and nothing else', () => {
+    expect(entriesOf(LISTING).entries).toEqual([
+      {
+        name: 'pb_data',
+        kind: 'directory',
+        sizeBytes: 4096,
+        modifiedAt: at('2026-02-04T09:05:00Z'),
+      },
+      { name: 'data.db', kind: 'file', sizeBytes: 32_768, modifiedAt: at('2026-01-15T10:24:00Z') },
+      { name: 'latest.db', kind: 'other', sizeBytes: 11, modifiedAt: at('2026-01-15T10:24:00Z') },
+    ]);
+  });
+
+  // Everything that is not a regular file or a directory answers the same question the same way,
+  // so a symlink is shown, is not descendable, and never names what it points at.
+  test('a symlink is neither a file nor a way out of the volume', () => {
+    const [, , link] = entriesOf(LISTING).entries;
+    expect(link?.kind).toBe('other');
+    expect(JSON.stringify(link)).not.toInclude('->');
+  });
+
+  test('the filesystem own bookkeeping is not an entry', () => {
+    const names = entriesOf(LISTING).entries.map((entry) => entry.name);
+    expect(names).not.toContain('.');
+    expect(names).not.toContain('..');
+  });
+
+  // A name is whatever the tenant's binary created, and `ls -l` puts it last precisely so it can
+  // be anything. Everything after the time is the name, spaces and all.
+  test('a name is taken whole, however it is spelled', () => {
+    const awkward = [
+      '      2  40755 (2)      0      0    4096 15-Jan-2026 10:23 .',
+      '     20 100644 (1)      0      0       1 15-Jan-2026 10:23 my report v2.txt',
+      '     21 100644 (1)      0      0       2 15-Jan-2026 10:23 -rf',
+      "     22 100644 (1)      0      0       3 15-Jan-2026 10:23 it's",
+      '     23 100644 (1)      0      0       4 15-Jan-2026 10:23 données.txt',
+    ].join('\n');
+    expect(entriesOf(awkward).entries.map((entry) => entry.name)).toEqual([
+      'my report v2.txt',
+      '-rf',
+      "it's",
+      'données.txt',
+    ]);
+  });
+});
+
+// `debugfs` writes its failures to stderr and exits 0 regardless, so the output is the only
+// evidence. Every ext4 directory holds `.`, which separates "unreadable" from "empty" — and the
+// export path's emptiness check cannot, because both look identical to it.
+describe('a read that did not happen is told from a directory that is empty', () => {
+  test('output with no self entry is a failed read', () => {
+    expect(Either.isLeft(listingOf(''))).toBe(true);
+    expect(
+      Either.isLeft(listingOf('/dev/nbd7: No such file or directory while opening filesystem')),
+    ).toBe(true);
+  });
+
+  test('a directory holding only its own bookkeeping is empty rather than broken', () => {
+    const empty = [
+      '      2  40755 (2)      0      0    4096 15-Jan-2026 10:23 .',
+      '      2  40755 (2)      0      0    4096 15-Jan-2026 10:23 ..',
+    ].join('\n');
+    expect(entriesOf(empty)).toEqual({ path: ROOT, entries: [], truncated: false });
+  });
+
+  // A filename containing a newline reaches us as fragments no line can parse. Dropping the
+  // fragments loses that one file; failing the read would lose every file beside it.
+  test('an unparseable line costs its own entry and no other', () => {
+    const torn = [
+      '      2  40755 (2)      0      0    4096 15-Jan-2026 10:23 .',
+      '     30 100644 (1)      0      0       9 15-Jan-2026 10:23 first',
+      'half a line with no columns at all',
+      '     31 100644 (1)      0      0       9 15-Jan-2026 10:23 second',
+    ].join('\n');
+    expect(entriesOf(torn).entries.map((entry) => entry.name)).toEqual(['first', 'second']);
+  });
+});
+
+/** Root takes inode 2, so a directory's own children start above it. */
+const FIRST_CHILD_INODE = 3;
+
+function childLine(index: number): string {
+  const inode = FIRST_CHILD_INODE + index;
+  return `  ${inode} 100644 (1) 0 0 1 15-Jan-2026 10:23 file-${index}`;
+}
+
+test('a directory larger than the wire allows says so rather than being cut silently', () => {
+  const many = [
+    '      2  40755 (2)      0      0    4096 15-Jan-2026 10:23 .',
+    ...Array.from(Array(DIRECTORY_ENTRY_LIMIT + 1).keys()).map(childLine),
+  ].join('\n');
+  const listing = entriesOf(many);
+  expect(listing.entries).toHaveLength(DIRECTORY_ENTRY_LIMIT);
+  expect(listing.truncated).toBe(true);
+});
+
+describe('the command is built so debugfs cannot be handed a second one', () => {
+  test('a valid path is quoted into a read-only invocation', () => {
+    const command = listingCommand({ devicePath: DEVICE, path: '/pb_data' as GuestPath });
+    expect(Either.isRight(command) && command.right).toEqual([
+      'debugfs',
+      '-R',
+      'ls -l "/pb_data"',
+      DEVICE,
+    ]);
+  });
+
+  // The schema already refuses these, so reaching this branch means a peer did not honour it —
+  // which is exactly when trusting the wire would be the bug.
+  test('a path the schema would have refused is refused again here', () => {
+    for (const path of ['/pb_data" -R "rm /pb_data', '/..', 'relative', '/pb_data/']) {
+      expect(Either.isLeft(listingCommand({ devicePath: DEVICE, path: path as GuestPath }))).toBe(
+        true,
+      );
+    }
+  });
+
+  test('no invocation carries the write flag', () => {
+    const command = listingCommand({ devicePath: DEVICE, path: ROOT });
+    expect(Either.isRight(command) && command.right).not.toContain('-w');
+  });
+});


### PR DESCRIPTION
debugfs walks inodes in userspace, so the host still never asks its kernel to
interpret tenant metadata — and without -w the device is opened read-only.

The parse is anchored on the date rather than a column count, because the
file-type column ls -l prints is not in every e2fsprogs. An absent "." is what
tells an unreadable device from a directory a tenant emptied: debugfs reports
failure on stderr and exits 0 either way.

CommandRequest gains env so the listing can pin TZ and LC_ALL, which is what
makes an mtime the same instant whatever the host is set to.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>