### PR TITLE
feat(agent): the agent answers filesystem queries

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -5,9 +5,13 @@ plane, long-polls for desired state, converges the host onto it, and reports wha
 is never sent a command. Read `lib/reconcile/`, `lib/volumes/topology.ts` and
 `lib/network/slot.ts` first.
 
+It answers one kind of question besides converging: `lib/agent/filesystem.ts` polls for a
+directory read and answers it, on routes of its own. A read is not a state anything converges on,
+so it carries no generation and cannot delay a stop.
+
 **Written in Effect.** Every effectful path is an `Effect` with a typed error channel; anything a
 test needs to substitute is a service. State that used to be
-mutable class fields lives in a `Ref`. The four loops in `lib/agent/` are fibers, and their retry
+mutable class fields lives in a `Ref`. The loops in `lib/agent/` are fibers, and their retry
 cadence is a `Schedule` rather than a failure counter. Interruption is the shutdown path:
 `BunRuntime.runMain` cancels the fibers and scoped finalizers close the log sockets. Nothing stops
 a tenant VM, which is what keeps redeploying the agent free.

--- a/apps/agent/src/lib/agent/filesystem.ts
+++ b/apps/agent/src/lib/agent/filesystem.ts
@@ -1,0 +1,92 @@
+import type { FilesystemQuery, FilesystemQueryResult } from '@repo/protocol';
+import { type Duration, Effect } from 'effect';
+import { CONTROL_PLANE_BACKOFF } from '#lib/agent/backoff.ts';
+import { supervised } from '#lib/agent/loop.ts';
+import { reportedMessage } from '#lib/failure.ts';
+import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
+import { ControlPlane } from '#services/control-plane.service.ts';
+import { FilesystemReader } from '#services/filesystem-reader.service.ts';
+import { SlotAllocator } from '#services/slot-allocator.service.ts';
+
+/**
+ * Slept after every pass, not only after an idle one. The control plane hands out a standing
+ * query that nothing retires, so a loop that only paused when it had nothing to do would read a
+ * tenant device as fast as `debugfs` could return — this is what bounds that to a rate.
+ *
+ * It is also the floor on how stale a listing can be, which is why it is seconds rather than the
+ * minute the read itself would tolerate.
+ */
+const POLL_INTERVAL: Duration.DurationInput = '5 seconds';
+
+/**
+ * A read this host can serve is one it has a device for, which is what the slot table records.
+ * Sent on every poll rather than registered once: a volume torn down between two polls stops
+ * being offered on the next one, with nothing to invalidate.
+ */
+const servedAppIds = Effect.map(
+  Effect.flatMap(SlotAllocator, (allocator) => allocator.slots),
+  (slots) => slots.map((slot) => slot.appId),
+);
+
+/**
+ * Answered whatever happens, because the failure is the answer as far as the caller is concerned.
+ * A host that stays quiet about a device it could not read turns a refusal somebody could act on
+ * into a timeout they cannot.
+ */
+export const answer = (query: FilesystemQuery) =>
+  Effect.gen(function* () {
+    const reader = yield* FilesystemReader;
+    return yield* reader.list({ appId: query.appId, path: query.path }).pipe(
+      Effect.map(
+        (listing) =>
+          ({
+            queryId: query.queryId,
+            outcome: { status: 'listed', listing },
+          }) satisfies FilesystemQueryResult,
+      ),
+      Effect.catchAll((error) =>
+        Effect.logWarning('filesystem read failed', error).pipe(
+          Effect.annotateLogs({ queryId: query.queryId, appId: query.appId }),
+          Effect.as({
+            queryId: query.queryId,
+            outcome: { status: 'failed', message: reportedMessage(error) },
+          } satisfies FilesystemQueryResult),
+        ),
+      ),
+    );
+  });
+
+const once = Effect.gen(function* () {
+  const control = yield* ControlPlane;
+  const sessions = yield* AgentSessionHolder;
+  const session = yield* sessions.current;
+
+  const response = yield* control.fetchFilesystemQuery({
+    sessionToken: session.sessionToken,
+    request: { servedAppIds: yield* servedAppIds },
+  });
+
+  if (response.result === 'query') {
+    yield* control.sendFilesystemQueryResult({
+      sessionToken: session.sessionToken,
+      result: yield* answer(response.query),
+    });
+  }
+
+  yield* Effect.sleep(POLL_INTERVAL);
+});
+
+/**
+ * The fifth loop, and deliberately not part of the reconcile: a read observes the host without
+ * changing it, so a slow device delays the person waiting on it and nothing else. A backlog of
+ * reads must never be able to hold up a stop.
+ */
+export const filesystemLoop = Effect.gen(function* () {
+  const sessions = yield* AgentSessionHolder;
+  // An idle tick is not a failure, so a host nobody is browsing never backs off.
+  yield* supervised({
+    once: Effect.tapErrorTag(once, 'ControlPlaneError', sessions.onExpired),
+    onFailure: (cause) => Effect.logWarning('filesystem query loop failed', cause),
+    schedule: CONTROL_PLANE_BACKOFF,
+  });
+});

