### PR TITLE
feat(cli): an owner lists their app's filesystem from their terminal

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -27,6 +27,12 @@ the layout under `src/commands/` is the command tree.
   prints the parent's usage rather than a missing-argument error, because the
   walk stops at the node above the param — that listing is the only place the
   command's description is read, so it has to say what the value is for.
+- An **optional** positional is that node given a command of its own:
+  `commands/apps/ls.ts` beside `commands/apps/ls/[path].ts` makes `nib apps ls`
+  and `nib apps ls <path>` two commands, and the walk picks whichever the
+  positional it was handed reaches. There is no other spelling — a param is how
+  routing gets there, so a command reached without one is a different command.
+  Flags they share go on the `ls` node with `forwardToChildren: true`.
 - **`options` is required by `defineCommand` even when a command has none.**
   Omitting it matches the alias overload instead, whose errors talk about
   `undefined` and never mention options. `options: {}` is the fix.

--- a/packages/cli/src/command-tree.gen.ts
+++ b/packages/cli/src/command-tree.gen.ts
@@ -4,6 +4,8 @@ import type { InferForwardedOptions, InferParams, RuntimeNode } from '@parshjs/c
 import type { command as appsCmd } from './commands/apps.ts';
 import type { command as appsExportDestinationCmd } from './commands/apps/export/[destination].ts';
 import type { command as appsLogsCmd } from './commands/apps/logs.ts';
+import type { command as appsLsCmd } from './commands/apps/ls.ts';
+import type { command as appsLsPathCmd } from './commands/apps/ls/[path].ts';
 import type { command as loginCmd } from './commands/login.ts';
 import type { command as runCommandCmd } from './commands/run/[command].ts';
 
@@ -22,6 +24,19 @@ declare module '@parshjs/core' {
     'apps logs': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+      };
+      rootOptions: {};
+    };
+    'apps ls': {
+      parents: {
+        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+      };
+      rootOptions: {};
+    };
+    'apps ls [path]': {
+      parents: {
+        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+        'apps ls': { options: InferForwardedOptions<typeof appsLsCmd.options>; params: InferParams<typeof appsLsCmd.params> };
       };
       rootOptions: {};
     };
@@ -60,6 +75,17 @@ export const commandTree: RuntimeNode = {
           command: { path: 'apps logs', load: () => import('./commands/apps/logs.ts').then((m) => m.command) },
           literalChildren: {},
           paramChild: null,
+        },
+        'ls': {
+          segment: { kind: 'literal', value: 'ls' },
+          command: { path: 'apps ls', load: () => import('./commands/apps/ls.ts').then((m) => m.command) },
+          literalChildren: {},
+          paramChild: {
+            segment: { kind: 'param', name: 'path' },
+            command: { path: 'apps ls [path]', load: () => import('./commands/apps/ls/[path].ts').then((m) => m.command) },
+            literalChildren: {},
+            paramChild: null,
+          },
         },
       },
       paramChild: null,

--- a/packages/cli/src/commands/apps/logs.ts
+++ b/packages/cli/src/commands/apps/logs.ts
@@ -1,9 +1,9 @@
 import { defineCommand } from '@parshjs/core';
 import { DEFAULT_LOG_TIMERANGE, LOG_TIMERANGE_PATTERN } from '@repo/protocol';
 import { z } from 'zod';
