### PR TITLE
fix: an exported app arrives whole and ready to run

### DIFF
--- a/apps/agent/src/lib/exports/bundle.ts
+++ b/apps/agent/src/lib/exports/bundle.ts
@@ -2,7 +2,7 @@ import { basename } from 'node:path';
 import { FileSystem, Path } from '@effect/platform';
 import type { DesiredArtifact } from '@repo/protocol';
 import { Data, Duration, Effect, Either } from 'effect';
-import { downloadAndVerify } from '#lib/vm/artifacts.ts';
+import { BINARY_MODE, downloadAndVerify } from '#lib/vm/artifacts.ts';
 import { MKFS_ROOT_ENTRIES } from '#lib/volumes/ext4.ts';
 import { stdoutOf } from '#services/command-runner.service.ts';
 
@@ -91,7 +91,11 @@ export const writeBundle = Effect.fn('writeBundle')(function* ({
   yield* fs.makeDirectory(stagingDir, { recursive: true, mode: STAGING_MODE });
 
   yield* dumpFilesystem({ devicePath, destination: path.join(stagingDir, DATA_DIRECTORY) });
-  yield* downloadAndVerify({ artifact, destination: path.join(stagingDir, binaryName) });
+  const binaryPath = path.join(stagingDir, binaryName);
+  yield* downloadAndVerify({ artifact, destination: binaryPath });
+  // A transfer writes what a transfer writes, and `tar` records the mode it finds. Without this
+  // the bundle carries a binary the owner has to chmod before the copy they were handed will run.
+  yield* fs.chmod(binaryPath, BINARY_MODE);
 
   const bundlePath = path.join(stagingDir, BUNDLE_NAME);
   yield* stdoutOf({

--- a/apps/agent/src/lib/vm/artifacts.ts
+++ b/apps/agent/src/lib/vm/artifacts.ts
@@ -9,7 +9,8 @@ const HEX_ENCODING = 'hex';
 const SQUASHFS_FILENAME = 'artifact.squashfs';
 /** The path the guest's init execs, fixed by the boot contract. */
 const GUEST_BINARY_NAME = 'server';
-const BINARY_MODE = 0o755;
+/** What a binary has to be to be one, wherever it lands — the guest's squashfs or an export. */
+export const BINARY_MODE = 0o755;
 const CACHE_DIR_MODE = 0o755;
 
 export class DigestMismatch extends Data.TaggedError('DigestMismatch')<{

--- a/apps/agent/tests/lib/exports/bundle.test.ts
+++ b/apps/agent/tests/lib/exports/bundle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdir, readdir, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { type Filename, FilenameSchema, Value } from '@repo/protocol';
 import { Effect, Either, Layer } from 'effect';
@@ -10,6 +10,9 @@ import { artifact } from '#tests/support/fixtures.ts';
 import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
 
 const DEVICE_PATH = '/dev/nbd7';
+const PERMISSION_BITS = 0o777;
+/** Spelled out rather than imported: what the archive has to carry, not what the source says it does. */
+const RUNNABLE_MODE = 0o755;
 
 const run = provided(Layer.merge(artifactStore(), platform));
 
@@ -54,7 +57,12 @@ function bundling({ dumps = 'tenant' }: { dumps?: keyof typeof DUMPS } = {}) {
       ),
     );
     const archived = yield* Effect.promise(() => readdir(dataDir).catch(() => [] as string[]));
-    return { commands, result, stagingDir, archived };
+    const binaryMode = yield* Effect.promise(() =>
+      stat(join(stagingDir, 'pocketbase'))
+        .then((stats) => stats.mode & PERMISSION_BITS)
+        .catch(() => null),
+    );
+    return { commands, result, stagingDir, archived, binaryMode };
   });
 }
 
@@ -89,6 +97,14 @@ test('archives the data tree and the binary under its uploaded name', async () =
   // `.` would sweep the archive into itself.
   expect(tar?.command).not.toContain('.');
   expect(Either.isRight(result)).toBe(true);
+});
+
+// The bundle exists so the copy can be run, and `tar` records the mode the staging tree has. A
+// transfer writes 0644, so without a chmod the binary arrives needing one.
+test('the binary is archived able to run', async () => {
+  const { binaryMode } = await run(bundling());
+
+  expect(binaryMode).toBe(RUNNABLE_MODE);
 });
 
 test('a dump that produced nothing is a failure rather than an empty bundle', async () => {

--- a/packages/cli/src/lib/exports.test.ts
+++ b/packages/cli/src/lib/exports.test.ts
@@ -2,9 +2,28 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { bundlePath } from '#lib/exports.ts';
+import { bundlePath, writeStream } from '#lib/exports.ts';
 
 const SLUG = 'quiet-otter';
+
+const CHUNK_COUNT = 4;
+const CHUNK_BYTES = 64;
+
+/**
+ * A body that arrives in pieces rather than at once, which is every transfer that crosses a
+ * network and the only kind `Bun.write` cannot be given a `Response` for.
+ */
+function trickling(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      for (let sent = 0; sent < CHUNK_COUNT; sent += 1) {
+        controller.enqueue(new Uint8Array(CHUNK_BYTES).fill(sent));
+        await Bun.sleep(1);
+      }
+      controller.close();
+    },
+  });
+}
 
 let root = '';
 
