### PR TITLE
fix(api): an app is created with the arguments it was given

### DIFF
--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -193,7 +193,7 @@ export interface ISelectCurrentAppConfigResult {
 
 /** Result of query `InsertPatchedAppConfig`. */
 export interface IInsertPatchedAppConfigResult {
-    id: string | null;
+    id: string;
 }
 
 /** Result of query `TouchAppAfterConfigPatch`. */

--- a/apps/api/src/lib/pg-errors.ts
+++ b/apps/api/src/lib/pg-errors.ts
@@ -4,6 +4,10 @@ import { SQL } from 'bun';
 const UNIQUE_VIOLATION = '23505';
 const INVALID_TEXT_REPRESENTATION = '22P02';
 
+// Postgres raises 22P02 for every type that cannot read the text it was handed, and names the
+// function that failed. This is the one that parses a uuid; `array_in` and the rest are ours.
+const UUID_PARSE_ROUTINE = 'string_to_uuid';
+
 /**
  * Narrowed to one named constraint on purpose: a caller that retries on any unique violation
  * would also retry the ones that mean the request itself is wrong, forever.
@@ -28,7 +32,15 @@ export function isUniqueViolation({
  * `identifierSchema` bounds ids to a short token, not to a uuid, so a path parameter like
  * `app-1` is valid on the wire and reaches Postgres as one. No such value can name a row, so
  * this is the request being wrong rather than the server.
+ *
+ * The routine is checked and not just the SQLSTATE, because everything Postgres cannot parse
+ * shares it — a value this end failed to encode included. Answering 400 to one of those tells a
+ * caller their request was wrong about something only the server could have got wrong.
  */
 export function isMalformedIdentifier(error: unknown): boolean {
-  return error instanceof SQL.PostgresError && error.errno === INVALID_TEXT_REPRESENTATION;
+  return (
+    error instanceof SQL.PostgresError &&
+    error.errno === INVALID_TEXT_REPRESENTATION &&
+    error.routine === UUID_PARSE_ROUTINE
+  );
 }

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -1,7 +1,15 @@
 import type { AppHostnameKind, AppId, AppState, DnsLabel, Hostname, OwnerId } from '@repo/protocol';
+import type { ArrayType } from 'bun';
 import type { Queries } from '#db/queries.gen.d.ts';
 import { type AppConfigPatch, type PublicAppConfig, toAppConfig } from '#lib/app-config.ts';
 import { Repository } from '#repositories/repository.ts';
+
+/**
+ * `sql.array` encodes as JSON when the element type is left out, and `text[]` reads that JSON
+ * back element by element — so the arguments would arrive quoted rather than rejected. Naming
+ * the type is what makes the column and the parameter agree.
+ */
+const TENANT_ARGS_TYPE: ArrayType = 'TEXT';
 
 export type AppRow = Queries['SelectAppById'];
 export type AppHostnameRow = Queries['SelectAppHostnamesByApp'];
@@ -71,7 +79,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
           restart_backoff_factor, restart_reset_after_ms
         )
         VALUES (
-          ${inserted.id}, ${config.guestPort}, ${config.args},
+          ${inserted.id}, ${config.guestPort}, ${tx.array(config.args, TENANT_ARGS_TYPE)},
           ${config.resources.vcpuCount}, ${config.resources.memoryMib},
           ${config.healthCheck.path ?? null}, ${config.healthCheck.intervalMs},
           ${config.healthCheck.timeoutMs}, ${config.healthCheck.gracePeriodMs},
@@ -218,7 +226,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
           restart_backoff_factor, restart_reset_after_ms
         )
         VALUES (
-          ${appId}, ${config.guestPort}, ${config.args},
+          ${appId}, ${config.guestPort}, ${tx.array(config.args, TENANT_ARGS_TYPE)},
           ${config.resources.vcpuCount}, ${config.resources.memoryMib},
           ${config.healthCheck.path ?? null}, ${config.healthCheck.intervalMs},
           ${config.healthCheck.timeoutMs}, ${config.healthCheck.gracePeriodMs},

--- a/apps/api/tests/lib/pg-errors.test.ts
+++ b/apps/api/tests/lib/pg-errors.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, test } from 'bun:test';
 import { isMalformedIdentifier, isUniqueViolation } from '#lib/pg-errors.ts';
