### PR TITLE
refactor(api): a path segment is a string until a handler parses it

### DIFF
--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -1,3 +1,4 @@
+import { AssertError } from '@repo/protocol';
 import { type ErrorHandler, StatusMap } from 'elysia';
 import { createLogger } from '#lib/logger.ts';
 import { isMalformedIdentifier } from '#lib/pg-errors.ts';
@@ -81,6 +82,11 @@ export function elysiaErrorHandler({
     return status(error.statusCode, { error: error.message });
   }
   if (code === 'VALIDATION') {
+    return status(StatusMap['Bad Request'], { error: 'Validation error', details: error.message });
+  }
+  // A path segment is only a branded identifier once a handler has parsed it, so the schema that
+  // rejects a malformed one throws here rather than at the edge, and would otherwise be a 500.
+  if (error instanceof AssertError) {
     return status(StatusMap['Bad Request'], { error: 'Validation error', details: error.message });
   }
   if (code === 'NOT_FOUND') {

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -86,8 +86,12 @@ export function elysiaErrorHandler({
   }
   // A path segment is only a branded identifier once a handler has parsed it, so the schema that
   // rejects a malformed one throws here rather than at the edge, and would otherwise be a 500.
+  // Named apart from Elysia's own so the two are told apart: this one failed past the edge.
   if (error instanceof AssertError) {
-    return status(StatusMap['Bad Request'], { error: 'Validation error', details: error.message });
+    return status(StatusMap['Bad Request'], {
+      error: 'Protocol type validation error',
+      details: error.message,
+    });
   }
   if (code === 'NOT_FOUND') {
     return status(StatusMap['Not Found'], { error: 'Not Found' });

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
@@ -7,7 +7,6 @@ import {
 } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
-import { ArtifactParamsSchema } from '#routes/api/apps/[appId]/artifacts/model.ts';
 import { ArtifactsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdArtifactsArtifactIdController = new Elysia()
@@ -26,7 +25,6 @@ export const AppsAppIdArtifactsArtifactIdController = new Elysia()
       return status(StatusMap.OK, artifact);
     },
     {
-      params: ArtifactParamsSchema,
       response: { [StatusMap.OK]: ArtifactSchema },
     },
   );

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
@@ -1,4 +1,10 @@
-import { ArtifactSchema, OwnerIdSchema, Value } from '@repo/protocol';
+import {
+  AppIdSchema,
+  ArtifactIdSchema,
+  ArtifactSchema,
+  OwnerIdSchema,
+  Value,
+} from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import { ArtifactParamsSchema } from '#routes/api/apps/[appId]/artifacts/model.ts';
@@ -13,8 +19,8 @@ export const AppsAppIdArtifactsArtifactIdController = new Elysia()
     '/apps/:appId/artifacts/:artifactId',
     async ({ artifactsService, params, user, status }) => {
       const artifact = await artifactsService.get({
-        appId: params.appId,
-        artifactId: params.artifactId,
+        appId: Value.Parse(AppIdSchema, params.appId),
+        artifactId: Value.Parse(ArtifactIdSchema, params.artifactId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, artifact);

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
@@ -1,4 +1,4 @@
-import { ArtifactSchema, OwnerIdSchema, Value } from '@repo/protocol';
+import { AppIdSchema, ArtifactSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -17,7 +17,7 @@ export const AppsAppIdArtifactsController = new Elysia()
     '/apps/:appId/artifacts',
     async ({ artifactsService, params, user, status }) => {
       const artifacts = await artifactsService.list({
-        appId: params.appId,
+        appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, { artifacts });
@@ -31,7 +31,7 @@ export const AppsAppIdArtifactsController = new Elysia()
     '/apps/:appId/artifacts',
     async ({ artifactsService, params, body, user, status }) => {
       const artifact = await artifactsService.create({
-        appId: params.appId,
+        appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
         binary: body.binary,
       });

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
@@ -5,7 +5,6 @@ import {
   CreateArtifactBodySchema,
   ListArtifactsResponseSchema,
 } from '#routes/api/apps/[appId]/artifacts/model.ts';
-import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
 import { ArtifactsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdArtifactsController = new Elysia()
@@ -23,7 +22,6 @@ export const AppsAppIdArtifactsController = new Elysia()
       return status(StatusMap.OK, { artifacts });
     },
     {
-      params: AppParamsSchema,
       response: { [StatusMap.OK]: ListArtifactsResponseSchema },
     },
   )
@@ -38,7 +36,6 @@ export const AppsAppIdArtifactsController = new Elysia()
       return status(StatusMap.Created, artifact);
     },
     {
-      params: AppParamsSchema,
       body: CreateArtifactBodySchema,
       response: { [StatusMap.Created]: ArtifactSchema },
     },

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
@@ -1,4 +1,4 @@
-import { ArtifactIdSchema, ArtifactSchema } from '@repo/protocol';
+import { ArtifactSchema } from '@repo/protocol';
 import { t } from 'elysia';
 import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
 
@@ -8,7 +8,7 @@ const MAX_ARTIFACT_SIZE = '256m';
 
 export const ArtifactParamsSchema = t.Composite([
   AppParamsSchema,
-  t.Object({ artifactId: ArtifactIdSchema }),
+  t.Object({ artifactId: t.String() }),
 ]);
 
 export const CreateArtifactBodySchema = t.Object({

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
@@ -1,15 +1,9 @@
 import { ArtifactSchema } from '@repo/protocol';
 import { t } from 'elysia';
-import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
 
 // The api buffers the upload to hash it, so this bound is what a single request may cost the
 // control plane's memory, not a judgement about how large a binary may be.
 const MAX_ARTIFACT_SIZE = '256m';
-
-export const ArtifactParamsSchema = t.Composite([
-  AppParamsSchema,
-  t.Object({ artifactId: t.String() }),
-]);
 
 export const CreateArtifactBodySchema = t.Object({
   binary: t.File({ maxSize: MAX_ARTIFACT_SIZE }),

--- a/apps/api/src/routes/api/apps/[appId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/controller.ts
@@ -1,4 +1,4 @@
-import { OwnerIdSchema, Value } from '@repo/protocol';
+import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
@@ -14,7 +14,7 @@ export const AppsAppIdController = new Elysia()
     '/apps/:appId',
     async ({ appsService, params, user, status }) => {
       const app = await appsService.get({
-        appId: params.appId,
+        appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, app);
@@ -28,7 +28,7 @@ export const AppsAppIdController = new Elysia()
     '/apps/:appId',
     async ({ appsService, params, body, user, status }) => {
       const app = await appsService.updateConfig({
-        appId: params.appId,
+        appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
         patch: body,
       });
@@ -46,7 +46,7 @@ export const AppsAppIdController = new Elysia()
     '/apps/:appId',
     async ({ appsService, params, user, status }) => {
       const app = await appsService.delete({
-        appId: params.appId,
+        appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.Accepted, app);

--- a/apps/api/src/routes/api/apps/[appId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/controller.ts
@@ -1,7 +1,6 @@
 import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
-import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
 import { AppConfigPatchSchema, AppResponseSchema } from '#routes/api/apps/model.ts';
 import { AppsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
@@ -20,7 +19,6 @@ export const AppsAppIdController = new Elysia()
       return status(StatusMap.OK, app);
     },
     {
-      params: AppParamsSchema,
       response: { [StatusMap.OK]: AppResponseSchema },
     },
   )
@@ -35,7 +33,6 @@ export const AppsAppIdController = new Elysia()
       return status(StatusMap.OK, app);
     },
     {
-      params: AppParamsSchema,
       body: AppConfigPatchSchema,
       response: { [StatusMap.OK]: AppResponseSchema },
     },
@@ -52,7 +49,6 @@ export const AppsAppIdController = new Elysia()
       return status(StatusMap.Accepted, app);
     },
     {
-      params: AppParamsSchema,
       response: { [StatusMap.Accepted]: AppResponseSchema },
     },
   );

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/controller.ts
@@ -1,10 +1,7 @@
 import { AppIdSchema, DeploymentIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
-import {
-  DeploymentParamsSchema,
-  DeploymentResponseSchema,
-} from '#routes/api/apps/[appId]/deployments/model.ts';
+import { DeploymentResponseSchema } from '#routes/api/apps/[appId]/deployments/model.ts';
 import { DeploymentsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdDeploymentsDeploymentIdController = new Elysia()
@@ -23,7 +20,6 @@ export const AppsAppIdDeploymentsDeploymentIdController = new Elysia()
       return status(StatusMap.OK, deployment);
     },
     {
-      params: DeploymentParamsSchema,
       response: { [StatusMap.OK]: DeploymentResponseSchema },
     },
   );

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/controller.ts
@@ -1,4 +1,4 @@
-import { OwnerIdSchema, Value } from '@repo/protocol';
+import { AppIdSchema, DeploymentIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -16,8 +16,8 @@ export const AppsAppIdDeploymentsDeploymentIdController = new Elysia()
     '/apps/:appId/deployments/:deploymentId',
     async ({ deploymentsService, params, user, status }) => {
       const deployment = await deploymentsService.get({
-        appId: params.appId,
-        deploymentId: params.deploymentId,
+        appId: Value.Parse(AppIdSchema, params.appId),
+        deploymentId: Value.Parse(DeploymentIdSchema, params.deploymentId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, deployment);

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/controller.ts
@@ -9,7 +9,6 @@ import {
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import { ReadDirectoryQuerySchema } from '#routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/model.ts';
-import { DeploymentParamsSchema } from '#routes/api/apps/[appId]/deployments/model.ts';
 import { FilesystemServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 /**
@@ -40,7 +39,6 @@ export const AppsAppIdDeploymentsDeploymentIdFilesystemController = new Elysia()
       return status(StatusMap.OK, listing);
     },
     {
-      params: DeploymentParamsSchema,
       query: ReadDirectoryQuerySchema,
       response: { [StatusMap.OK]: DirectoryListingSchema },
     },

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/controller.ts
@@ -1,4 +1,11 @@
-import { DirectoryListingSchema, GUEST_PATH_ROOT, OwnerIdSchema, Value } from '@repo/protocol';
+import {
+  AppIdSchema,
+  DeploymentIdSchema,
+  DirectoryListingSchema,
+  GUEST_PATH_ROOT,
+  OwnerIdSchema,
+  Value,
+} from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import { ReadDirectoryQuerySchema } from '#routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/model.ts';
@@ -24,8 +31,8 @@ export const AppsAppIdDeploymentsDeploymentIdFilesystemController = new Elysia()
     '/apps/:appId/deployments/:deploymentId/filesystem',
     async ({ filesystemService, params, query, user, request, status }) => {
       const listing = await filesystemService.readDirectory({
-        appId: params.appId,
-        deploymentId: params.deploymentId,
+        appId: Value.Parse(AppIdSchema, params.appId),
+        deploymentId: Value.Parse(DeploymentIdSchema, params.deploymentId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
         path: query.path ?? GUEST_PATH_ROOT,
         signal: AbortSignal.any([request.signal, AbortSignal.timeout(MAX_WAIT_MS)]),

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
@@ -1,4 +1,10 @@
-import { OwnerIdSchema, type TenantLogRecord, Value } from '@repo/protocol';
+import {
+  AppIdSchema,
+  DeploymentIdSchema,
+  OwnerIdSchema,
+  type TenantLogRecord,
+  Value,
+} from '@repo/protocol';
 import { Elysia, sse } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -28,8 +34,8 @@ export const AppsAppIdDeploymentsDeploymentIdLogsController = new Elysia()
     async ({ logsService, params, query, user, request }) => {
       const signal = AbortSignal.any([request.signal, AbortSignal.timeout(MAX_TAIL_MS)]);
       const records = await logsService.openTail({
-        appId: params.appId,
-        deploymentId: params.deploymentId,
+        appId: Value.Parse(AppIdSchema, params.appId),
+        deploymentId: Value.Parse(DeploymentIdSchema, params.deploymentId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
         startOffset: query.startOffset ?? DEFAULT_START_OFFSET,
         signal,

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
@@ -11,7 +11,6 @@ import {
   DEFAULT_START_OFFSET,
   TailLogsQuerySchema,
 } from '#routes/api/apps/[appId]/deployments/[deploymentId]/logs/model.ts';
-import { DeploymentParamsSchema } from '#routes/api/apps/[appId]/deployments/model.ts';
 import { LogsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 /**
@@ -43,7 +42,6 @@ export const AppsAppIdDeploymentsDeploymentIdLogsController = new Elysia()
       return events({ records, signal });
     },
     {
-      params: DeploymentParamsSchema,
       query: TailLogsQuerySchema,
     },
   );

--- a/apps/api/src/routes/api/apps/[appId]/deployments/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/controller.ts
@@ -1,4 +1,4 @@
-import { OwnerIdSchema, Value } from '@repo/protocol';
+import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -18,7 +18,7 @@ export const AppsAppIdDeploymentsController = new Elysia()
     '/apps/:appId/deployments',
     async ({ deploymentsService, params, user, status }) => {
       const deployments = await deploymentsService.list({
-        appId: params.appId,
+        appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, { deployments });
@@ -32,7 +32,7 @@ export const AppsAppIdDeploymentsController = new Elysia()
     '/apps/:appId/deployments',
     async ({ deploymentsService, params, body, user, status }) => {
       const deployment = await deploymentsService.createOrRollback({
-        appId: params.appId,
+        appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
         source: body,
       });

--- a/apps/api/src/routes/api/apps/[appId]/deployments/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/controller.ts
@@ -6,7 +6,6 @@ import {
   DeploymentResponseSchema,
   ListDeploymentsResponseSchema,
 } from '#routes/api/apps/[appId]/deployments/model.ts';
-import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
 import { DeploymentsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdDeploymentsController = new Elysia()
@@ -24,7 +23,6 @@ export const AppsAppIdDeploymentsController = new Elysia()
       return status(StatusMap.OK, { deployments });
     },
     {
-      params: AppParamsSchema,
       response: { [StatusMap.OK]: ListDeploymentsResponseSchema },
     },
   )
@@ -39,7 +37,6 @@ export const AppsAppIdDeploymentsController = new Elysia()
       return status(StatusMap.Created, deployment);
     },
     {
-      params: AppParamsSchema,
       body: CreateDeploymentBodySchema,
       response: { [StatusMap.Created]: DeploymentResponseSchema },
     },

--- a/apps/api/src/routes/api/apps/[appId]/deployments/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/model.ts
@@ -1,12 +1,6 @@
 import { ArtifactIdSchema, DeploymentIdSchema, DeploymentSchema } from '@repo/protocol';
 import { t } from 'elysia';
-import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
 import { PublicAppConfigSchema } from '#routes/api/apps/model.ts';
-
-export const DeploymentParamsSchema = t.Composite([
-  AppParamsSchema,
-  t.Object({ deploymentId: t.String() }),
-]);
 
 /**
  * An artifact to run, or a release to go back to — never both and never neither. A union rather

--- a/apps/api/src/routes/api/apps/[appId]/deployments/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/model.ts
@@ -5,7 +5,7 @@ import { PublicAppConfigSchema } from '#routes/api/apps/model.ts';
 
 export const DeploymentParamsSchema = t.Composite([
   AppParamsSchema,
-  t.Object({ deploymentId: DeploymentIdSchema }),
+  t.Object({ deploymentId: t.String() }),
 ]);
 
 /**

--- a/apps/api/src/routes/api/apps/[appId]/exports/[exportId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/[exportId]/controller.ts
@@ -1,10 +1,7 @@
 import { AppIdSchema, ExportIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
-import {
-  ExportParamsSchema,
-  ExportResponseSchema,
-} from '#routes/api/apps/[appId]/exports/model.ts';
+import { ExportResponseSchema } from '#routes/api/apps/[appId]/exports/model.ts';
 import { ExportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 /**
@@ -28,7 +25,6 @@ export const AppsAppIdExportsExportIdController = new Elysia()
       return status(StatusMap.OK, found);
     },
     {
-      params: ExportParamsSchema,
       response: { [StatusMap.OK]: ExportResponseSchema },
     },
   );

--- a/apps/api/src/routes/api/apps/[appId]/exports/[exportId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/[exportId]/controller.ts
@@ -1,4 +1,4 @@
-import { OwnerIdSchema, Value } from '@repo/protocol';
+import { AppIdSchema, ExportIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -21,8 +21,8 @@ export const AppsAppIdExportsExportIdController = new Elysia()
     '/apps/:appId/exports/:exportId',
     async ({ exportsService, params, user, status }) => {
       const found = await exportsService.get({
-        appId: params.appId,
-        exportId: params.exportId,
+        appId: Value.Parse(AppIdSchema, params.appId),
+        exportId: Value.Parse(ExportIdSchema, params.exportId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, found);

--- a/apps/api/src/routes/api/apps/[appId]/exports/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/controller.ts
@@ -5,7 +5,6 @@ import {
   ExportResponseSchema,
   ListExportsResponseSchema,
 } from '#routes/api/apps/[appId]/exports/model.ts';
-import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
 import { ExportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdExportsController = new Elysia()
@@ -23,7 +22,6 @@ export const AppsAppIdExportsController = new Elysia()
       return status(StatusMap.OK, { exports });
     },
     {
-      params: AppParamsSchema,
       response: { [StatusMap.OK]: ListExportsResponseSchema },
     },
   )
@@ -41,7 +39,6 @@ export const AppsAppIdExportsController = new Elysia()
       return status(StatusMap.Accepted, requested);
     },
     {
-      params: AppParamsSchema,
       response: { [StatusMap.Accepted]: ExportResponseSchema },
     },
   );

--- a/apps/api/src/routes/api/apps/[appId]/exports/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/controller.ts
@@ -1,4 +1,4 @@
-import { OwnerIdSchema, Value } from '@repo/protocol';
+import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
@@ -17,7 +17,7 @@ export const AppsAppIdExportsController = new Elysia()
     '/apps/:appId/exports',
     async ({ exportsService, params, user, status }) => {
       const exports = await exportsService.list({
-        appId: params.appId,
+        appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.OK, { exports });
@@ -35,7 +35,7 @@ export const AppsAppIdExportsController = new Elysia()
     '/apps/:appId/exports',
     async ({ exportsService, params, user, status }) => {
       const requested = await exportsService.request({
-        appId: params.appId,
+        appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
       });
       return status(StatusMap.Accepted, requested);

--- a/apps/api/src/routes/api/apps/[appId]/exports/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/model.ts
@@ -1,10 +1,10 @@
-import { ExportIdSchema, ExportSchema } from '@repo/protocol';
+import { ExportSchema } from '@repo/protocol';
 import { t } from 'elysia';
 import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
 
 export const ExportParamsSchema = t.Composite([
   AppParamsSchema,
-  t.Object({ exportId: ExportIdSchema }),
+  t.Object({ exportId: t.String() }),
 ]);
 
 /**

--- a/apps/api/src/routes/api/apps/[appId]/exports/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/model.ts
@@ -1,11 +1,5 @@
 import { ExportSchema } from '@repo/protocol';
 import { t } from 'elysia';
-import { AppParamsSchema } from '#routes/api/apps/[appId]/model.ts';
-
-export const ExportParamsSchema = t.Composite([
-  AppParamsSchema,
-  t.Object({ exportId: t.String() }),
-]);
 
 /**
  * `objectKey` is dropped and a signed URL put in its place: where the bundle sits is this end's

--- a/apps/api/src/routes/api/apps/[appId]/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/model.ts
@@ -1,3 +1,0 @@
-import { t } from 'elysia';
-
-export const AppParamsSchema = t.Object({ appId: t.String() });

--- a/apps/api/src/routes/api/apps/[appId]/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/model.ts
@@ -1,4 +1,3 @@
-import { AppIdSchema } from '@repo/protocol';
 import { t } from 'elysia';
 
-export const AppParamsSchema = t.Object({ appId: AppIdSchema });
+export const AppParamsSchema = t.Object({ appId: t.String() });

--- a/apps/api/tests/controllers/apps.test.ts
+++ b/apps/api/tests/controllers/apps.test.ts
@@ -18,6 +18,15 @@ describe('nothing under /api/apps answers a caller with no session', () => {
     // Unauthorized rather than Not Found: every route is mounted, each one refuses to serve.
     expect((await sendJson(route)).status).toBe(StatusMap.Unauthorized);
   });
+
+  // A path segment is a plain string until a handler parses it, so a malformed one is refused
+  // for the session it lacks rather than for its shape — which is the order a stranger should
+  // meet: whether the id was well-formed is not something an unauthenticated caller learns.
+  test('an appId the schema would refuse is still refused for the session first', async () => {
+    const response = await sendJson({ method: 'GET', url: `${APPS_URL}/-not-an-app-id` });
+
+    expect(response.status).toBe(StatusMap.Unauthorized);
+  });
 });
 
 // Elysia raises its own 422 for a schema violation; `elysiaErrorHandler` rewrites it, and a

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -2,7 +2,7 @@
 
 // Re-exported so a consumer can `Value.Parse` a branded schema without taking its own
 // dependency on the validator this package already owns.
-export { Value } from '@sinclair/typebox/value';
+export { AssertError, Value } from '@sinclair/typebox/value';
 export {
   DESIRED_INSTANCE_STATES,
   DESIRED_PRESENCE,


### PR DESCRIPTION
Stacked on #116.

A path param carries no brand, so a controller states where an identifier is admitted rather than inheriting one from the route schema:

```ts
appId: Value.Parse(AppIdSchema, params.appId)
```

The param schemas go with it. `t.Object({ appId: t.String() })` is exactly what `/apps/:appId` already yields, so they restated what Elysia infers; `[appId]/model.ts` held nothing else and is gone. TypeBox's `AssertError` maps to a bad request, named apart from Elysia's own so the two are told apart.

**Behaviour change worth a look.** Elysia validated params ahead of the auth guard; a handler parses after it. An unauthenticated caller sending a malformed id met a 400 and now meets a 401. That reads like the better order — whether the id was well-formed is not something a stranger should learn — but it is a change, and there is a test pinning it.