### PR TITLE
fix(agent): what mkfs made is not what the tenant made

### DIFF
--- a/apps/agent/src/lib/exports/bundle.ts
+++ b/apps/agent/src/lib/exports/bundle.ts
@@ -3,6 +3,7 @@ import { FileSystem, Path } from '@effect/platform';
 import type { DesiredArtifact } from '@repo/protocol';
 import { Data, Duration, Effect, Either } from 'effect';
 import { downloadAndVerify } from '#lib/vm/artifacts.ts';
+import { MKFS_ROOT_ENTRIES } from '#lib/volumes/ext4.ts';
 import { stdoutOf } from '#services/command-runner.service.ts';
 
 const STAGING_MODE = 0o700;
@@ -37,6 +38,7 @@ export class UnsafeFilename extends Data.TaggedError('UnsafeFilename')<{
 const dumpFilesystem = ({ devicePath, destination }: { devicePath: string; destination: string }) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
     yield* fs.makeDirectory(destination, { recursive: true, mode: STAGING_MODE });
     yield* stdoutOf({
       command: ['debugfs', '-R', `rdump / ${destination}`, devicePath],
@@ -45,6 +47,14 @@ const dumpFilesystem = ({ devicePath, destination }: { devicePath: string; desti
     if ((yield* fs.readDirectory(destination)).length === 0) {
       return yield* new EmptyDump({ devicePath });
     }
+    // Dropped after the emptiness check and never before it: a filesystem holding nothing but
+    // `lost+found` is a tenant who has written no data, and removing it first would report that
+    // as a dump that failed.
+    yield* Effect.forEach(
+      MKFS_ROOT_ENTRIES,
+      (entry) => fs.remove(path.join(destination, entry), { recursive: true, force: true }),
+      { discard: true },
+    );
   });
 
 /**

--- a/apps/agent/src/lib/filesystem/debugfs.ts
+++ b/apps/agent/src/lib/filesystem/debugfs.ts
@@ -3,6 +3,7 @@ import {
   type DirectoryListing,
   type FilesystemEntry,
   type FilesystemEntryKind,
+  GUEST_PATH_ROOT,
   type GuestPath,
   GuestPathSchema,
   isValidMessage,
@@ -10,6 +11,7 @@ import {
 } from '@repo/protocol';
 import { Data, Either } from 'effect';
 import type { CommandLine } from '#lib/exec.ts';
+import { MKFS_ROOT_ENTRIES } from '#lib/volumes/ext4.ts';
 
 /**
  * Reading a tenant filesystem with `debugfs`, which walks inodes in userspace — the same reason
@@ -164,6 +166,7 @@ export function parseListing({
   path: GuestPath;
 }): Either.Either<DirectoryListing, 'no-directory'> {
   const entries: FilesystemEntry[] = [];
+  const atRoot = path === GUEST_PATH_ROOT;
   let sawSelf = false;
   let truncated = false;
 
@@ -174,6 +177,9 @@ export function parseListing({
     }
     if (SELF_AND_PARENT.has(parsed.name)) {
       sawSelf ||= parsed.name === '.';
+      continue;
+    }
+    if (atRoot && MKFS_ROOT_ENTRIES.has(parsed.name)) {
       continue;
     }
     if (entries.length === DIRECTORY_ENTRY_LIMIT) {

--- a/apps/agent/src/lib/volumes/ext4.ts
+++ b/apps/agent/src/lib/volumes/ext4.ts
@@ -11,6 +11,16 @@ const SECOND_BYTE = 1;
 
 export const FILESYSTEM_LABEL = 'nibrun-data';
 
+/**
+ * What `mkfs.ext4` below puts at the root of every filesystem it writes. A tenant did not create
+ * these and has no use for them, so neither a listing nor an export shows them.
+ *
+ * **At the root only.** `lost+found` is reserved by the filesystem in exactly one directory; the
+ * same name deeper in the tree is a directory a tenant made, and hiding it would be hiding their
+ * own data from them.
+ */
+export const MKFS_ROOT_ENTRIES: ReadonlySet<string> = new Set(['lost+found']);
+
 export function hasExtMagic(bytes: Uint8Array): boolean {
   if (bytes.length < MAGIC_BYTE_COUNT) {
     return false;

--- a/apps/agent/tests/lib/exports/bundle.test.ts
+++ b/apps/agent/tests/lib/exports/bundle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { Filename } from '@repo/protocol';
 import { Effect, Either, Layer } from 'effect';
@@ -13,17 +13,32 @@ const DEVICE_PATH = '/dev/nbd7';
 
 const run = provided(Layer.merge(artifactStore(), platform));
 
-/** What a real `debugfs` and `tar` would leave behind, so each step downstream has its input. */
-function bundling({ dump = true }: { dump?: boolean } = {}) {
+/** `lost+found` is written by `mkfs.ext4`, so a real `rdump` of any root always produces it. */
+const DUMPS = {
+  tenant: async (dataDir: string) => {
+    await mkdir(join(dataDir, 'pb_data'), { recursive: true });
+    await writeFile(join(dataDir, 'pb_data', 'data.db'), 'tenant');
+    await mkdir(join(dataDir, 'lost+found'), { recursive: true });
+  },
+  'mkfs-only': async (dataDir: string) => {
+    await mkdir(join(dataDir, 'lost+found'), { recursive: true });
+  },
+  none: () => Promise.resolve(),
+} as const;
+
+/**
+ * What a real `debugfs` and `tar` would leave behind, so each step downstream has its input. The
+ * staging tree is read inside the scope that owns it, because it is gone by the time the test
+ * body resumes.
+ */
+function bundling({ dumps = 'tenant' }: { dumps?: keyof typeof DUMPS } = {}) {
   return Effect.gen(function* () {
     const stagingDir = yield* temporaryDirectory;
+    const dataDir = join(stagingDir, 'data');
     const { commands, layer } = recordingCommands(({ command }) =>
       Effect.gen(function* () {
-        if (command[0] === 'debugfs' && dump) {
-          yield* Effect.promise(async () => {
-            await mkdir(join(stagingDir, 'data', 'pb_data'), { recursive: true });
-            await writeFile(join(stagingDir, 'data', 'pb_data', 'data.db'), 'tenant');
-          });
+        if (command[0] === 'debugfs') {
+          yield* Effect.promise(() => DUMPS[dumps](dataDir));
         }
         if (command[0] === 'tar') {
           yield* Effect.promise(() => writeFile(join(stagingDir, 'bundle.tar.gz'), 'archive'));
@@ -38,7 +53,8 @@ function bundling({ dump = true }: { dump?: boolean } = {}) {
         layer,
       ),
     );
-    return { commands, result, stagingDir };
+    const archived = yield* Effect.promise(() => readdir(dataDir).catch(() => [] as string[]));
+    return { commands, result, stagingDir, archived };
   });
 }
 
@@ -76,9 +92,26 @@ test('archives the data tree and the binary under its uploaded name', async () =
 });
 
 test('a dump that produced nothing is a failure rather than an empty bundle', async () => {
-  const { result } = await run(bundling({ dump: false }));
+  const { result } = await run(bundling({ dumps: 'none' }));
 
   expect(Either.isLeft(result) && result.left._tag).toBe('EmptyDump');
+});
+
+// Somebody extracting this on their own machine gets what they put in the volume, not the
+// bookkeeping the filesystem needed to hold it.
+test('what mkfs left at the root does not reach the archive', async () => {
+  const { archived } = await run(bundling());
+
+  expect(archived).toEqual(['pb_data']);
+});
+
+// The emptiness check has to see the raw dump: a volume holding only `lost+found` is a tenant who
+// has written nothing, and reporting that as a failed read would fail their export forever.
+test('a volume holding only that is an empty export rather than a failed one', async () => {
+  const { result, archived } = await run(bundling({ dumps: 'mkfs-only' }));
+
+  expect(Either.isRight(result)).toBe(true);
+  expect(archived).toEqual([]);
 });
 
 describe('the bundle keeps the name the binary was uploaded under', () => {

--- a/apps/agent/tests/lib/filesystem/debugfs.test.ts
+++ b/apps/agent/tests/lib/filesystem/debugfs.test.ts
@@ -80,6 +80,29 @@ describe('a directory is read off the columns debugfs prints', () => {
   });
 });
 
+describe('what mkfs left at the root is not the tenant data', () => {
+  const withLostAndFound = [
+    '      2  40755 (2)      0      0    4096 15-Jan-2026 10:23 .',
+    '      2  40755 (2)      0      0    4096 15-Jan-2026 10:23 ..',
+    '     11  40700 (2)      0      0   16384 15-Jan-2026 10:23 lost+found',
+    '     12  40755 (2)      0      0    4096 15-Jan-2026 10:24 pb_data',
+  ].join('\n');
+
+  test('it is left out of the root', () => {
+    expect(entriesOf(withLostAndFound).entries.map((entry) => entry.name)).toEqual(['pb_data']);
+  });
+
+  // The name is reserved in one directory only. Anywhere else it is a directory the tenant made,
+  // and hiding it would be hiding their own data from them.
+  test('but the same name below the root is the tenant own directory', () => {
+    const listing = parseListing({ output: withLostAndFound, path: '/pb_data' as GuestPath });
+    if (Either.isLeft(listing)) {
+      throw new Error('expected a readable directory');
+    }
+    expect(listing.right.entries.map((entry) => entry.name)).toEqual(['lost+found', 'pb_data']);
+  });
+});
+
 // `debugfs` writes its failures to stderr and exits 0 regardless, so the output is the only
 // evidence. Every ext4 directory holds `.`, which separates "unreadable" from "empty" — and the
 // export path's emptiness check cannot, because both look identical to it.


### PR DESCRIPTION
lost+found is created by mkfs.ext4 and by nothing a tenant did, so it belongs
in neither a listing nor an export. Named once beside the mkfs call that writes
it, so the two readers cannot disagree about what to hide.

Root only: the name is reserved in one directory, and the same name deeper in
the tree is a directory the tenant made.

The export drops it after the emptiness check rather than before — a volume
holding nothing else is a tenant who has written no data, and checking second
would report that as a dump that failed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>