--- a/apps/agent/src/lib/agent/run.ts
+++ b/apps/agent/src/lib/agent/run.ts
@@ -1,4 +1,5 @@
 import { Effect, Option } from 'effect';
+import { filesystemLoop } from '#lib/agent/filesystem.ts';
 import { heartbeatLoop } from '#lib/agent/heartbeat.ts';
 import { logLoop } from '#lib/agent/logs.ts';
 import { pollLoop, reconcileSafely } from '#lib/agent/poll.ts';
@@ -56,7 +57,7 @@ export const run = Effect.gen(function* () {
   }
 
   yield* sessions.current;
-  yield* Effect.all([pollLoop, statusLoop, reportLoop, logLoop, heartbeatLoop], {
+  yield* Effect.all([pollLoop, statusLoop, reportLoop, logLoop, heartbeatLoop, filesystemLoop], {
     concurrency: 'unbounded',
   });
 });

--- a/apps/agent/src/lib/control/client.ts
+++ b/apps/agent/src/lib/control/client.ts
@@ -5,6 +5,9 @@ import {
   AgentSessionSchema,
   type DesiredStateRequest,
   DesiredStateResponseSchema,
+  type FilesystemQueryRequest,
+  FilesystemQueryResponseSchema,
+  type FilesystemQueryResult,
   type HostReportedState,
   PROTOCOL_VERSION,
   PROTOCOL_VERSION_HEADER,
@@ -131,6 +134,37 @@ export const makeControlPlaneClient = ({ baseUrl }: { baseUrl: string }) => {
         call({
           route: AGENT_ROUTES.reportedState,
           send: () => api.internal.agent['reported-state'].post(report, options(sessionToken)),
+        }),
+      ),
+
+    fetchFilesystemQuery: ({
+      sessionToken,
+      request,
+    }: {
+      sessionToken: SecretString;
+      request: FilesystemQueryRequest;
+    }) =>
+      call({
+        route: AGENT_ROUTES.filesystemQuery,
+        send: () => api.internal.agent['filesystem-query'].post(request, options(sessionToken)),
+      }).pipe(
+        Effect.flatMap((value) =>
+          decode(() => parseMessage({ schema: FilesystemQueryResponseSchema, value })),
+        ),
+      ),
+
+    sendFilesystemQueryResult: ({
+      sessionToken,
+      result,
+    }: {
+      sessionToken: SecretString;
+      result: FilesystemQueryResult;
+    }) =>
+      Effect.asVoid(
+        call({
+          route: AGENT_ROUTES.filesystemQueryResult,
+          send: () =>
+            api.internal.agent['filesystem-query-result'].post(result, options(sessionToken)),
         }),
       ),
   };

--- a/apps/agent/src/services/agent-session-holder.service.ts
+++ b/apps/agent/src/services/agent-session-holder.service.ts
@@ -13,7 +13,7 @@ export class AgentSessionHolder extends Effect.Service<AgentSessionHolder>()('Ag
     const cached = yield* SynchronizedRef.make(Option.none<AgentSession>());
 
     /**
-     * Synchronized because four loops ask for the session, and a plain `Ref` would have every one
+     * Synchronized because every loop asks for the session, and a plain `Ref` would have each one
      * of them see the same expired value and open a session of its own.
      */
     const current = SynchronizedRef.modifyEffect(cached, (existing) =>

--- a/apps/agent/tests/lib/agent/filesystem.test.ts
+++ b/apps/agent/tests/lib/agent/filesystem.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import type {
+  AppId,
+  DirectoryListing,
+  FilesystemQuery,
+  FilesystemQueryId,
+  GuestPath,
+  Timestamp,
+} from '@repo/protocol';
+import { Effect, Layer } from 'effect';
+import { answer } from '#lib/agent/filesystem.ts';
+import { UnreadableDirectory } from '#lib/filesystem/debugfs.ts';
+import { FilesystemReader, NoDeviceForApp } from '#services/filesystem-reader.service.ts';
+import { recordingCommands } from '#tests/support/commands.ts';
+
+const APP = 'app-pocketbase' as AppId;
+const QUERY: FilesystemQuery = {
+  queryId: 'query-1' as FilesystemQueryId,
+  appId: APP,
+  path: '/' as GuestPath,
+};
+
+const LISTING: DirectoryListing = {
+  path: '/' as GuestPath,
+  entries: [
+    {
+      name: 'pb_data',
+      kind: 'directory',
+      sizeBytes: 4096,
+      modifiedAt: '2026-08-03T09:41:00Z' as Timestamp,
+    },
+  ],
+  truncated: false,
+};
+
+/**
+ * `CommandRunner` comes along because a real read shells out, and the stub keeps its signature.
+ * Nothing here reaches it — a test that ran a subprocess would be testing the host, not this.
+ */
+function answering(list: FilesystemReader['list']) {
+  const layer = Layer.merge(
+    Layer.succeed(FilesystemReader, FilesystemReader.make({ list })),
+    recordingCommands().layer,
+  );
+  return Effect.runPromise(Effect.provide(answer(QUERY), layer));
+}
+
+// Somebody is holding a request open on the other end of this, so silence is the one outcome
+// that helps nobody: it turns a refusal they could act on into a timeout they cannot.
+describe('a query is answered whatever the read did', () => {
+  test('a directory that was read comes back as it was read', async () => {
+    const result = await answering(() => Effect.succeed(LISTING));
+
+    expect(result).toEqual({
+      queryId: QUERY.queryId,
+      outcome: { status: 'listed', listing: LISTING },
+    });
+  });
+
+  test('a device this host does not hold is still an answer', async () => {
+    const result = await answering(() => new NoDeviceForApp({ appId: APP }));
+
+    expect(result.queryId).toBe(QUERY.queryId);
+    expect(result.outcome.status).toBe('failed');
+  });
+
+  test('a device that could not be read is too', async () => {
+    const result = await answering(() => new UnreadableDirectory({ devicePath: '/dev/nbd7' }));
+
+    expect(result.outcome.status).toBe('failed');
+  });
+
+  // The message reaches whoever asked, so it has to read as a sentence rather than as a tag —
+  // and it must not carry the path, which is the tenant's to know.
+  test('a failure explains itself without quoting what was asked for', async () => {
+    const result = await answering(() => new UnreadableDirectory({ devicePath: '/dev/nbd7' }));
+
+    if (result.outcome.status !== 'failed') {
+      throw new Error('a failed read must answer with a failure');
+    }
+    expect(result.outcome.message).toContain('/dev/nbd7');
+    expect(result.outcome.message).not.toContain('UnreadableDirectory');
+  });
+});

--- a/apps/agent/tests/lib/control/client.test.ts
+++ b/apps/agent/tests/lib/control/client.test.ts
@@ -112,6 +112,60 @@ describe('every request identifies the protocol it speaks', () => {
   });
 });
 
+// The read channel is separate from desired state all the way down to the wire, and these are
+// what say so: a different route, and a reply carrying no generation for anything to act on.
+describe('a filesystem read travels on its own routes', () => {
+  test('a poll for a read reaches the query route', async () => {
+    const { call, baseUrl } = await runScoped(
+      Effect.gen(function* () {
+        const { client, received, baseUrl } = yield* controlPlane({ body: { result: 'none' } });
+        yield* client.fetchFilesystemQuery({
+          sessionToken: SESSION_TOKEN,
+          request: { servedAppIds: [] },
+        });
+        return { call: received[0], baseUrl };
+      }),
+    );
+
+    expect(call?.url).toBe(`${baseUrl}${AGENT_API_PREFIX}${AGENT_ROUTES.filesystemQuery}`);
+    expect(call?.headers.authorization).toBe(`Bearer ${SESSION_TOKEN}`);
+  });
+
+  test('an answer is posted to the result route and expects no reply', async () => {
+    const { result, call, baseUrl } = await runScoped(
+      Effect.gen(function* () {
+        const { client, received, baseUrl } = yield* controlPlane(NO_REPLY);
+        const result = yield* client.sendFilesystemQueryResult({
+          sessionToken: SESSION_TOKEN,
+          result: {
+            queryId: 'query-1' as never,
+            outcome: { status: 'failed', message: 'no device is attached on this host' },
+          },
+        });
+        return { result, call: received[0], baseUrl };
+      }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(call?.url).toBe(`${baseUrl}${AGENT_API_PREFIX}${AGENT_ROUTES.filesystemQueryResult}`);
+  });
+
+  test('a malformed query is rejected rather than read as a directory', async () => {
+    const error = await runScoped(
+      Effect.flatMap(controlPlane({ body: { result: 'query' } }), ({ client }) =>
+        Effect.flip(
+          client.fetchFilesystemQuery({
+            sessionToken: SESSION_TOKEN,
+            request: { servedAppIds: [] },
+          }),
+        ),
+      ),
+    );
+
+    expect(String(error)).toContain('does not match the protocol');
+  });
+});
+
 describe('validation at the boundary', () => {
   test('a response missing a required field is rejected rather than believed', async () => {
     const error = await sessionFailure({ body: { hostId: 'host-1', sessionToken: 'granted' } });


### PR DESCRIPTION
A loop of its own, outside the reconcile: a read observes the host without
changing it, so a slow device delays only whoever asked.

It sleeps after every pass rather than only an idle one, because the standing
query the control plane hands out is never retired — otherwise a host would
read a tenant device as fast as debugfs could return.

Which apps it can serve is read off the slot table on every poll, so a volume
torn down between two polls stops being offered on the next one with nothing to
invalidate. A read that fails is still answered: silence would leave whoever
asked with a timeout instead of a reason.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>