### PR TITLE
fix: every line an app writes in one millisecond reaches the reader

### DIFF
--- a/apps/api/src/repositories/logs.repository.ts
+++ b/apps/api/src/repositories/logs.repository.ts
@@ -38,8 +38,33 @@ export class LogsRepository implements LogsRepositoryContract {
       query: tenantQuery({ appId, deploymentId, limit }),
       start: since,
     });
-    return rows.map(toRecord).filter((record) => record !== undefined);
+    return rows
+      .map(toRecord)
+      .filter((record) => record !== undefined)
+      .sort(byWritingOrder);
   }
+}
+
+/**
+ * The order a guest wrote its output in, which is the order it is read back in.
+ *
+ * `sort by (_time)` settles the instant and nothing within it, and a guest writes many lines inside
+ * one millisecond — a program announcing itself at startup writes all of them there. How the store
+ * holds those is the store's own business, and the order it hands them back in is not the order
+ * they were written. `sequence` is: it counts what one source wrote, in order.
+ *
+ * Across sources it settles nothing, because two sources never share a counter — but a window read
+ * twice has to come back the same way twice, so `sourceId` breaks that tie rather than the store.
+ */
+// biome-ignore lint/complexity/useMaxParams: a comparator compares two records
+function byWritingOrder(left: TenantLogRecord, right: TenantLogRecord): number {
+  if (left._time !== right._time) {
+    return left._time < right._time ? -1 : 1;
+  }
+  if (left.sourceId !== right.sourceId) {
+    return left.sourceId < right.sourceId ? -1 : 1;
+  }
+  return left.sequence - right.sequence;
 }
 
 /**

--- a/apps/api/src/services/logs.service.ts
+++ b/apps/api/src/services/logs.service.ts
@@ -1,4 +1,11 @@
-import type { AppId, DeploymentId, OwnerId, TenantLogRecord, Timestamp } from '@repo/protocol';
+import {
+  type AppId,
+  type DeploymentId,
+  type OwnerId,
+  SeenTenantLogs,
+  type TenantLogRecord,
+  type Timestamp,
+} from '@repo/protocol';
 import { durationToMs } from '#lib/duration.ts';
 import { NotFoundError } from '#lib/errors.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
@@ -81,7 +88,7 @@ export class LogsService extends Service {
     since: Timestamp;
     signal: AbortSignal;
   }): AsyncGenerator<TenantLogRecord> {
-    const delivered = new Delivered();
+    const delivered = new SeenTenantLogs();
     let from = since;
 
     while (!signal.aborted) {
@@ -104,27 +111,6 @@ export class LogsService extends Service {
   }
 }
 
-/**
- * What this stream has already handed over, so the overlap between two windows is handed over once.
- *
- * A window resumes on the instant the last one ended rather than after it — see `resumeAt` — so
- * every window but the first begins with records its predecessor already carried. `sourceId` and
- * `sequence` are what tell a second copy from a second record: sequence counts within one source
- * and only rises, so the highest seen is the whole of what has to be kept.
- */
-class Delivered {
-  readonly #highest = new Map<string, number>();
-
-  admit(record: TenantLogRecord): boolean {
-    const seen = this.#highest.get(record.sourceId);
-    if (seen !== undefined && record.sequence <= seen) {
-      return false;
-    }
-    this.#highest.set(record.sourceId, record.sequence);
-    return true;
-  }
-}
-
 function startOf(timerange: string): Timestamp {
   return toTimestamp(new Date(Date.now() - durationToMs(timerange)));
 }
