### PR TITLE
fix(api): an app its owner deleted is one they cannot name again

### DIFF
--- a/apps/api/src/db/migrations/0012_create_nibrun_live_apps.sql
+++ b/apps/api/src/db/migrations/0012_create_nibrun_live_apps.sql
@@ -1,0 +1,11 @@
+-- An app its owner deleted and a host confirmed gone is one they cannot name again, so every
+-- statement resolving an app for its owner reads this rather than the table. The predicate lives
+-- in one place, and a statement naming `nibrun.apps` instead is visibly reaching past it — which
+-- is what the fleet's own reads and the writes that move an app between states do on purpose.
+--
+-- Columns rather than `*`: a view built from `*` fixes its shape when it is created, so a column
+-- added to `apps` later would go missing here rather than appear.
+CREATE VIEW nibrun.live_apps AS
+  SELECT id, owner_id, slug, state, created_at, updated_at
+  FROM nibrun.apps
+  WHERE state <> 'deleted';

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -34,7 +34,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
   async isOwnedBy({ appId, ownerId }: OwnedApp): Promise<boolean> {
     const [row] = await this.sql.SelectAppOwnership`
       SELECT a.id
-      FROM nibrun.apps a
+      FROM nibrun.live_apps a
       WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
     `;
     return row !== undefined;
@@ -100,7 +100,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
                c.health_check_unhealthy_threshold,
                c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
                c.restart_backoff_factor, c.restart_reset_after_ms
-        FROM nibrun.apps a
+        FROM nibrun.live_apps a
         JOIN LATERAL (
           SELECT * FROM nibrun.app_configs c
           WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1
@@ -125,7 +125,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
              c.health_check_unhealthy_threshold,
              c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
              c.restart_backoff_factor, c.restart_reset_after_ms
-      FROM nibrun.apps a
+      FROM nibrun.live_apps a
       JOIN LATERAL (
         SELECT * FROM nibrun.app_configs c
         WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1
@@ -139,7 +139,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
     return this.sql.SelectAppHostnamesByOwner`
       SELECT h.app_id, h.hostname, h.kind
       FROM nibrun.app_hostnames h
-      JOIN nibrun.apps a ON a.id = h.app_id
+      JOIN nibrun.live_apps a ON a.id = h.app_id
       WHERE a.owner_id = ${ownerId}
       ORDER BY h.app_id, h.hostname
     `;
@@ -155,7 +155,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
              c.health_check_unhealthy_threshold,
              c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
              c.restart_backoff_factor, c.restart_reset_after_ms
-      FROM nibrun.apps a
+      FROM nibrun.live_apps a
       JOIN LATERAL (
         SELECT * FROM nibrun.app_configs c
         WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1
@@ -169,7 +169,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
     return this.sql.SelectAppHostnamesByApp`
       SELECT h.hostname, h.kind
       FROM nibrun.app_hostnames h
-      JOIN nibrun.apps a ON a.id = h.app_id
+      JOIN nibrun.live_apps a ON a.id = h.app_id
       WHERE h.app_id = ${appId} AND a.owner_id = ${ownerId}
       ORDER BY h.hostname
     `;
@@ -182,7 +182,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
     return this.sql.begin(async (tx) => {
       const [locked] = await tx.SelectAppForConfigUpdate`
         SELECT a.id
-        FROM nibrun.apps a
+        FROM nibrun.live_apps a
         WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
         FOR UPDATE
       `;
@@ -275,7 +275,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
       const [updated] = await tx.UpdateAppState`
         UPDATE nibrun.apps
         SET state = ${state}
-        WHERE id = ${appId} AND owner_id = ${ownerId}
+        WHERE id = ${appId} AND owner_id = ${ownerId} AND state <> 'deleted'
         RETURNING id
       `;
       if (!updated) {
@@ -291,7 +291,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
                c.health_check_unhealthy_threshold,
                c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
                c.restart_backoff_factor, c.restart_reset_after_ms
-        FROM nibrun.apps a
+        FROM nibrun.live_apps a
         JOIN LATERAL (
           SELECT * FROM nibrun.app_configs c
           WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1

--- a/apps/api/src/repositories/artifacts.repository.ts
+++ b/apps/api/src/repositories/artifacts.repository.ts
@@ -36,7 +36,7 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
       /* @notNull created_at */
       INSERT INTO nibrun.artifacts (app_id, digest, size_bytes, object_key, original_file_name)
       SELECT a.id, ${digest}, ${sizeBytes}, ${objectKey}, ${originalFileName}
-      FROM nibrun.apps a
+      FROM nibrun.live_apps a
       WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
       RETURNING id, app_id, digest, size_bytes, object_key, original_file_name, created_at
     `;
@@ -49,7 +49,7 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
       SELECT ar.id, ar.app_id, ar.digest, ar.size_bytes, ar.object_key, ar.original_file_name,
              ar.created_at
       FROM nibrun.artifacts ar
-      JOIN nibrun.apps a ON a.id = ar.app_id
+      JOIN nibrun.live_apps a ON a.id = ar.app_id
       WHERE ar.app_id = ${appId} AND a.owner_id = ${ownerId}
       ORDER BY ar.id DESC
     `;
@@ -69,7 +69,7 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
       SELECT ar.id, ar.app_id, ar.digest, ar.size_bytes, ar.object_key, ar.original_file_name,
              ar.created_at
       FROM nibrun.artifacts ar
-      JOIN nibrun.apps a ON a.id = ar.app_id
+      JOIN nibrun.live_apps a ON a.id = ar.app_id
       WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.owner_id = ${ownerId}
     `;
     return row ?? null;

--- a/apps/api/src/repositories/deployments.repository.ts
+++ b/apps/api/src/repositories/deployments.repository.ts
@@ -79,7 +79,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
       const [deployable] = await tx.SelectDeployableArtifact`
         SELECT ar.id
         FROM nibrun.artifacts ar
-        JOIN nibrun.apps a ON a.id = ar.app_id
+        JOIN nibrun.live_apps a ON a.id = ar.app_id
         WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.owner_id = ${ownerId}
       `;
       if (!deployable) {
@@ -92,7 +92,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
       const [inserted] = await tx.InsertDeployment`
         INSERT INTO nibrun.deployments (app_id, artifact_id, config_id)
         SELECT a.id, ar.id, c.id
-        FROM nibrun.apps a
+        FROM nibrun.live_apps a
         JOIN nibrun.artifacts ar ON ar.app_id = a.id
         JOIN LATERAL (
           SELECT id FROM nibrun.app_configs c
@@ -122,7 +122,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
       const [replayable] = await tx.SelectDeploymentToReplay`
         SELECT d.id
         FROM nibrun.deployments d
-        JOIN nibrun.apps a ON a.id = d.app_id
+        JOIN nibrun.live_apps a ON a.id = d.app_id
         WHERE d.id = ${rollbackOf} AND d.app_id = ${appId} AND a.owner_id = ${ownerId}
       `;
       if (!replayable) {
@@ -135,7 +135,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
           (app_id, artifact_id, config_id, rollback_of_deployment_id)
         SELECT src.app_id, src.artifact_id, src.config_id, src.id
         FROM nibrun.deployments src
-        JOIN nibrun.apps a ON a.id = src.app_id
+        JOIN nibrun.live_apps a ON a.id = src.app_id
         WHERE src.id = ${rollbackOf} AND src.app_id = ${appId} AND a.owner_id = ${ownerId}
         RETURNING id
       `;
@@ -155,7 +155,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
                c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
                c.restart_backoff_factor, c.restart_reset_after_ms
       FROM nibrun.deployments d
-      JOIN nibrun.apps a ON a.id = d.app_id
+      JOIN nibrun.live_apps a ON a.id = d.app_id
       JOIN nibrun.app_configs c ON c.id = d.config_id
       WHERE d.app_id = ${appId} AND a.owner_id = ${ownerId}
       ORDER BY d.id DESC
@@ -178,7 +178,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
                c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
                c.restart_backoff_factor, c.restart_reset_after_ms
       FROM nibrun.deployments d
-      JOIN nibrun.apps a ON a.id = d.app_id
+      JOIN nibrun.live_apps a ON a.id = d.app_id
       JOIN nibrun.app_configs c ON c.id = d.config_id
       WHERE d.app_id = ${appId} AND d.id = ${deploymentId} AND a.owner_id = ${ownerId}
     `;
@@ -272,7 +272,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
     await tx.SupersedeLiveDeployment`
       UPDATE nibrun.deployments d
       SET state = 'superseded'
-      FROM nibrun.apps a
+      FROM nibrun.live_apps a
       WHERE a.id = d.app_id
         AND d.app_id = ${appId}
         AND a.owner_id = ${ownerId}


### PR DESCRIPTION
Follows #111, which stopped at the filesystem. `deleting` only ever reached the app's own state, so every owner-facing read went on finding it: an owner deleted an app and it stayed in their list, kept answering `GET`, and kept accepting deployments and artifact uploads.

**`nibrun.live_apps`** holds the predicate once, rather than twenty copies of `AND a.state <> 'deleted'`. One rule decides which relation a statement reads:

- scopes by owner → `nibrun.live_apps`
- does not → `nibrun.apps`, on purpose (the fleet is told about every app it runs, and the writes that move an app between states have to see it)

A statement naming the table while taking an `ownerId` is then visibly wrong, which is checkable by reading rather than by remembering. Columns rather than `*`, so a column added to `apps` later goes missing loudly instead of silently.

**Deleting twice is refused.** Without the guard on `UpdateAppState`, a second `DELETE` put a finished deletion back to `deleting` — and the fleet would provision the filesystem all over again.

Log access needed nothing: `LogsService` resolves ownership through `deploymentsRepo.findById`, which now reads the view.

Verified against Postgres 18 on top of merged main — all twelve migrations apply, `FOR UPDATE` works through the view (`SelectAppForConfigUpdate` locks through it), a `deleting` app stays visible so an owner can watch it go, and a `deleted` one leaves every owner-facing read. The predicates are covered by that probe rather than by tests: api tests point Postgres at a closed port, so nothing in `tests/` reaches a query.

An app keeps its slug and hostname after deletion, so the name is held rather than freed for reuse.