### PR TITLE
feat(api): the api asks a host for a directory and logs the answer

### DIFF
--- a/apps/api/src/repositories/filesystem.repository.ts
+++ b/apps/api/src/repositories/filesystem.repository.ts
@@ -1,0 +1,18 @@
+import type { AppId, FilesystemQuery, FilesystemQueryId } from '@repo/protocol';
+import { GUEST_PATH_ROOT } from '@repo/protocol';
+import { Repository } from '#repositories/repository.ts';
+
+// One query, written out here, for the same reason the desired app in `agent.repository.ts` is:
+// there is no table to read it from yet. It is what proves the channel end to end — a host picks
+// it up, reads the device and answers — and replacing it is replacing the body of `pendingQuery`.
+const STANDING_QUERY = {
+  queryId: 'query-pocketbase-root' as FilesystemQueryId,
+  appId: 'app-pocketbase' as AppId,
+  path: GUEST_PATH_ROOT,
+} satisfies FilesystemQuery;
+
+export class FilesystemRepository extends Repository {
+  pendingQuery(): Promise<FilesystemQuery> {
+    return Promise.resolve(STANDING_QUERY);
+  }
+}

--- a/apps/api/src/routes/internal/agent/controller.test.ts
+++ b/apps/api/src/routes/internal/agent/controller.test.ts
@@ -5,6 +5,7 @@ import {
   type AgentSessionRequest,
   AgentSessionSchema,
   DesiredStateResponseSchema,
+  FilesystemQueryResponseSchema,
   type HostCapacity,
   type HostReportedState,
   type HostVersions,
@@ -175,7 +176,121 @@ describe('an agent can register and be told what to run', () => {
   });
 });
 
