### PR TITLE
feat(infra): a machine is rebuilt from the deploy workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,10 @@ on:
         description: "Apply even if the plan destroys or replaces resources"
         type: boolean
         default: false
+      replace:
+        description: "Terraform addresses to recreate, comma-separated (e.g. aws_instance.app_host[0]). Replacing is a destroy, so allow_destroy has to be on too."
+        type: string
+        default: ""
 
 concurrency:
   group: cd
@@ -107,6 +111,7 @@ jobs:
           TF_VAR_app_host_caddy_tls_cert: ${{ vars.APP_HOST_CADDY_TLS_CERT }}
           TF_VAR_app_host_caddy_tls_key: ${{ secrets.APP_HOST_CADDY_TLS_KEY }}
           ALLOW_DESTROY: ${{ inputs.allow_destroy }}
+          TERRAFORM_REPLACE: ${{ inputs.replace }}
         run: bun run --filter @repo/internal-scripts terraform-apply
 
   deploy-api:

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -51,4 +51,8 @@ command history, in the clear, for 30 days — so Terraform writes secrets into 
 instance decrypts with its own role. Both GHCR packages must be public for the same reason: the box
 pulls with no registry credentials.
 
-`workflow_dispatch` takes `allow_destroy` for the times a plan legitimately replaces something.
+`workflow_dispatch` takes `allow_destroy` for the times a plan legitimately replaces something, and
+`replace` for recreating a machine nothing in the configuration would otherwise touch — e.g.
+`aws_instance.app_host[0]`, with `allow_destroy` on, to rebuild a host from its bootstrap up. An app
+host's ZeroFS prefix is keyed on its instance id, so a replacement starts on an empty prefix and
+orphans the old one.

--- a/packages/internal-scripts/src/terraform-apply.ts
+++ b/packages/internal-scripts/src/terraform-apply.ts
@@ -34,9 +34,28 @@ await group({
   run: () => terraform(['init', '-input=false']),
 });
 
+// The one operation a plan cannot express, because nothing in the configuration
+// changed: recreating a resource whose state is fine and whose *machine* is not
+// — a host to rebuild from scratch, a bootstrap to re-run.
+const replaced = (optionalEnv('TERRAFORM_REPLACE') ?? '')
+  .split(',')
+  .map((address) => address.trim())
+  .filter(Boolean);
+
+if (replaced.length > 0) {
+  console.log(bold(`\nRecreating: ${replaced.join(' ')}`));
+}
+
 await group({
   title: 'terraform plan',
-  run: () => terraform(['plan', '-input=false', '-out', PLAN_FILE]),
+  run: () =>
+    terraform([
+      'plan',
+      '-input=false',
+      ...replaced.map((address) => `-replace=${address}`),
+      '-out',
+      PLAN_FILE,
+    ]),
 });
 
 if (optionalEnv('ALLOW_DESTROY') !== 'true') {


### PR DESCRIPTION
`workflow_dispatch` takes a `replace` input, so recreating a machine nothing in the configuration would otherwise touch — an app host to rebuild from its bootstrap up — is a dispatch rather than a local `terraform apply` with every secret on hand.

Replacing is a destroy, so it still needs `allow_destroy` on: the gate is unchanged.