@@ -42,6 +61,27 @@ describe('where the bundle lands', () => {
     await expect(bundlePath({ destination: missing, slug: SLUG })).rejects.toThrow(
       `No such directory: ${join(root, 'nowhere')}.`,
     );
+  });
+});
+
+// The bug this covers ends in a download that never finishes rather than one that fails, so what
+// it asserts is that the write settles at all — the bytes are the easy half.
+describe('a bundle arrives in pieces and still lands whole', () => {
+  test('every chunk is written', async () => {
+    const landed = join(root, 'trickled.bin');
+
+    await writeStream({ stream: trickling(), path: landed });
+
+    expect(Bun.file(landed).size).toBe(CHUNK_COUNT * CHUNK_BYTES);
+  });
+
+  test('the last chunk is there, not just the first', async () => {
+    const landed = join(root, 'trickled-tail.bin');
+
+    await writeStream({ stream: trickling(), path: landed });
+
+    const bytes = new Uint8Array(await Bun.file(landed).arrayBuffer());
+    expect(bytes.at(-1)).toBe(CHUNK_COUNT - 1);
   });
 });
 

--- a/packages/cli/src/lib/exports.ts
+++ b/packages/cli/src/lib/exports.ts
@@ -135,17 +135,41 @@ async function awaitBundle({
  */
 async function download({ url, path }: { url: string; path: string }): Promise<void> {
   const response = await fetch(url);
-  if (!response.ok) {
+  if (!response.ok || response.body === null) {
     throw new ApiError(`The bundle could not be downloaded: ${response.status}.`);
   }
 
   const partial = `${path}${PARTIAL_SUFFIX}`;
   try {
-    await Bun.write(partial, response);
+    await writeStream({ stream: response.body, path: partial });
     await rename(partial, path);
   } catch (failure) {
     await rm(partial, { force: true });
     throw failure;
+  }
+}
+
+/**
+ * `Bun.write` takes a `Response` and would be the whole of this, but in Bun 1.4 it never settles
+ * when the body arrives in more than one piece: nothing is written, nothing throws, and the
+ * download waits for good. A body that arrives at once is fine, which is why a local server does
+ * not show it and every real transfer does. Reading the stream is the same thing said in a way
+ * that finishes.
+ */
+export async function writeStream({
+  stream,
+  path,
+}: {
+  stream: ReadableStream<Uint8Array>;
+  path: string;
+}): Promise<void> {
+  const sink = Bun.file(path).writer();
+  try {
+    for await (const chunk of stream) {
+      sink.write(chunk);
+    }
+  } finally {
+    await sink.end();
   }
 }
 


### PR DESCRIPTION
Two things stood between `nib apps --app <slug> export <destination>` and a copy somebody can use. Neither is visible from the code alone, so both are pinned by a test that fails without the fix.

## The download never finished

It prepared the bundle and then sat on `downloading 11.6 MiB` for good. The bytes were in the bucket and the URL was fine — a ranged GET answers `206` in 145ms. What never finished was writing them down.

`Bun.write(path, response)` is documented to take a `Response`, and in Bun 1.4 it never settles when the body arrives in more than one piece: nothing is written, nothing throws, and the await waits forever. A body that arrives at once is fine, which is the trap — a local server hands one over in a single go and the call looks correct, while every transfer that crosses a network splits into pieces and hangs. Reduced to a local repro, no network or S3 involved:

```js
// 12 MiB as one chunk -> ok in 38ms.  the same 12 MiB as 48 chunks 1ms apart -> hangs at 0 bytes.
await Bun.write('/tmp/out.bin', await fetch(url))
```

Reading the stream and writing the chunks is the same thing said in a way that finishes. The two tests covering it fail by timing out rather than by asserting, because that is how the bug presents — a download that never finishes rather than one that fails.

Worth knowing beyond this command: nothing else here writes a `Response` to disk today, but the obvious way to do it is the broken one.

## The binary arrived unable to run

`-rw-r--r--`, so the copy an owner is handed needs a `chmod +x` before it does anything. The bundle ships the binary precisely so it can be run, which makes that the difference between a copy of an app and an archive of one.

The two paths that fetch an artifact had drifted. The guest-image path chmods `0755` after the transfer; the export path called the same `downloadAndVerify` — which writes through `fs.sink` at the default `0644` — and handed it straight to `tar`, which records the mode it finds. `BINARY_MODE` is now shared between them rather than being a fact one path knew and the other did not.

## Verifying

The download fix is confirmed end to end against the real service: the bundle lands, extracts, and the binary inside hashes to the digest the database pinned. The chmod runs on the host, so it is covered by test rather than by a live export — the mode a real bundle carries is not something this branch can observe until an agent ships.
