### PR TITLE
fix: an export record does not outlive the row behind it

### DIFF
--- a/apps/agent/src/lib/reconcile/plan.ts
+++ b/apps/agent/src/lib/reconcile/plan.ts
@@ -228,6 +228,12 @@ function planVolumes({
 /**
  * Not a diff against reality: the host cannot see the bucket it writes to, so a bundle already
  * written is left alone even if the object has since expired underneath it.
+ *
+ * Authoritative, like `instances` and unlike `volumes`: an export this end remembers and desired
+ * state does not mention is dropped. `absent` can only be said about a row the control plane
+ * still has, so it cannot reach one it never had or has since lost — and a note nothing will ever
+ * withdraw is one the host reports for as long as it runs. Safe to be authoritative about because
+ * forgetting costs a re-upload at worst, where forgetting a volume would cost the tenant's data.
  */
 function planExports({
   desired,
@@ -239,14 +245,20 @@ function planExports({
   const writtenIds = new Set(
     observed.exports.filter((current) => current.written).map((current) => current.exportId),
   );
-  return desired.exports.map((wanted): ExportPlan => {
-    if (wanted.desiredState === 'absent') {
-      return { action: 'forget', exportId: wanted.exportId };
-    }
-    return writtenIds.has(wanted.exportId)
-      ? { action: 'none', exportId: wanted.exportId }
-      : { action: 'write', desired: wanted };
-  });
+  const desiredIds = new Set(desired.exports.map((wanted) => wanted.exportId));
+  return [
+    ...desired.exports.map((wanted): ExportPlan => {
+      if (wanted.desiredState === 'absent') {
+        return { action: 'forget', exportId: wanted.exportId };
+      }
+      return writtenIds.has(wanted.exportId)
+        ? { action: 'none', exportId: wanted.exportId }
+        : { action: 'write', desired: wanted };
+    }),
+    ...observed.exports
+      .filter((current) => !desiredIds.has(current.exportId))
+      .map((current): ExportPlan => ({ action: 'forget', exportId: current.exportId })),
+  ];
 }
 
 function planCheckpoints({

--- a/apps/agent/tests/lib/reconcile/plan.test.ts
+++ b/apps/agent/tests/lib/reconcile/plan.test.ts
@@ -246,4 +246,14 @@ describe('exports', () => {
     });
     expect(plan.exports).toEqual([{ action: 'forget', exportId: EXPORT_ID }]);
   });
+
+  // `absent` only reaches a record the control plane still has. One it never had, or has lost,
+  // is a record nothing would ever withdraw — and the host reports it for as long as it runs.
+  test('a record desired state does not mention at all is forgotten too', () => {
+    const plan = planReconcile({
+      desired: desiredState({ exports: [] }),
+      observed: observedState({ exports: [{ exportId: EXPORT_ID, written: true }] }),
+    });
+    expect(plan.exports).toEqual([{ action: 'forget', exportId: EXPORT_ID }]);
+  });
 });

--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -464,6 +464,10 @@ export interface ISelectExportByIdResult {
 export interface IApplyReportedExportResult {
 }
 
+/** Result of query `FailInFlightExports`. */
+export interface IFailInFlightExportsResult {
+}
+
 /** Result of query `SelectInFlightExport`. */
 export interface ISelectInFlightExportResult {
     id: import("@repo/protocol").ExportId;
@@ -525,6 +529,7 @@ export interface Queries {
     SelectExportsByApp: ISelectExportsByAppResult;
     SelectExportById: ISelectExportByIdResult;
     ApplyReportedExport: IApplyReportedExportResult;
+    FailInFlightExports: IFailInFlightExportsResult;
     SelectInFlightExport: ISelectInFlightExportResult;
     SelectHealthPing: ISelectHealthPingResult;
 }

--- a/apps/api/src/repositories/exports.repository.ts
+++ b/apps/api/src/repositories/exports.repository.ts
@@ -35,6 +35,7 @@ export abstract class ExportsRepositoryContract {
   abstract listByApp(input: ExportsByAppInput): Promise<ExportRow[]>;
   abstract findById(input: ExportByIdInput): Promise<ExportRow | null>;
   abstract applyReport(input: { reported: ReportedExportRow[] }): Promise<void>;
+  abstract failInFlight(input: { appId: AppId; message: string }): Promise<void>;
 }
 
 export class ExportsRepository extends Repository implements ExportsRepositoryContract {
@@ -114,6 +115,17 @@ export class ExportsRepository extends Repository implements ExportsRepositoryCo
         `;
       }
     });
+  }
+
+  /**
+   * No owner in the predicate: the caller has already been answered on whether the app is theirs,
+   * and an export the owner cannot reach is one this end has to finish regardless of who asks.
+   */
+  async failInFlight({ appId, message }: { appId: AppId; message: string }): Promise<void> {
+    await this.sql.FailInFlightExports`
+      UPDATE nibrun.exports SET state = 'failed', message = ${message}
+      WHERE app_id = ${appId} AND state IN ('pending', 'preparing')
+    `;
   }
 
   private async findInFlight({ appId, ownerId }: ExportsByAppInput): Promise<ExportRow | null> {

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -15,6 +15,7 @@ import type {
   AppRow,
   AppsRepositoryContract,
 } from '#repositories/apps.repository.ts';
+import type { ExportsRepositoryContract } from '#repositories/exports.repository.ts';
 import { Service } from '#services/service.ts';
 
 export type PublicApp = Omit<App, 'config'> & { config: PublicAppConfig };
@@ -31,19 +32,28 @@ const SLUG_CONSTRAINTS = ['apps_slug_key', 'app_hostnames_hostname_key'];
 // a signal that something other than luck is wrong.
 const MAX_SLUG_ATTEMPTS = 5;
 
+/** What deleting an app needs from the exports it leaves behind, and nothing else. */
+export type ExportCancellation = Pick<ExportsRepositoryContract, 'failInFlight'>;
+
+const APP_DELETED = 'The app was deleted while this export was still being written.';
+
 export class AppsService extends Service {
   private readonly appsRepo: AppsRepositoryContract;
+  private readonly exportsRepo: ExportCancellation;
   private readonly appHostDomain: string;
 
   constructor({
     appsRepo,
+    exportsRepo,
     appHostDomain,
   }: {
     appsRepo: AppsRepositoryContract;
+    exportsRepo: ExportCancellation;
     appHostDomain: string;
   }) {
     super();
     this.appsRepo = appsRepo;
+    this.exportsRepo = exportsRepo;
     this.appHostDomain = appHostDomain;
   }
 
@@ -136,8 +146,18 @@ export class AppsService extends Service {
     }
   }
 
+  /**
+   * An export still running is ended here rather than left to finish, because there is nothing
+   * left for it to finish into: the bundle would be reachable only through the app that is going,
+   * and the host would spend minutes reading a filesystem the same reconcile pass tears down.
+   *
+   * After the state change, so it is only ever reached by an owner the app answered to — and
+   * while the app is `deleting` rather than once it is `deleted`, which is the last generation of
+   * desired state the host is told about it in.
+   */
   async delete({ appId, ownerId }: OwnedApp): Promise<PublicApp> {
     const app = requireApp(await this.appsRepo.updateState({ appId, ownerId, state: 'deleting' }));
+    await this.exportsRepo.failInFlight({ appId, message: APP_DELETED });
     const hostnames = await this.appsRepo.listHostnamesByApp({ appId, ownerId });
 
     return toPublicApp({ app, hostnames });

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -38,6 +38,7 @@ const logsRepository = new LogsRepository(new VictoriaLogsClient(env.VICTORIALOG
 const deploymentsService = new DeploymentsService({ deploymentsRepo: deploymentsRepository });
 const appsService = new AppsService({
   appsRepo: appsRepository,
+  exportsRepo: exportsRepository,
   appHostDomain: env.APP_HOST_DOMAIN,
 });
 const exportsService = new ExportsService({

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -21,7 +21,7 @@ import type {
   CreatedApp,
   OwnedAppHostnameRow,
 } from '#repositories/apps.repository.ts';
-import { AppsService } from '#services/apps.service.ts';
+import { AppsService, type ExportCancellation } from '#services/apps.service.ts';
 import {
   APP_HOST_DOMAIN,
   APP_ID,
@@ -149,8 +149,23 @@ class StubAppsRepository implements AppsRepositoryContract {
 const VOLUME_ID = Value.Parse(VolumeIdSchema, APP_ID);
 const NO_BYTES = 0;
 
-function serviceWith(appsRepo: AppsRepositoryContract) {
-  return new AppsService({ appsRepo, appHostDomain: APP_HOST_DOMAIN });
+class StubExportCancellation implements ExportCancellation {
+  readonly cancelled: AppId[] = [];
+
+  failInFlight({ appId }: { appId: AppId; message: string }): Promise<void> {
+    this.cancelled.push(appId);
+    return Promise.resolve();
+  }
+}
+
+function serviceWith({
+  appsRepo,
+  exportsRepo = new StubExportCancellation(),
+}: {
+  appsRepo: AppsRepositoryContract;
+  exportsRepo?: ExportCancellation;
+}) {
+  return new AppsService({ appsRepo, exportsRepo, appHostDomain: APP_HOST_DOMAIN });
 }
 
 function createApp({
@@ -160,7 +175,7 @@ function createApp({
   appsRepo: AppsRepositoryContract;
   config?: AppConfigPatch;
 }) {
-  return serviceWith(appsRepo).create({ ownerId: OWNER_ID, name: APP_NAME, config });
+  return serviceWith({ appsRepo }).create({ ownerId: OWNER_ID, name: APP_NAME, config });
 }
 
 describe('a taken hostname is a re-roll, not something the owner sees', () => {
@@ -267,7 +282,7 @@ describe('an app is created with no environment and never reports one', () => {
 // A 403 would confirm the app exists to someone with no right to know it does.
 describe('an app the caller does not own is one that does not exist', () => {
   test('a statement that matches no row is a 404', async () => {
-    const service = serviceWith(new StubAppsRepository({ failures: 0 }));
+    const service = serviceWith({ appsRepo: new StubAppsRepository({ failures: 0 }) });
     const owned = { appId: APP_ID, ownerId: OWNER_ID };
 
     await expect(service.get(owned)).rejects.toBeInstanceOf(NotFoundError);
@@ -291,17 +306,40 @@ describe('an app is deleted when its filesystem is gone, not when it is asked fo
     const appsRepo = new StubAppsRepository({ failures: 0 });
     appsRepo.owns = true;
 
-    const app = await serviceWith(appsRepo).delete({ appId: APP_ID, ownerId: OWNER_ID });
+    const app = await serviceWith({ appsRepo }).delete({ appId: APP_ID, ownerId: OWNER_ID });
 
     expect(app.state).toBe('deleting');
     expect(appsRepo.deleted).toEqual([]);
+  });
+
+  // The bundle would be reachable only through the app that is going, and the host would spend
+  // minutes reading a filesystem the same reconcile pass tears down.
+  test('an export still being written is ended rather than left to finish', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.owns = true;
+    const exportsRepo = new StubExportCancellation();
+
+    await serviceWith({ appsRepo, exportsRepo }).delete({ appId: APP_ID, ownerId: OWNER_ID });
+
+    expect(exportsRepo.cancelled).toEqual([APP_ID]);
+  });
+
+  // Reached only by an owner the app answered to: the state change is what says it is theirs.
+  test('and an app the caller does not own has none of its exports touched', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    const exportsRepo = new StubExportCancellation();
+
+    await expect(
+      serviceWith({ appsRepo, exportsRepo }).delete({ appId: APP_ID, ownerId: OWNER_ID }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+    expect(exportsRepo.cancelled).toEqual([]);
   });
 
   test('a host saying the filesystem is gone is what finishes it', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
     appsRepo.deleting = [APP_ID];
 
-    await serviceWith(appsRepo).completeDeletions({ volumes: [reportedVolume('deleted')] });
+    await serviceWith({ appsRepo }).completeDeletions({ volumes: [reportedVolume('deleted')] });
 
     expect(appsRepo.deleted).toEqual([APP_ID]);
   });
@@ -314,7 +352,7 @@ describe('an app is deleted when its filesystem is gone, not when it is asked fo
       const appsRepo = new StubAppsRepository({ failures: 0 });
       appsRepo.deleting = [APP_ID];
 
-      await serviceWith(appsRepo).completeDeletions({ volumes: [reportedVolume(state)] });
+      await serviceWith({ appsRepo }).completeDeletions({ volumes: [reportedVolume(state)] });
 
       expect(appsRepo.deleted).toEqual([]);
     });
@@ -325,7 +363,7 @@ describe('an app is deleted when its filesystem is gone, not when it is asked fo
   test('the same report arriving again deletes nothing a second time', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
     appsRepo.deleting = [APP_ID];
-    const apps = serviceWith(appsRepo);
+    const apps = serviceWith({ appsRepo });
 
     await apps.completeDeletions({ volumes: [reportedVolume('deleted')] });
     await apps.completeDeletions({ volumes: [reportedVolume('deleted')] });
@@ -338,7 +376,7 @@ describe('an app is deleted when its filesystem is gone, not when it is asked fo
   test('an app nobody asked to delete survives its volume going missing', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
 
-    await serviceWith(appsRepo).completeDeletions({ volumes: [reportedVolume('deleted')] });
+    await serviceWith({ appsRepo }).completeDeletions({ volumes: [reportedVolume('deleted')] });
 
     expect(appsRepo.deleted).toEqual([]);
   });

--- a/apps/api/tests/services/exports.test.ts
+++ b/apps/api/tests/services/exports.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  type AppId,
   type ExportId,
   ExportIdSchema,
   type ExportState,
@@ -92,6 +93,15 @@ class FakeExportsRepository implements ExportsRepositoryContract {
 
   applyReport({ reported }: { reported: ReportedExportRow[] }): Promise<void> {
     this.reported.push(reported);
+    return Promise.resolve();
+  }
+
+  failInFlight({ appId, message }: { appId: AppId; message: string }): Promise<void> {
+    this.rows = this.rows.map((row) =>
+      row.app_id === appId && (row.state === 'pending' || row.state === 'preparing')
+        ? { ...row, state: 'failed', message }
+        : row,
+    );
     return Promise.resolve();
   }
 }


### PR DESCRIPTION
An export the host remembers and the control plane no longer has is a record nothing will ever withdraw: `absent` can only be said about a row that still exists, so the host reports it for as long as it runs. That is the failure migration `0013` names in its own comment; it is reachable two ways it does not cover.

**Deleting an app while its export is still being written** — `desired_exports` stops carrying the row the moment the app is `deleted`, so the host is never told `absent`. Worse than the stranded record: the host writes the bundle before it tears the volume down, so it spends minutes reading a filesystem that pass is about to destroy, into a bundle only reachable through an app that is gone, while the owner's poll gets a not-found. The api now ends those exports while the app is still `deleting` — the last generation of desired state they appear in.

**A host offline longer than the retention window** — the row expires out of the view with nobody there to be told. No window closes this: `absent` is a message, and it needs a recipient present to hear it. So exports are now authoritative on the host the way `instances` already are — a record desired state does not mention is dropped. `volumes` stay explicit-`absent`; forgetting an export costs a re-upload, forgetting a volume costs the tenant's data.

The second half also clears `exp-pocketbase-1`, left on the app host by the hardcoded desired state in #49 and answered 400 by every report since #114.