### PR TITLE
feat(api): a deployment streams its logs

### DIFF
--- a/apps/api/src/lib/victorialogs/client.ts
+++ b/apps/api/src/lib/victorialogs/client.ts
@@ -1,0 +1,100 @@
+import { type LogRow, lines, toRow } from '#lib/victorialogs/parse.ts';
+
+const TAIL_PATH = '/select/logsql/tail';
+
+/** The store's own name for a query submitted in a body, which is where a filter this long belongs. */
+const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded';
+
+const MAX_ERROR_BODY = 256;
+
+export class VictoriaLogsError extends Error {
+  constructor({ status, body }: { status: number; body: string }) {
+    super(`the log store answered ${status}: ${body}`);
+    this.name = 'VictoriaLogsError';
+  }
+}
+
+/**
+ * One endpoint of the store, holding the URL it resolves to and the one way of asking it.
+ *
+ * Subclassed per endpoint rather than switched on a path, so what a caller may ask for is what
+ * the type offers: `tail.subscribe(…)` names the endpoint and what it does in the same phrase,
+ * and an endpoint added later inherits the base URL rather than re-deriving it.
+ */
+abstract class VictoriaLogsEndpoint {
+  private readonly url: string;
+
+  constructor({ baseUrl, path }: { baseUrl: URL; path: string }) {
+    this.url = new URL(path, baseUrl).toString();
+  }
+
+  protected async post({
+    params,
+    signal,
+  }: {
+    params: Record<string, string>;
+    signal: AbortSignal;
+  }): Promise<Response> {
+    const response = await fetch(this.url, {
+      method: 'POST',
+      headers: { 'content-type': FORM_CONTENT_TYPE },
+      body: new URLSearchParams(params),
+      signal,
+    });
+    if (!response.ok) {
+      throw new VictoriaLogsError({
+        status: response.status,
+        body: (await response.text().catch(() => '')).slice(0, MAX_ERROR_BODY),
+      });
+    }
+    return response;
+  }
+}
+
+export type TailRequest = {
+  /** LogsQL. This endpoint refuses `sort`, `limit`, `offset` and the stats pipes. */
+  query: string;
+  /** How much history precedes the follow, as a LogsQL duration such as `5m`. */
+  startOffset: string;
+  signal: AbortSignal;
+};
+
+/**
+ * Live tailing, rather than a query run over and over: the store follows the stream itself and
+ * holds the response open, so nothing here keeps a cursor. It delays new records briefly to let
+ * late arrivals land in order, which is why a tail runs a few seconds behind rather than a poll
+ * away.
+ */
+export class VictoriaLogsTail extends VictoriaLogsEndpoint {
+  constructor(baseUrl: URL) {
+    super({ baseUrl, path: TAIL_PATH });
+  }
+
+  async *subscribe({ query, startOffset, signal }: TailRequest): AsyncGenerator<LogRow> {
+    const response = await this.post({ params: { query, start_offset: startOffset }, signal });
+    if (!response.body) {
+      return;
+    }
+    for await (const line of lines(response.body)) {
+      const row = toRow(line);
+      if (row) {
+        yield row;
+      }
+    }
+  }
+}
+
+/**
+ * Reads the store, and only reads it.
+ *
+ * Records arrive from the fleet over an ingest listener that admits app hosts and nothing else,
+ * so `/insert` is not this process's to call — and the api is the only thing that queries,
+ * because deciding who may see an app is its question to answer.
+ */
+export class VictoriaLogsClient {
+  readonly tail: VictoriaLogsTail;
+
+  constructor(baseUrl: URL) {
+    this.tail = new VictoriaLogsTail(baseUrl);
+  }
+}

