### PR TITLE
refactor(cli): an owner names an app the same way wherever they name one

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -20,8 +20,9 @@ the layout under `src/commands/` is the command tree.
   `forwardToChildren: true` and read as `parents['<path>'].options`, never
   redeclared per child. The parent is then a group: no handler, so `nib apps`
   lists what is under it, and the flag stays optional — a required one would make
-  that listing an error. parsh spells a flag exactly as its key, so `--app-slug`
-  is the key `'app-slug'`.
+  that listing an error. parsh spells a flag exactly as its key, so `--app` is
+  the key `'app'` — and a flag two unrelated commands both take is that key held
+  in `src/config.ts` (`APP_OPTION`), so they cannot drift apart.
 - A positional is a path segment, so a command taking one lives at
   `commands/<…>/[name].ts` and its path string ends in `[name]`. Leaving it out
   prints the parent's usage rather than a missing-argument error, because the
@@ -47,10 +48,10 @@ the layout under `src/commands/` is the command tree.
   `src/lib/command-line.ts`. parsh cannot tell a trailing `--verbose` meant for
   the tenant from one meant for us, so quoting is what says which — never add a
   bare variadic and never reintroduce a `--` separator.
-- Prompting is gated on both ends of the pipe being a terminal (`isInteractive()`)
-  and on `--yes` being absent. A command must work with neither: whatever the
-  flags left open still needs a default. `ctx.print` stays the plain-output path,
-  clack the interactive one — see `src/lib/ui.ts`.
+- Prompting is gated on both ends of the pipe being a terminal
+  (`isInteractive()`). A command must work without one: whatever the flags left
+  open still needs a default. `ctx.print` stays the plain-output path, clack the
+  interactive one — see `src/lib/ui.ts`.
 - Run it with `bun run --filter @repo/cli nib …`. A package script runs from the
   package directory, so relative paths resolve against `packages/cli` rather than
   the caller's shell — pass absolute ones until the CLI ships as a real `bin`.

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -1,11 +1,12 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
+import { APP_OPTION } from '#config.ts';
 
 /**
  * A group rather than a command. Naming an app is what everything under here has in common, so
  * the flag that names one is declared once and forwarded rather than repeated on each child —
- * which is also what makes `nib apps --app-slug x logs` and `nib apps logs --app-slug x` the same
- * thing said two ways.
+ * which is also what makes `nib apps --app x logs` and `nib apps logs --app x` the same thing
+ * said two ways.
  *
  * No handler, so asking for nothing is answered with what can be asked for. Optional even though
  * every child needs it: a required flag would make `nib apps` an error rather than a list.
@@ -13,7 +14,7 @@ import { z } from 'zod';
 export const command = defineCommand('apps', {
   description: 'Work with one of your apps.',
   options: {
-    'app-slug': {
+    [APP_OPTION]: {
       schema: z.string().min(1).optional(),
       forwardToChildren: true,
       description: 'Slug of the app to work with.',

--- a/packages/cli/src/commands/apps/export/[destination].ts
+++ b/packages/cli/src/commands/apps/export/[destination].ts
@@ -24,7 +24,7 @@ export const command = defineCommand('apps export [destination]', {
     ui.open('nib apps export');
     await exportApp({
       api,
-      slug: requireAppSlug(parents.apps.options['app-slug']),
+      slug: requireAppSlug(parents.apps.options.app),
       destination: params.destination,
       ui,
     });

--- a/packages/cli/src/commands/apps/logs.ts
+++ b/packages/cli/src/commands/apps/logs.ts
@@ -28,7 +28,7 @@ export const command = defineCommand('apps logs', {
     const { api } = context;
     const { appId, deploymentId } = await addressedDeployment({
       api,
-      slug: requireAppSlug(parents.apps.options['app-slug']),
+      slug: requireAppSlug(parents.apps.options.app),
       deploymentId: options['deployment-id'],
       print,
     });

--- a/packages/cli/src/commands/apps/ls.ts
+++ b/packages/cli/src/commands/apps/ls.ts
@@ -24,7 +24,7 @@ export const command = defineCommand('apps ls', {
   handler: async ({ options, parents, context, print }) => {
     await listDirectory({
       api: context.api,
-      slug: requireAppSlug(parents.apps.options['app-slug']),
+      slug: requireAppSlug(parents.apps.options.app),
       deploymentId: options['deployment-id'],
       path: GUEST_PATH_ROOT,
       print,

--- a/packages/cli/src/commands/apps/ls/[path].ts
+++ b/packages/cli/src/commands/apps/ls/[path].ts
@@ -20,7 +20,7 @@ export const command = defineCommand('apps ls [path]', {
 
     await listDirectory({
       api: context.api,
-      slug: requireAppSlug(parents.apps.options['app-slug']),
+      slug: requireAppSlug(parents.apps.options.app),
       deploymentId: parents['apps ls'].options['deployment-id'],
       path,
       print,

--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -1,5 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
+import { APP_OPTION } from '#config.ts';
 import { parseCommandLine } from '#lib/command-line.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { deploy, readBinary } from '#lib/deploy.ts';
@@ -13,7 +14,7 @@ export const command = defineCommand('run [command]', {
     command: { schema: z.string().min(1) },
   },
   options: {
-    app: {
+    [APP_OPTION]: {
       schema: z.string().optional(),
       description: 'Slug of an existing app to deploy onto. Asked for when omitted.',
     },
@@ -25,30 +26,18 @@ export const command = defineCommand('run [command]', {
       schema: z.number().int().optional(),
       description: 'Port the binary listens on inside the guest.',
     },
-    vcpu: { schema: z.number().int().optional(), description: 'vCPUs the guest is given.' },
-    memory: {
-      schema: z.number().int().optional(),
-      description: 'Memory the guest is given, in MiB.',
-    },
     detach: {
       schema: z.boolean().optional(),
       aliases: ['d'],
       description: 'Return once the deployment is created instead of waiting for it to serve.',
     },
-    yes: {
-      schema: z.boolean().optional(),
-      aliases: ['y'],
-      description: 'Take the defaults for anything not given instead of asking.',
-    },
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ params, options, context, print }) => {
-    const { yes, detach, ...given } = options;
+    const { detach, ...given } = options;
     const { binaryPath, args } = parseCommandLine(params.command);
     const { api } = context;
 
-    // A terminal decides how this looks; `--yes` only decides whether it asks. Someone who wants
-    // the defaults taken has not thereby asked for the output of a log file.
     const interactive = isInteractive();
     const ui = createUi({ print, interactive });
 
@@ -57,10 +46,9 @@ export const command = defineCommand('run [command]', {
     const binary = await readBinary(binaryPath);
     ui.open('nib run');
 
-    const resolved =
-      interactive && yes !== true
-        ? await completeOptions({ api, options: given, binaryPath, args })
-        : given;
+    const resolved = interactive
+      ? await completeOptions({ api, options: given, binaryPath, args })
+      : given;
 
     await deploy({ ...resolved, api, ui, binary, args, detach });
   },

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,3 +1,7 @@
 export const PROGRAM_NAME = 'nib';
 
 export const DEFAULT_API_URL = 'https://app.nibrun.com';
+
+// `nib run` and `nib apps` both take the app to work on, and one name for it is what makes them
+// the same flag rather than two that happen to rhyme.
+export const APP_OPTION = 'app';

--- a/packages/cli/src/lib/apps.ts
+++ b/packages/cli/src/lib/apps.ts
@@ -1,12 +1,13 @@
 import type { Print } from '@parshjs/core';
+import { APP_OPTION } from '#config.ts';
 import { type Api, unwrap } from '#lib/api.ts';
 import { ApiError, UsageError } from '#lib/errors.ts';
 
-const NO_APP_NAMED = 'Which app? Name one with --app-slug.';
+const NO_APP_NAMED = `Which app? Name one with --${APP_OPTION}.`;
 const NO_DEPLOYMENTS = 'This app has never been deployed.';
 
 /**
- * `--app-slug` is optional on `apps` so that asking for nothing is answered with a listing rather
+ * `--app` is optional on `apps` so that asking for nothing is answered with a listing rather
  * than an error, which leaves every command underneath to say what going without one means. They
  * all mean the same thing, so they say it from here.
  */

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -1,12 +1,5 @@
 import { basename } from 'node:path';