-import { MALFORMED_IDENTIFIER, postgresError, uniqueViolation } from '#tests/support/postgres.ts';
+import { malformedArrayLiteral, malformedUuid, uniqueViolation } from '#tests/support/postgres.ts';
 
 describe('a malformed identifier is the request being wrong, not the server', () => {
   test('a uuid column refusing a wire-valid id is recognised', () => {
-    expect(isMalformedIdentifier(postgresError({ sqlstate: MALFORMED_IDENTIFIER }))).toBe(true);
+    expect(isMalformedIdentifier(malformedUuid())).toBe(true);
+  });
+
+  // Everything Postgres cannot parse answers to 22P02, a value this end failed to encode
+  // included. Calling one of those a bad request blames the caller for the server's mistake and
+  // hides it behind a 400 nobody will investigate.
+  test('a value this end encoded wrongly shares the sqlstate and is not one', () => {
+    expect(isMalformedIdentifier(malformedArrayLiteral())).toBe(false);
   });
 
   test('nothing else is', () => {

--- a/apps/api/tests/support/postgres.ts
+++ b/apps/api/tests/support/postgres.ts
@@ -8,15 +8,28 @@ export const MALFORMED_IDENTIFIER = '22P02';
 export function postgresError({
   sqlstate,
   constraint,
+  routine,
 }: {
   sqlstate: string;
   constraint?: string;
+  routine?: string;
 }): SQL.PostgresError {
   return new SQL.PostgresError('postgres said no', {
     code: 'ERR_POSTGRES_SERVER_ERROR',
     errno: sqlstate,
     ...(constraint && { constraint }),
+    ...(routine && { routine }),
   });
+}
+
+// The two ways a statement reaches 22P02: a path parameter no uuid column can hold, and a value
+// this end failed to encode. Only the first is the caller's doing.
+export function malformedUuid(): SQL.PostgresError {
+  return postgresError({ sqlstate: MALFORMED_IDENTIFIER, routine: 'string_to_uuid' });
+}
+
+export function malformedArrayLiteral(): SQL.PostgresError {
+  return postgresError({ sqlstate: MALFORMED_IDENTIFIER, routine: 'array_in' });
 }
 
 export function uniqueViolation(constraint: string): SQL.PostgresError {

--- a/packages/cli/src/lib/api.test.ts
+++ b/packages/cli/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { authHeaders } from '#lib/api.ts';
+import { authHeaders, describeFailure } from '#lib/api.ts';
 
 const API_URL = 'http://localhost:3000';
 
@@ -25,4 +25,30 @@ test('a token issued by another api is not sent to this one', () => {
 // nothing to authenticate with.
 test('being signed out builds a client rather than refusing to', () => {
   expect(authHeaders({ baseUrl: API_URL, credentials: null })).toEqual({});
+});
+
+test('a refusal is reported as the api answering, not as this program deciding', () => {
+  const failure = Object.assign(new Error('[object Object]'), {
+    status: 404,
+    value: { error: 'Not Found' },
+  });
+
+  expect(describeFailure(failure)).toBe('The api answered 404: Not Found');
+});
+
+test('a body that names no error is still worth repeating', () => {
+  const failure = Object.assign(new Error('nope'), { status: 500, value: 'nope' });
+
+  expect(describeFailure(failure)).toBe('The api answered 500: nope');
+});
+
+// Eden reports a request it never sent as a 503 of its own, and saying the api answered it would
+// blame a server that was never reached.
+test('an api that could not be reached is not one that answered', () => {
+  const failure = Object.assign(new Error('unreachable'), {
+    status: 503,
+    value: new TypeError('Unable to connect'),
+  });
+
+  expect(describeFailure(failure)).toBe('Unable to connect');
 });

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -42,13 +42,29 @@ export function unwrap<R extends Reply>(reply: R): NonNullable<R['data']> {
   return reply.data as NonNullable<R['data']>;
 }
 
-// Eden wraps the body it was given in an `Error` whose message is that body stringified, which
-// for the api's `{ error }` shape reads as `[object Object]`. The body itself is the message.
-function describeFailure(failure: unknown): string {
+/**
+ * Eden wraps the body it was given in an `Error` whose message is that body stringified, which
+ * for the api's `{ error }` shape reads as `[object Object]`.
+ *
+ * The status is said as well as the body, because the body alone reads as this program's own
+ * verdict: `Not Found` sounds like a binary that could not be opened rather than a route that
+ * does not exist.
+ */
+export function describeFailure(failure: unknown): string {
   if (typeof failure !== 'object' || failure === null || !('value' in failure)) {
     return String(failure);
   }
   const { value } = failure;
+  // Eden reports a request it never managed to send as a 503 of its own, so a thrown value is
+  // this end failing to reach the api rather than the api answering.
+  if (value instanceof Error) {
+    return value.message;
+  }
+  const status = 'status' in failure ? String(failure.status) : 'no status';
+  return `The api answered ${status}: ${bodyMessage(value)}`;
+}
+
+function bodyMessage(value: unknown): string {
   if (typeof value === 'object' && value !== null && 'error' in value) {
     return String(value.error);
   }


### PR DESCRIPTION
`POST /api/apps` has never worked. Every attempt dies on `22P02 malformed array literal`, which is why production has zero apps — found while running `nib run` against app.nibrun.com.

`${config.args}` reaches Postgres comma-joined, and `text[]` refuses it. `sql.array` is the right helper but [encodes as JSON when the element type is omitted](https://bun.sh/docs/api/sql), and `text[]` reads that JSON back element by element — so the arguments would have arrived quoted rather than rejected, which is worse. Naming `TEXT` fixes both call sites.

`isMalformedIdentifier` matched SQLSTATE alone. Everything Postgres cannot parse answers to 22P02, so a value the server failed to encode came back as a 400 telling the caller their request was wrong. It now reads `routine` too — `string_to_uuid` is the uuid case, `array_in` and the rest are ours.

The CLI change is unrelated except in how it surfaced: `nib: Not Found` reads as a binary that could not be opened. It now says `The api answered 404: Not Found`, while still reporting a request Eden never managed to send as this end's failure rather than the api's.

## Verified

Against a throwaway Postgres 18 with these migrations, driving the real `AppsRepository`:

```
create ok -> pocketbase-abc123 | args: ["serve","--http=0.0.0.0:8090","--dir=/app/data/pb_data"]
round-trips: true
patch ok  -> args: ["serve","x y"]
```

and at rest, read through `psql` with no Bun in the path:

```
                        args                         | first_len
-----------------------------------------------------+-----------
 {serve,--http=0.0.0.0:8090,--dir=/app/data/pb_data} |         5
 {serve,"x y"}                                       |         5
```

## Not in here

A repository test against a real Postgres, deliberately — no container in CI for now. Worth saying plainly that this is the gap that let a never-working INSERT ship: `tests/support/postgres.ts` only fabricates error objects, so no test has ever executed this statement. The unit tests added here cover the error predicate and the CLI message, not the SQL.