--- a/apps/api/src/lib/victorialogs/parse.ts
+++ b/apps/api/src/lib/victorialogs/parse.ts
@@ -1,0 +1,46 @@
+/**
+ * One record as the store returns it.
+ *
+ * Every value is a string whatever it was ingested as — the store converts numbers, booleans and
+ * arrays on the way in, to keep full-text search over them one kind of thing. So a caller wanting
+ * a number back is the one that has to say so; nothing here guesses which fields were ones.
+ */
+export type LogRow = Record<string, string>;
+
+/**
+ * Newline-delimited JSON off a response the store holds open, so a record straddling two reads is
+ * the ordinary case rather than an edge one: what is left after the last newline is carried into
+ * the next chunk instead of being parsed as a line of its own.
+ */
+export async function* lines(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const decoder = new TextDecoder();
+  let buffered = '';
+  for await (const chunk of body) {
+    buffered += decoder.decode(chunk, { stream: true });
+    const parts = buffered.split('\n');
+    buffered = parts.pop() ?? '';
+    for (const part of parts) {
+      if (part.length > 0) {
+        yield part;
+      }
+    }
+  }
+  if (buffered.length > 0) {
+    yield buffered;
+  }
+}
+
+/**
+ * A line that is not a JSON object is not a record, and is dropped rather than thrown: a live
+ * tail must not end because the store wrote something this client cannot read.
+ */
+export function toRow(line: string): LogRow | undefined {
+  try {
+    const parsed: unknown = JSON.parse(line);
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as LogRow)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/api/src/repositories/logs.repository.ts
+++ b/apps/api/src/repositories/logs.repository.ts
@@ -1,0 +1,84 @@
+import {
+  type AppId,
+  type DeploymentId,
+  isValidMessage,
+  type TenantLogRecord,
+  TenantLogRecordSchema,
+} from '@repo/protocol';
+import type { VictoriaLogsTail } from '#lib/victorialogs/client.ts';
+import type { LogRow } from '#lib/victorialogs/parse.ts';
+
+/** The whole of what this repository asks of the store, so a test can be that and nothing more. */
+export type TenantLogStore = { tail: Pick<VictoriaLogsTail, 'subscribe'> };
+
+export type TenantLogTail = {
+  appId: AppId;
+  deploymentId: DeploymentId;
+  /** How much history precedes the follow, as a LogsQL duration. */
+  startOffset: string;
+  signal: AbortSignal;
+};
+
+export abstract class LogsRepositoryContract {
+  abstract tail(input: TenantLogTail): AsyncIterable<TenantLogRecord>;
+}
+
+/** Reads one deployment's tenant output back out of the log store. */
+export class LogsRepository implements LogsRepositoryContract {
+  private readonly store: TenantLogStore;
+
+  constructor(store: TenantLogStore) {
+    this.store = store;
+  }
+
+  async *tail({ appId, deploymentId, startOffset, signal }: TenantLogTail) {
+    const rows = this.store.tail.subscribe({
+      query: tenantQuery({ appId, deploymentId }),
+      startOffset,
+      signal,
+    });
+    for await (const row of rows) {
+      const record = toRecord(row);
+      if (record) {
+        yield record;
+      }
+    }
+  }
+}
+
+/**
+ * `SOURCE` and `appId` key the stream, so naming both is what narrows the search to one app's
+ * streams before anything is read; `deploymentId` then filters within them. Values are quoted
+ * even though identifiers cannot contain a LogsQL operator — the schema that says so is not this
+ * file's, and a filter that only works because of a rule enforced elsewhere is one to write out.
+ */
+function tenantQuery({
+  appId,
+  deploymentId,
+}: {
+  appId: AppId;
+  deploymentId: DeploymentId;
+}): string {
+  return `SOURCE:=${quoted('tenant')} appId:=${quoted(appId)} deploymentId:=${quoted(deploymentId)}`;
+}
+
+const quoted = (value: string) => JSON.stringify(value);
+
+/**
+ * The store keeps every field as a string, so the two numbers a record carries are read back as
+ * text and have to be numbers again before the record is the shape the protocol declares.
+ *
+ * A record that then fails to validate is skipped rather than thrown: a live tail must not end
+ * because one line is malformed. `TenantLogRecordSchema` is what would catch a field renamed on
+ * the writing side, so a tail that suddenly yields nothing is that drift showing up.
+ */
+function toRecord(row: LogRow): TenantLogRecord | undefined {
+  const value = {
+    ...row,
+    sequence: Number(row.sequence),
+    ...(row.droppedBytes === undefined ? {} : { droppedBytes: Number(row.droppedBytes) }),
+  };
+  return isValidMessage({ schema: TenantLogRecordSchema, value })
+    ? (value as TenantLogRecord)
+    : undefined;
+}

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
@@ -1,0 +1,68 @@
+import type { OwnerId, TenantLogRecord } from '@repo/protocol';
+import { Elysia, sse } from 'elysia';
+import { authPlugin } from '#lib/auth/plugin.ts';
+import {
+  DEFAULT_START_OFFSET,
+  TailLogsQuerySchema,
+} from '#routes/api/apps/[appId]/deployments/[deploymentId]/logs/model.ts';
+import { DeploymentParamsSchema } from '#routes/api/apps/[appId]/deployments/model.ts';
+import { LogsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+
+/**
+ * A tail is closed after this long and the client reconnects, which is what keeps an
+ * authorization decision made at the start of a stream from outliving the stream.
+ */
+const MAX_TAIL_MINUTES = 15;
+const MS_PER_MINUTE = 60_000;
+const MAX_TAIL_MS = MAX_TAIL_MINUTES * MS_PER_MINUTE;
+
+export const AppsAppIdDeploymentsDeploymentIdLogsController = new Elysia()
+  .use(loggerPlugin('appsAppIdDeploymentsDeploymentIdLogsController'))
+  .use(authPlugin)
+  .use(LogsServicePlugin)
+  .guard({ auth: true })
+  .get(
+    '/apps/:appId/deployments/:deploymentId/logs',
+    // Not a generator itself: the ownership check has to answer before anything is streamed, and
+    // a generator body would only run once the response had already been committed as a stream.
+    async ({ logsService, params, query, user, request }) => {
+      const signal = AbortSignal.any([request.signal, AbortSignal.timeout(MAX_TAIL_MS)]);
+      const records = await logsService.openTail({
+        appId: params.appId,
+        deploymentId: params.deploymentId,
+        ownerId: user.id as OwnerId,
+        startOffset: query.startOffset ?? DEFAULT_START_OFFSET,
+        signal,
+      });
+      return events({ records, signal });
+    },
+    {
+      params: DeploymentParamsSchema,
+      query: TailLogsQuerySchema,
+    },
+  );
+
+/**
+ * A closed tail is the ordinary ending — the cap above reaches it on every long-lived stream, and
+ * so does a reader navigating away — so an abort finishes the response rather than failing it.
+ *
+ * The signal decides that, not the error: a cancelled request and an expired cap raise different
+ * exceptions (`AbortError` and `TimeoutError`), and the cap is the one that fires every time.
+ */
+async function* events({
+  records,
+  signal,
+}: {
+  records: AsyncIterable<TenantLogRecord>;
+  signal: AbortSignal;
+}) {
+  try {
+    for await (const record of records) {
+      yield sse({ event: 'log', data: record });
+    }
+  } catch (error) {
+    if (!signal.aborted) {
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/model.ts
@@ -1,0 +1,19 @@
+import { t } from 'elysia';
+
+/**
+ * How much history precedes the follow. A LogsQL duration rather than a line count: the store's
+ * tail cannot be limited by rows, so the only bound expressible here is one in time.
+ */
+const START_OFFSET_PATTERN = '^[1-9][0-9]{0,3}[smh]$';
+
+export const DEFAULT_START_OFFSET = '5m';
+
+export const TailLogsQuerySchema = t.Object({
+  startOffset: t.Optional(
+    t.String({
+      pattern: START_OFFSET_PATTERN,
+      default: DEFAULT_START_OFFSET,
+      description: 'How far back the tail starts, as a LogsQL duration such as 5m.',
+    }),
+  ),
+});

--- a/apps/api/src/routes/api/controller.ts
+++ b/apps/api/src/routes/api/controller.ts
@@ -4,6 +4,7 @@ import { AppsAppIdArtifactsArtifactIdController } from '#routes/api/apps/[appId]
 import { AppsAppIdArtifactsController } from '#routes/api/apps/[appId]/artifacts/controller.ts';
 import { AppsAppIdController } from '#routes/api/apps/[appId]/controller.ts';
 import { AppsAppIdDeploymentsDeploymentIdController } from '#routes/api/apps/[appId]/deployments/[deploymentId]/controller.ts';
+import { AppsAppIdDeploymentsDeploymentIdLogsController } from '#routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts';
 import { AppsAppIdDeploymentsController } from '#routes/api/apps/[appId]/deployments/controller.ts';
 import { AppsController } from '#routes/api/apps/controller.ts';
 import { AuthController } from '#routes/api/auth/controller.ts';
@@ -17,4 +18,5 @@ export const ApiController = new Elysia({ prefix: RoutePrefix.Api })
   .use(AppsAppIdArtifactsController)
   .use(AppsAppIdArtifactsArtifactIdController)
   .use(AppsAppIdDeploymentsController)
-  .use(AppsAppIdDeploymentsDeploymentIdController);
+  .use(AppsAppIdDeploymentsDeploymentIdController)
+  .use(AppsAppIdDeploymentsDeploymentIdLogsController);

--- a/apps/api/src/services/logs.service.ts
+++ b/apps/api/src/services/logs.service.ts
@@ -1,0 +1,58 @@
+import type { AppId, DeploymentId, OwnerId, TenantLogRecord } from '@repo/protocol';
+import { NotFoundError } from '#lib/errors.ts';
+import type { DeploymentsRepositoryContract } from '#repositories/deployments.repository.ts';
+import type { LogsRepositoryContract } from '#repositories/logs.repository.ts';
+import { Service } from '#services/service.ts';
+
+// A deployment the caller does not own has to be indistinguishable from one that does not exist.
+const NO_SUCH_DEPLOYMENT = 'Deployment not found.';
+
+export type DeploymentLookup = Pick<DeploymentsRepositoryContract, 'findById'>;
+
+export type TenantLogTailRequest = {
+  appId: AppId;
+  deploymentId: DeploymentId;
+  ownerId: OwnerId;
+  startOffset: string;
+};
+
+export class LogsService extends Service {
+  private readonly logsRepo: LogsRepositoryContract;
+  private readonly deploymentsRepo: DeploymentLookup;
+
+  constructor({
+    logsRepo,
+    deploymentsRepo,
+  }: {
+    logsRepo: LogsRepositoryContract;
+    deploymentsRepo: DeploymentLookup;
+  }) {
+    super();
+    this.logsRepo = logsRepo;
+    this.deploymentsRepo = deploymentsRepo;
+  }
+
+  /**
+   * Resolves who may read before it returns anything to read from, so a caller who owns nothing
+   * is answered rather than connected to. The check is Postgres' — the log store holds no owner
+   * — and it is made once, at the point the stream opens: a connection held open past a transfer
+   * keeps the access it was granted, which is what bounds how long the route lets one live.
+   *
+   * The deployment is looked up rather than the app, because a deployment belonging to another
+   * owner's app must not be readable by naming this owner's app in the path.
+   */
+  async openTail({
+    appId,
+    deploymentId,
+    ownerId,
+    startOffset,
+    signal,
+  }: TenantLogTailRequest & { signal: AbortSignal }): Promise<AsyncIterable<TenantLogRecord>> {
+    const deployment = await this.deploymentsRepo.findById({ appId, deploymentId, ownerId });
+    if (!deployment) {
+      throw new NotFoundError(NO_SUCH_DEPLOYMENT);
+    }
+    this.logger.info('tenant log tail opened', { appId, deploymentId, startOffset });
+    return this.logsRepo.tail({ appId, deploymentId, startOffset, signal });
+  }
+}

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -3,6 +3,7 @@ import { sql } from '#db/client.ts';
 import { env } from '#lib/env.ts';
 import { createLogger } from '#lib/logger.ts';
 import { s3 } from '#lib/s3/client.ts';
+import { VictoriaLogsClient } from '#lib/victorialogs/client.ts';
 import { AgentRepository } from '#repositories/agent.repository.ts';
 import { AppsRepository } from '#repositories/apps.repository.ts';
 import { ArtifactStorageRepository } from '#repositories/artifact-storage.repository.ts';
@@ -11,6 +12,7 @@ import { AssetsRepository } from '#repositories/assets.repository.ts';
 import { DeploymentsRepository } from '#repositories/deployments.repository.ts';
 import { FilesystemRepository } from '#repositories/filesystem.repository.ts';
 import { HealthRepository } from '#repositories/health.repository.ts';
+import { LogsRepository } from '#repositories/logs.repository.ts';
 import { AgentService } from '#services/agent.service.ts';
 import { AppsService } from '#services/apps.service.ts';
 import { ArtifactsService } from '#services/artifacts.service.ts';
@@ -18,6 +20,7 @@ import { AssetsService } from '#services/assets.service.ts';
 import { DeploymentsService } from '#services/deployments.service.ts';
 import { FilesystemService } from '#services/filesystem.service.ts';
 import { HealthService } from '#services/health.service.ts';
+import { LogsService } from '#services/logs.service.ts';
 
 const agentRepository = new AgentRepository(sql);
 const assetsRepository = new AssetsRepository(sql);
@@ -27,6 +30,7 @@ const appsRepository = new AppsRepository(sql);
 const artifactsRepository = new ArtifactsRepository(sql);
 const deploymentsRepository = new DeploymentsRepository(sql);
 const artifactStorageRepository = new ArtifactStorageRepository(s3);
+const logsRepository = new LogsRepository(new VictoriaLogsClient(env.VICTORIALOGS_ENDPOINT));
 
 const deploymentsService = new DeploymentsService({ deploymentsRepo: deploymentsRepository });
 const agentService = new AgentService({ agentRepo: agentRepository, deploymentsService });
@@ -42,6 +46,11 @@ const artifactsService = new ArtifactsService({
   storageRepo: artifactStorageRepository,
   appsRepo: appsRepository,
 });
+const logsService = new LogsService({
+  logsRepo: logsRepository,
+  deploymentsRepo: deploymentsRepository,
+});
+
 export function loggerPlugin(name: string) {
   const logger = createLogger(name);
   return new Elysia({ name: `logger.${name}` }).derive({ as: 'scoped' }, () => ({ logger }));
@@ -80,4 +89,9 @@ export const ArtifactsServicePlugin = new Elysia({ name: 'service.artifacts' }).
 export const DeploymentsServicePlugin = new Elysia({ name: 'service.deployments' }).decorate(
   'deploymentsService',
   deploymentsService,
+);
+
+export const LogsServicePlugin = new Elysia({ name: 'service.logs' }).decorate(
+  'logsService',
+  logsService,
 );

--- a/apps/api/tests/controllers/logs.test.ts
+++ b/apps/api/tests/controllers/logs.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { StatusMap } from 'elysia';
+import { ORIGIN, send } from '#tests/controllers/support/api.ts';
+
+const APP_ID = 'app-1';
+const DEPLOYMENT_ID = 'deployment-1';
+const LOGS_URL = `${ORIGIN}/api/apps/${APP_ID}/deployments/${DEPLOYMENT_ID}/logs`;
+
+// A 401 rather than a 404 is what proves the route is mounted: an unmounted path under /api
+// answers 404, so these assertions cover both the auth gate and the route tree.
+describe('a deployment logs are read through the api that owns the app', () => {
+  test('tailing without a session is refused', async () => {
+    expect((await send({ url: LOGS_URL })).status).toBe(StatusMap.Unauthorized);
+  });
+
+  // The offset reaches the store inside a LogsQL query, so a value the schema does not admit is
+  // refused here rather than carried down and rejected as a syntax error by the store.
+  test('a start offset that is not a duration never reaches the store', async () => {
+    const response = await send({ url: `${LOGS_URL}?startOffset=forever` });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+});

--- a/apps/api/tests/lib/victorialogs.test.ts
+++ b/apps/api/tests/lib/victorialogs.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { VictoriaLogsClient, VictoriaLogsError } from '#lib/victorialogs/client.ts';
+import type { LogRow } from '#lib/victorialogs/parse.ts';
+
+const QUERY = 'SOURCE:="tenant"';
+const START_OFFSET = '5m';
+const TAIL_TIMEOUT_MS = 5_000;
+const HALF = 2;
+const BAD_REQUEST = 400;
+
+const jsonLine = (fields: Record<string, string>) => `${JSON.stringify(fields)}\n`;
+
+type Answer = { status?: number; body: string; chunkAt?: number };
+type Asked = { path: string; form: URLSearchParams };
+
+const asked: Asked[] = [];
+let answer: Answer = { body: '' };
+
+// A real socket rather than a stubbed fetch: what is under test is reading a response the store
+// holds open, and a stub handing back one whole string never splits a record across two reads.
+const store = Bun.serve({
+  port: 0,
+  async fetch(request) {
+    asked.push({
+      path: new URL(request.url).pathname,
+      form: new URLSearchParams(await request.text()),
+    });
+    const { status = 200, body, chunkAt } = answer;
+    if (chunkAt === undefined) {
+      return new Response(body, { status });
+    }
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const bytes = new TextEncoder().encode(body);
+        controller.enqueue(bytes.slice(0, chunkAt));
+        controller.enqueue(bytes.slice(chunkAt));
+        controller.close();
+      },
+    });
+    return new Response(stream, { status });
+  },
+});
+
+afterAll(() => store.stop(true));
+
+const client = new VictoriaLogsClient(new URL(store.url.toString()));
+
+async function collect(): Promise<LogRow[]> {
+  asked.length = 0;
+  const rows: LogRow[] = [];
+  for await (const row of client.tail.subscribe({
+    query: QUERY,
+    startOffset: START_OFFSET,
+    signal: AbortSignal.timeout(TAIL_TIMEOUT_MS),
+  })) {
+    rows.push(row);
+  }
+  return rows;
+}
+
+describe('the tail endpoint follows a query the store holds open', () => {
+  test('it asks its own path, with the query in the body', async () => {
+    answer = { body: '' };
+    await collect();
+
+    expect(asked[0]?.path).toBe('/select/logsql/tail');
+    expect(asked[0]?.form.get('query')).toBe(QUERY);
+    expect(asked[0]?.form.get('start_offset')).toBe(START_OFFSET);
+  });
+
+  test('each line is a row', async () => {
+    answer = { body: `${jsonLine({ _msg: 'first' })}${jsonLine({ _msg: 'second' })}` };
+
+    expect((await collect()).map((row) => row._msg)).toEqual(['first', 'second']);
+  });
+
+  // The store writes as records arrive, so a record straddling two reads is ordinary.
+  test('a record split across two reads is still one row', async () => {
+    const body = jsonLine({ _msg: 'listening on 0.0.0.0:8090' });
+    answer = { body, chunkAt: Math.floor(body.length / HALF) };
+
+    expect(await collect()).toHaveLength(1);
+  });
+
+  // Ending the stream would take the whole log view down with it, and the reader is watching a
+  // live app rather than auditing the store.
+  test('a line that is not a JSON object is skipped rather than ending the tail', async () => {
+    answer = { body: `not json\n${jsonLine({ _msg: 'kept' })}[1,2]\n` };
+
+    expect((await collect()).map((row) => row._msg)).toEqual(['kept']);
+  });
+
+  test('a store that refuses the query says so rather than reading empty', () => {
+    answer = { status: BAD_REQUEST, body: 'unexpected token' };
+
+    expect(collect()).rejects.toThrow(VictoriaLogsError);
+  });
+});

--- a/apps/api/tests/repositories/logs.test.ts
+++ b/apps/api/tests/repositories/logs.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+import type { AppId, DeploymentId, HostId } from '@repo/protocol';
+import type { TailRequest } from '#lib/victorialogs/client.ts';
+import type { LogRow } from '#lib/victorialogs/parse.ts';
+import { LogsRepository, type TenantLogStore } from '#repositories/logs.repository.ts';
+
+const APP_ID = 'app-1' as AppId;
+const DEPLOYMENT_ID = 'deployment-1' as DeploymentId;
+const HOST_ID = 'host-1' as HostId;
+const START_OFFSET = '5m';
+const DROPPED_BYTES = 4096;
+const TAIL_TIMEOUT_MS = 1_000;
+
+/**
+ * A row as the store hands it over: every value a string, whatever the agent wrote. The client's
+ * own tests cover getting this far; what matters here is what the repository makes of it.
+ */
+function storedRow(overrides: Record<string, string> = {}): LogRow {
+  return {
+    _time: '2026-08-06T09:41:00.123456789Z',
+    _msg: 'listening on 0.0.0.0:8090',
+    hostId: HOST_ID,
+    SOURCE: 'tenant',
+    appId: APP_ID,
+    deploymentId: DEPLOYMENT_ID,
+    stream: 'stdout',
+    sourceId: 'source-1',
+    sequence: '0',
+    ...overrides,
+  };
+}
+
+function store(rows: LogRow[]): TenantLogStore & { asked: TailRequest[] } {
+  const asked: TailRequest[] = [];
+  return {
+    asked,
+    tail: {
+      subscribe(request: TailRequest) {
+        asked.push(request);
+        return (async function* () {
+          yield* rows;
+        })();
+      },
+    },
+  };
+}
+
+async function collect(rows: LogRow[]) {
+  const client = store(rows);
+  const repository = new LogsRepository(client);
+  const records = [];
+  for await (const record of repository.tail({
+    appId: APP_ID,
+    deploymentId: DEPLOYMENT_ID,
+    startOffset: START_OFFSET,
+    signal: AbortSignal.timeout(TAIL_TIMEOUT_MS),
+  })) {
+    records.push(record);
+  }
+  return { records, asked: client.asked };
+}
+
+describe('a tail reads one deployment out of the store', () => {
+  test('the filter names the stream fields before the deployment', async () => {
+    const { asked } = await collect([]);
+
+    expect(asked[0]?.query).toBe(
+      `SOURCE:="tenant" appId:="${APP_ID}" deploymentId:="${DEPLOYMENT_ID}"`,
+    );
+    expect(asked[0]?.startOffset).toBe(START_OFFSET);
+  });
+
+  test('a stored row becomes a record the protocol accepts', async () => {
+    const { records } = await collect([storedRow()]);
+
+    expect(records[0]?.sequence).toBe(0);
+    expect(records[0]?.deploymentId).toBe(DEPLOYMENT_ID);
+    expect(records[0]?._msg).toBe('listening on 0.0.0.0:8090');
+  });
+
+  test('a gap keeps the byte count it reports as a number', async () => {
+    const { records } = await collect([
+      storedRow({ droppedBytes: String(DROPPED_BYTES), stream: 'stderr' }),
+    ]);
+
+    expect(records[0]?.droppedBytes).toBe(DROPPED_BYTES);
+  });
+
+  // The schema is what would catch a field renamed on the writing side, and the reader is
+  // watching a live app rather than auditing the store — so it drops the row and carries on.
+  test('a row the protocol does not recognise is skipped rather than ending the tail', async () => {
+    const { hostId: _hostId, ...missingAField } = storedRow();
+    const { records } = await collect([missingAField, storedRow()]);
+
+    expect(records).toHaveLength(1);
+  });
+});

--- a/apps/api/tests/services/logs.test.ts
+++ b/apps/api/tests/services/logs.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import type { TenantLogRecord } from '@repo/protocol';
+import { NotFoundError } from '#lib/errors.ts';
+import type { DeploymentByIdInput, DeploymentRow } from '#repositories/deployments.repository.ts';
+import type { LogsRepositoryContract, TenantLogTail } from '#repositories/logs.repository.ts';
+import { type DeploymentLookup, LogsService } from '#services/logs.service.ts';
+import {
+  APP_ID,
+  DEPLOYMENT_ID,
+  OTHER_OWNER_ID,
+  OWNER_ID,
+} from '#tests/services/support/fixtures.ts';
+
+const START_OFFSET = '5m';
+const OPEN_TIMEOUT_MS = 1_000;
+
+const OWNED: DeploymentByIdInput = {
+  appId: APP_ID,
+  deploymentId: DEPLOYMENT_ID,
+  ownerId: OWNER_ID,
+};
+
+/** What the store hands back is the repository's business; this service only decides who may ask. */
+const NO_RECORDS: AsyncIterable<TenantLogRecord> = {
+  [Symbol.asyncIterator]() {
+    return { next: () => Promise.resolve({ done: true, value: undefined }) };
+  },
+};
+
+// The row's contents are never read — only whether there was one — so this is the whole of what
+// the service asks Postgres for.
+const A_ROW = {} as DeploymentRow;
+
+function deployments(
+  row: DeploymentRow | null,
+): DeploymentLookup & { asked: DeploymentByIdInput[] } {
+  const asked: DeploymentByIdInput[] = [];
+  return {
+    asked,
+    findById(input) {
+      asked.push(input);
+      return Promise.resolve(row);
+    },
+  };
+}
+
+function logs(): LogsRepositoryContract & { asked: TenantLogTail[] } {
+  const asked: TenantLogTail[] = [];
+  return {
+    asked,
+    tail(input) {
+      asked.push(input);
+      return NO_RECORDS;
+    },
+  };
+}
+
+function service({ row }: { row: DeploymentRow | null }) {
+  const deploymentsRepo = deployments(row);
+  const logsRepo = logs();
+  return {
+    logsRepo,
+    deploymentsRepo,
+    logsService: new LogsService({ logsRepo, deploymentsRepo }),
+  };
+}
+
+function open({
+  subject,
+  ownerId = OWNER_ID,
+}: {
+  subject: ReturnType<typeof service>;
+  ownerId?: typeof OWNER_ID;
+}) {
+  return subject.logsService.openTail({
+    appId: APP_ID,
+    deploymentId: DEPLOYMENT_ID,
+    ownerId,
+    startOffset: START_OFFSET,
+    signal: AbortSignal.timeout(OPEN_TIMEOUT_MS),
+  });
+}
+
+describe('reading a deployment logs is asking whether you own it', () => {
+  test('an owned deployment opens a tail filtered to itself', async () => {
+    const subject = service({ row: A_ROW });
+
+    await open({ subject });
+
+    expect(subject.deploymentsRepo.asked).toEqual([OWNED]);
+    expect(subject.logsRepo.asked[0]).toMatchObject({
+      appId: APP_ID,
+      deploymentId: DEPLOYMENT_ID,
+      startOffset: START_OFFSET,
+    });
+  });
+
+  // A deployment the caller cannot see must not be confirmed to exist, so the store is never
+  // reached — not merely filtered on the way out.
+  test('a deployment the caller does not own is a 404 the store never hears about', async () => {
+    const subject = service({ row: null });
+
+    await expect(open({ subject, ownerId: OTHER_OWNER_ID })).rejects.toThrow(NotFoundError);
+    expect(subject.logsRepo.asked).toHaveLength(0);
+  });
+
+  // Scoped in the query rather than compared afterwards, like every other read of a tenant row.
+  test('ownership travels into the lookup', async () => {
+    const subject = service({ row: A_ROW });
+
+    await open({ subject });
+
+    expect(subject.deploymentsRepo.asked[0]?.ownerId).toBe(OWNER_ID);
+  });
+});


### PR DESCRIPTION
Adds `GET /api/apps/:appId/deployments/:deploymentId/logs` as SSE, reading the adjacent VictoriaLogs container over its own `/select/logsql/tail`. `?startOffset=5m` gives history and follow in one request; the tail is capped at 15 minutes so the authorization decision taken at open can't outlive the stream.

Two details the repository exists to absorb: the store keeps every field as a string whatever it was ingested as, so `sequence` comes back as text; and a record is skipped rather than throwing, because one malformed line must not end a live tail. There's no counter on those skips — worth a metric if it should be visible.

`tail` takes no `limit`, so a chatty app is bounded only by the duration cap and the client's buffer.