-import {
-  DEFAULT_INSTANCE_RESOURCES,
-  type DeploymentState,
-  GuestPortSchema,
-  type InstanceResources,
-  type TenantArguments,
-  Value,
-} from '@repo/protocol';
+import { type DeploymentState, GuestPortSchema, type TenantArguments, Value } from '@repo/protocol';
 import { type Api, unwrap } from '#lib/api.ts';
 import { appBySlug } from '#lib/apps.ts';
 import { ApiError, UsageError } from '#lib/errors.ts';
@@ -39,15 +32,11 @@ export async function deploy({
   args,
   app: slug,
   name,
+  port,
   detach,
-  ...resources
 }: DeployInput): Promise<void> {
   const target = slug === undefined ? null : await appBySlug({ api, slug });
-  const config = configPatch({
-    args,
-    current: target?.config.resources ?? DEFAULT_INSTANCE_RESOURCES,
-    ...resources,
-  });
+  const config = configPatch({ args, port });
 
   const app =
     target === null
@@ -93,22 +82,10 @@ export async function readBinary(path: string): Promise<File> {
  * run with, and carrying over the last deploy's arguments because none were given this time
  * would run something nobody asked for.
  */
-function configPatch({
-  args,
-  current,
-  port,
-  vcpu,
-  memory,
-}: RunOptions & { args: TenantArguments; current: InstanceResources }) {
+function configPatch({ args, port }: Pick<RunOptions, 'port'> & { args: TenantArguments }) {
   return {
     args,
     ...(port !== undefined && { guestPort: Value.Parse(GuestPortSchema, port) }),
-    ...((vcpu !== undefined || memory !== undefined) && {
-      resources: {
-        vcpuCount: vcpu ?? current.vcpuCount,
-        memoryMib: memory ?? current.memoryMib,
-      },
-    }),
   };
 }
 

--- a/packages/cli/src/lib/plan.test.ts
+++ b/packages/cli/src/lib/plan.test.ts
@@ -82,14 +82,14 @@ test('an app the owner cannot deploy onto is not offered', async () => {
 
 test('a flag already given is not asked about again', async () => {
   const resolved = await completeOptions({
-    api: apiListing([{ slug: 'demo-abc123', state: 'active' }]),
-    options: { app: 'demo-abc123', vcpu: 2 },
+    api: apiListing([]),
+    options: { name: 'my-app', port: 8080 },
     binaryPath: '/tmp/my-server',
     args: ['serve', '--verbose'],
   });
 
-  expect(resolved).toEqual({ app: 'demo-abc123', vcpu: 2 });
-  expect(asked).toEqual(['confirm:Deploy onto demo-abc123? This replaces what it is running.']);
+  expect(resolved).toEqual({ name: 'my-app', port: 8080 });
+  expect(asked).toEqual(['confirm:Create my-app and deploy?']);
 });
 
 test('what the binary will be run with is shown before anything is uploaded', async () => {

--- a/packages/cli/src/lib/plan.ts
+++ b/packages/cli/src/lib/plan.ts
@@ -8,8 +8,6 @@ export type RunOptions = {
   app?: string | undefined;
   name?: string | undefined;
   port?: number | undefined;
-  vcpu?: number | undefined;
-  memory?: number | undefined;
 };
 
 type Plan = {
@@ -21,9 +19,8 @@ type Plan = {
 /**
  * Ask for what the flags left open, then show what it all adds up to.
  *
- * Only the two answers that decide where a first deploy lands are asked for. Resources are not:
- * they have defaults worth taking, and a question asked on every run is one that gets answered
- * without reading it.
+ * Only the answers that decide where a first deploy lands are asked for — a question asked on
+ * every run is one that gets answered without reading it.
  */
 export async function completeOptions({ api, options, binaryPath, args }: Plan & { api: Api }) {
   const completed = await fillGaps({ api, options, binaryPath });
@@ -106,8 +103,6 @@ function summary({ options, binaryPath, args }: Plan): string {
     ['binary', binaryPath],
     ['app', options.app ?? options.name],
     ['port', options.port],
-    ['vcpu', options.vcpu],
-    ['memory', options.memory],
     ['args', args.length === 0 ? undefined : args.join(' ')],
   ];
   return rows


### PR DESCRIPTION
`--app-slug` becomes `--app`, held as one constant in `src/config.ts` so `nib apps` and `nib run` cannot drift apart.

`nib run` also drops `--vcpu`, `--memory` and `--yes`: guest resources are the api's to default, and whether to ask is what a terminal already answers.