### PR TITLE
fix(api): deleting an app reclaims the filesystem it was using

### DIFF
--- a/apps/agent/src/lib/reconcile/plan.ts
+++ b/apps/agent/src/lib/reconcile/plan.ts
@@ -25,6 +25,7 @@ export type ObservedInstance = {
 
 export type ObservedVolume = {
   readonly volumeId: VolumeId;
+  readonly appId: AppId;
   readonly attached: boolean;
   readonly sizeBytes: number;
   readonly storagePrefix: ObjectKey;

--- a/apps/agent/src/lib/reconcile/volumes.ts
+++ b/apps/agent/src/lib/reconcile/volumes.ts
@@ -16,6 +16,7 @@ const provision = (desired: DesiredVolume) =>
           Effect.annotateLogs({ volumeId: desired.volumeId }),
           Effect.as({
             volumeId: desired.volumeId,
+            appId: desired.appId,
             state: 'failed',
             sizeBytes: desired.sizeBytes,
             message: reportedMessage(error),

--- a/apps/agent/src/lib/volumes/manager.ts
+++ b/apps/agent/src/lib/volumes/manager.ts
@@ -8,6 +8,7 @@ import type { ObservedVolume } from '#lib/reconcile/plan.ts';
 export function toReportedVolume(observed: ObservedVolume): ReportedVolume {
   return {
     volumeId: observed.volumeId,
+    appId: observed.appId,
     state: observed.attached ? 'ready' : 'detached',
     sizeBytes: observed.sizeBytes,
     storagePrefix: observed.storagePrefix,

--- a/apps/agent/src/services/volume-manager.service.ts
+++ b/apps/agent/src/services/volume-manager.service.ts
@@ -43,10 +43,12 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
     const observeFile = ({
       filesystem,
       volumeId,
+      appId,
       slot,
     }: {
       filesystem: ZerofsFilesystem;
       volumeId: VolumeId;
+      appId: AppId;
       slot: Option.Option<AppSlot>;
     }) =>
       Effect.gen(function* () {
@@ -57,6 +59,7 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
         const attached = Option.isSome(slot) ? yield* isAttached(slot.value.nbdDevicePath) : false;
         return Option.some<ObservedVolume>({
           volumeId,
+          appId,
           sizeBytes: sizeBytes.value,
           storagePrefix: filesystem.storagePrefix,
           attached,
@@ -81,10 +84,19 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
               ),
               Effect.orElseSucceed(() => [] as string[]),
             );
+            // A device file with no app is one this agent has lost its record of. Reporting it
+            // under a guessed app would be worse than leaving it out: the control plane reads
+            // these to decide a tenant's filesystem is gone.
             const observed = yield* Effect.forEach(names, (name) =>
-              Effect.flatMap(slotFor({ volumeId: name as VolumeId, appIdByVolume }), (slot) =>
-                observeFile({ filesystem, volumeId: name as VolumeId, slot }),
-              ),
+              Effect.gen(function* () {
+                const volumeId = name as VolumeId;
+                const appId = appIdByVolume.get(volumeId);
+                if (appId === undefined) {
+                  return Option.none<ObservedVolume>();
+                }
+                const slot = yield* slotFor({ volumeId, appIdByVolume });
+                return yield* observeFile({ filesystem, volumeId, appId, slot });
+              }),
             );
             return Arr.getSomes(observed);
           }),
@@ -116,6 +128,7 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
 
       return {
         volumeId: desired.volumeId,
+        appId: desired.appId,
         state: 'ready',
         sizeBytes,
         devicePath: slot.nbdDevicePath,
@@ -141,9 +154,12 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
         { force: true },
       );
       yield* allocator.release(desired.appId);
+      // `deleted` rather than `deleting`: everything above has already happened, and the control
+      // plane finishes deleting the app on the strength of this.
       return {
         volumeId: desired.volumeId,
-        state: 'deleting',
+        appId: desired.appId,
+        state: 'deleted',
         sizeBytes: EMPTY_SIZE,
       } satisfies ReportedVolume;
     });

--- a/apps/agent/tests/lib/report/build-report.test.ts
+++ b/apps/agent/tests/lib/report/build-report.test.ts
@@ -101,7 +101,9 @@ describe('the assembled report satisfies the protocol', () => {
       },
       versions: { agent: 'sha', guestImage: '6.1', zerofs: '2.2.1', firecracker: '1.16.1' },
       records: [record({ startedAt: OBSERVED_AT })],
-      volumes: [{ volumeId: VOLUME_ID, state: 'ready', sizeBytes: VOLUME_SIZE_BYTES }],
+      volumes: [
+        { volumeId: VOLUME_ID, appId: APP_ID, state: 'ready', sizeBytes: VOLUME_SIZE_BYTES },
+      ],
       checkpoints: [],
       exports: [
         {

--- a/apps/agent/tests/lib/volumes/manager.test.ts
+++ b/apps/agent/tests/lib/volumes/manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { toReportedVolume } from '#lib/volumes/manager.ts';
 import { HOST_STORAGE_PREFIX } from '#tests/support/config.ts';
-import { observedVolume, VOLUME_ID, VOLUME_SIZE_BYTES } from '#tests/support/fixtures.ts';
+import { APP_ID, observedVolume, VOLUME_ID, VOLUME_SIZE_BYTES } from '#tests/support/fixtures.ts';
 
 describe('a volume reports itself from having been found', () => {
   // The regression: reports used to accumulate from provisioning, so a volume nobody touched
@@ -9,6 +9,7 @@ describe('a volume reports itself from having been found', () => {
   test('a healthy volume is reportable without anything having provisioned it', () => {
     expect(toReportedVolume(observedVolume())).toEqual({
       volumeId: VOLUME_ID,
+      appId: APP_ID,
       state: 'ready',
       sizeBytes: VOLUME_SIZE_BYTES,
       storagePrefix: HOST_STORAGE_PREFIX,

--- a/apps/agent/tests/support/fixtures.ts
+++ b/apps/agent/tests/support/fixtures.ts
@@ -125,6 +125,7 @@ export function observedInstance(overrides: Partial<ObservedInstance> = {}): Obs
 export function observedVolume(overrides: Partial<ObservedVolume> = {}): ObservedVolume {
   return {
     volumeId: VOLUME_ID,
+    appId: APP_ID,
     attached: true,
     sizeBytes: VOLUME_SIZE_BYTES,
     storagePrefix: HOST_STORAGE_PREFIX,

--- a/apps/api/src/db/migrations/0011_create_nibrun_desired_volumes.sql
+++ b/apps/api/src/db/migrations/0011_create_nibrun_desired_volumes.sql
@@ -1,0 +1,13 @@
+-- A filesystem outlives the deployments that ran against it, so this is anchored on the app
+-- having ever been deployed rather than on it running now: an app whose every deployment failed
+-- keeps its data, and so does one nobody has redeployed in a year.
+--
+-- `deleting` is the only state that produces an `absent`, and an app stays here while it does —
+-- a host is told to remove a filesystem by being told to, never by an app quietly dropping out
+-- of a list. `deleted` leaves, because by then the host has said it is gone.
+
+CREATE VIEW nibrun.desired_volumes AS
+  SELECT a.id AS app_id, a.state
+  FROM nibrun.apps a
+  WHERE a.state <> 'deleted'
+    AND EXISTS (SELECT 1 FROM nibrun.deployments d WHERE d.app_id = a.id);

--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -30,6 +30,12 @@ export interface ISelectDesiredDeploymentsResult {
     restart_reset_after_ms: number;
 }
 
+/** Result of query `SelectDesiredVolumes`. */
+export interface ISelectDesiredVolumesResult {
+    app_id: import("@repo/protocol").AppId;
+    state: import("@repo/protocol").AppState;
+}
+
 /** Result of query `SelectDesiredHostnames`. */
 export interface ISelectDesiredHostnamesResult {
     app_id: import("@repo/protocol").AppId;
@@ -197,6 +203,11 @@ export interface ITouchAppAfterConfigPatchResult {
     restart_max_backoff_ms: number;
     restart_backoff_factor: number;
     restart_reset_after_ms: number;
+}
+
+/** Result of query `FinishDeletingApp`. */
+export interface IFinishDeletingAppResult {
+    id: import("@repo/protocol").AppId;
 }
 
 /** Result of query `UpdateAppState`. */
@@ -403,6 +414,7 @@ export interface ISelectHealthPingResult {
 
 export interface Queries {
     SelectDesiredDeployments: ISelectDesiredDeploymentsResult;
+    SelectDesiredVolumes: ISelectDesiredVolumesResult;
     SelectDesiredHostnames: ISelectDesiredHostnamesResult;
     SelectAppOwnership: ISelectAppOwnershipResult;
     InsertApp: IInsertAppResult;
@@ -417,6 +429,7 @@ export interface Queries {
     SelectCurrentAppConfig: ISelectCurrentAppConfigResult;
     InsertPatchedAppConfig: IInsertPatchedAppConfigResult;
     TouchAppAfterConfigPatch: ITouchAppAfterConfigPatchResult;
+    FinishDeletingApp: IFinishDeletingAppResult;
     UpdateAppState: IUpdateAppStateResult;
     SelectAppAfterStateChange: ISelectAppAfterStateChangeResult;
     InsertArtifact: IInsertArtifactResult;

--- a/apps/api/src/lib/deployments/desired-state.ts
+++ b/apps/api/src/lib/deployments/desired-state.ts
@@ -13,6 +13,8 @@ export type DesiredDeploymentRow = Queries['SelectDesiredDeployments'];
 
 export type DesiredHostnameRow = Queries['SelectDesiredHostnames'];
 
+export type DesiredVolumeRow = Queries['SelectDesiredVolumes'];
+
 /**
  * The app's own id, because an app has one filesystem and the two never differ. Kept a type apart
  * so an app holding a second one later is a schema change rather than a wire change.
@@ -22,16 +24,16 @@ function volumeIdOf(appId: AppId): VolumeId {
 }
 
 /**
- * Always `present`. A suspended app keeps its filesystem — that is what suspending it means —
- * and removing one is the business of deleting the app, which says `absent` deliberately rather
- * than by leaving a volume out of a list.
+ * A suspended app keeps its filesystem — that is what suspending it means — so deleting the app
+ * is the only thing that asks for one to go, and it asks by saying so. A volume is never removed
+ * by falling out of a list.
  */
-export function toDesiredVolume(row: DesiredDeploymentRow): DesiredVolume {
+export function toDesiredVolume(row: DesiredVolumeRow): DesiredVolume {
   return {
     volumeId: volumeIdOf(row.app_id),
     appId: row.app_id,
     sizeBytes: VOLUME_SIZE_BYTES,
-    desiredState: 'present',
+    desiredState: row.state === 'deleting' ? 'absent' : 'present',
   };
 }
 

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -50,6 +50,9 @@ export class AgentRepository extends Repository implements AgentRepositoryContra
              restart_backoff_factor, restart_reset_after_ms
       FROM nibrun.desired_deployments
     `;
+    const volumes = await this.sql.SelectDesiredVolumes`
+      SELECT app_id, state FROM nibrun.desired_volumes
+    `;
     const hostnames = hostnamesByApp(
       await this.sql.SelectDesiredHostnames`
         SELECT app_id, hostname, kind FROM nibrun.desired_hostnames
@@ -58,7 +61,7 @@ export class AgentRepository extends Repository implements AgentRepositoryContra
 
     return {
       hostId,
-      volumes: deployments.map(toDesiredVolume),
+      volumes: volumes.map(toDesiredVolume),
       instances: deployments.map((row) => toDesiredInstance({ row, hostnames })),
       checkpoints: [],
       exports: [],

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -24,6 +24,7 @@ export abstract class AppsRepositoryContract {
   abstract listHostnamesByApp(input: OwnedApp): Promise<AppHostnameRow[]>;
   abstract updateConfig(input: OwnedApp & { patch: AppConfigPatch }): Promise<AppRow | null>;
   abstract updateState(input: OwnedApp & { state: AppState }): Promise<AppRow | null>;
+  abstract finishDeleting(input: { appId: AppId }): Promise<boolean>;
   abstract isOwnedBy(input: OwnedApp): Promise<boolean>;
 }
 
@@ -250,6 +251,23 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
       `;
       return app ?? null;
     });
+  }
+
+  /**
+   * The fleet's view rather than an owner's, so there is no `ownerId` to scope on: an app is
+   * deleted once the host holding its filesystem says the filesystem is gone.
+   *
+   * `state = 'deleting'` in the predicate rather than around it. A host reports the same volume
+   * every heartbeat until desired state stops mentioning it, so this is asked many times for one
+   * deletion, and what comes back says which of them was the one that finished it.
+   */
+  async finishDeleting({ appId }: { appId: AppId }): Promise<boolean> {
+    const rows = await this.sql.FinishDeletingApp`
+      UPDATE nibrun.apps SET state = 'deleted'
+      WHERE id = ${appId} AND state = 'deleting'
+      RETURNING id
+    `;
+    return rows.length > 0;
   }
 
   updateState({ appId, ownerId, state }: OwnedApp & { state: AppState }) {

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@repo/protocol';
 import { UnauthorizedError } from '#lib/errors.ts';
 import type { AgentRepositoryContract } from '#repositories/agent.repository.ts';
+import type { AppsService } from '#services/apps.service.ts';
 import type { DeploymentsService } from '#services/deployments.service.ts';
 import { Service } from '#services/service.ts';
 
@@ -20,17 +21,21 @@ const SESSION_LIFETIME_MS = SECONDS_PER_HOUR * MS_PER_SECOND;
 export class AgentService extends Service {
   private readonly agentRepo: AgentRepositoryContract;
   private readonly deploymentsService: DeploymentsService;
+  private readonly appsService: AppsService;
 
   constructor({
     agentRepo,
     deploymentsService,
+    appsService,
   }: {
     agentRepo: AgentRepositoryContract;
     deploymentsService: DeploymentsService;
+    appsService: AppsService;
   }) {
     super();
     this.agentRepo = agentRepo;
     this.deploymentsService = deploymentsService;
+    this.appsService = appsService;
   }
 
   /**
@@ -79,9 +84,12 @@ export class AgentService extends Service {
   }
 
   /**
-   * Only what the report says about deployments is kept. Capacity, versions and the host's own
-   * state have no table to land in while hosts are not modelled, and holding them in this process
-   * would be a second source of truth to unpick once they do.
+   * Read by the two things that own what it talks about: the releases running on the host, and
+   * the apps whose filesystems it is holding or has just let go of.
+   *
+   * The rest is dropped. Capacity, versions and the host's own state have no table to land in
+   * while hosts are not modelled, and holding them in this process would be a second source of
+   * truth to unpick once they do.
    */
   async acceptReport({ reported }: { reported: HostReportedState }): Promise<void> {
     this.logger.info('host reported', {
@@ -91,5 +99,6 @@ export class AgentService extends Service {
       volumes: reported.volumes.length,
     });
     await this.deploymentsService.applyHostReport({ reported });
+    await this.appsService.completeDeletions({ volumes: reported.volumes });
   }
 }

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -1,4 +1,4 @@
-import type { App, AppHostname, AppId, OwnerId } from '@repo/protocol';
+import type { App, AppHostname, AppId, OwnerId, ReportedVolume } from '@repo/protocol';
 import {
   type AppConfigPatch,
   configWithDefaults,
@@ -117,6 +117,25 @@ export class AppsService extends Service {
    * The row stays behind: tearing an app down is the agent's work, the owner follows it through
    * this same state, and the slug must never be handed to a second app whatever happens.
    */
+  /**
+   * Deleting an app finishes on the host that held its data. Until a host says the filesystem is
+   * gone the app stays `deleting`, because the alternative is calling it deleted while a tenant's
+   * bytes are still on a disk somewhere.
+   *
+   * Read off the volumes rather than their absence: a report that lost some would otherwise
+   * delete the apps it forgot to mention.
+   */
+  async completeDeletions({ volumes }: { volumes: readonly ReportedVolume[] }): Promise<void> {
+    for (const volume of volumes) {
+      if (volume.state !== 'deleted') {
+        continue;
+      }
+      if (await this.appsRepo.finishDeleting({ appId: volume.appId })) {
+        this.logger.info('app deleted', { appId: volume.appId, volumeId: volume.volumeId });
+      }
+    }
+  }
+
   async delete({ appId, ownerId }: OwnedApp): Promise<PublicApp> {
     const app = requireApp(await this.appsRepo.updateState({ appId, ownerId, state: 'deleting' }));
     const hostnames = await this.appsRepo.listHostnamesByApp({ appId, ownerId });

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -29,14 +29,18 @@ const deploymentsRepository = new DeploymentsRepository(sql);
 const artifactStorageRepository = new ArtifactStorageRepository(s3);
 
 const deploymentsService = new DeploymentsService({ deploymentsRepo: deploymentsRepository });
-const agentService = new AgentService({ agentRepo: agentRepository, deploymentsService });
-const assetsService = new AssetsService(assetsRepository);
-const healthService = new HealthService(healthRepository);
-const filesystemService = new FilesystemService({ filesystemRepo: filesystemRepository });
 const appsService = new AppsService({
   appsRepo: appsRepository,
   appHostDomain: env.APP_HOST_DOMAIN,
 });
+const agentService = new AgentService({
+  agentRepo: agentRepository,
+  deploymentsService,
+  appsService,
+});
+const assetsService = new AssetsService(assetsRepository);
+const healthService = new HealthService(healthRepository);
+const filesystemService = new FilesystemService({ filesystemRepo: filesystemRepository });
 const artifactsService = new ArtifactsService({
   artifactsRepo: artifactsRepository,
   storageRepo: artifactStorageRepository,

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -4,11 +4,13 @@ import type {
   HostDesiredState,
   HostId,
   HostReportedState,
+  ReportedVolume,
   SecretString,
 } from '@repo/protocol';
 import { UnauthorizedError } from '#lib/errors.ts';
 import type { AgentRepositoryContract } from '#repositories/agent.repository.ts';
 import { AgentService } from '#services/agent.service.ts';
+import type { AppsService } from '#services/apps.service.ts';
 import type { DeploymentsService } from '#services/deployments.service.ts';
 
 const SESSION_REQUEST = {
@@ -45,6 +47,15 @@ class FakeAgentRepository implements AgentRepositoryContract {
   }
 }
 
+class FakeAppsService {
+  readonly volumes: ReportedVolume[][] = [];
+
+  completeDeletions({ volumes }: { volumes: readonly ReportedVolume[] }): Promise<void> {
+    this.volumes.push([...volumes]);
+    return Promise.resolve();
+  }
+}
+
 class FakeDeploymentsService {
   readonly reports: HostReportedState[] = [];
 
@@ -56,11 +67,14 @@ class FakeDeploymentsService {
 
 function build() {
   const deployments = new FakeDeploymentsService();
+  const apps = new FakeAppsService();
   return {
+    apps,
     deployments,
     service: new AgentService({
       agentRepo: new FakeAgentRepository(),
       deploymentsService: deployments as unknown as DeploymentsService,
+      appsService: apps as unknown as AppsService,
     }),
   };
 }

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from 'bun:test';
-import type { AppId, AppState, DnsLabel, Hostname, OwnerId } from '@repo/protocol';
+import type {
+  AppId,
+  AppState,
+  DnsLabel,
+  Hostname,
+  OwnerId,
+  ReportedVolume,
+  VolumeId,
+} from '@repo/protocol';
 import { SQL } from 'bun';
 import type { AppConfigPatch, PublicAppConfig } from '#lib/app-config.ts';
 import { ConflictError, NotFoundError } from '#lib/errors.ts';
@@ -52,12 +60,24 @@ function appRow(slug: DnsLabel): AppRow {
 class StubAppsRepository implements AppsRepositoryContract {
   readonly offeredSlugs: DnsLabel[] = [];
   readonly offeredConfigs: PublicAppConfig[] = [];
+  readonly deleted: AppId[] = [];
+  deleting: AppId[] = [];
+  owns = false;
   #remainingFailures: number;
   readonly #failure: unknown;
 
   constructor({ failures, failure }: { failures: number; failure?: unknown }) {
     this.#remainingFailures = failures;
     this.#failure = failure;
+  }
+
+  finishDeleting({ appId }: { appId: AppId }): Promise<boolean> {
+    if (!this.deleting.includes(appId)) {
+      return Promise.resolve(false);
+    }
+    this.deleting = this.deleting.filter((id) => id !== appId);
+    this.deleted.push(appId);
+    return Promise.resolve(true);
   }
 
   create({
@@ -110,10 +130,19 @@ class StubAppsRepository implements AppsRepositoryContract {
     return Promise.resolve(null);
   }
 
-  updateState(_: { appId: AppId; ownerId: OwnerId; state: AppState }): Promise<AppRow | null> {
-    return Promise.resolve(null);
+  updateState({
+    state,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    state: AppState;
+  }): Promise<AppRow | null> {
+    return Promise.resolve(this.owns ? { ...appRow(APP_NAME as DnsLabel), state } : null);
   }
 }
+
+const VOLUME_ID = APP_ID as string as VolumeId;
+const NO_BYTES = 0;
 
 function serviceWith(appsRepo: AppsRepositoryContract) {
   return new AppsService({ appsRepo, appHostDomain: APP_HOST_DOMAIN });
@@ -241,5 +270,71 @@ describe('an app the caller does not own is one that does not exist', () => {
       NotFoundError,
     );
     await expect(service.delete(owned)).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+/**
+ * Deleting is asked for here and finished on the host that holds the data, so nothing below
+ * calls an app deleted while a tenant's bytes are still on a disk somewhere.
+ */
+describe('an app is deleted when its filesystem is gone, not when it is asked for', () => {
+  function reportedVolume(state: ReportedVolume['state']): ReportedVolume {
+    return { volumeId: VOLUME_ID, appId: APP_ID, state, sizeBytes: NO_BYTES };
+  }
+
+  test('asking leaves the app deleting rather than deleted', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.owns = true;
+
+    const app = await serviceWith(appsRepo).delete({ appId: APP_ID, ownerId: OWNER_ID });
+
+    expect(app.state).toBe('deleting');
+    expect(appsRepo.deleted).toEqual([]);
+  });
+
+  test('a host saying the filesystem is gone is what finishes it', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.deleting = [APP_ID];
+
+    await serviceWith(appsRepo).completeDeletions({ volumes: [reportedVolume('deleted')] });
+
+    expect(appsRepo.deleted).toEqual([APP_ID]);
+  });
+
+  // A volume the host still holds is one whose app is not deleted, however long it has been
+  // asked for — `deleting` on the app is a request, not an outcome.
+  const held: ReportedVolume['state'][] = ['ready', 'detached', 'pending', 'failed'];
+  for (const state of held) {
+    test(`a volume the host reports as ${state} leaves the app where it is`, async () => {
+      const appsRepo = new StubAppsRepository({ failures: 0 });
+      appsRepo.deleting = [APP_ID];
+
+      await serviceWith(appsRepo).completeDeletions({ volumes: [reportedVolume(state)] });
+
+      expect(appsRepo.deleted).toEqual([]);
+    });
+  }
+
+  // The host keeps reporting the volume until desired state stops naming it, so this arrives
+  // many times for one deletion.
+  test('the same report arriving again deletes nothing a second time', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.deleting = [APP_ID];
+    const apps = serviceWith(appsRepo);
+
+    await apps.completeDeletions({ volumes: [reportedVolume('deleted')] });
+    await apps.completeDeletions({ volumes: [reportedVolume('deleted')] });
+
+    expect(appsRepo.deleted).toEqual([APP_ID]);
+  });
+
+  // Nothing asked for this one to go, so a host that lost a filesystem must not be able to
+  // delete the app that owns it.
+  test('an app nobody asked to delete survives its volume going missing', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+
+    await serviceWith(appsRepo).completeDeletions({ volumes: [reportedVolume('deleted')] });
+
+    expect(appsRepo.deleted).toEqual([]);
   });
 });

--- a/packages/protocol/src/control/reported-state.ts
+++ b/packages/protocol/src/control/reported-state.ts
@@ -48,6 +48,7 @@ export type ReportedInstance = typeof ReportedInstanceSchema.static;
 
 export const ReportedVolumeSchema = Type.Object({
   volumeId: VolumeIdSchema,
+  appId: AppIdSchema,
   state: VolumeStateSchema,
   sizeBytes: ByteSizeSchema,
   // Which ZeroFS filesystem the host put it in.

--- a/packages/protocol/src/domain/volume.ts
+++ b/packages/protocol/src/domain/volume.ts
@@ -3,7 +3,9 @@ import { AppIdSchema, VolumeIdSchema } from '#domain/identifiers.ts';
 import { stringEnum } from '#lib/string-enum.ts';
 import { ByteSizeSchema, ObjectKeySchema, TimestampSchema } from '#lib/wire.ts';
 
-export const VOLUME_STATES = ['pending', 'ready', 'detached', 'deleting', 'failed'] as const;
+// `deleted` is reported once the filesystem is actually gone, which is what lets the control
+// plane finish deleting an app rather than leave it saying `deleting` forever.
+export const VOLUME_STATES = ['pending', 'ready', 'detached', 'deleted', 'failed'] as const;
 
 export const VolumeStateSchema = stringEnum(VOLUME_STATES);
 


### PR DESCRIPTION
`delete` set the app to `deleting` and nothing carried it further — the microVM stopped, but the volume was never told `absent`, the app never reached `deleted`, and every owner-facing read went on finding it.

**The filesystem**

- **`nibrun.desired_volumes`**, a view of its own. Anchored on the app having ever been deployed rather than on it running now, so a broken deploy cannot cost a tenant their data, and an app being deleted stays in desired state long enough to be told `absent`.
- **A host can say the filesystem is gone.** `VOLUME_STATES` had no terminal member — teardown reported `deleting` *after* it had finished, a name that lies and a signal the api cannot act on. Renamed to `deleted`; nothing else ever reported the old one.
- **`ReportedVolume` carries `appId`**, as `DesiredVolume` already does, so the api reads which app a filesystem belonged to rather than reversing the id rule.
- **`AppsService.completeDeletions`** moves `deleting → deleted`, guarded by `AND state = 'deleting'` in the statement — a host reports the same volume every heartbeat, so this is asked many times and only one of them can be the one that finished it.

**The app**

- **`nibrun.live_apps`** holds the predicate once. Every owner-scoped statement reads it, so one naming `nibrun.apps` instead is visibly reaching past it — which the fleet's reads and the writes moving an app between states do on purpose. Columns rather than `*`, so a column added to `apps` later goes missing loudly rather than silently.
- **Deleting twice is refused.** Without the guard a second `DELETE` put a finished deletion back to `deleting`, and the fleet would provision the filesystem all over again.

Deletion takes two reconcile passes: the volume plan is computed against the instance still being observed, so the first defers it as `blocked` and `deferredWork` brings the second. ≤2s at the current poll interval.

Verified against Postgres 18 — the six lifecycle states, `FOR UPDATE` through `live_apps`, and a deleted app leaving every owner-facing read. The SQL predicates are covered by that probe rather than by tests: api tests point Postgres at a closed port, so nothing in `tests/` reaches a query.

An app keeps its slug and hostname after deletion, so the name is held rather than freed for reuse.