+describe('a host polls for filesystem reads on a channel of its own', () => {
+  test('a host with nothing to answer is told so, and told no generation', async () => {
+    const session = await readSession(await openSession());
+    const response = await post({
+      route: AGENT_ROUTES.filesystemQuery,
+      body: { servedAppIds: [] },
+      sessionToken: session.sessionToken,
+    });
+
+    const body = parseMessage({
+      schema: FilesystemQueryResponseSchema,
+      value: await response.json(),
+    });
+    expect(body).toEqual({ result: 'none' });
+  });
+
+  // A read that could bump a generation would make one person opening a folder cost every host
+  // in the fleet a re-read. The two channels stay disjoint, and this is what says so.
+  test('polling for a read leaves desired state where it was', async () => {
+    const session = await readSession(await openSession());
+    const before = await readDesired(
+      await post({
+        route: AGENT_ROUTES.desiredState,
+        body: { knownGeneration: FIRST_POLL_GENERATION },
+        sessionToken: session.sessionToken,
+      }),
+    );
+    if (before.result !== 'changed') {
+      throw new Error('A host that has never polled must be given state to converge to.');
+    }
+
+    await post({
+      route: AGENT_ROUTES.filesystemQuery,
+      body: { servedAppIds: [] },
+      sessionToken: session.sessionToken,
+    });
+
+    const after = await readDesired(
+      await post({
+        route: AGENT_ROUTES.desiredState,
+        body: { knownGeneration: before.state.generation },
+        sessionToken: session.sessionToken,
+      }),
+    );
+    expect(after).toEqual({ result: 'unchanged', generation: before.state.generation });
+  });
+
+  test('a host serving the app is given something to read', async () => {
+    const session = await readSession(await openSession());
+    const desired = await readDesired(
+      await post({
+        route: AGENT_ROUTES.desiredState,
+        body: { knownGeneration: FIRST_POLL_GENERATION },
+        sessionToken: session.sessionToken,
+      }),
+    );
+    if (desired.result !== 'changed') {
+      throw new Error('A host that has never polled must be given state to converge to.');
+    }
+
+    const response = await post({
+      route: AGENT_ROUTES.filesystemQuery,
+      body: { servedAppIds: desired.state.volumes.map((volume) => volume.appId) },
+      sessionToken: session.sessionToken,
+    });
+
+    const body = parseMessage({
+      schema: FilesystemQueryResponseSchema,
+      value: await response.json(),
+    });
+    expect(body.result).toBe('query');
+  });
+
+  // Nothing comes back, for the same reason nothing comes back from a report: a generation
+  // travels on one channel only, and a second copy here would be a second thing to keep true.
+  test('an answer is taken and not replied to', async () => {
+    const session = await readSession(await openSession());
+    const response = await post({
+      route: AGENT_ROUTES.filesystemQueryResult,
+      body: {
+        queryId: 'query-pocketbase-root',
+        outcome: { status: 'failed', message: 'no device is attached on this host' },
+      },
+      sessionToken: session.sessionToken,
+    });
+
+    expect(response.status).toBe(StatusMap['No Content']);
+    expect(await response.text()).toBe('');
+  });
+});
+
 describe('nothing reaches desired state without proving what it is', () => {
+  test('an unknown session cannot collect another tenant read', async () => {
+    const response = await post({
+      route: AGENT_ROUTES.filesystemQuery,
+      body: { servedAppIds: [] },
+      sessionToken: 'not-a-session',
+    });
+
+    expect(response.status).toBe(StatusMap.Unauthorized);
+  });
+
+  test('nor answer one', async () => {
+    const response = await post({
+      route: AGENT_ROUTES.filesystemQueryResult,
+      body: {
+        queryId: 'query-1',
+        outcome: { status: 'failed', message: 'not mine to answer' },
+      },
+      sessionToken: 'not-a-session',
+    });
+
+    expect(response.status).toBe(StatusMap.Unauthorized);
+  });
+
   test('an unknown session is refused rather than served a default host', async () => {
     const response = await post({
       route: AGENT_ROUTES.desiredState,

--- a/apps/api/src/routes/internal/agent/controller.ts
+++ b/apps/api/src/routes/internal/agent/controller.ts
@@ -2,6 +2,8 @@ import { AGENT_API_PREFIX } from '@repo/protocol';
 import { Elysia } from 'elysia';
 import { pathBelow, RoutePrefix } from '#lib/routes/prefixes.ts';
 import { AgentDesiredStateController } from '#routes/internal/agent/desired-state/controller.ts';
+import { AgentFilesystemQueryController } from '#routes/internal/agent/filesystem-query/controller.ts';
+import { AgentFilesystemQueryResultController } from '#routes/internal/agent/filesystem-query-result/controller.ts';
 import { AgentReportedStateController } from '#routes/internal/agent/reported-state/controller.ts';
 import { AgentSessionController } from '#routes/internal/agent/session/controller.ts';
 
@@ -13,4 +15,6 @@ const AGENT_PREFIX = pathBelow({ path: AGENT_API_PREFIX, prefix: RoutePrefix.Int
 export const AgentController = new Elysia({ prefix: AGENT_PREFIX })
   .use(AgentSessionController)
   .use(AgentDesiredStateController)
-  .use(AgentReportedStateController);
+  .use(AgentReportedStateController)
+  .use(AgentFilesystemQueryController)
+  .use(AgentFilesystemQueryResultController);

--- a/apps/api/src/routes/internal/agent/filesystem-query-result/controller.ts
+++ b/apps/api/src/routes/internal/agent/filesystem-query-result/controller.ts
@@ -1,0 +1,30 @@
+import { AGENT_ROUTES, FilesystemQueryResultSchema } from '@repo/protocol';
+import { Elysia, StatusMap, t } from 'elysia';
+import { assertProtocolVersion } from '#lib/agent/protocol-version.ts';
+import { sessionTokenFrom } from '#lib/agent/session-token.ts';
+import { ProtocolHeadersSchema } from '#routes/internal/agent/model.ts';
+import { AgentServicePlugin, FilesystemServicePlugin, loggerPlugin } from '#services/plugins.ts';
+
+/**
+ * What the host read. Nothing comes back, and nothing is waiting on it yet — the answer is
+ * logged, which is what says a host can read a live tenant filesystem at all.
+ */
+export const AgentFilesystemQueryResultController = new Elysia()
+  .use(loggerPlugin('agentFilesystemQueryResultController'))
+  .use(AgentServicePlugin)
+  .use(FilesystemServicePlugin)
+  .post(
+    AGENT_ROUTES.filesystemQueryResult,
+    async ({ agentService, filesystemService, body, headers, status }) => {
+      assertProtocolVersion(headers);
+      await agentService.hostForSession({ sessionToken: sessionTokenFrom(headers) });
+
+      filesystemService.acceptResult(body);
+      return status(StatusMap['No Content'], undefined);
+    },
+    {
+      body: FilesystemQueryResultSchema,
+      headers: ProtocolHeadersSchema,
+      response: { [StatusMap['No Content']]: t.Void() },
+    },
+  );

--- a/apps/api/src/routes/internal/agent/filesystem-query/controller.ts
+++ b/apps/api/src/routes/internal/agent/filesystem-query/controller.ts
@@ -1,0 +1,39 @@
+import {
+  AGENT_ROUTES,
+  FilesystemQueryRequestSchema,
+  FilesystemQueryResponseSchema,
+} from '@repo/protocol';
+import { Elysia, StatusMap } from 'elysia';
+import { assertProtocolVersion } from '#lib/agent/protocol-version.ts';
+import { sessionTokenFrom } from '#lib/agent/session-token.ts';
+import { ProtocolHeadersSchema } from '#routes/internal/agent/model.ts';
+import { AgentServicePlugin, FilesystemServicePlugin, loggerPlugin } from '#services/plugins.ts';
+
+/**
+ * What a host should read, if anything.
+ *
+ * It carries no generation, and that is what keeps this off the desired-state channel: a read is
+ * not a state anything converges on, so it must not be able to disturb one. Tenant output took a
+ * separate path for the same kind of reason.
+ */
+export const AgentFilesystemQueryController = new Elysia()
+  .use(loggerPlugin('agentFilesystemQueryController'))
+  .use(AgentServicePlugin)
+  .use(FilesystemServicePlugin)
+  .post(
+    AGENT_ROUTES.filesystemQuery,
+    async ({ agentService, filesystemService, body, headers }) => {
+      assertProtocolVersion(headers);
+      // Resolved and discarded: nothing below needs the host id, but an expired session must not
+      // be able to collect another tenant's query.
+      await agentService.hostForSession({ sessionToken: sessionTokenFrom(headers) });
+
+      const query = await filesystemService.pendingQuery({ servedAppIds: body.servedAppIds });
+      return query ? { result: 'query' as const, query } : { result: 'none' as const };
+    },
+    {
+      body: FilesystemQueryRequestSchema,
+      headers: ProtocolHeadersSchema,
+      response: { [StatusMap.OK]: FilesystemQueryResponseSchema },
+    },
+  );

--- a/apps/api/src/services/filesystem.service.test.ts
+++ b/apps/api/src/services/filesystem.service.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import type { AppId, GuestPath, Timestamp } from '@repo/protocol';
+import { FilesystemRepository } from '#repositories/filesystem.repository.ts';
+import { FilesystemService } from '#services/filesystem.service.ts';
+
+const OTHER_APP = 'app-somebody-else' as AppId;
+
+// The real repository, because the query it holds is what is under test. It reads no database,
+// so the client it is handed is never touched.
+const repository = new FilesystemRepository(undefined as never);
+
+function standingQuery() {
+  return repository.pendingQuery();
+}
+
+describe('a read is offered to the host that says it holds the volume', () => {
+  test('a host serving the app is given the query', async () => {
+    const query = await standingQuery();
+    const service = new FilesystemService({ filesystemRepo: repository });
+
+    expect(await service.pendingQuery({ servedAppIds: [query.appId] })).toEqual(query);
+  });
+
+  // Without this the first host to poll would take every tenant's read and fail all but its own.
+  test('a host that does not serve it is given nothing', async () => {
+    const service = new FilesystemService({ filesystemRepo: repository });
+
+    expect(await service.pendingQuery({ servedAppIds: [OTHER_APP] })).toBeUndefined();
+    expect(await service.pendingQuery({ servedAppIds: [] })).toBeUndefined();
+  });
+
+  // Nothing marks it answered, so it is handed out again on the next poll. That is what makes it
+  // a standing query rather than a queue, and what has to change when a caller is waiting on one.
+  test('answering it does not retire it', async () => {
+    const query = await standingQuery();
+    const service = new FilesystemService({ filesystemRepo: repository });
+
+    service.acceptResult({
+      queryId: query.queryId,
+      outcome: {
+        status: 'listed',
+        listing: { path: '/' as GuestPath, entries: [], truncated: false },
+      },
+    });
+
+    expect(await service.pendingQuery({ servedAppIds: [query.appId] })).toEqual(query);
+  });
+});
+
+describe('a result is taken whatever it says', () => {
+  test('a listing is accepted', () => {
+    const service = new FilesystemService({ filesystemRepo: repository });
+
+    expect(() =>
+      service.acceptResult({
+        queryId: 'query-1' as never,
+        outcome: {
+          status: 'listed',
+          listing: {
+            path: '/' as GuestPath,
+            entries: [
+              {
+                name: 'pb_data',
+                kind: 'directory',
+                sizeBytes: 4096,
+                modifiedAt: '2026-08-03T09:41:00Z' as Timestamp,
+              },
+            ],
+            truncated: false,
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test('so is a failure, which is the answer that says the host tried', () => {
+    const service = new FilesystemService({ filesystemRepo: repository });
+
+    expect(() =>
+      service.acceptResult({
+        queryId: 'query-1' as never,
+        outcome: { status: 'failed', message: 'no device is attached on this host' },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/api/src/services/filesystem.service.ts
+++ b/apps/api/src/services/filesystem.service.ts
@@ -1,0 +1,53 @@
+import type { AppId, FilesystemQuery, FilesystemQueryResult } from '@repo/protocol';
+import type { FilesystemRepository } from '#repositories/filesystem.repository.ts';
+import { Service } from '#services/service.ts';
+
+const LOGGED_ENTRY_NAMES = 10;
+
+export class FilesystemService extends Service {
+  private readonly filesystemRepo: FilesystemRepository;
+
+  constructor({ filesystemRepo }: { filesystemRepo: FilesystemRepository }) {
+    super();
+    this.filesystemRepo = filesystemRepo;
+  }
+
+  /**
+   * Offered only to a host that says it serves the app. The claim is the host's, restated on each
+   * poll: it is the only party that knows what it has attached, and a control plane deciding this
+   * from its own records would keep sending reads to a host that no longer holds the volume.
+   */
+  async pendingQuery({
+    servedAppIds,
+  }: {
+    servedAppIds: readonly AppId[];
+  }): Promise<FilesystemQuery | undefined> {
+    const query = await this.filesystemRepo.pendingQuery();
+    return servedAppIds.includes(query.appId) ? query : undefined;
+  }
+
+  /**
+   * Logged rather than kept. Nothing is waiting on this yet, so a listing has nowhere to go —
+   * what it answers for now is whether a host can read a live tenant filesystem at all.
+   */
+  acceptResult(result: FilesystemQueryResult): void {
+    if (result.outcome.status === 'failed') {
+      this.logger.warn('host could not read a directory', {
+        queryId: result.queryId,
+        message: result.outcome.message,
+      });
+      return;
+    }
+
+    const { listing } = result.outcome;
+    this.logger.info('host read a directory', {
+      queryId: result.queryId,
+      path: listing.path,
+      entries: listing.entries.length,
+      truncated: listing.truncated,
+      // The names are the whole point while this is a smoke test: a count alone cannot tell a
+      // directory that was read from one that was not.
+      names: listing.entries.slice(0, LOGGED_ENTRY_NAMES).map((entry) => entry.name),
+    });
+  }
+}

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -4,18 +4,22 @@ import { env } from '#lib/env.ts';
 import { createLogger } from '#lib/logger.ts';
 import { AgentRepository } from '#repositories/agent.repository.ts';
 import { AssetsRepository } from '#repositories/assets.repository.ts';
+import { FilesystemRepository } from '#repositories/filesystem.repository.ts';
 import { HealthRepository } from '#repositories/health.repository.ts';
 import { AgentService } from '#services/agent.service.ts';
 import { AssetsService } from '#services/assets.service.ts';
+import { FilesystemService } from '#services/filesystem.service.ts';
 import { HealthService } from '#services/health.service.ts';
 
 const agentRepository = new AgentRepository(sql);
 const assetsRepository = new AssetsRepository(sql);
 const healthRepository = new HealthRepository(sql);
+const filesystemRepository = new FilesystemRepository(sql);
 
 const agentService = new AgentService({ agentRepo: agentRepository });
 const assetsService = new AssetsService(assetsRepository);
 const healthService = new HealthService(healthRepository);
+const filesystemService = new FilesystemService({ filesystemRepo: filesystemRepository });
 
 export function loggerPlugin(name: string) {
   const logger = createLogger(name);
@@ -35,4 +39,9 @@ export const HealthServicePlugin = new Elysia({ name: 'service.health' }).decora
 export const AgentServicePlugin = new Elysia({ name: 'service.agent' }).decorate(
   'agentService',
   agentService,
+);
+
+export const FilesystemServicePlugin = new Elysia({ name: 'service.filesystem' }).decorate(
+  'filesystemService',
+  filesystemService,
 );

--- a/packages/protocol/src/control/filesystem-query.ts
+++ b/packages/protocol/src/control/filesystem-query.ts
@@ -1,0 +1,68 @@
+import { Type } from '@sinclair/typebox';
+import { DirectoryListingSchema, GuestPathSchema } from '#domain/filesystem.ts';
+import { AppIdSchema, FilesystemQueryIdSchema } from '#domain/identifiers.ts';
+
+/**
+ * A channel of its own, beside desired state rather than inside it.
+ *
+ * Desired state describes a world a host converges on, and a directory listing is not one: it has
+ * an answer, it is wanted once, and nobody converges on it. Expressing it there would mint a
+ * generation per click and make every host in the fleet re-read its own state because one person
+ * opened a folder. Tenant output already took a separate path for the same kind of reason.
+ *
+ * The direction is unchanged, which is the point — the host still calls the control plane, and
+ * the control plane still never connects to a host.
+ */
+
+const MAX_QUERY_MESSAGE_LENGTH = 512;
+
+/**
+ * What a host is willing to answer, restated on every poll rather than remembered by the control
+ * plane. It is the host that knows which devices it has attached, so a query is offered to a host
+ * that says it can serve the app rather than to one a stale table claims should be able to.
+ */
+const MAX_SERVED_APPS = 200;
+
+export const FilesystemQueryRequestSchema = Type.Object({
+  servedAppIds: Type.Array(AppIdSchema, { maxItems: MAX_SERVED_APPS }),
+});
+
+export type FilesystemQueryRequest = typeof FilesystemQueryRequestSchema.static;
+
+export const FilesystemQuerySchema = Type.Object({
+  queryId: FilesystemQueryIdSchema,
+  appId: AppIdSchema,
+  path: GuestPathSchema,
+});
+
+export type FilesystemQuery = typeof FilesystemQuerySchema.static;
+
+/**
+ * `none` is the common answer and carries nothing. Shaped as a union rather than an optional
+ * field so that a host holding a query and a host holding nothing are different values, the way
+ * `changed` and `unchanged` are on the desired-state poll.
+ */
+export const FilesystemQueryResponseSchema = Type.Union([
+  Type.Object({ result: Type.Literal('none') }),
+  Type.Object({ result: Type.Literal('query'), query: FilesystemQuerySchema }),
+]);
+
+export type FilesystemQueryResponse = typeof FilesystemQueryResponseSchema.static;
+
+/**
+ * Answered exactly once per `queryId`, including when it could not be answered: somebody is
+ * holding a request open on the other end, so a host that stays quiet about a failure turns a
+ * refusal into a timeout.
+ */
+export const FilesystemQueryResultSchema = Type.Object({
+  queryId: FilesystemQueryIdSchema,
+  outcome: Type.Union([
+    Type.Object({ status: Type.Literal('listed'), listing: DirectoryListingSchema }),
+    Type.Object({
+      status: Type.Literal('failed'),
+      message: Type.String({ maxLength: MAX_QUERY_MESSAGE_LENGTH }),
+    }),
+  ]),
+});
+
+export type FilesystemQueryResult = typeof FilesystemQueryResultSchema.static;

--- a/packages/protocol/src/control/transport.ts
+++ b/packages/protocol/src/control/transport.ts
@@ -33,6 +33,10 @@ export const AGENT_ROUTES = {
   session: '/session',
   desiredState: '/desired-state',
   reportedState: '/reported-state',
+  // A question and its answer, on a channel of their own. Neither carries a generation: a read
+  // is not a state anything converges on, so it must not be able to disturb one.
+  filesystemQuery: '/filesystem-query',
+  filesystemQueryResult: '/filesystem-query-result',
 } as const;
 
 /**

--- a/packages/protocol/src/domain/identifiers.ts
+++ b/packages/protocol/src/domain/identifiers.ts
@@ -35,3 +35,8 @@ export type ExportId = Identifier<'ExportId'>;
 export const ExportIdSchema = identifierSchema<ExportId>(
   'One request for a downloadable copy of an app.',
 );
+
+export type FilesystemQueryId = Identifier<'FilesystemQueryId'>;
+export const FilesystemQueryIdSchema = identifierSchema<FilesystemQueryId>(
+  'One read of one directory, alive only while its answer is still awaited.',
+);

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -21,6 +21,16 @@ export {
   HostDesiredStateSchema,
 } from '#control/desired-state.ts';
 export {
+  type FilesystemQuery,
+  type FilesystemQueryRequest,
+  FilesystemQueryRequestSchema,
+  type FilesystemQueryResponse,
+  FilesystemQueryResponseSchema,
+  type FilesystemQueryResult,
+  FilesystemQueryResultSchema,
+  FilesystemQuerySchema,
+} from '#control/filesystem-query.ts';
+export {
   type HostReportedState,
   HostReportedStateSchema,
   type ReportedCheckpoint,
@@ -134,6 +144,8 @@ export {
   DeploymentIdSchema,
   type ExportId,
   ExportIdSchema,
+  type FilesystemQueryId,
+  FilesystemQueryIdSchema,
   type HostId,
   HostIdSchema,
   type InstanceId,


### PR DESCRIPTION
One standing query, written out beside the desired app in agent.repository.ts
and for the same reason: there is no table to read one from yet. It is what
proves the channel end to end — a host picks it up, reads the device, answers.

Nothing is waiting on the answer, so it is logged rather than kept. A read
carries no generation, which is what keeps it off the desired-state channel: it
is not a state anything converges on, so it must not disturb one.

Which host gets it is the host's own claim of the apps it serves, restated on
every poll, so nothing here keeps a host-to-app table that could go stale.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>