### PR TITLE
refactor: a branded type is parsed into rather than asserted

### DIFF
--- a/apps/agent/src/lib/clock.ts
+++ b/apps/agent/src/lib/clock.ts
@@ -1,7 +1,8 @@
-import type { Timestamp } from '@repo/protocol';
+import { type Timestamp, TimestampSchema, Value } from '@repo/protocol';
 import { Clock, Effect } from 'effect';
 
-export const fromEpochMs = (value: number): Timestamp => new Date(value).toISOString() as Timestamp;
+export const fromEpochMs = (value: number): Timestamp =>
+  Value.Parse(TimestampSchema, new Date(value).toISOString());
 
 export const toEpochMs = (value: Timestamp): number => Date.parse(value);
 

--- a/apps/agent/src/lib/filesystem/debugfs.ts
+++ b/apps/agent/src/lib/filesystem/debugfs.ts
@@ -8,6 +8,8 @@ import {
   GuestPathSchema,
   isValidMessage,
   type Timestamp,
+  TimestampSchema,
+  Value,
 } from '@repo/protocol';
 import { Data, Either } from 'effect';
 import type { CommandLine } from '#lib/exec.ts';
@@ -110,7 +112,10 @@ function timestampFrom({ date, time }: { date: string; time: string }): Timestam
   }
   const paddedDay = day.padStart(TWO_DIGITS, '0');
   const paddedHour = hour.padStart(TWO_DIGITS, '0');