@@ -134,8 +120,8 @@ function startOf(timerange: string): Timestamp {
  *
  * The store stamps to the millisecond, so records sharing the last one's instant may not all have
  * been written when this window was read — starting past it would lose them, and starting on it
- * repeats what has already been handed over. A repeat is the recoverable half, and `Delivered` is
- * what recovers it.
+ * repeats what has already been handed over. A repeat is the recoverable half, and
+ * `SeenTenantLogs` is what recovers it.
  *
  * A full window that begins and ends in the same instant is the one case that would start on
  * itself forever, and it moves on instead. Reaching it means a guest wrote a window of output

--- a/apps/api/tests/repositories/logs.test.ts
+++ b/apps/api/tests/repositories/logs.test.ts
@@ -14,6 +14,8 @@ const APP_ID = Value.Parse(AppIdSchema, 'app-1');
 const DEPLOYMENT_ID = Value.Parse(DeploymentIdSchema, 'deployment-1');
 const HOST_ID = Value.Parse(HostIdSchema, 'host-1');
 const SINCE = Value.Parse(TimestampSchema, '2026-08-06T09:41:00.123Z');
+const AN_INSTANT = Value.Parse(TimestampSchema, '2026-08-06T09:41:00.687Z');
+const A_LATER_INSTANT = Value.Parse(TimestampSchema, '2026-08-06T09:41:00.756Z');
 const LIMIT = 500;
 const DROPPED_BYTES = 4096;
 
@@ -101,5 +103,49 @@ describe('a read takes one window of one deployment out of the store', () => {
     const { records } = await read([missingAField, storedRow()]);
 
     expect(records).toHaveLength(1);
+  });
+});
+
+describe('a window comes back in the order the app wrote it', () => {
+  /**
+   * `sort by (_time)` settles nothing within one millisecond, and a program announcing itself
+   * writes several lines in one. Here the store hands that instant back newest first, which is a
+   * log printed backwards until `sequence` puts it right.
+   */
+  test('records sharing an instant are ordered by what the source counted', async () => {
+    const { records } = await read([
+      storedRow({ sequence: '2', _msg: '└─ Dashboard: ...' }),
+      storedRow({ sequence: '1', _msg: '├─ REST API: ...' }),
+      storedRow({ sequence: '0', _msg: 'Server started at ...' }),
+    ]);
+
+    expect(records.map((record) => record.sequence)).toEqual([0, 1, 2]);
+  });
+
+  test('an instant still decides against a later one', async () => {
+    const { records } = await read([
+      storedRow({ _time: A_LATER_INSTANT, sequence: '0' }),
+      storedRow({ _time: AN_INSTANT, sequence: '9' }),
+    ]);
+
+    expect(records.map((record) => record._time)).toEqual([AN_INSTANT, A_LATER_INSTANT]);
+  });
+
+  // Two sources never share a counter, so the tie is arbitrary — but a window read twice has to
+  // come back the same way twice, which is the whole of what settling it buys.
+  test('two sources within one instant are separated rather than interleaved', async () => {
+    const { records } = await read([
+      storedRow({ sourceId: 'source-2', sequence: '0' }),
+      storedRow({ sourceId: 'source-1', sequence: '1' }),
+      storedRow({ sourceId: 'source-2', sequence: '1' }),
+      storedRow({ sourceId: 'source-1', sequence: '0' }),
+    ]);
+
+    expect(records.map((record) => `${record.sourceId}/${record.sequence}`)).toEqual([
+      'source-1/0',
+      'source-1/1',
+      'source-2/0',
+      'source-2/1',
+    ]);
   });
 });

--- a/apps/api/tests/services/logs.test.ts
+++ b/apps/api/tests/services/logs.test.ts
@@ -199,6 +199,27 @@ describe('a stream is windows of the store, and reads as one log', () => {
     expect(seen.map((entry) => entry.sequence)).toEqual([0, 1, 2]);
   });
 
