### PR TITLE
fix(protocol): an export names the binary it packages

### DIFF
--- a/apps/agent/src/lib/reconcile/exports.ts
+++ b/apps/agent/src/lib/reconcile/exports.ts
@@ -20,27 +20,18 @@ const forget = (exportId: ExportId) =>
   });
 
 /**
- * The artifact is joined from the instance desired state rather than carried on the export, so a
- * bundle can only pair a filesystem with the binary this host was told to run against it.
+ * The device is the only thing an export needs this host to still have: the volume is provisioned
+ * from its own desired state, so it stays attached whether or not anything is running against it.
  */
-const write = ({
-  action,
-  desired,
-}: {
-  action: Extract<ExportPlan, { action: 'write' }>;
-  desired: HostDesiredState;
-}) =>
+const write = ({ action }: { action: Extract<ExportPlan, { action: 'write' }> }) =>
   Effect.gen(function* () {
     const exports = yield* ExportManager;
     const allocator = yield* SlotAllocator;
-    const { exportId, appId } = action.desired;
-    const artifact = desired.instances.find((instance) => instance.appId === appId)?.artifact;
+    const { exportId, appId, artifact } = action.desired;
     const slot = yield* allocator.lookup(appId);
 
-    if (!artifact || Option.isNone(slot)) {
-      const reason = artifact
-        ? 'no device attached for this app'
-        : 'no instance to take a binary from';
+    if (Option.isNone(slot)) {
+      const reason = 'no device attached for this app';
       yield* Effect.logError('export not writable here').pipe(
         Effect.annotateLogs({ exportId, appId, reason }),
       );
@@ -63,13 +54,7 @@ const write = ({
       );
   });
 
-export const applyExports = ({
-  plan,
-  desired,
-}: {
-  plan: ReconcilePlan;
-  desired: HostDesiredState;
-}) =>
+export const applyExports = ({ plan }: { plan: ReconcilePlan }) =>
   Effect.forEach(
     plan.exports,
     (action) => {
@@ -78,7 +63,7 @@ export const applyExports = ({
       }
       return action.action === 'forget'
         ? forget(action.exportId)
-        : Effect.flatMap(write({ action, desired }), setReport);
+        : Effect.flatMap(write({ action }), setReport);
     },
     { discard: true },
   );

--- a/apps/agent/src/services/reconciler.service.ts
+++ b/apps/agent/src/services/reconciler.service.ts
@@ -203,7 +203,7 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       yield* applyCheckpoints({ plan, desired }).pipe(Effect.withSpan('reconcile.checkpoints'));
       // After starts, so an export never competes with a boot for the device it reads, and
       // before teardowns, so a volume marked absent this generation is still there to read.
-      yield* applyExports({ plan, desired }).pipe(Effect.withSpan('reconcile.exports'));
+      yield* applyExports({ plan }).pipe(Effect.withSpan('reconcile.exports'));
       yield* applyTeardowns(plan).pipe(Effect.withSpan('reconcile.teardowns'));
       // Again, because the instances started above are the ones whose forwards this renders.
       yield* applyNetwork.pipe(Effect.withSpan('reconcile.network'));

--- a/apps/agent/tests/support/fixtures.ts
+++ b/apps/agent/tests/support/fixtures.ts
@@ -96,6 +96,7 @@ export function desiredExport(overrides: Partial<DesiredExport> = {}): DesiredEx
     appId: APP_ID,
     volumeId: VOLUME_ID,
     objectKey: 'exports/app-1/exp-1.tar.gz' as ObjectKey,
+    artifact: artifact(),
     desiredState: 'present',
     ...overrides,
   };

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
   type DeploymentId,
+  type DesiredArtifact,
   type ExportId,
   type Filename,
   type GuestPort,
@@ -34,6 +35,17 @@ const VOLUME_SIZE_BYTES = 8_589_934_592;
 
 const POCKETBASE_PORT = 8090 as GuestPort;
 
+// Named once and pointed at twice: the binary an export packages is the binary the instance
+// runs, so two copies of it here would be two chances for a bundle to hold the wrong one.
+const POCKETBASE_ARTIFACT = {
+  // Uploaded by hand; the agent hashes the stream as it downloads and refuses
+  // on either mismatch, so both values below are load-bearing.
+  objectKey: 'artifacts/app-pocketbase/pb-0-39-10' as ObjectKey,
+  filename: 'pocketbase' as Filename,
+  digest: 'f119018534e7a9e0db837c2811dda589d03bbdb78a03decc0664aac864e53814' as Sha256Digest,
+  sizeBytes: 32_096_418,
+} satisfies DesiredArtifact;
+
 const DESIRED_APP = {
   generation: 5,
   volumes: [
@@ -51,14 +63,7 @@ const DESIRED_APP = {
       deploymentId: 'dep-pocketbase-3' as DeploymentId,
       volumeId: 'vol-pocketbase' as VolumeId,
       desiredState: 'running',
-      artifact: {
-        // Uploaded by hand; the agent hashes the stream as it downloads and refuses
-        // on either mismatch, so both values below are load-bearing.
-        objectKey: 'artifacts/app-pocketbase/pb-0-39-10' as ObjectKey,
-        filename: 'pocketbase' as Filename,
-        digest: 'f119018534e7a9e0db837c2811dda589d03bbdb78a03decc0664aac864e53814' as Sha256Digest,
-        sizeBytes: 32_096_418,
-      },
+      artifact: POCKETBASE_ARTIFACT,
       config: {
         guestPort: POCKETBASE_PORT,
         // `serve` because the binary is a multi-command tool; 0.0.0.0 because the
@@ -84,6 +89,7 @@ const DESIRED_APP = {
       appId: APP_ID,
       volumeId: 'vol-pocketbase' as VolumeId,
       objectKey: `exports/${APP_ID}/exp-pocketbase-1.tar.gz` as ObjectKey,
+      artifact: POCKETBASE_ARTIFACT,
       desiredState: 'present',
     },
   ],

--- a/packages/protocol/src/control/desired-state.ts
+++ b/packages/protocol/src/control/desired-state.ts
@@ -91,12 +91,18 @@ export type DesiredCheckpoint = typeof DesiredCheckpointSchema.static;
  * `objectKey` is chosen by the control plane rather than the host: it is what the download URL
  * is signed against, and a key the control plane did not choose is one it would have to be told
  * before it could sign anything.
+ *
+ * `artifact` is carried here rather than joined from `instances`, because the moment an owner
+ * most wants their data out is after they have stopped the app — and a stopped app has no
+ * instance to take a binary from. Which binary belongs in the bundle is a fact the control
+ * plane holds either way, so asking the host to infer it only made it inferrable less often.
  */
 export const DesiredExportSchema = Type.Object({
   exportId: ExportIdSchema,
   appId: AppIdSchema,
   volumeId: VolumeIdSchema,
   objectKey: ObjectKeySchema,
+  artifact: DesiredArtifactSchema,
   desiredState: DesiredPresenceSchema,
 });
 

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -11,6 +11,7 @@ import {
   DesiredStateResponseSchema,
   DIRECTORY_ENTRY_LIMIT,
   DirectoryListingSchema,
+  type ExportId,
   type Filename,
   FilesystemEntryNameSchema,
   GuestPathSchema,
@@ -82,6 +83,42 @@ const desiredState = (): HostDesiredState => ({
   ],
   checkpoints: [],
   exports: [],
+});
+
+const desiredExport = () => ({
+  exportId: 'exp_1' as ExportId,
+  appId: 'app_1' as AppId,
+  volumeId: 'vol_1' as VolumeId,
+  objectKey: 'exports/app_1/exp_1.tar.gz' as ObjectKey,
+  artifact: {
+    digest: hexDigest(),
+    sizeBytes: 2048,
+    objectKey: 'artifacts/app_1/a' as ObjectKey,
+    filename: 'server' as Filename,
+  },
+  desiredState: 'present',
+});
+
+// The moment an owner most wants their data out is after they have stopped the app, and a
+// stopped app puts no instance in desired state. The export naming its own binary is what
+// keeps the bundle writable then.
+describe('an export names the binary it packages', () => {
+  test('a host running nothing is still told how to write one', () => {
+    const stopped = { ...desiredState(), instances: [], exports: [desiredExport()] };
+
+    expect(isValidMessage({ schema: HostDesiredStateSchema, value: stopped })).toBe(true);
+  });
+
+  test('an export that names no binary is not one', () => {
+    const { artifact: _artifact, ...unnamed } = desiredExport();
+
+    expect(
+      isValidMessage({
+        schema: HostDesiredStateSchema,
+        value: { ...desiredState(), exports: [unnamed] },
+      }),
+    ).toBe(false);
+  });
 });
 
 // Branding a schema means overriding a type-level property on it. If that ever started


### PR DESCRIPTION
The agent joined an export's artifact from the instance desired state, so a bundle could only be written while the app was running — which is not when an owner asks for their data. `DesiredExport` carries its own artifact instead.

The volume is provisioned from its own desired state, so the device stays attached with nothing running against it. The instance join was the only thing making a stopped app unexportable.