-  return `${year}-${monthNumber}-${paddedDay}T${paddedHour}:${minute}:00Z` as Timestamp;
+  return Value.Parse(
+    TimestampSchema,
+    `${year}-${monthNumber}-${paddedDay}T${paddedHour}:${minute}:00Z`,
+  );
 }
 
 /**

--- a/apps/agent/src/lib/network/allocator.ts
+++ b/apps/agent/src/lib/network/allocator.ts
@@ -1,4 +1,4 @@
-import type { AppId } from '@repo/protocol';
+import { type AppId, AppIdSchema, Value } from '@repo/protocol';
 import { Data } from 'effect';
 import { FIRST_SLOT, SLOT_COUNT } from '#lib/network/slot.ts';
 
@@ -30,7 +30,7 @@ export function assignmentsFrom(records: SlotRecords): Assignments {
     if (slot < FIRST_SLOT || slot >= SLOT_COUNT || taken.has(slot)) {
       continue;
     }
-    assignments.set(appId as AppId, slot);
+    assignments.set(Value.Parse(AppIdSchema, appId), slot);
     taken.add(slot);
   }
   return assignments;

--- a/apps/agent/src/lib/network/slot.ts
+++ b/apps/agent/src/lib/network/slot.ts
@@ -1,4 +1,11 @@
-import type { AppId, HostPort, Ipv4Address } from '@repo/protocol';
+import {
+  type AppId,
+  type HostPort,
+  HostPortSchema,
+  type Ipv4Address,
+  Ipv4AddressSchema,
+  Value,
+} from '@repo/protocol';
 
 /**
  * A host port, a tap, a /30 and an NBD minor all derive from one small integer, so there is one
@@ -39,7 +46,10 @@ export type AppSlot = {
 };
 
 const addressAt = (index: number): Ipv4Address =>
-  `${GUEST_NETWORK_FIRST_OCTET}.${GUEST_NETWORK_SECOND_OCTET}.${Math.floor(index / OCTET_SIZE)}.${index % OCTET_SIZE}` as Ipv4Address;
+  Value.Parse(
+    Ipv4AddressSchema,
+    `${GUEST_NETWORK_FIRST_OCTET}.${GUEST_NETWORK_SECOND_OCTET}.${Math.floor(index / OCTET_SIZE)}.${index % OCTET_SIZE}`,
+  );
 
 const macFor = (address: Ipv4Address) =>
   [
@@ -55,7 +65,7 @@ export function describeSlot({ slot, appId }: { slot: number; appId: AppId }): A
   return {
     slot,
     appId,
-    hostPort: (HOST_PORT_BASE + slot) as HostPort,
+    hostPort: Value.Parse(HostPortSchema, HOST_PORT_BASE + slot),
     hostIpv4: addressAt(base + HOST_ADDRESS_OFFSET),
     guestIpv4,
     guestMac: macFor(guestIpv4),

--- a/apps/agent/src/lib/vm/systemd.ts
+++ b/apps/agent/src/lib/vm/systemd.ts
@@ -1,4 +1,4 @@
-import { type AppId, AppIdSchema, isValidMessage } from '@repo/protocol';
+import { type AppId, AppIdSchema, Value } from '@repo/protocol';
 import { Effect } from 'effect';
 import {
   parsePropertyBlocks,
@@ -25,7 +25,11 @@ export function appIdFromUnit(unitName: string): AppId | undefined {
     return undefined;
   }
   const value = unitName.slice(VM_UNIT_TEMPLATE.length, -UNIT_SUFFIX.length);
-  return isValidMessage({ schema: AppIdSchema, value }) ? (value as AppId) : undefined;
+  try {
+    return Value.Parse(AppIdSchema, value);
+  } catch {
+    return undefined;
+  }
 }
 
 export function parseUnitNames(output: string): string[] {

--- a/apps/agent/src/services/volume-manager.service.ts
+++ b/apps/agent/src/services/volume-manager.service.ts
@@ -1,5 +1,12 @@
 import { FileSystem, Path } from '@effect/platform';
-import type { AppId, DesiredVolume, ReportedVolume, VolumeId } from '@repo/protocol';
+import {
+  type AppId,
+  type DesiredVolume,
+  type ReportedVolume,
+  Value,
+  type VolumeId,
+  VolumeIdSchema,
+} from '@repo/protocol';
 import { Array as Arr, Effect, Option } from 'effect';
 import type { AppSlot } from '#lib/network/slot.ts';
 import type { ObservedVolume } from '#lib/reconcile/plan.ts';
@@ -89,7 +96,7 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
             // these to decide a tenant's filesystem is gone.
             const observed = yield* Effect.forEach(names, (name) =>
               Effect.gen(function* () {
-                const volumeId = name as VolumeId;
+                const volumeId = Value.Parse(VolumeIdSchema, name);
                 const appId = appIdByVolume.get(volumeId);
                 if (appId === undefined) {
                   return Option.none<ObservedVolume>();

--- a/apps/agent/src/services/zerofs-topology.service.ts
+++ b/apps/agent/src/services/zerofs-topology.service.ts
@@ -1,4 +1,4 @@
-import type { ObjectKey } from '@repo/protocol';
+import { ObjectKeySchema, Value } from '@repo/protocol';
 import { Effect } from 'effect';
 import type { ZerofsFilesystem } from '#lib/volumes/topology.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
@@ -18,7 +18,7 @@ export class ZerofsTopology extends Effect.Service<ZerofsTopology>()('ZerofsTopo
     const config = yield* AgentConfig;
     const filesystems: readonly [ZerofsFilesystem, ...ZerofsFilesystem[]] = [
       {
-        storagePrefix: config.zerofsStoragePrefix as ObjectKey,
+        storagePrefix: Value.Parse(ObjectKeySchema, config.zerofsStoragePrefix),
         mountPath: config.zerofsMount,
         nbdSocketPath: config.zerofsNbdSocket,
         admin: { binary: config.zerofsBinary, configFile: config.zerofsConfigFile },

--- a/apps/agent/tests/lib/agent/filesystem.test.ts
+++ b/apps/agent/tests/lib/agent/filesystem.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import type {
-  AppId,
-  DirectoryListing,
-  FilesystemQuery,
-  FilesystemQueryId,
-  GuestPath,
-  Timestamp,
+import {
+  AppIdSchema,
+  type DirectoryListing,
+  type FilesystemQuery,
+  FilesystemQueryIdSchema,
+  GuestPathSchema,
+  TimestampSchema,
+  Value,
 } from '@repo/protocol';
 import { Effect, Layer } from 'effect';
 import { answer } from '#lib/agent/filesystem.ts';
@@ -13,21 +14,21 @@ import { UnreadableDirectory } from '#lib/filesystem/debugfs.ts';
 import { FilesystemReader, NoDeviceForApp } from '#services/filesystem-reader.service.ts';
 import { recordingCommands } from '#tests/support/commands.ts';
 
-const APP = 'app-pocketbase' as AppId;
+const APP = Value.Parse(AppIdSchema, 'app-pocketbase');
 const QUERY: FilesystemQuery = {
-  queryId: 'query-1' as FilesystemQueryId,
+  queryId: Value.Parse(FilesystemQueryIdSchema, 'query-1'),
   appId: APP,
-  path: '/' as GuestPath,
+  path: Value.Parse(GuestPathSchema, '/'),
 };
 
 const LISTING: DirectoryListing = {
-  path: '/' as GuestPath,
+  path: Value.Parse(GuestPathSchema, '/'),
   entries: [
     {
       name: 'pb_data',
       kind: 'directory',
       sizeBytes: 4096,
-      modifiedAt: '2026-08-03T09:41:00Z' as Timestamp,
+      modifiedAt: Value.Parse(TimestampSchema, '2026-08-03T09:41:00Z'),
     },
   ],
   truncated: false,

--- a/apps/agent/tests/lib/control/client.test.ts
+++ b/apps/agent/tests/lib/control/client.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, test } from 'bun:test';
 import {
   AGENT_API_PREFIX,
   AGENT_ROUTES,
-  type HostId,
+  HostIdSchema,
   type HostReportedState,
   PROTOCOL_VERSION,
   PROTOCOL_VERSION_HEADER,
-  type SecretString,
+  SecretStringSchema,
+  Value,
 } from '@repo/protocol';
 import { Effect } from 'effect';
 import { ControlPlaneError, makeControlPlaneClient } from '#lib/control/client.ts';
@@ -18,7 +19,7 @@ import {
   recordingServer,
 } from '#tests/support/server.ts';
 
-const SESSION_TOKEN = 'session-token' as SecretString;
+const SESSION_TOKEN = Value.Parse(SecretStringSchema, 'session-token');
 
 const VALID_DESIRED_STATE = {
   hostId: 'host-1',
@@ -99,7 +100,7 @@ describe('every request identifies the protocol it speaks', () => {
       }),
     );
 
-    expect(session.hostId).toBe('host-1' as HostId);
+    expect(session.hostId).toBe(Value.Parse(HostIdSchema, 'host-1'));
     expect(call?.headers.authorization).toBeUndefined();
   });
 

--- a/apps/agent/tests/lib/exports/bundle.test.ts
+++ b/apps/agent/tests/lib/exports/bundle.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { mkdir, readdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { Filename } from '@repo/protocol';
+import { type Filename, FilenameSchema, Value } from '@repo/protocol';
 import { Effect, Either, Layer } from 'effect';
 import { bundleBinaryName, writeBundle } from '#lib/exports/bundle.ts';
 import { artifactStore } from '#tests/support/artifacts.ts';
@@ -116,9 +116,9 @@ test('a volume holding only that is an empty export rather than a failed one', a
 
 describe('the bundle keeps the name the binary was uploaded under', () => {
   test('the uploaded name is what lands in the archive', () => {
-    expect(bundleBinaryName(artifact({ filename: 'pocketbase' as Filename }))).toEqual(
-      Either.right('pocketbase'),
-    );
+    expect(
+      bundleBinaryName(artifact({ filename: Value.Parse(FilenameSchema, 'pocketbase') })),
+    ).toEqual(Either.right('pocketbase'));
   });
 
   // The schema rejects all of these, so reaching here means a peer that did not honour it. The

--- a/apps/agent/tests/lib/failure.test.ts
+++ b/apps/agent/tests/lib/failure.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { AppId, Sha256Digest } from '@repo/protocol';
+import { AppIdSchema, Sha256DigestSchema, Value } from '@repo/protocol';
 import { InstanceCredentialsError } from '#lib/aws/credentials.ts';
 import { ControlPlaneError } from '#lib/control/client.ts';
 import { CommandFailed, CommandTimedOut } from '#lib/exec.ts';
@@ -26,7 +26,10 @@ const SOME_LIMIT = 200;
 
 const everyFailure = [
   new SlotExhausted({ limit: SOME_LIMIT }),
-  new DigestMismatch({ expected: 'a'.repeat(DIGEST_HEX_LENGTH) as Sha256Digest, actual: 'b' }),
+  new DigestMismatch({
+    expected: Value.Parse(Sha256DigestSchema, 'a'.repeat(DIGEST_HEX_LENGTH)),
+    actual: 'b',
+  }),
   new ArtifactSizeMismatch({ expected: SOME_SIZE, actual: OTHER_SIZE }),
   new ArtifactTransferError({ cause: new Error('connection reset') }),
   new UnrepresentableEnvironment({ variableName: 'API_KEY' }),
@@ -46,7 +49,7 @@ const everyFailure = [
   new ProtocolMismatch({ issues: [] }),
   new UnsafeGuestPath({ reason: 'it is not an absolute in-volume path' }),
   new UnreadableDirectory({ devicePath: '/dev/nbd7' }),
-  new NoDeviceForApp({ appId: 'app-pocketbase' as AppId }),
+  new NoDeviceForApp({ appId: Value.Parse(AppIdSchema, 'app-pocketbase') }),
 ];
 
 // The message is what a report carries to the control plane, and from there to whoever is

--- a/apps/agent/tests/lib/filesystem/debugfs.test.ts
+++ b/apps/agent/tests/lib/filesystem/debugfs.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, test } from 'bun:test';
-import { DIRECTORY_ENTRY_LIMIT, type GuestPath, type Timestamp } from '@repo/protocol';
+import {
+  DIRECTORY_ENTRY_LIMIT,
+  type GuestPath,
+  GuestPathSchema,
+  type Timestamp,
+  TimestampSchema,
+  Value,
+} from '@repo/protocol';
 import { Either } from 'effect';
 import { listingCommand, parseListing } from '#lib/filesystem/debugfs.ts';
 
 const DEVICE = '/dev/nbd7';
-const ROOT = '/' as GuestPath;
+const ROOT = Value.Parse(GuestPathSchema, '/');
 
 // Captured from `debugfs -R "ls -l /" <device>`: inode, mode, an e2fsprogs-dependent file-type
 // column, owner, group, size, then the date, time and name.
@@ -30,7 +37,7 @@ function entriesOf(output: string) {
 }
 
 function at(value: string): Timestamp {
-  return value as Timestamp;
+  return Value.Parse(TimestampSchema, value);
 }
 
 describe('a directory is read off the columns debugfs prints', () => {
@@ -95,7 +102,10 @@ describe('what mkfs left at the root is not the tenant data', () => {
   // The name is reserved in one directory only. Anywhere else it is a directory the tenant made,
   // and hiding it would be hiding their own data from them.
   test('but the same name below the root is the tenant own directory', () => {
-    const listing = parseListing({ output: withLostAndFound, path: '/pb_data' as GuestPath });
+    const listing = parseListing({
+      output: withLostAndFound,
+      path: Value.Parse(GuestPathSchema, '/pb_data'),
+    });
     if (Either.isLeft(listing)) {
       throw new Error('expected a readable directory');
     }
@@ -155,7 +165,10 @@ test('a directory larger than the wire allows says so rather than being cut sile
 
 describe('the command is built so debugfs cannot be handed a second one', () => {
   test('a valid path is quoted into a read-only invocation', () => {
-    const command = listingCommand({ devicePath: DEVICE, path: '/pb_data' as GuestPath });
+    const command = listingCommand({
+      devicePath: DEVICE,
+      path: Value.Parse(GuestPathSchema, '/pb_data'),
+    });
     expect(Either.isRight(command) && command.right).toEqual([
       'debugfs',
       '-R',

--- a/apps/agent/tests/lib/health/probe.test.ts
+++ b/apps/agent/tests/lib/health/probe.test.ts
@@ -2,18 +2,19 @@ import { describe, expect, test } from 'bun:test';
 import { FetchHttpClient } from '@effect/platform';
 import {
   DEFAULT_HEALTH_CHECK,
-  type GuestPort,
+  GuestPortSchema,
   type HealthCheck,
-  type Ipv4Address,
+  Ipv4AddressSchema,
+  Value,
 } from '@repo/protocol';
 import { Effect } from 'effect';
 import { probeInstance } from '#lib/health/probe.ts';
 import { provided } from '#tests/support/run.ts';
 import { HTTP_SERVER_ERROR, serving } from '#tests/support/server.ts';
 
-const LOOPBACK = '127.0.0.1' as Ipv4Address;
+const LOOPBACK = Value.Parse(Ipv4AddressSchema, '127.0.0.1');
 // Nothing listens here, so a probe against it must fail rather than hang.
-const CLOSED_PORT = 1 as GuestPort;
+const CLOSED_PORT = Value.Parse(GuestPortSchema, 1);
 const WITH_PATH: HealthCheck = { ...DEFAULT_HEALTH_CHECK, path: '/health' };
 
 const run = provided(FetchHttpClient.layer);
@@ -29,7 +30,7 @@ function probing({
     const server = yield* serving(answer);
     return yield* probeInstance({
       guestIpv4: LOOPBACK,
-      guestPort: server.port as GuestPort,
+      guestPort: Value.Parse(GuestPortSchema, server.port),
       healthCheck,
     });
   });

--- a/apps/agent/tests/lib/network/allocator.test.ts
+++ b/apps/agent/tests/lib/network/allocator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { AppId, HostPort, Ipv4Address } from '@repo/protocol';
+import { type AppId, AppIdSchema, HostPortSchema, Ipv4AddressSchema, Value } from '@repo/protocol';
 import { Effect, Either, Layer, Option } from 'effect';
 import { assignmentsFrom, readSlotRecords, type SlotRecords } from '#lib/network/allocator.ts';
 import { describeSlot, HOST_PORT_BASE, SLOT_COUNT } from '#lib/network/slot.ts';
@@ -21,7 +21,7 @@ const run = provided(
 );
 
 function app(name: string | number) {
-  return `app-${name}` as AppId;
+  return Value.Parse(AppIdSchema, `app-${name}`);
 }
 
 function withAllocator<A, E>(use: (allocator: SlotAllocator) => Effect.Effect<A, E>) {
@@ -33,9 +33,9 @@ describe('slot derivation', () => {
     expect(describeSlot({ slot: 0, appId: app(0) })).toEqual({
       slot: 0,
       appId: app(0),
-      hostPort: HOST_PORT_BASE as HostPort,
-      hostIpv4: '10.201.0.1' as Ipv4Address,
-      guestIpv4: '10.201.0.2' as Ipv4Address,
+      hostPort: Value.Parse(HostPortSchema, HOST_PORT_BASE),
+      hostIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.1'),
+      guestIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.2'),
       guestMac: '02:00:0a:c9:00:02',
       tapName: 'nbr0',
       nbdDevicePath: '/dev/nbd0',
@@ -46,14 +46,14 @@ describe('slot derivation', () => {
   test('slots do not overlap', () => {
     const first = describeSlot({ slot: 0, appId: app(0) });
     const second = describeSlot({ slot: 1, appId: app(1) });
-    expect(second.hostIpv4).toBe('10.201.0.5' as Ipv4Address);
-    expect(second.guestIpv4).toBe('10.201.0.6' as Ipv4Address);
-    expect(second.hostPort).toBe((first.hostPort + 1) as HostPort);
+    expect(second.hostIpv4).toBe(Value.Parse(Ipv4AddressSchema, '10.201.0.5'));
+    expect(second.guestIpv4).toBe(Value.Parse(Ipv4AddressSchema, '10.201.0.6'));
+    expect(second.hostPort).toBe(Value.Parse(HostPortSchema, first.hostPort + 1));
   });
 
   test('addressing carries past an octet boundary', () => {
     expect(describeSlot({ slot: BOUNDARY_SLOT, appId: app(BOUNDARY_SLOT) }).guestIpv4).toBe(
-      '10.201.1.2' as Ipv4Address,
+      Value.Parse(Ipv4AddressSchema, '10.201.1.2'),
     );
   });
 });
@@ -67,7 +67,7 @@ describe('allocation is stable for the lifetime of an app', () => {
         return [first.hostPort, second.hostPort];
       }).pipe(Effect.orDie),
     );
-    expect(ports[0]).toBe(ports[1] as HostPort);
+    expect(ports[0]).toBe(Value.Parse(HostPortSchema, ports[1]));
   });
 
   test('distinct apps never share a slot', async () => {

--- a/apps/agent/tests/lib/network/firewall.test.ts
+++ b/apps/agent/tests/lib/network/firewall.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { GuestPort, HostPort, Ipv4Address } from '@repo/protocol';
+import { GuestPortSchema, HostPortSchema, Ipv4AddressSchema, Value } from '@repo/protocol';
 import {
   type FirewallState,
   INSTANCE_METADATA_ADDRESS_V4,
@@ -13,11 +13,14 @@ const DNS_PORT = 53;
 // The ranges the blanket v6 rule covers, to assert that a VPC's range is not among them.
 const PRIVATE_DESTINATIONS_V6_SAMPLE = ['::1', 'fe80:', 'fc', 'fd'];
 
+const HOST_PORT_NUMBER = 21_000;
+const GUEST_PORT_NUMBER = 3000;
+
 const instance = {
-  hostPort: 21_000 as HostPort,
-  guestPort: 3000 as GuestPort,
-  hostIpv4: '10.201.0.1' as Ipv4Address,
-  guestIpv4: '10.201.0.2' as Ipv4Address,
+  hostPort: Value.Parse(HostPortSchema, HOST_PORT_NUMBER),
+  guestPort: Value.Parse(GuestPortSchema, GUEST_PORT_NUMBER),
+  hostIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.1'),
+  guestIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.2'),
 };
 
 function state(overrides: Partial<FirewallState> = {}): FirewallState {

--- a/apps/agent/tests/lib/network/tap.test.ts
+++ b/apps/agent/tests/lib/network/tap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { Ipv4Address } from '@repo/protocol';
+import { Ipv4AddressSchema, Value } from '@repo/protocol';
 import { Effect } from 'effect';
 import type { CommandRequest } from '#lib/exec.ts';
 import { ensureTap } from '#lib/network/tap.ts';
@@ -7,7 +7,7 @@ import { recordingCommands, succeeding } from '#tests/support/commands.ts';
 
 const tap = {
   tapName: 'nbr7',
-  hostIpv4: '10.201.0.29' as Ipv4Address,
+  hostIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.29'),
   subnetPrefixLength: 30,
 };
 

--- a/apps/agent/tests/lib/proxy/caddyfile.test.ts
+++ b/apps/agent/tests/lib/proxy/caddyfile.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, test } from 'bun:test';
-import type { AppHostname, AppId, Hostname, HostPort } from '@repo/protocol';
+import {
+  type AppHostname,
+  AppIdSchema,
+  type Hostname,
+  HostPortSchema,
+  Value,
+} from '@repo/protocol';
 import { renderAppSites } from '#lib/proxy/caddyfile.ts';
 import type { RouteTarget } from '#lib/report/routes.ts';
 import { APP_ID, FIRST_HOST_PORT } from '#tests/support/fixtures.ts';
 
-const SECOND_HOST_PORT = (FIRST_HOST_PORT + 1) as HostPort;
+const SECOND_HOST_PORT = Value.Parse(HostPortSchema, FIRST_HOST_PORT + 1);
 
+// Cast rather than parsed: these stand in for whatever a peer put on the wire, and the tests
+// below turn on hostnames the schema would have refused, which parsing here would never yield.
 function platformHostname(hostname: string): AppHostname {
   return { hostname: hostname as Hostname, kind: 'platform' };
 }
@@ -31,7 +39,7 @@ describe('the rendered config is a projection of what is running', () => {
   });
 
   test('every site authenticates the edge, so none can be reached from the origin address', () => {
-    const sites = renderAppSites([route(), route({ appId: 'app-b' as AppId })]);
+    const sites = renderAppSites([route(), route({ appId: Value.Parse(AppIdSchema, 'app-b') })]);
     const blocks = sites.split('{').length - 1;
     expect(sites.split('import origin_tls').length - 1).toBe(blocks);
   });
@@ -50,8 +58,8 @@ describe('the rendered config is a projection of what is running', () => {
   });
 
   test('rendering twice from the same routes is byte-identical, whatever order they arrive in', () => {
-    const first = route({ appId: 'app-b' as AppId, hostPort: SECOND_HOST_PORT });
-    const second = route({ appId: 'app-a' as AppId });
+    const first = route({ appId: Value.Parse(AppIdSchema, 'app-b'), hostPort: SECOND_HOST_PORT });
+    const second = route({ appId: Value.Parse(AppIdSchema, 'app-a') });
     expect(renderAppSites([first, second])).toBe(renderAppSites([second, first]));
   });
 });

--- a/apps/agent/tests/lib/reconcile/plan.test.ts
+++ b/apps/agent/tests/lib/reconcile/plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { DeploymentId } from '@repo/protocol';
+import { DeploymentIdSchema, Value } from '@repo/protocol';
 import { hasDeferredWork, planReconcile } from '#lib/reconcile/plan.ts';
 import {
   APP_ID,
@@ -57,7 +57,7 @@ describe('instances are authoritative', () => {
     const plan = planReconcile({
       desired: desiredState({ instances: [desiredInstance()] }),
       observed: observedState({
-        instances: [observedInstance({ deploymentId: 'dep-0' as DeploymentId })],
+        instances: [observedInstance({ deploymentId: Value.Parse(DeploymentIdSchema, 'dep-0') })],
       }),
     });
     expect(plan.instances[0]?.action).toBe('replace');

--- a/apps/agent/tests/lib/report/build-report.test.ts
+++ b/apps/agent/tests/lib/report/build-report.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, test } from 'bun:test';
 import {
-  type AppId,
+  AppIdSchema,
   DEFAULT_GUEST_PORT,
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   type GuestPort,
-  type Hostname,
+  HostnameSchema,
   type HostPort,
+  HostPortSchema,
   HostReportedStateSchema,
   type InstanceState,
-  type Ipv4Address,
+  Ipv4AddressSchema,
   isValidMessage,
-  type Sha256Digest,
+  Sha256DigestSchema,
+  Value,
 } from '@repo/protocol';
 import { initialTracker } from '#lib/health/state.ts';
 import { buildReportedState, toReportedInstance } from '#lib/report/build-report.ts';
@@ -52,11 +54,11 @@ function record(overrides: Partial<InstanceRecord> = {}): InstanceRecord {
     appId: APP_ID,
     deploymentId: DEPLOYMENT_ID,
     volumeId: VOLUME_ID,
-    hostnames: [{ hostname: 'a.example.com' as Hostname, kind: 'platform' }],
+    hostnames: [{ hostname: Value.Parse(HostnameSchema, 'a.example.com'), kind: 'platform' }],
     hostPort: FIRST_HOST_PORT,
     guestPort: DEFAULT_GUEST_PORT,
-    guestIpv4: '10.201.0.2' as Ipv4Address,
-    artifactDigest: 'a'.repeat(DIGEST_HEX_LENGTH) as Sha256Digest,
+    guestIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.2'),
+    artifactDigest: Value.Parse(Sha256DigestSchema, 'a'.repeat(DIGEST_HEX_LENGTH)),
     state: 'running' as InstanceState,
     health: initialTracker(),
     healthCheck: DEFAULT_HEALTH_CHECK,
@@ -122,8 +124,8 @@ describe('the same records render the routing layer', () => {
   test('only instances whose tenant answered are routable', () => {
     const records = [
       record(),
-      record({ appId: 'inst-2' as AppId, state: 'starting' }),
-      record({ appId: 'inst-3' as AppId, state: 'unhealthy' }),
+      record({ appId: Value.Parse(AppIdSchema, 'inst-2'), state: 'starting' }),
+      record({ appId: Value.Parse(AppIdSchema, 'inst-3'), state: 'unhealthy' }),
     ];
     expect(renderableRoutes(records)).toEqual([
       {
@@ -168,6 +170,6 @@ describe('allocatable capacity', () => {
     const guestPort: GuestPort = DEFAULT_GUEST_PORT;
     // @ts-expect-error a GuestPort is not a HostPort, which is what stops a routing bug type-checking
     const hostPort: HostPort = guestPort;
-    expect(hostPort).toBe(guestPort as unknown as HostPort);
+    expect(hostPort).toBe(Value.Parse(HostPortSchema, guestPort as unknown));
   });
 });

--- a/apps/agent/tests/lib/vm/artifacts.test.ts
+++ b/apps/agent/tests/lib/vm/artifacts.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Path } from '@effect/platform';
 import { BunPath } from '@effect/platform-bun';
-import type { DesiredArtifact, Sha256Digest } from '@repo/protocol';
+import { type DesiredArtifact, Sha256DigestSchema, Value } from '@repo/protocol';
 import { Effect, Either } from 'effect';
 import { artifactImagePath, downloadAndVerify } from '#lib/vm/artifacts.ts';
 import { ARTIFACT_BYTES, ARTIFACT_DIGEST, artifactStore } from '#tests/support/artifacts.ts';
@@ -9,7 +9,7 @@ import { artifact } from '#tests/support/fixtures.ts';
 import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
 
 const DIGEST_HEX_LENGTH = 64;
-const WRONG_DIGEST = 'b'.repeat(DIGEST_HEX_LENGTH) as Sha256Digest;
+const WRONG_DIGEST = Value.Parse(Sha256DigestSchema, 'b'.repeat(DIGEST_HEX_LENGTH));
 const CACHE_DIR = '/var/lib/nibrun/artifacts';
 const HALF = Math.floor(ARTIFACT_BYTES.byteLength / 2);
 const SPLIT_CHUNKS = [ARTIFACT_BYTES.slice(0, HALF), ARTIFACT_BYTES.slice(HALF)];

--- a/apps/agent/tests/lib/vm/firecracker-config.test.ts
+++ b/apps/agent/tests/lib/vm/firecracker-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { DEFAULT_INSTANCE_RESOURCES, type Ipv4Address } from '@repo/protocol';
+import { DEFAULT_INSTANCE_RESOURCES, Ipv4AddressSchema, Value } from '@repo/protocol';
 import {
   DRIVE_IDS,
   netmaskFor,
@@ -16,8 +16,8 @@ const SLASH_0 = 0;
 const network = {
   tapName: 'nbr3',
   guestMac: '02:00:0a:c9:00:0e',
-  guestIpv4: '10.201.0.14' as Ipv4Address,
-  hostIpv4: '10.201.0.13' as Ipv4Address,
+  guestIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.14'),
+  hostIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.13'),
   subnetPrefixLength: SUBNET_PREFIX_LENGTH,
 };
 

--- a/apps/agent/tests/lib/vm/instance-env.test.ts
+++ b/apps/agent/tests/lib/vm/instance-env.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, test } from 'bun:test';
 import {
   DEFAULT_GUEST_PORT,
   DEFAULT_RESTART_POLICY,
-  type GuestPort,
-  type SecretString,
+  GuestPortSchema,
+  SecretStringSchema,
+  Value,
 } from '@repo/protocol';
 import { Either } from 'effect';
 import { renderInstanceEnv } from '#lib/vm/instance-env.ts';
 
+const NON_DEFAULT_PORT = 8080;
+
 function secret(value: string) {
-  return value as SecretString;
+  return Value.Parse(SecretStringSchema, value);
 }
 
 type Overrides = Partial<Parameters<typeof renderInstanceEnv>[0]>;
@@ -78,7 +81,9 @@ describe('what apps/runtime parses off the config drive', () => {
   });
 
   test('a non-default port is the one written', () => {
-    expect(render({ guestPort: 8080 as GuestPort })).toContain('NIBRUN_PORT=8080\n');
+    expect(render({ guestPort: Value.Parse(GuestPortSchema, NON_DEFAULT_PORT) })).toContain(
+      `NIBRUN_PORT=${NON_DEFAULT_PORT}\n`,
+    );
   });
 });
 

--- a/apps/agent/tests/lib/vm/systemd.test.ts
+++ b/apps/agent/tests/lib/vm/systemd.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import type { AppId } from '@repo/protocol';
+import { AppIdSchema, Value } from '@repo/protocol';
 import { appIdFromUnit, parseUnitNames, vmUnitName } from '#lib/vm/systemd.ts';
 import { parseProperties, parsePropertyBlocks, unitStatusFrom } from '#lib/vm/unit-status.ts';
 
 describe('unit naming round-trips', () => {
   test('an instance id becomes a template instance and back', () => {
-    const appId = 'inst-A_1' as AppId;
+    const appId = Value.Parse(AppIdSchema, 'inst-A_1');
     expect(vmUnitName(appId)).toBe('nibrun-vm@inst-A_1.service');
     expect(appIdFromUnit(vmUnitName(appId))).toBe(appId);
   });

--- a/apps/agent/tests/lib/volumes/zerofs.test.ts
+++ b/apps/agent/tests/lib/volumes/zerofs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { CheckpointId } from '@repo/protocol';
+import { CheckpointIdSchema, Value } from '@repo/protocol';
 import { Effect } from 'effect';
 import {
   createCheckpoint,
@@ -12,7 +12,7 @@ import { recordingCommands } from '#tests/support/commands.ts';
 
 const BINARY = '/opt/nibrun/bin/zerofs/zerofs';
 const target = { binary: BINARY, configFile: '/etc/z.toml' };
-const checkpointId = 'cp-1' as CheckpointId;
+const checkpointId = Value.Parse(CheckpointIdSchema, 'cp-1');
 
 // The deploy puts every binary under a versioned path and none on PATH, so a bare name resolves
 // to nothing — and the flush that fails is the one that makes a stop a durability point.

--- a/apps/agent/tests/support/artifacts.ts
+++ b/apps/agent/tests/support/artifacts.ts
@@ -1,11 +1,12 @@
-import type { Sha256Digest } from '@repo/protocol';
+import { Sha256DigestSchema, Value } from '@repo/protocol';
 import { Effect, Layer } from 'effect';
 import { ArtifactStore } from '#services/artifact-store.service.ts';
 
 export const ARTIFACT_BYTES = new TextEncoder().encode('#!/usr/bin/env fake-binary\n');
-export const ARTIFACT_DIGEST = new Bun.CryptoHasher('sha256')
-  .update(ARTIFACT_BYTES)
-  .digest('hex') as Sha256Digest;
+export const ARTIFACT_DIGEST = Value.Parse(
+  Sha256DigestSchema,
+  new Bun.CryptoHasher('sha256').update(ARTIFACT_BYTES).digest('hex'),
+);
 
 /** The artifact bucket as the chunks the transfer is meant to see, in the order it sees them. */
 export function artifactStore(chunks: readonly Uint8Array[] = [ARTIFACT_BYTES]) {

--- a/apps/agent/tests/support/config.ts
+++ b/apps/agent/tests/support/config.ts
@@ -1,8 +1,8 @@
-import type { ObjectKey } from '@repo/protocol';
+import { ObjectKeySchema, Value } from '@repo/protocol';
 import { Layer } from 'effect';
 import { AgentConfig } from '#services/agent-config.service.ts';
 
-export const HOST_STORAGE_PREFIX = 'filesystems/host-1' as ObjectKey;
+export const HOST_STORAGE_PREFIX = Value.Parse(ObjectKeySchema, 'filesystems/host-1');
 
 /** `slotsFile` names a directory nothing creates: what a test persists never reaches a host. */
 export const AGENT_CONFIG = {

--- a/apps/agent/tests/support/fixtures.ts
+++ b/apps/agent/tests/support/fixtures.ts
@@ -1,24 +1,25 @@
 import {
-  type AppId,
-  type CheckpointId,
+  AppIdSchema,
+  CheckpointIdSchema,
   DEFAULT_GUEST_PORT,
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
-  type DeploymentId,
+  DeploymentIdSchema,
   type DesiredArtifact,
   type DesiredCheckpoint,
   type DesiredExport,
   type DesiredInstance,
   type DesiredVolume,
-  type ExportId,
-  type Filename,
+  ExportIdSchema,
+  FilenameSchema,
   type HostDesiredState,
-  type HostId,
-  type HostPort,
-  type ObjectKey,
-  type Timestamp,
-  type VolumeId,
+  HostIdSchema,
+  HostPortSchema,
+  ObjectKeySchema,
+  TimestampSchema,
+  Value,
+  VolumeIdSchema,
 } from '@repo/protocol';
 import type { TenantLogEvent } from '#lib/logs/event.ts';
 import { HOST_PORT_BASE } from '#lib/network/slot.ts';
@@ -26,24 +27,24 @@ import type { ObservedInstance, ObservedState, ObservedVolume } from '#lib/recon
 import { ARTIFACT_BYTES, ARTIFACT_DIGEST } from '#tests/support/artifacts.ts';
 import { HOST_STORAGE_PREFIX } from '#tests/support/config.ts';
 
-export const APP_ID = 'app-1' as AppId;
-export const VOLUME_ID = 'vol-1' as VolumeId;
-export const DEPLOYMENT_ID = 'dep-1' as DeploymentId;
-export const HOST_ID = 'host-1' as HostId;
-export const CHECKPOINT_ID = 'chk-1' as CheckpointId;
-export const EXPORT_ID = 'exp-1' as ExportId;
-export const OBSERVED_AT = '2026-08-03T10:00:00.000Z' as Timestamp;
+export const APP_ID = Value.Parse(AppIdSchema, 'app-1');
+export const VOLUME_ID = Value.Parse(VolumeIdSchema, 'vol-1');
+export const DEPLOYMENT_ID = Value.Parse(DeploymentIdSchema, 'dep-1');
+export const HOST_ID = Value.Parse(HostIdSchema, 'host-1');
+export const CHECKPOINT_ID = Value.Parse(CheckpointIdSchema, 'chk-1');
+export const EXPORT_ID = Value.Parse(ExportIdSchema, 'exp-1');
+export const OBSERVED_AT = Value.Parse(TimestampSchema, '2026-08-03T10:00:00.000Z');
 
 export const VOLUME_SIZE_BYTES = 4_096;
-export const FIRST_HOST_PORT = HOST_PORT_BASE as HostPort;
+export const FIRST_HOST_PORT = Value.Parse(HostPortSchema, HOST_PORT_BASE);
 
 export function artifact(overrides: Partial<DesiredArtifact> = {}): DesiredArtifact {
   return {
     digest: ARTIFACT_DIGEST,
     sizeBytes: ARTIFACT_BYTES.byteLength,
     // A uuid, as the api will assign: it carries no name, which is why `filename` exists.
-    objectKey: 'artifacts/9f1c2f0e-0d4e-4a1b-9c3a-1f8b6d2e7a45' as ObjectKey,
-    filename: 'pocketbase' as Filename,
+    objectKey: Value.Parse(ObjectKeySchema, 'artifacts/9f1c2f0e-0d4e-4a1b-9c3a-1f8b6d2e7a45'),
+    filename: Value.Parse(FilenameSchema, 'pocketbase'),
     ...overrides,
   };
 }
@@ -92,7 +93,7 @@ export function desiredExport(overrides: Partial<DesiredExport> = {}): DesiredEx
     exportId: EXPORT_ID,
     appId: APP_ID,
     volumeId: VOLUME_ID,
-    objectKey: 'exports/app-1/exp-1.tar.gz' as ObjectKey,
+    objectKey: Value.Parse(ObjectKeySchema, 'exports/app-1/exp-1.tar.gz'),
     artifact: artifact(),
     desiredState: 'present',
     ...overrides,

--- a/apps/api/src/lib/app-hostname.ts
+++ b/apps/api/src/lib/app-hostname.ts
@@ -1,4 +1,4 @@
-import type { DnsLabel, Hostname } from '@repo/protocol';
+import { type DnsLabel, type Hostname, HostnameSchema, Value } from '@repo/protocol';
 
 /**
  * The app domain is a different registrable domain from the one the dashboard is served on, so
@@ -11,5 +11,5 @@ export function platformHostname({
   slug: DnsLabel;
   appHostDomain: string;
 }): Hostname {
-  return `${slug}.${appHostDomain}` as Hostname;
+  return Value.Parse(HostnameSchema, `${slug}.${appHostDomain}`);
 }

--- a/apps/api/src/lib/app-slug.ts
+++ b/apps/api/src/lib/app-slug.ts
@@ -1,4 +1,4 @@
-import { type DnsLabel, MAX_DNS_LABEL_LENGTH } from '@repo/protocol';
+import { type DnsLabel, DnsLabelSchema, MAX_DNS_LABEL_LENGTH, Value } from '@repo/protocol';
 
 const SEPARATOR = '-';
 
@@ -32,7 +32,7 @@ const TRAILING_HYPHENS = /-+$/;
  * thing get two labels rather than a collision.
  */
 export function deriveAppSlug(name: string): DnsLabel {
-  return `${stemOf(name)}${SEPARATOR}${randomSuffix()}` as DnsLabel;
+  return Value.Parse(DnsLabelSchema, `${stemOf(name)}${SEPARATOR}${randomSuffix()}`);
 }
 
 function stemOf(name: string): string {

--- a/apps/api/src/lib/artifact-digest.ts
+++ b/apps/api/src/lib/artifact-digest.ts
@@ -1,4 +1,10 @@
-import type { ObjectKey, Sha256Digest } from '@repo/protocol';
+import {
+  type ObjectKey,
+  ObjectKeySchema,
+  type Sha256Digest,
+  Sha256DigestSchema,
+  Value,
+} from '@repo/protocol';
 
 const DIGEST_ALGORITHM = 'sha256';
 const HEX_ENCODING = 'hex';
@@ -16,13 +22,14 @@ export type ArtifactIdentity = {
  * that never converges rather than a rejected upload.
  */
 export function identifyArtifact(bytes: Uint8Array): ArtifactIdentity {
-  const digest = new Bun.CryptoHasher(DIGEST_ALGORITHM)
-    .update(bytes)
-    .digest(HEX_ENCODING) as Sha256Digest;
+  const digest = Value.Parse(
+    Sha256DigestSchema,
+    new Bun.CryptoHasher(DIGEST_ALGORITHM).update(bytes).digest(HEX_ENCODING),
+  );
 
   return {
     digest,
     sizeBytes: bytes.byteLength,
-    objectKey: digest as string as ObjectKey,
+    objectKey: Value.Parse(ObjectKeySchema, digest),
   };
 }

--- a/apps/api/src/lib/deployments/desired-state.ts
+++ b/apps/api/src/lib/deployments/desired-state.ts
@@ -1,10 +1,12 @@
-import type {
-  AppConfig,
-  AppHostname,
-  AppId,
-  DesiredInstance,
-  DesiredVolume,
-  VolumeId,
+import {
+  type AppConfig,
+  type AppHostname,
+  type AppId,
+  type DesiredInstance,
+  type DesiredVolume,
+  Value,
+  type VolumeId,
+  VolumeIdSchema,
 } from '@repo/protocol';
 import type { Queries } from '#db/queries.gen.d.ts';
 import { toAppConfig, VOLUME_SIZE_BYTES } from '#lib/app-config.ts';
@@ -20,7 +22,7 @@ export type DesiredVolumeRow = Queries['SelectDesiredVolumes'];
  * so an app holding a second one later is a schema change rather than a wire change.
  */
 export function volumeIdOf(appId: AppId): VolumeId {
-  return appId as string as VolumeId;
+  return Value.Parse(VolumeIdSchema, appId);
 }
 
 /**

--- a/apps/api/src/lib/filesystem/pending-queries.ts
+++ b/apps/api/src/lib/filesystem/pending-queries.ts
@@ -1,9 +1,11 @@
-import type {
-  AppId,
-  FilesystemQuery,
-  FilesystemQueryId,
-  FilesystemQueryResult,
-  GuestPath,
+import {
+  type AppId,
+  type FilesystemQuery,
+  type FilesystemQueryId,
+  FilesystemQueryIdSchema,
+  type FilesystemQueryResult,
+  type GuestPath,
+  Value,
 } from '@repo/protocol';
 
 type Outcome = FilesystemQueryResult['outcome'];
@@ -118,7 +120,11 @@ export class PendingFilesystemQueries {
         return read;
       }
     }
-    const query = { queryId: crypto.randomUUID() as FilesystemQueryId, appId, path };
+    const query = {
+      queryId: Value.Parse(FilesystemQueryIdSchema, crypto.randomUUID()),
+      appId,
+      path,
+    };
     const read: Read = { query, waiting: new Set(), claimed: false };
     this.#reads.set(query.queryId, read);
     return read;

--- a/apps/api/src/lib/timestamp.ts
+++ b/apps/api/src/lib/timestamp.ts
@@ -1,5 +1,5 @@
-import type { Timestamp } from '@repo/protocol';
+import { type Timestamp, TimestampSchema, Value } from '@repo/protocol';
 
 export function toTimestamp(value: Date): Timestamp {
-  return value.toISOString() as Timestamp;
+  return Value.Parse(TimestampSchema, value.toISOString());
 }

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
@@ -1,4 +1,4 @@
-import { ArtifactSchema, type OwnerId } from '@repo/protocol';
+import { ArtifactSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import { ArtifactParamsSchema } from '#routes/api/apps/[appId]/artifacts/model.ts';
@@ -15,7 +15,7 @@ export const AppsAppIdArtifactsArtifactIdController = new Elysia()
       const artifact = await artifactsService.get({
         appId: params.appId,
         artifactId: params.artifactId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, artifact);
     },

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
@@ -1,4 +1,4 @@
-import { ArtifactSchema, type OwnerId } from '@repo/protocol';
+import { ArtifactSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -18,7 +18,7 @@ export const AppsAppIdArtifactsController = new Elysia()
     async ({ artifactsService, params, user, status }) => {
       const artifacts = await artifactsService.list({
         appId: params.appId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, { artifacts });
     },
@@ -32,7 +32,7 @@ export const AppsAppIdArtifactsController = new Elysia()
     async ({ artifactsService, params, body, user, status }) => {
       const artifact = await artifactsService.create({
         appId: params.appId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
         binary: body.binary,
       });
       return status(StatusMap.Created, artifact);

--- a/apps/api/src/routes/api/apps/[appId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/controller.ts
@@ -1,4 +1,4 @@
-import type { OwnerId } from '@repo/protocol';
+import { OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
@@ -13,7 +13,10 @@ export const AppsAppIdController = new Elysia()
   .get(
     '/apps/:appId',
     async ({ appsService, params, user, status }) => {
-      const app = await appsService.get({ appId: params.appId, ownerId: user.id as OwnerId });
+      const app = await appsService.get({
+        appId: params.appId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
+      });
       return status(StatusMap.OK, app);
     },
     {
@@ -26,7 +29,7 @@ export const AppsAppIdController = new Elysia()
     async ({ appsService, params, body, user, status }) => {
       const app = await appsService.updateConfig({
         appId: params.appId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
         patch: body,
       });
       return status(StatusMap.OK, app);
@@ -42,7 +45,10 @@ export const AppsAppIdController = new Elysia()
   .delete(
     '/apps/:appId',
     async ({ appsService, params, user, status }) => {
-      const app = await appsService.delete({ appId: params.appId, ownerId: user.id as OwnerId });
+      const app = await appsService.delete({
+        appId: params.appId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
+      });
       return status(StatusMap.Accepted, app);
     },
     {

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/controller.ts
@@ -1,4 +1,4 @@
-import type { OwnerId } from '@repo/protocol';
+import { OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -18,7 +18,7 @@ export const AppsAppIdDeploymentsDeploymentIdController = new Elysia()
       const deployment = await deploymentsService.get({
         appId: params.appId,
         deploymentId: params.deploymentId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, deployment);
     },

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/controller.ts
@@ -1,4 +1,4 @@
-import { DirectoryListingSchema, GUEST_PATH_ROOT, type OwnerId } from '@repo/protocol';
+import { DirectoryListingSchema, GUEST_PATH_ROOT, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import { ReadDirectoryQuerySchema } from '#routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/model.ts';
@@ -26,7 +26,7 @@ export const AppsAppIdDeploymentsDeploymentIdFilesystemController = new Elysia()
       const listing = await filesystemService.readDirectory({
         appId: params.appId,
         deploymentId: params.deploymentId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
         path: query.path ?? GUEST_PATH_ROOT,
         signal: AbortSignal.any([request.signal, AbortSignal.timeout(MAX_WAIT_MS)]),
       });

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
@@ -1,4 +1,4 @@
-import type { OwnerId, TenantLogRecord } from '@repo/protocol';
+import { OwnerIdSchema, type TenantLogRecord, Value } from '@repo/protocol';
 import { Elysia, sse } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -30,7 +30,7 @@ export const AppsAppIdDeploymentsDeploymentIdLogsController = new Elysia()
       const records = await logsService.openTail({
         appId: params.appId,
         deploymentId: params.deploymentId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
         startOffset: query.startOffset ?? DEFAULT_START_OFFSET,
         signal,
       });

--- a/apps/api/src/routes/api/apps/[appId]/deployments/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/controller.ts
@@ -1,4 +1,4 @@
-import type { OwnerId } from '@repo/protocol';
+import { OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -19,7 +19,7 @@ export const AppsAppIdDeploymentsController = new Elysia()
     async ({ deploymentsService, params, user, status }) => {
       const deployments = await deploymentsService.list({
         appId: params.appId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, { deployments });
     },
@@ -33,7 +33,7 @@ export const AppsAppIdDeploymentsController = new Elysia()
     async ({ deploymentsService, params, body, user, status }) => {
       const deployment = await deploymentsService.createOrRollback({
         appId: params.appId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
         source: body,
       });
       return status(StatusMap.Created, deployment);

--- a/apps/api/src/routes/api/apps/[appId]/exports/[exportId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/[exportId]/controller.ts
@@ -1,4 +1,4 @@
-import type { OwnerId } from '@repo/protocol';
+import { OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -23,7 +23,7 @@ export const AppsAppIdExportsExportIdController = new Elysia()
       const found = await exportsService.get({
         appId: params.appId,
         exportId: params.exportId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, found);
     },

--- a/apps/api/src/routes/api/apps/[appId]/exports/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/controller.ts
@@ -1,4 +1,4 @@
-import type { OwnerId } from '@repo/protocol';
+import { OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -18,7 +18,7 @@ export const AppsAppIdExportsController = new Elysia()
     async ({ exportsService, params, user, status }) => {
       const exports = await exportsService.list({
         appId: params.appId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, { exports });
     },
@@ -36,7 +36,7 @@ export const AppsAppIdExportsController = new Elysia()
     async ({ exportsService, params, user, status }) => {
       const requested = await exportsService.request({
         appId: params.appId,
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.Accepted, requested);
     },

--- a/apps/api/src/routes/api/apps/controller.ts
+++ b/apps/api/src/routes/api/apps/controller.ts
@@ -1,4 +1,4 @@
-import type { OwnerId } from '@repo/protocol';
+import { OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -16,7 +16,7 @@ export const AppsController = new Elysia()
   .get(
     '/apps',
     async ({ appsService, user, status }) => {
-      const apps = await appsService.list({ ownerId: user.id as OwnerId });
+      const apps = await appsService.list({ ownerId: Value.Parse(OwnerIdSchema, user.id) });
       return status(StatusMap.OK, { apps });
     },
     {
@@ -27,7 +27,7 @@ export const AppsController = new Elysia()
     '/apps',
     async ({ appsService, body, user, status }) => {
       const app = await appsService.create({
-        ownerId: user.id as OwnerId,
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
         name: body.name,
         config: body.config,
       });

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -4,9 +4,11 @@ import {
   DEFAULT_AGENT_POLL_SETTINGS,
   type HostDesiredState,
   type HostId,
+  HostIdSchema,
   type HostReportedState,
-  type SecretString,
-  type Timestamp,
+  SecretStringSchema,
+  TimestampSchema,
+  Value,
 } from '@repo/protocol';
 import { UnauthorizedError } from '#lib/errors.ts';
 import type { AgentRepositoryContract } from '#repositories/agent.repository.ts';
@@ -54,8 +56,8 @@ export class AgentService extends Service {
   async openSession(request: AgentSessionRequest): Promise<AgentSession> {
     // The agent persists what it is given and presents it next time, so a host keeps its
     // identity across a reinstall. Nothing allocates one yet, so its own is honoured.
-    const hostId = request.hostId ?? (crypto.randomUUID() as HostId);
-    const sessionToken = crypto.randomUUID() as SecretString;
+    const hostId = request.hostId ?? Value.Parse(HostIdSchema, crypto.randomUUID());
+    const sessionToken = Value.Parse(SecretStringSchema, crypto.randomUUID());
     await this.agentRepo.saveSession({ sessionToken, hostId });
 
     this.logger.info('agent session opened', {
@@ -67,7 +69,10 @@ export class AgentService extends Service {
     return {
       hostId,
       sessionToken,
-      expiresAt: new Date(Date.now() + SESSION_LIFETIME_MS).toISOString() as Timestamp,
+      expiresAt: Value.Parse(
+        TimestampSchema,
+        new Date(Date.now() + SESSION_LIFETIME_MS).toISOString(),
+      ),
       poll: DEFAULT_AGENT_POLL_SETTINGS,
     };
   }

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -4,8 +4,8 @@ import {
   type ArtifactId,
   type Filename,
   FilenameSchema,
-  isValidMessage,
   type OwnerId,
+  Value,
 } from '@repo/protocol';
 import { identifyArtifact } from '#lib/artifact-digest.ts';
 import { isElfExecutable } from '#lib/elf.ts';
@@ -31,10 +31,11 @@ export type AppOwnership = Pick<AppsRepositoryContract, 'isOwnedBy'>;
 // A host writes this name into an export archive, so a browser-supplied one that is not a
 // single path segment has to be refused here rather than sanitised into something else.
 function asFilename(name: string): Filename {
-  if (!isValidMessage({ schema: FilenameSchema, value: name })) {
+  try {
+    return Value.Parse(FilenameSchema, name);
+  } catch {
     throw new BadRequestError(NOT_A_FILENAME);
   }
-  return name as Filename;
 }
 
 function toArtifact(row: ArtifactRow): Artifact {

--- a/apps/api/tests/controllers/agent.test.ts
+++ b/apps/api/tests/controllers/agent.test.ts
@@ -5,17 +5,19 @@ import {
   type AgentSessionRequest,
   AgentSessionSchema,
   type AppId,
+  AppIdSchema,
   FilesystemQueryResponseSchema,
   type HostCapacity,
   type HostVersions,
   PROTOCOL_VERSION,
   PROTOCOL_VERSION_HEADER,
   parseMessage,
+  Value,
 } from '@repo/protocol';
 import { StatusMap } from 'elysia';
 import { ORIGIN, sendJson } from '#tests/controllers/support/api.ts';
 
-const A_SERVED_APP_ID = 'app-pocketbase' as AppId;
+const A_SERVED_APP_ID = Value.Parse(AppIdSchema, 'app-pocketbase');
 
 const PROTOCOL_VERSION_SKEW = 1;
 

--- a/apps/api/tests/lib/artifact-digest.test.ts
+++ b/apps/api/tests/lib/artifact-digest.test.ts
@@ -1,18 +1,16 @@
 import { describe, expect, test } from 'bun:test';
-import {
-  isValidMessage,
-  type ObjectKey,
-  ObjectKeySchema,
-  type Sha256Digest,
-  Sha256DigestSchema,
-} from '@repo/protocol';
+import { isValidMessage, ObjectKeySchema, Sha256DigestSchema, Value } from '@repo/protocol';
 import { identifyArtifact } from '#lib/artifact-digest.ts';
 
 // From the SHA-256 test vectors: the digest of the empty input and of "abc".
-const EMPTY_DIGEST =
-  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' as Sha256Digest;
-const ABC_DIGEST =
-  'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad' as Sha256Digest;
+const EMPTY_DIGEST = Value.Parse(
+  Sha256DigestSchema,
+  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+);
+const ABC_DIGEST = Value.Parse(
+  Sha256DigestSchema,
+  'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+);
 
 // One character, two bytes — which is the whole point of the size test below.
 const MULTI_BYTE_CHARACTER = 'é';
@@ -47,7 +45,9 @@ describe('an artifact is identified by what was stored, not by what was claimed'
   });
 
   test('the key names the digest algorithm, so a future one cannot alias this object', () => {
-    expect(identifyArtifact(bytesOf('abc')).objectKey).toBe(ABC_DIGEST as string as ObjectKey);
+    expect(identifyArtifact(bytesOf('abc')).objectKey).toBe(
+      Value.Parse(ObjectKeySchema, ABC_DIGEST),
+    );
   });
 
   test('the identity satisfies the schemas the agent will read it back through', () => {

--- a/apps/api/tests/lib/deployments/lifecycle.test.ts
+++ b/apps/api/tests/lib/deployments/lifecycle.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, test } from 'bun:test';
-import type {
-  AppId,
-  DeploymentId,
-  DeploymentState,
-  InstanceState,
-  ReportedInstance,
+import {
+  AppIdSchema,
+  DeploymentIdSchema,
+  type DeploymentState,
+  type InstanceState,
+  type ReportedInstance,
+  Value,
 } from '@repo/protocol';
 import { DeploymentLifecycle, STARTUP_DEADLINE_MS } from '#lib/deployments/lifecycle.ts';
 
-const APP_ID = 'app-1' as AppId;
-const DEPLOYMENT_ID = 'deployment-1' as DeploymentId;
+const APP_ID = Value.Parse(AppIdSchema, 'app-1');
+const DEPLOYMENT_ID = Value.Parse(DeploymentIdSchema, 'deployment-1');
 const CREATED_AT = new Date('2026-08-04T10:00:00.000Z');
 const JUST_DEPLOYED_MS = 1000;
 

--- a/apps/api/tests/lib/exports/desired-state.test.ts
+++ b/apps/api/tests/lib/exports/desired-state.test.ts
@@ -1,14 +1,23 @@
 import { describe, expect, test } from 'bun:test';
-import type { ExportId, ExportState, Filename, ObjectKey, Sha256Digest } from '@repo/protocol';
+import {
+  ExportIdSchema,
+  type ExportState,
+  FilenameSchema,
+  ObjectKeySchema,
+  Sha256DigestSchema,
+  Value,
+} from '@repo/protocol';
 import { type DesiredExportRow, toDesiredExport } from '#lib/exports/desired-state.ts';
 import { APP_ID } from '#tests/services/support/fixtures.ts';
 
-const EXPORT_ID = 'export-1' as ExportId;
-const OBJECT_KEY = `exports/${APP_ID}/${EXPORT_ID}.tar.gz` as ObjectKey;
-const ARTIFACT_OBJECT_KEY = 'artifacts/abc' as ObjectKey;
-const ARTIFACT_FILENAME = 'pocketbase' as Filename;
-const ARTIFACT_DIGEST =
-  'd9403d88cdf0684fbb9d8e97cf3508e9fb4506cf309a34e42653a1c2bc04a298' as Sha256Digest;
+const EXPORT_ID = Value.Parse(ExportIdSchema, 'export-1');
+const OBJECT_KEY = Value.Parse(ObjectKeySchema, `exports/${APP_ID}/${EXPORT_ID}.tar.gz`);
+const ARTIFACT_OBJECT_KEY = Value.Parse(ObjectKeySchema, 'artifacts/abc');
+const ARTIFACT_FILENAME = Value.Parse(FilenameSchema, 'pocketbase');
+const ARTIFACT_DIGEST = Value.Parse(
+  Sha256DigestSchema,
+  'd9403d88cdf0684fbb9d8e97cf3508e9fb4506cf309a34e42653a1c2bc04a298',
+);
 const ARTIFACT_SIZE_BYTES = 4096;
 
 function desiredExportRow(state: ExportState): DesiredExportRow {

--- a/apps/api/tests/repositories/logs.test.ts
+++ b/apps/api/tests/repositories/logs.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import type { AppId, DeploymentId, HostId } from '@repo/protocol';
+import { AppIdSchema, DeploymentIdSchema, HostIdSchema, Value } from '@repo/protocol';
 import type { TailRequest } from '#lib/victorialogs/client.ts';
 import type { LogRow } from '#lib/victorialogs/parse.ts';
 import { LogsRepository, type TenantLogStore } from '#repositories/logs.repository.ts';
 
-const APP_ID = 'app-1' as AppId;
-const DEPLOYMENT_ID = 'deployment-1' as DeploymentId;
-const HOST_ID = 'host-1' as HostId;
+const APP_ID = Value.Parse(AppIdSchema, 'app-1');
+const DEPLOYMENT_ID = Value.Parse(DeploymentIdSchema, 'deployment-1');
+const HOST_ID = Value.Parse(HostIdSchema, 'host-1');
 const START_OFFSET = '5m';
 const DROPPED_BYTES = 4096;
 const TAIL_TIMEOUT_MS = 1_000;

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from 'bun:test';
-import type {
-  AgentSessionRequest,
-  HostDesiredState,
-  HostId,
-  HostReportedState,
-  ReportedVolume,
-  SecretString,
+import {
+  type AgentSessionRequest,
+  type HostDesiredState,
+  type HostId,
+  HostIdSchema,
+  type HostReportedState,
+  type ReportedVolume,
+  type SecretString,
+  Value,
 } from '@repo/protocol';
 import { UnauthorizedError } from '#lib/errors.ts';
 import type { AgentRepositoryContract } from '#repositories/agent.repository.ts';
@@ -95,7 +97,7 @@ function build() {
 describe('a session is the identity a host is answered as', () => {
   test('a host presenting its own id keeps it across a reinstall', async () => {
     const { service } = build();
-    const hostId = 'host-of-record' as HostId;
+    const hostId = Value.Parse(HostIdSchema, 'host-of-record');
 
     expect((await service.openSession({ ...SESSION_REQUEST, hostId })).hostId).toBe(hostId);
   });
@@ -120,7 +122,7 @@ describe('a host is told the whole of what it should be running', () => {
   // Desired state carries no host id of its own, so a host can only ever be told about itself.
   test('and told it about itself', async () => {
     const { service } = build();
-    const hostId = 'host-1' as HostId;
+    const hostId = Value.Parse(HostIdSchema, 'host-1');
 
     expect(await service.desiredState({ hostId })).toEqual({
       hostId,
@@ -136,7 +138,7 @@ describe('a report is read by whatever owns what it talks about', () => {
   test('and by each of them, so no part of it is dropped on the way in', async () => {
     const { deployments, exports, service } = build();
     const reported = {
-      hostId: 'host-1' as HostId,
+      hostId: Value.Parse(HostIdSchema, 'host-1'),
       instances: [],
       volumes: [],
       exports: [],

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from 'bun:test';
-import type {
-  AppId,
-  AppState,
-  DnsLabel,
-  Hostname,
-  OwnerId,
-  ReportedVolume,
-  VolumeId,
+import {
+  type AppId,
+  type AppState,
+  type DnsLabel,
+  DnsLabelSchema,
+  type Hostname,
+  HostnameSchema,
+  type OwnerId,
+  type ReportedVolume,
+  Value,
+  VolumeIdSchema,
 } from '@repo/protocol';
 import { SQL } from 'bun';
 import type { AppConfigPatch, PublicAppConfig } from '#lib/app-config.ts';
@@ -137,11 +140,13 @@ class StubAppsRepository implements AppsRepositoryContract {
     ownerId: OwnerId;
     state: AppState;
   }): Promise<AppRow | null> {
-    return Promise.resolve(this.owns ? { ...appRow(APP_NAME as DnsLabel), state } : null);
+    return Promise.resolve(
+      this.owns ? { ...appRow(Value.Parse(DnsLabelSchema, APP_NAME)), state } : null,
+    );
   }
 }
 
-const VOLUME_ID = APP_ID as string as VolumeId;
+const VOLUME_ID = Value.Parse(VolumeIdSchema, APP_ID);
 const NO_BYTES = 0;
 
 function serviceWith(appsRepo: AppsRepositoryContract) {
@@ -172,7 +177,7 @@ describe('a taken hostname is a re-roll, not something the owner sees', () => {
     expect(appsRepo.offeredSlugs.every((slug) => slug.startsWith(`${APP_NAME}-`))).toBe(true);
     expect(distinct(appsRepo.offeredSlugs)).toBe(2);
     // The app answers to the label that was accepted, not to the one that was refused.
-    expect(app.slug).toBe(appsRepo.offeredSlugs[1] as DnsLabel);
+    expect(app.slug).toBe(Value.Parse(DnsLabelSchema, appsRepo.offeredSlugs[1]));
   });
 
   // The hostname is unique platform-wide, so a collision on either constraint means the same
@@ -188,7 +193,7 @@ describe('a taken hostname is a re-roll, not something the owner sees', () => {
     expect(appsRepo.offeredSlugs).toHaveLength(COLLISIONS_BEFORE_SUCCESS + 1);
     expect(distinct(appsRepo.offeredSlugs)).toBe(appsRepo.offeredSlugs.length);
     expect(app.hostnames).toEqual([
-      { hostname: `${app.slug}.${APP_HOST_DOMAIN}` as Hostname, kind: 'platform' },
+      { hostname: Value.Parse(HostnameSchema, `${app.slug}.${APP_HOST_DOMAIN}`), kind: 'platform' },
     ]);
   });
 });

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, test } from 'bun:test';
 import {
   type AppId,
   type ArtifactId,
+  ArtifactIdSchema,
   ArtifactSchema,
-  type Filename,
+  FilenameSchema,
   isValidMessage,
   type ObjectKey,
+  ObjectKeySchema,
   type OwnerId,
-  type Sha256Digest,
-  type Timestamp,
+  Sha256DigestSchema,
+  TimestampSchema,
+  Value,
 } from '@repo/protocol';
 import { BadRequestError, NotFoundError } from '#lib/errors.ts';
 import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
@@ -34,7 +37,7 @@ function binary(name = UPLOADED_NAME): File {
   return new File([bytesOf(BINARY_TEXT)], name);
 }
 
-const SEEDED_DIGEST = 'a'.repeat(BINARY_DIGEST.length) as Sha256Digest;
+const SEEDED_DIGEST = Value.Parse(Sha256DigestSchema, 'a'.repeat(BINARY_DIGEST.length));
 const SEEDED_SIZE_BYTES = 4096;
 const SEEDED_CREATED_AT = new Date('2026-01-02T03:04:05.000Z');
 
@@ -96,15 +99,15 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
       app_id: APP_ID,
       digest: SEEDED_DIGEST,
       size_bytes: String(SEEDED_SIZE_BYTES),
-      object_key: SEEDED_DIGEST as string as ObjectKey,
-      original_file_name: UPLOADED_NAME as Filename,
+      object_key: Value.Parse(ObjectKeySchema, SEEDED_DIGEST),
+      original_file_name: Value.Parse(FilenameSchema, UPLOADED_NAME),
     });
   }
 
   private remember(row: Omit<ArtifactRow, 'id' | 'created_at'>): ArtifactRow {
     const stored: ArtifactRow = {
       ...row,
-      id: `artifact-${this.rows.size}` as ArtifactId,
+      id: Value.Parse(ArtifactIdSchema, `artifact-${this.rows.size}`),
       created_at: SEEDED_CREATED_AT,
     };
     this.rows.set(stored.id, stored);
@@ -162,7 +165,7 @@ describe('the api records the digest of what it stored', () => {
     const artifact = await service.create({ appId: APP_ID, ownerId: OWNER_ID, binary: binary() });
 
     const [written] = storage.written;
-    expect(artifact.digest).toBe(BINARY_DIGEST as Sha256Digest);
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
     expect(artifactsRepo.inserted[0]?.digest).toBe(artifact.digest);
     expect(written?.objectKey).toBe(artifact.objectKey);
     expect(written?.bytes).toEqual(bytesOf(BINARY_TEXT));
@@ -275,7 +278,7 @@ describe('a row becomes the wire shape the dashboard and the agent both read', (
     });
 
     expect(artifact.sizeBytes).toBe(SEEDED_SIZE_BYTES);
-    expect(artifact.createdAt).toBe(SEEDED_CREATED_AT.toISOString() as Timestamp);
+    expect(artifact.createdAt).toBe(Value.Parse(TimestampSchema, SEEDED_CREATED_AT.toISOString()));
     expect(isValidMessage({ schema: ArtifactSchema, value: artifact })).toBe(true);
   });
 });

--- a/apps/api/tests/services/deployments.test.ts
+++ b/apps/api/tests/services/deployments.test.ts
@@ -5,13 +5,14 @@ import {
   DEFAULT_RESTART_POLICY,
   type DeploymentId,
   type DeploymentState,
-  type GuestPort,
-  type HostPort,
+  GuestPortSchema,
+  HostPortSchema,
   type HostReportedState,
   type InstanceState,
-  type Ipv4Address,
+  Ipv4AddressSchema,
   type ReportedInstance,
-  type Timestamp,
+  TimestampSchema,
+  Value,
 } from '@repo/protocol';
 import { type PublicAppConfig, VOLUME_SIZE_BYTES } from '#lib/app-config.ts';
 import { STARTUP_DEADLINE_MS } from '#lib/deployments/lifecycle.ts';
@@ -37,14 +38,17 @@ import {
 } from '#tests/services/support/fixtures.ts';
 import { uniqueViolation } from '#tests/support/postgres.ts';
 
-const GUEST_PORT = 8090 as GuestPort;
+const GUEST_PORT_NUMBER = 8090;
+const HOST_PORT_NUMBER = 30_001;
+
+const GUEST_PORT = Value.Parse(GuestPortSchema, GUEST_PORT_NUMBER);
 const OWNER_SCOPED_METHODS = 4;
 const CREATED_AT = new Date('2026-08-04T10:00:00.000Z');
 const ACTIVATED_AT = new Date('2026-08-04T11:30:00.000Z');
 const HEALTHY_AT = new Date('2026-08-04T11:31:00.000Z');
 const REPORTED_AT = new Date('2026-08-04T11:32:00.000Z');
-const HOST_PORT = 30_001 as HostPort;
-const GUEST_IPV4 = '10.0.0.2' as Ipv4Address;
+const HOST_PORT = Value.Parse(HostPortSchema, HOST_PORT_NUMBER);
+const GUEST_IPV4 = Value.Parse(Ipv4AddressSchema, '10.0.0.2');
 const RESTART_COUNT = 2;
 
 // The config version this deployment pins. `app_configs` never changes a row, so this is what
@@ -227,7 +231,7 @@ describe('a deployment publishes the config version it pins', () => {
 
     const deployment = await service.get(OWNED_DEPLOYMENT);
 
-    expect(deployment.activatedAt).toBe(ACTIVATED_AT.toISOString() as Timestamp);
+    expect(deployment.activatedAt).toBe(Value.Parse(TimestampSchema, ACTIVATED_AT.toISOString()));
   });
 });
 
@@ -330,7 +334,10 @@ describe('a host reporting is what moves a release through its states', () => {
 
     await service.applyHostReport({
       reported: report([
-        instance({ state: 'running', lastHealthyAt: HEALTHY_AT.toISOString() as Timestamp }),
+        instance({
+          state: 'running',
+          lastHealthyAt: Value.Parse(TimestampSchema, HEALTHY_AT.toISOString()),
+        }),
       ]),
     });
 
@@ -378,7 +385,7 @@ describe('a host reporting is what moves a release through its states', () => {
           hostPort: HOST_PORT,
           guestIpv4: GUEST_IPV4,
           restartCount: RESTART_COUNT,
-          lastHealthyAt: HEALTHY_AT.toISOString() as Timestamp,
+          lastHealthyAt: Value.Parse(TimestampSchema, HEALTHY_AT.toISOString()),
         }),
       ]),
     });

--- a/apps/api/tests/services/exports.test.ts
+++ b/apps/api/tests/services/exports.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from 'bun:test';
-import type {
-  ExportId,
-  ExportState,
-  HostReportedState,
-  ObjectKey,
-  OwnerId,
-  Timestamp,
+import {
+  type ExportId,
+  ExportIdSchema,
+  type ExportState,
+  type HostReportedState,
+  type ObjectKey,
+  ObjectKeySchema,
+  type OwnerId,
+  TimestampSchema,
+  Value,
 } from '@repo/protocol';
 import { ConflictError, NotFoundError } from '#lib/errors.ts';
 import type { ExportStorageRepositoryContract } from '#repositories/export-storage.repository.ts';
@@ -19,8 +22,8 @@ import type { AppOwnership } from '#services/artifacts.service.ts';
 import { ExportsService } from '#services/exports.service.ts';
 import { APP_ID, OTHER_OWNER_ID, OWNER_ID } from '#tests/services/support/fixtures.ts';
 
-const EXPORT_ID = 'export-1' as ExportId;
-const OBJECT_KEY = `exports/${APP_ID}/${EXPORT_ID}.tar.gz` as ObjectKey;
+const EXPORT_ID = Value.Parse(ExportIdSchema, 'export-1');
+const OBJECT_KEY = Value.Parse(ObjectKeySchema, `exports/${APP_ID}/${EXPORT_ID}.tar.gz`);
 const SIGNED_URL = 'https://exports.test/signed';
 const RETENTION_DAYS = 1;
 const MS_PER_DAY = 86_400_000;
@@ -63,7 +66,7 @@ class FakeExportsRepository implements ExportsRepositoryContract {
       return Promise.resolve(inFlight);
     }
     const row = exportRow({
-      id: `export-${this.rows.length + 1}` as ExportId,
+      id: Value.Parse(ExportIdSchema, `export-${this.rows.length + 1}`),
       expires_at: input.expiresAt,
     });
     this.rows.push(row);
@@ -227,7 +230,7 @@ describe('polling an export', () => {
 describe('what a host says about the bundles it was told to write', () => {
   test('moves the export it names', async () => {
     const { service, exportsRepo } = build();
-    const readyAt = '2026-01-02T03:04:05.000Z' as Timestamp;
+    const readyAt = Value.Parse(TimestampSchema, '2026-01-02T03:04:05.000Z');
 
     await service.applyHostReport({
       reported: {

--- a/apps/api/tests/services/filesystem.test.ts
+++ b/apps/api/tests/services/filesystem.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 import {
-  type AppId,
+  AppIdSchema,
   type DirectoryListing,
   type FilesystemQuery,
   GUEST_PATH_ROOT,
   type GuestPath,
-  type Timestamp,
+  GuestPathSchema,
+  TimestampSchema,
+  Value,
 } from '@repo/protocol';
 import { BadGatewayError, GatewayTimeoutError, NotFoundError } from '#lib/errors.ts';
 import type { DeploymentRow } from '#repositories/deployments.repository.ts';
@@ -19,8 +21,8 @@ import {
   OWNER_ID,
 } from '#tests/services/support/fixtures.ts';
 
-const OTHER_APP = 'app-somebody-else' as AppId;
-const DATA = '/pb_data' as GuestPath;
+const OTHER_APP = Value.Parse(AppIdSchema, 'app-somebody-else');
+const DATA = Value.Parse(GuestPathSchema, '/pb_data');
 
 const UNREADABLE_DEVICE = 'no directory could be read from /dev/nbd7';
 
@@ -31,7 +33,7 @@ const LISTING: DirectoryListing = {
       name: 'data.db',
       kind: 'file',
       sizeBytes: 4096,
-      modifiedAt: '2026-08-03T09:41:00Z' as Timestamp,
+      modifiedAt: Value.Parse(TimestampSchema, '2026-08-03T09:41:00Z'),
     },
   ],
   truncated: false,

--- a/apps/api/tests/services/support/fixtures.ts
+++ b/apps/api/tests/services/support/fixtures.ts
@@ -1,12 +1,13 @@
 import {
-  type AppId,
-  type ArtifactId,
+  AppIdSchema,
+  ArtifactIdSchema,
   DEFAULT_GUEST_PORT,
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
-  type DeploymentId,
-  type OwnerId,
+  DeploymentIdSchema,
+  OwnerIdSchema,
+  Value,
 } from '@repo/protocol';
 import { type AppConfigColumns, type PublicAppConfig, VOLUME_SIZE_BYTES } from '#lib/app-config.ts';
 import type {
@@ -15,11 +16,11 @@ import type {
   DeploymentRow,
 } from '#repositories/deployments.repository.ts';
 
-export const OWNER_ID = 'owner-1' as OwnerId;
-export const OTHER_OWNER_ID = 'owner-2' as OwnerId;
-export const APP_ID = 'app-1' as AppId;
-export const ARTIFACT_ID = 'artifact-1' as ArtifactId;
-export const DEPLOYMENT_ID = 'deployment-1' as DeploymentId;
+export const OWNER_ID = Value.Parse(OwnerIdSchema, 'owner-1');
+export const OTHER_OWNER_ID = Value.Parse(OwnerIdSchema, 'owner-2');
+export const APP_ID = Value.Parse(AppIdSchema, 'app-1');
+export const ARTIFACT_ID = Value.Parse(ArtifactIdSchema, 'artifact-1');
+export const DEPLOYMENT_ID = Value.Parse(DeploymentIdSchema, 'deployment-1');
 
 export const APP_HOST_DOMAIN = 'apps.test';
 

--- a/bun.lock
+++ b/bun.lock
@@ -112,7 +112,7 @@
     "packages/protocol": {
       "name": "@repo/protocol",
       "dependencies": {
-        "@sinclair/typebox": "^0.34.52",
+        "@sinclair/typebox": "catalog:",
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
@@ -127,6 +127,7 @@
     "bun-types": "canary",
   },
   "catalog": {
+    "@sinclair/typebox": "^0.34.52",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "react": "^19.2.8",

--- a/bun.lock
+++ b/bun.lock
@@ -112,7 +112,7 @@
     "packages/protocol": {
       "name": "@repo/protocol",
       "dependencies": {
-        "@sinclair/typebox": "catalog:",
+        "@sinclair/typebox": "^0.34.52",
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
@@ -127,7 +127,6 @@
     "bun-types": "canary",
   },
   "catalog": {
-    "@sinclair/typebox": "^0.34.52",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "react": "^19.2.8",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
       "packages/*"
     ],
     "catalog": {
-      "@sinclair/typebox": "^0.34.52",
       "@types/react": "^19.2.18",
       "@types/react-dom": "^19.2.4",
       "react": "^19.2.8",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "packages/*"
     ],
     "catalog": {
+      "@sinclair/typebox": "^0.34.52",
       "@types/react": "^19.2.18",
       "@types/react-dom": "^19.2.4",
       "react": "^19.2.8",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -13,7 +13,7 @@
     "check:types": "bun run --bun tsc"
   },
   "dependencies": {
-    "@sinclair/typebox": "^0.34.52"
+    "@sinclair/typebox": "catalog:"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -13,7 +13,7 @@
     "check:types": "bun run --bun tsc"
   },
   "dependencies": {
-    "@sinclair/typebox": "catalog:"
+    "@sinclair/typebox": "^0.34.52"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/protocol/src/domain/filesystem.ts
+++ b/packages/protocol/src/domain/filesystem.ts
@@ -1,4 +1,5 @@
 import { type TString, Type } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
 import type { Brand, BrandedSchema } from '#lib/brand.ts';
 import { stringEnum } from '#lib/string-enum.ts';
 import { ByteSizeSchema, TimestampSchema } from '#lib/wire.ts';
@@ -72,7 +73,7 @@ export const GuestPathSchema = Type.String({
   maxLength: MAX_GUEST_PATH_LENGTH,
 }) as BrandedSchema<TString, GuestPath>;
 
-export const GUEST_PATH_ROOT = '/' as GuestPath;
+export const GUEST_PATH_ROOT = Value.Parse(GuestPathSchema, '/');
 
 export const FilesystemEntrySchema = Type.Object({
   name: FilesystemEntryNameSchema,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,5 +1,8 @@
 /** biome-ignore-all lint/performance/noBarrelFile: index is the only allowed file where we can export other files */
 
+// Re-exported so a consumer can `Value.Parse` a branded schema without taking its own
+// dependency on the validator this package already owns.
+export { Value } from '@sinclair/typebox/value';
 export {
   DESIRED_INSTANCE_STATES,
   DESIRED_PRESENCE,

--- a/packages/protocol/src/lib/wire.ts
+++ b/packages/protocol/src/lib/wire.ts
@@ -1,4 +1,5 @@
 import { type TInteger, type TString, Type } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
 import type { Brand, BrandedSchema } from '#lib/brand.ts';
 
 // Every schema in this package resolves to one of these. The wire format is JSON and only
@@ -129,4 +130,6 @@ export const HostPortSchema = Type.Integer({
   maximum: MAX_PORT,
 }) as BrandedSchema<TInteger, HostPort>;
 
-export const DEFAULT_GUEST_PORT = 3000 as GuestPort;
+const DEFAULT_GUEST_PORT_NUMBER = 3000;
+
+export const DEFAULT_GUEST_PORT = Value.Parse(GuestPortSchema, DEFAULT_GUEST_PORT_NUMBER);

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -1,41 +1,40 @@
 import { describe, expect, test } from 'bun:test';
 import {
-  type AppId,
   AppIdSchema,
   DEFAULT_AGENT_POLL_SETTINGS,
   DEFAULT_GUEST_PORT,
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
-  type DeploymentId,
+  DeploymentIdSchema,
   DesiredStateResponseSchema,
   DIRECTORY_ENTRY_LIMIT,
   DirectoryListingSchema,
-  type ExportId,
-  type Filename,
+  ExportIdSchema,
   FilesystemEntryNameSchema,
   GuestPathSchema,
   type GuestPort,
   type HostDesiredState,
   HostDesiredStateSchema,
-  type HostId,
-  type Hostname,
+  HostIdSchema,
+  HostnameSchema,
   type HostPort,
   isValidMessage,
-  type ObjectKey,
+  ObjectKeySchema,
   ProtocolValidationError,
   parseMessage,
   REDACTED,
   redactSecrets,
   type SecretString,
+  SecretStringSchema,
   Sha256DigestSchema,
-  type Timestamp,
   TimestampSchema,
-  type VolumeId,
+  Value,
+  VolumeIdSchema,
 } from '#index.ts';
 import { FilenameSchema, GuestPortSchema, HostPortSchema } from '#lib/wire.ts';
 
-const TENANT_SECRET = 'sk-live-do-not-log-this' as SecretString;
+const TENANT_SECRET = Value.Parse(SecretStringSchema, 'sk-live-do-not-log-this');
 
 const SHA256_HEX_LENGTH = 64;
 const TRUNCATED_DIGEST_LENGTH = SHA256_HEX_LENGTH - 1;
@@ -46,26 +45,26 @@ const OVERLONG_ENTRY_NAME_LENGTH = 256;
 const hexDigest = (length: number = SHA256_HEX_LENGTH) => 'a'.repeat(length);
 
 const desiredState = (): HostDesiredState => ({
-  hostId: 'host_1' as HostId,
+  hostId: Value.Parse(HostIdSchema, 'host_1'),
   volumes: [
     {
-      volumeId: 'vol_1' as VolumeId,
-      appId: 'app_1' as AppId,
+      volumeId: Value.Parse(VolumeIdSchema, 'vol_1'),
+      appId: Value.Parse(AppIdSchema, 'app_1'),
       sizeBytes: 1024,
       desiredState: 'present',
     },
   ],
   instances: [
     {
-      appId: 'app_1' as AppId,
-      deploymentId: 'dep_1' as DeploymentId,
-      volumeId: 'vol_1' as VolumeId,
+      appId: Value.Parse(AppIdSchema, 'app_1'),
+      deploymentId: Value.Parse(DeploymentIdSchema, 'dep_1'),
+      volumeId: Value.Parse(VolumeIdSchema, 'vol_1'),
       desiredState: 'running',
       artifact: {
         digest: hexDigest() as never,
         sizeBytes: 2048,
-        objectKey: 'artifacts/app_1/a' as ObjectKey,
-        filename: 'server' as Filename,
+        objectKey: Value.Parse(ObjectKeySchema, 'artifacts/app_1/a'),
+        filename: Value.Parse(FilenameSchema, 'server'),
       },
       config: {
         guestPort: DEFAULT_GUEST_PORT,
@@ -75,7 +74,7 @@ const desiredState = (): HostDesiredState => ({
         healthCheck: DEFAULT_HEALTH_CHECK,
         restartPolicy: DEFAULT_RESTART_POLICY,
       },
-      hostnames: [{ hostname: 'app-1.nibrun.app' as Hostname, kind: 'platform' }],
+      hostnames: [{ hostname: Value.Parse(HostnameSchema, 'app-1.nibrun.app'), kind: 'platform' }],
     },
   ],
   checkpoints: [],
@@ -83,15 +82,15 @@ const desiredState = (): HostDesiredState => ({
 });
 
 const desiredExport = () => ({
-  exportId: 'exp_1' as ExportId,
-  appId: 'app_1' as AppId,
-  volumeId: 'vol_1' as VolumeId,
-  objectKey: 'exports/app_1/exp_1.tar.gz' as ObjectKey,
+  exportId: Value.Parse(ExportIdSchema, 'exp_1'),
+  appId: Value.Parse(AppIdSchema, 'app_1'),
+  volumeId: Value.Parse(VolumeIdSchema, 'vol_1'),
+  objectKey: Value.Parse(ObjectKeySchema, 'exports/app_1/exp_1.tar.gz'),
   artifact: {
     digest: hexDigest(),
     sizeBytes: 2048,
-    objectKey: 'artifacts/app_1/a' as ObjectKey,
-    filename: 'server' as Filename,
+    objectKey: Value.Parse(ObjectKeySchema, 'artifacts/app_1/a'),
+    filename: Value.Parse(FilenameSchema, 'server'),
   },
   desiredState: 'present',
 });
@@ -327,11 +326,15 @@ describe('secrets', () => {
       value: desiredState(),
     }) as HostDesiredState;
     expect(redacted.hostId).toBe(desiredState().hostId);
-    expect(redacted.instances[0]?.hostnames[0]?.hostname).toBe('app-1.nibrun.app' as Hostname);
+    expect(redacted.instances[0]?.hostnames[0]?.hostname).toBe(
+      Value.Parse(HostnameSchema, 'app-1.nibrun.app'),
+    );
   });
 
   test('a validation failure never carries the offending value into its message', () => {
     const state = desiredState();
+    // Cast rather than parsed: the value has to violate the schema for the rejection this test
+    // is about to happen at all, so constructing it through the schema would defeat the test.
     const overlong = 'x'.repeat(OVERLONG_SECRET_LENGTH) as SecretString;
     const instance = state.instances[0];
     if (!instance) {
@@ -365,7 +368,7 @@ test('the poll settings the control plane hands out are themselves valid', () =>
   );
 });
 
-test('a timestamp brand still requires a cast from a plain string', () => {
-  const now = new Date().toISOString() as Timestamp;
+test('a timestamp brand is only obtained by parsing a plain string', () => {
+  const now = Value.Parse(TimestampSchema, new Date().toISOString());
   expect(isValidMessage({ schema: TimestampSchema, value: now })).toBe(true);
 });


### PR DESCRIPTION
`as AppId` compiles whatever it is handed. Every branded value is now obtained through `Value.Parse` against the schema that defines the type, so the brand cannot be acquired without meeting the constraints it stands for.

`Value` is re-exported from `@repo/protocol` — it already owns the typebox dependency and the schemas, and neither app should take its own.

Five casts survive, each on a value that has to violate its schema for the rejection under test to happen at all; each says so where it stands.

Path params are untouched: `params: AppParamsSchema` is now the only declarative parse left, and it validates before routing rather than inside a handler.