+  /**
+   * A guest writes several lines within one millisecond every time it announces itself, and only
+   * the overlap between windows is a repeat — sharing an instant with the record before it is not.
+   */
+  test('a burst written inside one millisecond is handed over whole', async () => {
+    const subject = service({
+      row: A_DEPLOYMENT_ROW,
+      windows: [
+        [
+          record({ at: AN_INSTANT, sequence: 0 }),
+          record({ at: AN_INSTANT, sequence: 1 }),
+          record({ at: AN_INSTANT, sequence: 2 }),
+        ],
+      ],
+    });
+
+    const seen = await drain(await open({ subject }));
+
+    expect(seen.map((entry) => entry.sequence)).toEqual([0, 1, 2]);
+  });
+
   test('the next window starts where the last one reached', async () => {
     const subject = service({
       row: A_DEPLOYMENT_ROW,

--- a/packages/cli/src/lib/logs.test.ts
+++ b/packages/cli/src/lib/logs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { Print } from '@parshjs/core';
 import type { TenantLogRecord } from '@repo/protocol';
-import { Printed, render, show } from '#lib/logs.ts';
+import { render, show } from '#lib/logs.ts';
 
 const DROPPED_BYTES = 4096;
 
@@ -32,30 +32,6 @@ function printer(): Print & { at: string[] } {
     dim: () => at.push('dim'),
   };
 }
-
-describe('a page that overlaps the one before it prints only what is new', () => {
-  test('a record is printed once', () => {
-    const printed = new Printed();
-
-    expect(printed.admit(record())).toBe(true);
-    expect(printed.admit(record())).toBe(false);
-  });
-
-  test('the next record from the same source is new', () => {
-    const printed = new Printed();
-    printed.admit(record());
-
-    expect(printed.admit(record({ sequence: 1 }))).toBe(true);
-  });
-
-  // Sequence counts within one source, so the same number from another one is another record.
-  test('a source that restarted is not the source that stopped', () => {
-    const printed = new Printed();
-    printed.admit(record());
-
-    expect(printed.admit(record({ sourceId: 'source-2' }))).toBe(true);
-  });
-});
 
 describe('a record is one line of what the app wrote', () => {
   test('the line carries the time of day, the stream and the message', () => {

--- a/packages/cli/src/lib/logs.test.ts
+++ b/packages/cli/src/lib/logs.test.ts
@@ -4,6 +4,7 @@ import type { TenantLogRecord } from '@repo/protocol';
 import { render, show } from '#lib/logs.ts';
 
 const DROPPED_BYTES = 4096;
+const ESCAPE_CODE = 27;
 
 function record(overrides: Partial<TenantLogRecord> = {}): TenantLogRecord {
   return {
@@ -33,13 +34,73 @@ function printer(): Print & { at: string[] } {
   };
 }
 
+const ESCAPE = String.fromCharCode(ESCAPE_CODE);
+const ANSI = new RegExp(`${ESCAPE}\\[\\d+m`, 'g');
+const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(Z|[+-]\d{2}:\d{2})$/;
+
+/** The three columns `render` lays out, with whatever styling it wrapped them in taken back off. */
+function columns(line: string) {
+  const [stamp = '', mark = '', ...rest] = line.replace(ANSI, '').split('  ');
+  return { stamp, mark, message: rest.join('  ') };
+}
+
+/**
+ * Rendering as it would reach a terminal. Nothing in a test run is one, so styling is off unless
+ * asked for — and `NO_COLOR` has to go while it is, since a environment that sets it wins.
+ */
+function withColour(rendering: () => string): string {
+  const { NO_COLOR, FORCE_COLOR } = process.env;
+  delete process.env.NO_COLOR;
+  process.env.FORCE_COLOR = '1';
+  try {
+    return rendering();
+  } finally {
+    restore({ name: 'NO_COLOR', value: NO_COLOR });
+    restore({ name: 'FORCE_COLOR', value: FORCE_COLOR });
+  }
+}
+
+function restore({ name, value }: { name: string; value: string | undefined }): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
 describe('a record is one line of what the app wrote', () => {
-  test('the line carries the time of day, the stream and the message', () => {
-    expect(render(record())).toBe('09:41:00.123 out listening on 0.0.0.0:8090');
+  test('the line is the message, behind the stream it came out of', () => {
+    const { mark, message } = columns(render(record()));
+
+    expect(mark).toBe('out');
+    expect(message).toBe('listening on 0.0.0.0:8090');
+  });
+
+  // Stamped in the reader's own timezone, so the text depends on where the test runs and the
+  // instant it stands for does not.
+  test('the stamp is RFC 3339 for the instant the record carries', () => {
+    const { stamp } = columns(render(record()));
+
+    expect(stamp).toMatch(RFC3339);
+    expect(Date.parse(stamp)).toBe(Date.parse('2026-08-06T09:41:00.123Z'));
   });
 
   test('what the app wrote to its error stream is labelled as such', () => {
-    expect(render(record({ stream: 'stderr' }))).toStartWith('09:41:00.123 err');
+    expect(columns(render(record({ stream: 'stderr' }))).mark).toBe('err');
+  });
+
+  // The store keeps the newline the guest wrote and printing supplies another, which is a blank
+  // line between every two records.
+  test('the newline that ended the message is not printed a second time', () => {
+    const line = render(record({ _msg: 'listening on 0.0.0.0:8090\n' }));
+
+    expect(line).not.toInclude('\n');
+    expect(columns(line).message).toBe('listening on 0.0.0.0:8090');
+  });
+
+  // Trailing spaces are the app's own, and only the terminator is this program's to remove.
+  test('what the app wrote is otherwise left alone', () => {
+    expect(columns(render(record({ _msg: 'waiting...  ' }))).message).toBe('waiting...  ');
   });
 
   // A gap stands for output the host had to drop, and how much is the whole of what it says.
@@ -47,6 +108,20 @@ describe('a record is one line of what the app wrote', () => {
     const line = render(record({ stream: 'stderr', droppedBytes: DROPPED_BYTES }));
 
     expect(line).toEndWith(`(${DROPPED_BYTES} bytes)`);
+  });
+});
+
+describe('only the part of a line the app did not write is dimmed', () => {
+  test('the stamp and the stream mark are, and the message is not', () => {
+    const line = withColour(() => render(record()));
+
+    expect(line).toStartWith(`${ESCAPE}[2m`);
+    expect(line).toEndWith(`${ESCAPE}[22m  listening on 0.0.0.0:8090`);
+  });
+
+  // Styling a line nobody will look at leaves escapes in whatever the output was redirected into.
+  test('a stream that is not a terminal is written plainly', () => {
+    expect(render(record())).not.toInclude(ESCAPE);
   });
 });
 

--- a/packages/cli/src/lib/logs.ts
+++ b/packages/cli/src/lib/logs.ts
@@ -1,5 +1,5 @@
 import type { Print } from '@parshjs/core';
-import type { TenantLogRecord } from '@repo/protocol';
+import { SeenTenantLogs, type TenantLogRecord } from '@repo/protocol';
 import { type Api, unwrap } from '#lib/api.ts';
 
 /**
@@ -7,7 +7,7 @@ import { type Api, unwrap } from '#lib/api.ts';
  *
  * Only the first stream wants the range the reader asked for; a later one is picking up after a
  * close and wants the seconds it was away, not that history again. Generous, because overlap is
- * cheap here — `Printed` drops what has already been shown — and a gap is not recoverable.
+ * cheap here — `SeenTenantLogs` drops what has already been shown — and a gap is not recoverable.
  */
 const RECONNECT_TIMERANGE = '30s';
 
@@ -41,8 +41,8 @@ export type FollowInput = {
  *
  * The api closes a stream on its own clock so that who may read it is asked again rather than
  * decided once, which makes reaching the end of one an instruction to open another rather than
- * the end of the log. Opening another is why `Printed` outlives them all: a reconnect asks for
- * the seconds it was away, and what it was not away for comes back a second time.
+ * the end of the log. Opening another is why `SeenTenantLogs` outlives them all: a reconnect asks
+ * for the seconds it was away, and what it was not away for comes back a second time.
  */
 export async function follow({
   api,
@@ -53,7 +53,7 @@ export async function follow({
   signal,
 }: FollowInput): Promise<void> {
   const logs = api.api.apps({ appId }).deployments({ deploymentId }).logs;
-  const printed = new Printed();
+  const printed = new SeenTenantLogs();
   let asked = timerange;
 
   // Stopping part-way through a stream is the ordinary ending, and it arrives as a failed request
@@ -73,27 +73,6 @@ export async function follow({
     if (!signal.aborted) {
       throw failure;
     }
-  }
-}
-
-/**
- * What has already been printed, so a reconnect does not print it again.
- *
- * A stream cannot be resumed from where the last one stopped — there is no cursor on the wire —
- * so a new one asks for the seconds around the gap and carries whatever else was in them.
- * `sourceId` and `sequence` are what tell a second copy from a second record: sequence counts
- * within one source and only rises, so the highest seen is the whole of what has to be remembered.
- */
-export class Printed {
-  readonly #highest = new Map<string, number>();
-
-  admit(record: TenantLogRecord): boolean {
-    const seen = this.#highest.get(record.sourceId);
-    if (seen !== undefined && record.sequence <= seen) {
-      return false;
-    }
-    this.#highest.set(record.sourceId, record.sequence);
-    return true;
   }
 }
 

--- a/packages/cli/src/lib/logs.ts
+++ b/packages/cli/src/lib/logs.ts
@@ -1,5 +1,5 @@
 import type { Print } from '@parshjs/core';
-import { SeenTenantLogs, type TenantLogRecord } from '@repo/protocol';
+import { SeenTenantLogs, type TenantLogRecord, type TenantLogStream } from '@repo/protocol';
 import { type Api, unwrap } from '#lib/api.ts';
 
 /**
@@ -94,18 +94,88 @@ export function show({ record, print }: { record: TenantLogRecord; print: Print 
   print.info(line);
 }
 
-export function render(record: TenantLogRecord): string {
-  const gap = record.droppedBytes === undefined ? '' : ` (${record.droppedBytes} bytes)`;
-  return `${clockOf(record._time)} ${record.stream === 'stderr' ? 'err' : 'out'} ${record._msg}${gap}`;
-}
-
-const CLOCK_START = 11;
-const CLOCK_END = 23;
+/** Wide enough that a column still reads as one against a message that begins with a space. */
+const COLUMN_GAP = '  ';
 
 /**
- * The time of day the store recorded, in UTC. The date is left off because someone watching an app
- * is watching now, and the whole date on every line would crowd out the line itself.
+ * What ends a line the guest wrote, which is not part of what it said.
+ *
+ * The store keeps the terminator, because a record is whatever bytes arrived. Printing is what
+ * supplies one — so leaving it on puts an empty line between every two records.
  */
-function clockOf(instant: string): string {
-  return new Date(instant).toISOString().slice(CLOCK_START, CLOCK_END);
+const TERMINATOR = /\r?\n$/;
+
+/** One record, one line: what the app wrote, behind a dimmed column saying when and from where. */
+export function render(record: TenantLogRecord): string {
+  const gap = record.droppedBytes === undefined ? '' : ` (${record.droppedBytes} bytes)`;
+  const mark = record.stream === 'stderr' ? 'err' : 'out';
+  const column = dimmed({
+    text: `${stampOf(record._time)}${COLUMN_GAP}${mark}`,
+    stream: record.stream,
+  });
+  return `${column}${COLUMN_GAP}${record._msg.replace(TERMINATOR, '')}${gap}`;
+}
+
+const MS_PER_MINUTE = 60_000;
+const MINUTES_PER_HOUR = 60;
+const OFFSET_DIGITS = 2;
+
+/** Through the milliseconds, which is as fine as the agent stamps one. */
+const RFC3339_LENGTH = 23;
+
+/**
+ * The instant the store recorded, as RFC 3339 in the reader's own timezone.
+ *
+ * Local rather than UTC because someone following their app is reading it against the clock on
+ * their own wall, and a stamp an hour off the one the dashboard shows reads as a different event.
+ * The offset is what keeps that unambiguous, and what leaves the line parseable by anything
+ * downstream — which the time of day alone was not.
+ */
+function stampOf(instant: string): string {
+  const at = new Date(instant);
+  const offset = -at.getTimezoneOffset();
+  const local = new Date(at.getTime() + offset * MS_PER_MINUTE);
+  return `${local.toISOString().slice(0, RFC3339_LENGTH)}${offsetOf(offset)}`;
+}
+
+function offsetOf(minutes: number): string {
+  if (minutes === 0) {
+    return 'Z';
+  }
+  const size = Math.abs(minutes);
+  const hours = twoDigits(Math.floor(size / MINUTES_PER_HOUR));
+  return `${minutes < 0 ? '-' : '+'}${hours}:${twoDigits(size % MINUTES_PER_HOUR)}`;
+}
+
+function twoDigits(value: number): string {
+  return String(value).padStart(OFFSET_DIGITS, '0');
+}
+
+const DIM = '\x1b[2m';
+const UNDIM = '\x1b[22m';
+
+/**
+ * Dimming for the part of a line the app did not write.
+ *
+ * `print` styles a whole message, so a column that is only part of one has to arrive already
+ * dimmed — and dimmed on the same terms `print` decides colour on, or a redirected stdout carries
+ * escapes nobody asked for. Each stream answers for itself: they go to different places, and only
+ * one of them may be a terminal.
+ */
+function dimmed({ text, stream }: { text: string; stream: TenantLogStream }): string {
+  return coloured(stream) ? `${DIM}${text}${UNDIM}` : text;
+}
+
+function coloured(stream: TenantLogStream): boolean {
+  const { NO_COLOR, FORCE_COLOR } = process.env;
+  if (NO_COLOR) {
+    return false;
+  }
+  if (FORCE_COLOR === '0' || FORCE_COLOR === 'false') {
+    return false;
+  }
+  if (FORCE_COLOR) {
+    return true;
+  }
+  return Boolean(stream === 'stderr' ? process.stderr.isTTY : process.stdout.isTTY);
 }

--- a/packages/protocol/src/domain/log.ts
+++ b/packages/protocol/src/domain/log.ts
@@ -60,6 +60,48 @@ export const TenantLogRecordSchema = Type.Object({
 export type TenantLogRecord = typeof TenantLogRecordSchema.static;
 
 /**
+ * What a reader has already been handed, so a record read twice is handed over once.
+ *
+ * Following re-reads on both sides: the api resumes a window on the instant the last one ended
+ * rather than after it, and a reader whose stream closes asks again for the seconds it was away.
+ * Both ask the same question of a record, so the answer lives here beside the fields it reads.
+ *
+ * `sourceId` and `sequence` are what tell a second copy from a second record — but sequence is not
+ * the order records arrive in. The store sorts on `_time`, a source writes many records within one
+ * millisecond, and their order within it is the store's own. So a high-water mark per source drops
+ * the rest of every instant whose newest record it happened to see first. What is kept instead is
+ * the newest instant handed over and the keys seen at it: older is a repeat, newer is not, and only
+ * a tie has to be looked up.
+ *
+ * Instants are compared to the millisecond, which is coarser than the store writes them. That can
+ * only put two records in one bucket that belong in two, which costs a key and decides nothing.
+ *
+ * Records must arrive oldest first. That is what bounds this to one instant's keys rather than the
+ * whole stream's, and what makes anything older than the newest a repeat rather than a late record.
+ */
+export class SeenTenantLogs {
+  #newest = Number.NEGATIVE_INFINITY;
+  readonly #keysAtNewest = new Set<string>();
+
+  admit(record: TenantLogRecord): boolean {
+    const at = Date.parse(record._time);
+    if (at < this.#newest) {
+      return false;
+    }
+    if (at > this.#newest) {
+      this.#newest = at;
+      this.#keysAtNewest.clear();
+    }
+    const key = `${record.sourceId}/${record.sequence}`;
+    if (this.#keysAtNewest.has(key)) {
+      return false;
+    }
+    this.#keysAtNewest.add(key);
+    return true;
+  }
+}
+
+/**
  * How much history a reader asks for before it starts following, as a duration such as `30s`.
  *
  * A duration rather than a number of lines, because the store is asked for a window of time and a

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -175,6 +175,7 @@ export {
   LogSourceSchema,
   type LogTimerange,
   LogTimerangeSchema,
+  SeenTenantLogs,
   TENANT_LOG_STREAMS,
   type TenantLogRecord,
   TenantLogRecordSchema,

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -27,7 +27,9 @@ import {
   redactSecrets,
   type SecretString,
   SecretStringSchema,
+  SeenTenantLogs,
   Sha256DigestSchema,
+  type TenantLogRecord,
   TimestampSchema,
   Value,
   VolumeIdSchema,
@@ -371,4 +373,76 @@ test('the poll settings the control plane hands out are themselves valid', () =>
 test('a timestamp brand is only obtained by parsing a plain string', () => {
   const now = Value.Parse(TimestampSchema, new Date().toISOString());
   expect(isValidMessage({ schema: TimestampSchema, value: now })).toBe(true);
+});
+
+const AN_INSTANT = Value.Parse(TimestampSchema, '2026-08-07T09:51:56.687Z');
+const A_LATER_INSTANT = Value.Parse(TimestampSchema, '2026-08-07T09:51:56.756Z');
+
+function logRecord(overrides: Partial<TenantLogRecord> = {}): TenantLogRecord {
+  return {
+    _time: AN_INSTANT,
+    _msg: 'Server started at http://0.0.0.0:8090',
+    hostId: 'host-1',
+    SOURCE: 'tenant',
+    appId: 'app-1',
+    deploymentId: 'deployment-1',
+    stream: 'stdout',
+    sourceId: 'source-1',
+    sequence: 0,
+    ...overrides,
+  } as TenantLogRecord;
+}
+
+describe('a record read twice is handed over once', () => {
+  test('the same record is not admitted a second time', () => {
+    const seen = new SeenTenantLogs();
+
+    expect(seen.admit(logRecord())).toBe(true);
+    expect(seen.admit(logRecord())).toBe(false);
+  });
+
+  /**
+   * The whole reason this is not a high-water mark. A program announcing itself writes several
+   * lines in one millisecond, and the store hands that instant back in an order of its own — so
+   * seeing the newest of them first must not condemn the rest as repeats.
+   */
+  test('the rest of an instant survives having seen its newest record first', () => {
+    const seen = new SeenTenantLogs();
+    seen.admit(logRecord({ sequence: 2 }));
+
+    expect(seen.admit(logRecord({ sequence: 1 }))).toBe(true);
+    expect(seen.admit(logRecord({ sequence: 0 }))).toBe(true);
+  });
+
+  test('the next record from the same source is new', () => {
+    const seen = new SeenTenantLogs();
+    seen.admit(logRecord());
+
+    expect(seen.admit(logRecord({ sequence: 1 }))).toBe(true);
+  });
+
+  // Sequence counts within one source, so the same number from another one is another record.
+  test('a source that restarted is not the source that stopped', () => {
+    const seen = new SeenTenantLogs();
+    seen.admit(logRecord());
+
+    expect(seen.admit(logRecord({ sourceId: 'source-2' }))).toBe(true);
+  });
+
+  // What a reconnect asks for: the seconds it was away, which carry what it did not miss.
+  test('an instant already passed is a repeat however it is numbered', () => {
+    const seen = new SeenTenantLogs();
+    seen.admit(logRecord({ _time: A_LATER_INSTANT, sequence: 5 }));
+
+    expect(seen.admit(logRecord({ _time: AN_INSTANT, sequence: 0 }))).toBe(false);
+  });
+
+  // Only the newest instant's keys are kept, so following an app for a day costs one instant.
+  test('moving on forgets the instant left behind', () => {
+    const seen = new SeenTenantLogs();
+    seen.admit(logRecord());
+    seen.admit(logRecord({ _time: A_LATER_INSTANT, sequence: 1 }));
+
+    expect(seen.admit(logRecord({ _time: A_LATER_INSTANT, sequence: 1 }))).toBe(false);
+  });
 });


### PR DESCRIPTION
Three of six pocketbase startup lines never reached `nib apps logs`.

The store sorts a window by `_time` alone. A guest announcing itself writes
several lines inside one millisecond, so their order within it is the store's
own — and it hands them back reversed. Two things read that order as the order
they were written in:

- the sort left the tie to the store, so a burst came back backwards
- the dedupe kept a high-water mark on `sequence` per source, so seeing a
  burst's newest record first condemned the rest of it as repeats

Exactly one line per millisecond survived, which is what the reporter saw.

`sequence` does record the writing order within a source, so the sort breaks
the tie on it. What has already been handed over is now the newest instant and
the keys seen at it — bounded by one instant rather than the stream, and
correct whatever order records arrive in within it.

The api and the CLI were deduplicating the same records the same wrong way, for
different overlaps: the api's windows resume on the instant the last one ended,
and a reconnecting CLI asks again for the seconds it was away. One rule answers
both, so it moves to `@repo/protocol` beside the fields it reads.

Verified against the reporter's six lines driven through the real repository
and service: all six delivered, in the order pocketbase wrote them.