-import { appBySlug, requireAppSlug } from '#lib/apps.ts';
+import { addressedDeployment, requireAppSlug } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { follow, latestDeployment, untilInterrupted } from '#lib/logs.ts';
+import { follow, untilInterrupted } from '#lib/logs.ts';
 
 export const command = defineCommand('apps logs', {
   description: 'Print an app output and keep printing it. Ends when you do.',
@@ -25,19 +25,17 @@ export const command = defineCommand('apps logs', {
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ options, parents, context, print }) => {
-    const slug = requireAppSlug(parents.apps.options['app-slug']);
     const { api } = context;
-
-    // The app is looked up either way — a deployment is addressed under the app that owns it — so
-    // what naming one skips is only the question of which deployment is current.
-    const app = await appBySlug({ api, slug });
-    const deploymentId =
-      options['deployment-id'] ?? (await latestDeployment({ api, appId: app.id }));
-    print.dim(`${app.slug} · deployment ${deploymentId}`);
+    const { appId, deploymentId } = await addressedDeployment({
+      api,
+      slug: requireAppSlug(parents.apps.options['app-slug']),
+      deploymentId: options['deployment-id'],
+      print,
+    });
 
     await follow({
       api,
-      appId: app.id,
+      appId,
       deploymentId,
       timerange: options.timerange,
       print,

--- a/packages/cli/src/commands/apps/ls.ts
+++ b/packages/cli/src/commands/apps/ls.ts
@@ -1,0 +1,33 @@
+import { defineCommand } from '@parshjs/core';
+import { GUEST_PATH_ROOT } from '@repo/protocol';
+import { z } from 'zod';
+import { requireAppSlug } from '#lib/apps.ts';
+import { requireSignedIn } from '#lib/credentials.ts';
+import { listDirectory } from '#lib/filesystem.ts';
+
+/**
+ * A command and the parent of `apps ls [path]` at once, which is how an optional positional is
+ * spelled: the walk stops here when nothing follows, and the volume's root is what listing
+ * without naming a directory means. `--deployment-id` is declared here and forwarded, so both
+ * spellings take it the same way.
+ */
+export const command = defineCommand('apps ls', {
+  description: "List a directory of an app's filesystem. Without a path, the volume root.",
+  options: {
+    'deployment-id': {
+      schema: z.string().min(1).optional(),
+      forwardToChildren: true,
+      description: 'Read this deployment instead of looking up the app latest.',
+    },
+  },
+  beforeHandler: ({ context }) => requireSignedIn(context),
+  handler: async ({ options, parents, context, print }) => {
+    await listDirectory({
+      api: context.api,
+      slug: requireAppSlug(parents.apps.options['app-slug']),
+      deploymentId: options['deployment-id'],
+      path: GUEST_PATH_ROOT,
+      print,
+    });
+  },
+});

--- a/packages/cli/src/commands/apps/ls/[path].ts
+++ b/packages/cli/src/commands/apps/ls/[path].ts
@@ -1,0 +1,29 @@
+import { defineCommand } from '@parshjs/core';
+import { z } from 'zod';
+import { requireAppSlug } from '#lib/apps.ts';
+import { requireSignedIn } from '#lib/credentials.ts';
+import { guestPath, listDirectory } from '#lib/filesystem.ts';
+
+export const command = defineCommand('apps ls [path]', {
+  description: 'Directory to list, as a path inside the app filesystem.',
+  options: {},
+  params: {
+    path: {
+      schema: z.string().min(1),
+    },
+  },
+  beforeHandler: ({ context }) => requireSignedIn(context),
+  handler: async ({ params, parents, context, print }) => {
+    // Parsed before anything is asked for: the read is a wait on a host, and a path that could
+    // never have been read is worth one line now rather than one line half a minute from now.
+    const path = guestPath(params.path);
+
+    await listDirectory({
+      api: context.api,
+      slug: requireAppSlug(parents.apps.options['app-slug']),
+      deploymentId: parents['apps ls'].options['deployment-id'],
+      path,
+      print,
+    });
+  },
+});

--- a/packages/cli/src/lib/apps.ts
+++ b/packages/cli/src/lib/apps.ts
@@ -1,7 +1,9 @@
+import type { Print } from '@parshjs/core';
 import { type Api, unwrap } from '#lib/api.ts';
 import { ApiError, UsageError } from '#lib/errors.ts';
 
 const NO_APP_NAMED = 'Which app? Name one with --app-slug.';
+const NO_DEPLOYMENTS = 'This app has never been deployed.';
 
 /**
  * `--app-slug` is optional on `apps` so that asking for nothing is answered with a listing rather
@@ -24,4 +26,42 @@ export async function appBySlug({ api, slug }: { api: Api; slug: string }) {
     throw new ApiError(`No app with slug ${slug}.`);
   }
   return found;
+}
+
+/**
+ * The deployment a reader means by not naming one. The api lists them newest first, so this is
+ * the head of the list rather than a search through it.
+ */
+async function latestDeployment({ api, appId }: { api: Api; appId: string }): Promise<string> {
+  const { deployments } = unwrap(await api.api.apps({ appId }).deployments.get());
+  const newest = deployments[0];
+  if (!newest) {
+    throw new ApiError(NO_DEPLOYMENTS);
+  }
+  return newest.id;
+}
+
+/**
+ * The deployment a command was pointed at, and a line saying which one it turned out to be.
+ *
+ * The app is looked up either way — a deployment is addressed under the app that owns it — so
+ * what naming one skips is only the question of which deployment is current. Which makes the line
+ * worth printing: the answer to that question is the difference between reading the release
+ * someone just made and reading the one before it.
+ */
+export async function addressedDeployment({
+  api,
+  slug,
+  deploymentId,
+  print,
+}: {
+  api: Api;
+  slug: string;
+  deploymentId: string | undefined;
+  print: Print;
+}): Promise<{ appId: string; deploymentId: string }> {
+  const app = await appBySlug({ api, slug });
+  const addressed = deploymentId ?? (await latestDeployment({ api, appId: app.id }));
+  print.dim(`${app.slug} · deployment ${addressed}`);
+  return { appId: app.id, deploymentId: addressed };
 }

--- a/packages/cli/src/lib/filesystem.test.ts
+++ b/packages/cli/src/lib/filesystem.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import type { FilesystemEntry } from '@repo/protocol';
+import { guestPath, render } from '#lib/filesystem.ts';
+
+function entry(overrides: Partial<FilesystemEntry> = {}): FilesystemEntry {
+  return {
+    name: 'app.db',
+    kind: 'file',
+    sizeBytes: 1258,
+    modifiedAt: '2026-08-06T09:41:00.123Z',
+    ...overrides,
+  } as FilesystemEntry;
+}
+
+function spelled(typed: string): string {
+  return guestPath(typed);
+}
+
+describe('a path is absolute because there is nowhere else it could start', () => {
+  test('one already spelled that way is left alone', () => {
+    expect(spelled('/uploads/2026')).toBe('/uploads/2026');
+  });
+
+  test('a leading slash left off is supplied', () => {
+    expect(spelled('uploads')).toBe('/uploads');
+  });
+
+  test('a trailing slash is spelling too', () => {
+    expect(spelled('/uploads/')).toBe('/uploads');
+  });
+
+  test('the root survives being trimmed', () => {
+    expect(spelled('/')).toBe('/');
+  });
+});
+
+describe('what is refused rather than repaired', () => {
+  // Resolving these is what would let a caller walk out of the filesystem they were scoped to.
+  test('a traversal is not resolved', () => {
+    expect(() => guestPath('/uploads/../../etc')).toThrow(
+      '/uploads/../../etc is not a path inside an app filesystem.',
+    );
+  });
+
+  test('a quote the reader tooling would tokenise is refused', () => {
+    expect(() => guestPath("/it's")).toThrow("/it's is not a path inside an app filesystem.");
+  });
+});
+
+describe('a listing is read down a column', () => {
+  test('entries are sorted by name rather than left in directory order', () => {
+    const lines = render([entry({ name: 'zeta' }), entry({ name: 'alpha' })]);
+
+    expect(lines.map((line) => line.split(' ').at(-1))).toEqual(['alpha', 'zeta']);
+  });
+
+  test('sizes line up under each other', () => {
+    const lines = render([
+      entry({ name: 'a', sizeBytes: 7 }),
+      entry({ name: 'b', sizeBytes: 4096 }),
+    ]);
+
+    expect(lines).toEqual([
+      'file         7 2026-08-06 09:41 a',
+      'file      4096 2026-08-06 09:41 b',
+    ]);
+  });
+
+  test('a kind wider than the one beside it does not shift the columns', () => {
+    const lines = render([entry({ name: 'uploads', kind: 'directory', sizeBytes: 4096 })]);
+
+    expect(lines).toEqual(['directory 4096 2026-08-06 09:41 uploads']);
+  });
+
+  // The tenant's binary made this name, so it has to survive being described rather than break
+  // the layout of everything after it.
+  test('a name the tenant chose is the last thing on the line', () => {
+    const lines = render([entry({ name: 'two\nlines' })]);
+
+    expect(lines).toEqual(['file      1258 2026-08-06 09:41 two\nlines']);
+  });
+});

--- a/packages/cli/src/lib/filesystem.ts
+++ b/packages/cli/src/lib/filesystem.ts
@@ -1,0 +1,107 @@
+import type { Print } from '@parshjs/core';
+import {
+  DIRECTORY_ENTRY_LIMIT,
+  FILESYSTEM_ENTRY_KINDS,
+  type FilesystemEntry,
+  type GuestPath,
+  GuestPathSchema,
+  Value,
+} from '@repo/protocol';
+import { type Api, unwrap } from '#lib/api.ts';
+import { addressedDeployment } from '#lib/apps.ts';
+import { UsageError } from '#lib/errors.ts';
+
+const KIND_WIDTH = Math.max(...FILESYSTEM_ENTRY_KINDS.map((kind) => kind.length));
+
+const DAY_AND_MINUTE_END = 16;
+
+/**
+ * What was typed, as a path the api will take.
+ *
+ * A path here is absolute because there is nothing for it to be relative to — the volume's root
+ * is the only place it can start — so a leading slash is spelling rather than meaning, and one
+ * left off is supplied rather than refused. A trailing one is the same. Nothing else is repaired:
+ * `.` and `..` are refused by the schema on purpose, and resolving them here is exactly what
+ * would put a caller outside the filesystem they were scoped to.
+ */
+export function guestPath(typed: string): GuestPath {
+  const absolute = typed.startsWith('/') ? typed : `/${typed}`;
+  const spelled = absolute.length > 1 ? absolute.replace(/\/$/, '') : absolute;
+  try {
+    return Value.Parse(GuestPathSchema, spelled);
+  } catch {
+    throw new UsageError(`${typed} is not a path inside an app filesystem.`);
+  }
+}
+
+export type ListInput = {
+  api: Api;
+  slug: string;
+  deploymentId: string | undefined;
+  path: GuestPath;
+  print: Print;
+};
+
+/**
+ * Print one directory of an app's filesystem.
+ *
+ * The request is held open by the api until a host next polls, so this is a wait rather than a
+ * read — hence the deployment being named before it starts rather than alongside the answer.
+ */
+export async function listDirectory({
+  api,
+  slug,
+  deploymentId,
+  path,
+  print,
+}: ListInput): Promise<void> {
+  const addressed = await addressedDeployment({ api, slug, deploymentId, print });
+  const listing = unwrap(
+    await api.api
+      .apps({ appId: addressed.appId })
+      .deployments({ deploymentId: addressed.deploymentId })
+      .filesystem.get({ query: { path } }),
+  );
+
+  for (const line of render(listing.entries)) {
+    print.info(line);
+  }
+  if (listing.truncated) {
+    print.warn(`Only the first ${DIRECTORY_ENTRY_LIMIT} entries of ${listing.path} are shown.`);
+  }
+}
+
+/**
+ * Sorted here because the order on the wire is the directory's own, which is an implementation
+ * detail of the filesystem and not something a reader looking for a name can use.
+ *
+ * The name goes last because it is the one field the tenant chose: anything ext4 allows is in it,
+ * including a newline, and a column after it would be the one that breaks.
+ *
+ * Sizes stay exact rather than rounded, because someone reading a tenant's filesystem is checking
+ * what their binary wrote, and `1.2 MiB` is what a second listing cannot be compared against.
+ */
+export function render(entries: readonly FilesystemEntry[]): string[] {
+  const sizeWidth = Math.max(0, ...entries.map((entry) => String(entry.sizeBytes).length));
+  return byName(entries).map((entry) =>
+    [
+      entry.kind.padEnd(KIND_WIDTH),
+      String(entry.sizeBytes).padStart(sizeWidth),
+      modifiedAt(entry.modifiedAt),
+      entry.name,
+    ].join(' '),
+  );
+}
+
+function byName(entries: readonly FilesystemEntry[]): FilesystemEntry[] {
+  // biome-ignore lint/complexity/useMaxParams: a comparator compares two entries
+  return [...entries].sort((left, right) => (left.name < right.name ? -1 : 1));
+}
+
+/**
+ * The date as well as the time, unlike a log line: what a log holds is what just happened, and
+ * what a filesystem holds may have been written months ago. UTC, as logs are.
+ */
+function modifiedAt(instant: string): string {
+  return new Date(instant).toISOString().slice(0, DAY_AND_MINUTE_END).replace('T', ' ');
+}

--- a/packages/cli/src/lib/logs.ts
+++ b/packages/cli/src/lib/logs.ts
@@ -1,9 +1,6 @@
 import type { Print } from '@parshjs/core';
 import type { TenantLogRecord } from '@repo/protocol';
 import { type Api, unwrap } from '#lib/api.ts';
-import { ApiError } from '#lib/errors.ts';
-
-const NO_DEPLOYMENTS = 'This app has never been deployed.';
 
 /**
  * How much of the gap a reconnect asks to be told about.
@@ -16,25 +13,6 @@ const RECONNECT_TIMERANGE = '30s';
 
 /** What a closed stream costs before we open another, so a refusing api is not hammered. */
 const RECONNECT_PAUSE_MS = 1_000;
-
-/**
- * The deployment a reader means by not naming one. The api lists them newest first, so this is
- * the head of the list rather than a search through it.
- */
-export async function latestDeployment({
-  api,
-  appId,
-}: {
-  api: Api;
-  appId: string;
-}): Promise<string> {
-  const { deployments } = unwrap(await api.api.apps({ appId }).deployments.get());
-  const newest = deployments[0];
-  if (!newest) {
-    throw new ApiError(NO_DEPLOYMENTS);
-  }
-  return newest.id;
-}
 
 /**
  * Ctrl-C, as something a loop can read rather than something that kills it mid-line.


### PR DESCRIPTION
`nib apps --app-slug <slug> ls [path] [--deployment-id <id>]` prints one directory of an app's volume — kind, size, modified, name — and says which deployment it read. Without a path, the volume root.

The api side already existed; this is its first consumer.

Three decisions worth a look:

**How an optional positional is spelled.** parsh routes on positionals, so a command reached without one is a different command: `commands/apps/ls.ts` sits beside `commands/apps/ls/[path].ts`, and the walk picks whichever the argument it was handed reaches. `--deployment-id` is declared on the `ls` node and forwarded, so the two spellings take it the same way rather than declaring it twice.

**What is repaired about a path and what is not.** A path here is absolute because there is nothing for it to be relative to, so a leading slash left off is spelling and gets supplied; a trailing one likewise. Nothing else is. `.` and `..` are refused by the schema on purpose, and resolving them in the CLI is exactly what would put a caller outside the filesystem they were scoped to.

**Exact sizes, and the name last.** Rounding is what stops one listing being comparable against the next, so byte counts go out whole. The name is the one field the tenant chose — anything ext4 allows is in it, including a newline — so it is the last column, where a name that breaks the layout breaks nothing after it. Entries are sorted here because the order on the wire is the directory's own.

`latestDeployment` moves to `src/lib/apps.ts` and joins the app lookup and the `<slug> · deployment <id>` line as `addressedDeployment`: `apps logs` and `apps ls` resolve the same thing the same way, so they now say it from one place.
