### PR TITLE
perf: a deploy is ready as soon as the tenant answers

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -15,6 +15,7 @@ import { ExportManager } from '#services/export-manager.service.ts';
 import { FilesystemReader } from '#services/filesystem-reader.service.ts';
 import { LogStore } from '#services/log-store.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
+import { ReportSignal } from '#services/report-signal.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { TenantLogQueue } from '#services/tenant-log-queue.service.ts';
 import { TenantLogReceiver } from '#services/tenant-log-receiver.service.ts';
@@ -32,6 +33,7 @@ const platform = Layer.mergeAll(BunContext.layer, FetchHttpClient.layer);
 const agent = Layer.mergeAll(
   AgentConfig.Default,
   AgentState.Default,
+  ReportSignal.Default,
   CommandRunner.Default,
   ControlPlane.Default,
   LogStore.Default,

--- a/apps/agent/src/lib/agent/report.ts
+++ b/apps/agent/src/lib/agent/report.ts
@@ -12,6 +12,13 @@ import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { ControlPlane } from '#services/control-plane.service.ts';
+import { ReportSignal } from '#services/report-signal.service.ts';
+
+/**
+ * The floor a raise cannot get under. Without it an instance flapping between two states would
+ * turn every transition into a request, which is the thing `reportIntervalMs` exists to bound.
+ */
+const MIN_REPORT_GAP: Duration.DurationInput = '250 millis';
 
 const report = Effect.gen(function* () {
   const config = yield* AgentConfig;
@@ -46,15 +53,26 @@ const report = Effect.gen(function* () {
   });
 });
 
+/**
+ * `reportIntervalMs` is the longest a host stays quiet, not the rate it reports at: a tenant
+ * that has just answered its first probe is news the control plane is holding a deploy open
+ * waiting for, and telling it on the next tick instead adds that tick to every deploy.
+ */
+const untilNextReport = Effect.gen(function* () {
+  const sessions = yield* AgentSessionHolder;
+  const poll = yield* sessions.pollSettings;
+  yield* Effect.race(
+    Effect.sleep(Duration.millis(poll.reportIntervalMs)),
+    Effect.andThen(Effect.sleep(MIN_REPORT_GAP), ReportSignal.awaited),
+  );
+});
+
 export const reportLoop = Effect.gen(function* () {
   const sessions = yield* AgentSessionHolder;
   yield* supervised({
-    once: Effect.andThen(
-      report,
-      Effect.flatMap(sessions.pollSettings, (poll) =>
-        Effect.sleep(Duration.millis(poll.reportIntervalMs)),
-      ),
-    ).pipe(Effect.tapErrorTag('ControlPlaneError', sessions.onExpired)),
+    once: Effect.andThen(report, untilNextReport).pipe(
+      Effect.tapErrorTag('ControlPlaneError', sessions.onExpired),
+    ),
     onFailure: (cause) => Effect.logWarning('report failed', cause),
     schedule: CONTROL_PLANE_BACKOFF,
   });

--- a/apps/agent/src/lib/agent/status.ts
+++ b/apps/agent/src/lib/agent/status.ts
@@ -1,13 +1,26 @@
 import { Duration, Effect, Schedule } from 'effect';
 import { supervised } from '#lib/agent/loop.ts';
+import { STARTUP_PROBE_INTERVAL_MS } from '#lib/health/state.ts';
+import type { InstanceRecord } from '#lib/report/instance-record.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
 
 const TICK = Duration.seconds(1);
+/** A probe cannot land sooner than the tick that runs it, so coming up is worth ticking for. */
+const SETTLING_TICK = Duration.millis(STARTUP_PROBE_INTERVAL_MS);
+
+function settling(record: InstanceRecord): boolean {
+  return record.state === 'pending' || record.state === 'starting';
+}
+
+const untilNextRefresh = Effect.flatMap(AgentState.records, (records) =>
+  Effect.sleep(records.some(settling) ? SETTLING_TICK : TICK),
+);
 
 export const statusLoop = Effect.gen(function* () {
   const reconciler = yield* Reconciler;
   yield* supervised({
-    once: Effect.andThen(reconciler.refresh, Effect.sleep(TICK)),
+    once: Effect.andThen(reconciler.refresh, untilNextRefresh),
     onFailure: (cause) => Effect.logWarning('status refresh failed', cause),
     schedule: Schedule.spaced(TICK),
   });

--- a/apps/agent/src/lib/agent/status.ts
+++ b/apps/agent/src/lib/agent/status.ts
@@ -1,21 +1,27 @@
-import { Duration, Effect, Schedule } from 'effect';
+import { Clock, Duration, Effect, Schedule } from 'effect';
 import { supervised } from '#lib/agent/loop.ts';
-import { STARTUP_PROBE_INTERVAL_MS } from '#lib/health/state.ts';
-import type { InstanceRecord } from '#lib/report/instance-record.ts';
+import { isOnStartupGrid, STARTUP_PROBE_INTERVAL_MS } from '#lib/health/state.ts';
+import { graceInputs } from '#lib/report/instance-record.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
 
 const TICK = Duration.seconds(1);
-/** A probe cannot land sooner than the tick that runs it, so coming up is worth ticking for. */
+/** A probe cannot land sooner than the tick that runs it, so the two share one cadence. */
 const SETTLING_TICK = Duration.millis(STARTUP_PROBE_INTERVAL_MS);
 
-function settling(record: InstanceRecord): boolean {
-  return record.state === 'pending' || record.state === 'starting';
-}
-
-const untilNextRefresh = Effect.flatMap(AgentState.records, (records) =>
-  Effect.sleep(records.some(settling) ? SETTLING_TICK : TICK),
-);
+/**
+ * Exactly the condition the fast probe grid runs on, rather than the states it tends to appear
+ * in: a tick this loop takes for something no longer being probed that fast is one it takes for
+ * as long as that instance is up.
+ */
+const untilNextRefresh = Effect.gen(function* () {
+  const records = yield* AgentState.records;
+  const nowMs = yield* Clock.currentTimeMillis;
+  const settling = records.some((record) =>
+    isOnStartupGrid({ tracker: record.health, ...graceInputs({ record, nowMs }) }),
+  );
+  yield* Effect.sleep(settling ? SETTLING_TICK : TICK);
+});
 
 export const statusLoop = Effect.gen(function* () {
   const reconciler = yield* Reconciler;

--- a/apps/agent/src/lib/health/state.ts
+++ b/apps/agent/src/lib/health/state.ts
@@ -4,6 +4,16 @@ import type { UnitStatus } from '#lib/vm/unit-status.ts';
 const NO_PROBES = 0;
 const ONE_PROBE = 1;
 
+/**
+ * How often a tenant that has never answered is asked again.
+ *
+ * `intervalMs` is a liveness cadence for something already serving, and spending it on a boot
+ * means the gap between a binary starting to listen and a deploy being called done is most of
+ * that interval. This is the grid a first answer lands on instead, and it is why the status
+ * loop ticks at the same rate while anything is coming up.
+ */
+export const STARTUP_PROBE_INTERVAL_MS = 250;
+
 export type HealthTracker = {
   readonly consecutiveSuccesses: number;
   readonly consecutiveFailures: number;
@@ -49,6 +59,31 @@ export function applyProbe({
   };
 }
 
+type GraceInputs = {
+  healthCheck: HealthCheck;
+  startedAtMs?: number;
+  nowMs: number;
+};
+
+/** An instance with no start time has not been booted by this agent, so nothing has run out yet. */
+export function isWithinGracePeriod({ healthCheck, startedAtMs, nowMs }: GraceInputs): boolean {
+  return startedAtMs === undefined || nowMs - startedAtMs < healthCheck.gracePeriodMs;
+}
+
+/**
+ * The fast grid applies only while a tenant is still owed its grace period, so a slow starter
+ * is failed on exactly the schedule it was before: `unhealthyThreshold` probes at `intervalMs`
+ * after the grace runs out.
+ */
+export function nextProbeDelayMs({
+  tracker,
+  ...grace
+}: GraceInputs & { tracker: HealthTracker }): number {
+  return !tracker.everHealthy && isWithinGracePeriod(grace)
+    ? Math.min(STARTUP_PROBE_INTERVAL_MS, grace.healthCheck.intervalMs)
+    : grace.healthCheck.intervalMs;
+}
+
 export type LifecycleInputs = {
   unit: UnitStatus;
   tracker: HealthTracker;
@@ -90,7 +125,7 @@ export function evaluateInstanceState({
   if (tracker.consecutiveSuccesses >= healthCheck.healthyThreshold) {
     return 'running';
   }
-  const withinGrace = startedAtMs === undefined || nowMs - startedAtMs < healthCheck.gracePeriodMs;
+  const withinGrace = isWithinGracePeriod({ healthCheck, startedAtMs, nowMs });
   if (tracker.consecutiveFailures >= healthCheck.unhealthyThreshold && !withinGrace) {
     return tracker.everHealthy ? 'unhealthy' : 'failed';
   }

--- a/apps/agent/src/lib/health/state.ts
+++ b/apps/agent/src/lib/health/state.ts
@@ -59,11 +59,13 @@ export function applyProbe({
   };
 }
 
-type GraceInputs = {
+export type GraceInputs = {
   healthCheck: HealthCheck;
   startedAtMs?: number;
   nowMs: number;
 };
+
+type ProbeInputs = GraceInputs & { tracker: HealthTracker };
 
 /** An instance with no start time has not been booted by this agent, so nothing has run out yet. */
 export function isWithinGracePeriod({ healthCheck, startedAtMs, nowMs }: GraceInputs): boolean {
@@ -71,17 +73,24 @@ export function isWithinGracePeriod({ healthCheck, startedAtMs, nowMs }: GraceIn
 }
 
 /**
+ * Whether this tenant is still being given its first chance to answer.
+ *
+ * Bounded by the grace period rather than by the state alone, which is what keeps it — and the
+ * loop that ticks for it — from running for as long as an app that never settles is up.
+ */
+export function isOnStartupGrid({ tracker, ...grace }: ProbeInputs): boolean {
+  return !tracker.everHealthy && isWithinGracePeriod(grace);
+}
+
+/**
  * The fast grid applies only while a tenant is still owed its grace period, so a slow starter
  * is failed on exactly the schedule it was before: `unhealthyThreshold` probes at `intervalMs`
  * after the grace runs out.
  */
-export function nextProbeDelayMs({
-  tracker,
-  ...grace
-}: GraceInputs & { tracker: HealthTracker }): number {
-  return !tracker.everHealthy && isWithinGracePeriod(grace)
-    ? Math.min(STARTUP_PROBE_INTERVAL_MS, grace.healthCheck.intervalMs)
-    : grace.healthCheck.intervalMs;
+export function nextProbeDelayMs(inputs: ProbeInputs): number {
+  return isOnStartupGrid(inputs)
+    ? Math.min(STARTUP_PROBE_INTERVAL_MS, inputs.healthCheck.intervalMs)
+    : inputs.healthCheck.intervalMs;
 }
 
 export type LifecycleInputs = {

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -4,12 +4,20 @@ import { isReadyToRetry, nextAttemptWindow } from '#lib/backoff.ts';
 import { nowTimestamp } from '#lib/clock.ts';
 import { reportedMessage } from '#lib/failure.ts';
 import { probeInstance } from '#lib/health/probe.ts';
-import { applyProbe, evaluateInstanceState, initialTracker } from '#lib/health/state.ts';
+import {
+  applyProbe,
+  evaluateInstanceState,
+  initialTracker,
+  nextProbeDelayMs,
+} from '#lib/health/state.ts';
+import type { ReconcilePlan } from '#lib/reconcile/plan.ts';
 import { type InstanceRecord, newInstanceRecord } from '#lib/report/instance-record.ts';
+import { ensureArtifactImage } from '#lib/vm/artifacts.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { UNKNOWN_UNIT } from '#lib/vm/unit-status.ts';
 import { flush } from '#lib/volumes/zerofs.ts';
 import { AgentState } from '#services/agent-state.service.ts';
+import { ReportSignal } from '#services/report-signal.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { VmManager } from '#services/vm-manager.service.ts';
 import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
@@ -90,6 +98,43 @@ const isStartable = ({
     isReadyToRetry({ window: existing.startAttempts, nowMs, policy })
   );
 };
+
+/**
+ * One entry per digest: two apps deploying the same bytes share the image, and fetching it
+ * twice at once would have them race for the same staging directory.
+ */
+function artifactsToStart(plan: ReconcilePlan) {
+  return new Map(
+    plan.instances.flatMap((action) =>
+      action.action === 'start' || action.action === 'replace'
+        ? [[action.desired.artifact.digest, action.desired.artifact] as const]
+        : [],
+    ),
+  ).values();
+}
+
+/**
+ * Downloading the artifact and building its image is the longest step of a deploy, and it does
+ * not need the host to have stopped anything — so it runs while the outgoing microVM is still
+ * serving rather than after it is gone.
+ *
+ * Best-effort: `startInstance` asks for the same image and is the one that reports a fetch that
+ * could not be made, so a failure here is only a head start that was not taken.
+ */
+export const prefetchArtifacts = Effect.fn('prefetchArtifacts')((plan: ReconcilePlan) =>
+  Effect.forEach(
+    artifactsToStart(plan),
+    (artifact) =>
+      ensureArtifactImage(artifact).pipe(
+        Effect.catchAll((error) =>
+          Effect.logWarning('artifact prefetch failed', error).pipe(
+            Effect.annotateLogs({ digest: artifact.digest }),
+          ),
+        ),
+      ),
+    { discard: true, concurrency: 'unbounded' },
+  ),
+);
 
 export const startInstance = Effect.fn('startInstance')(function* (desired: DesiredInstance) {
   yield* Effect.annotateCurrentSpan({ appId: desired.appId });
@@ -176,12 +221,15 @@ const probed = ({ record, nowMs }: { record: InstanceRecord; nowMs: number }) =>
       guestPort: record.guestPort,
       healthCheck: record.healthCheck,
     });
+    const delayMs = nextProbeDelayMs({
+      tracker: record.health,
+      healthCheck: record.healthCheck,
+      ...(record.startedAt ? { startedAtMs: Date.parse(record.startedAt) } : {}),
+      nowMs,
+    });
     yield* AgentState.modify((current) => ({
       ...current,
-      nextProbeAtMs: new Map(current.nextProbeAtMs).set(
-        record.appId,
-        nowMs + record.healthCheck.intervalMs,
-      ),
+      nextProbeAtMs: new Map(current.nextProbeAtMs).set(record.appId, nowMs + delayMs),
     }));
     return applyProbe({
       tracker: record.health,
@@ -232,6 +280,7 @@ export const refreshStates = Effect.gen(function* () {
               to: state,
             }),
           );
+          yield* ReportSignal.raise;
         }
       }),
     { discard: true },

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -11,7 +11,11 @@ import {
   nextProbeDelayMs,
 } from '#lib/health/state.ts';
 import type { ReconcilePlan } from '#lib/reconcile/plan.ts';
-import { type InstanceRecord, newInstanceRecord } from '#lib/report/instance-record.ts';
+import {
+  graceInputs,
+  type InstanceRecord,
+  newInstanceRecord,
+} from '#lib/report/instance-record.ts';
 import { ensureArtifactImage } from '#lib/vm/artifacts.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { UNKNOWN_UNIT } from '#lib/vm/unit-status.ts';
@@ -223,9 +227,7 @@ const probed = ({ record, nowMs }: { record: InstanceRecord; nowMs: number }) =>
     });
     const delayMs = nextProbeDelayMs({
       tracker: record.health,
-      healthCheck: record.healthCheck,
-      ...(record.startedAt ? { startedAtMs: Date.parse(record.startedAt) } : {}),
-      nowMs,
+      ...graceInputs({ record, nowMs }),
     });
     yield* AgentState.modify((current) => ({
       ...current,
@@ -256,11 +258,9 @@ export const refreshStates = Effect.gen(function* () {
         const state = evaluateInstanceState({
           unit: status,
           tracker: health,
-          healthCheck: record.healthCheck,
           desiredRunning: record.desiredRunning,
           stopRequested: record.stopRequested,
-          ...(record.startedAt ? { startedAtMs: Date.parse(record.startedAt) } : {}),
-          nowMs,
+          ...graceInputs({ record, nowMs }),
         });
 
         const changed = state !== record.state;

--- a/apps/agent/src/lib/report/instance-record.ts
+++ b/apps/agent/src/lib/report/instance-record.ts
@@ -13,7 +13,7 @@ import type {
   VolumeId,
 } from '@repo/protocol';
 import type { AttemptWindow } from '#lib/backoff.ts';
-import type { HealthTracker } from '#lib/health/state.ts';
+import type { GraceInputs, HealthTracker } from '#lib/health/state.ts';
 
 const NO_RESTARTS = 0;
 const NO_ATTEMPTS = 0;
@@ -52,6 +52,25 @@ export const newInstanceRecord = (
   startAttempts: { attempts: NO_ATTEMPTS },
   stopRequested: false,
 });
+
+/**
+ * What every health decision about a record needs, in the one place that knows `startedAt` is a
+ * wire timestamp here and a clock reading there — and that a record this agent never started has
+ * no start time at all.
+ */
+export function graceInputs({
+  record,
+  nowMs,
+}: {
+  record: InstanceRecord;
+  nowMs: number;
+}): GraceInputs {
+  return {
+    healthCheck: record.healthCheck,
+    ...(record.startedAt ? { startedAtMs: Date.parse(record.startedAt) } : {}),
+    nowMs,
+  };
+}
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);

--- a/apps/agent/src/lib/vm/artifacts.ts
+++ b/apps/agent/src/lib/vm/artifacts.ts
@@ -7,6 +7,15 @@ import { stdoutOf } from '#services/command-runner.service.ts';
 const DIGEST_ALGORITHM = 'sha256';
 const HEX_ENCODING = 'hex';
 const SQUASHFS_FILENAME = 'artifact.squashfs';
+/**
+ * The image is built once per digest on the path a deploy waits on, and read back off a local
+ * disk by one guest — so the compressor's job here is to finish, not to be small. On a 57 MiB
+ * release binary this measures 0.56s against 2.6s at the default level, for an image 8% larger.
+ *
+ * gzip rather than something faster because that is the choice: `squashfs-tools` on the host
+ * image is built with gzip, lzma and lzo only, and lzo measures slower than gzip at every level.
+ */
+const SQUASHFS_COMPRESSION_LEVEL = '1';
 /** The path the guest's init execs, fixed by the boot contract. */
 const GUEST_BINARY_NAME = 'server';
 /** What a binary has to be to be one, wherever it lands — the guest's squashfs or an export. */
@@ -125,7 +134,15 @@ export const ensureArtifactImage = Effect.fn('ensureArtifactImage')(function* (
         yield* fs.chmod(binaryPath, BINARY_MODE);
         yield* fs.remove(stagedImage, { force: true });
         yield* stdoutOf({
-          command: ['mksquashfs', stagingDir, stagedImage, '-no-progress', '-noappend'],
+          command: [
+            'mksquashfs',
+            stagingDir,
+            stagedImage,
+            '-no-progress',
+            '-noappend',
+            '-Xcompression-level',
+            SQUASHFS_COMPRESSION_LEVEL,
+          ],
         });
         yield* fs.makeDirectory(path.dirname(imagePath), {
           recursive: true,

--- a/apps/agent/src/lib/volumes/ext4.ts
+++ b/apps/agent/src/lib/volumes/ext4.ts
@@ -46,12 +46,22 @@ export const isFormatted = (devicePath: string) =>
     );
   });
 
+/**
+ * Every byte `mkfs.ext4` writes here travels NBD → ZeroFS → S3, which makes its defaults the
+ * wrong trade: on a volume this size they are a whole-device discard plus a few hundred MiB of
+ * zeroed inode tables and journal before an app has deployed once. All three are work the guest
+ * kernel does lazily after it mounts, off the path an owner is waiting on.
+ */
+const MKFS_EXTENDED_OPTIONS = 'nodiscard,lazy_itable_init=1,lazy_journal_init=1';
+
 /** Writing a filesystem is not parsing one, so this stays on the host and the guest only mounts. */
 export const formatOnce = Effect.fn('formatOnce')(function* (devicePath: string) {
   yield* Effect.annotateCurrentSpan({ devicePath });
   if (yield* isFormatted(devicePath)) {
     return false;
   }
-  yield* stdoutOf({ command: ['mkfs.ext4', '-q', '-L', FILESYSTEM_LABEL, devicePath] });
+  yield* stdoutOf({
+    command: ['mkfs.ext4', '-q', '-E', MKFS_EXTENDED_OPTIONS, '-L', FILESYSTEM_LABEL, devicePath],
+  });
   return true;
 });

--- a/apps/agent/src/lib/volumes/ext4.ts
+++ b/apps/agent/src/lib/volumes/ext4.ts
@@ -47,21 +47,19 @@ export const isFormatted = (devicePath: string) =>
   });
 
 /**
- * Every byte `mkfs.ext4` writes here travels NBD → ZeroFS → S3, which makes its defaults the
- * wrong trade: on a volume this size they are a whole-device discard plus a few hundred MiB of
- * zeroed inode tables and journal before an app has deployed once. All three are work the guest
- * kernel does lazily after it mounts, off the path an owner is waiting on.
+ * Deliberately the defaults.
+ *
+ * Formatting an 8 GiB volume here measures 0.10s against a real ZeroFS, and ~0.09s of that is
+ * recoverable only by `lazy_journal_init` — the one extended option that narrows what survives
+ * an unclean shutdown. A log-structured store with compression is why: a fresh filesystem is
+ * almost entirely zeroes, so what reaches S3 is a few hundred KiB whatever mke2fs is asked to
+ * write. There is no time here worth buying.
  */
-const MKFS_EXTENDED_OPTIONS = 'nodiscard,lazy_itable_init=1,lazy_journal_init=1';
-
-/** Writing a filesystem is not parsing one, so this stays on the host and the guest only mounts. */
 export const formatOnce = Effect.fn('formatOnce')(function* (devicePath: string) {
   yield* Effect.annotateCurrentSpan({ devicePath });
   if (yield* isFormatted(devicePath)) {
     return false;
   }
-  yield* stdoutOf({
-    command: ['mkfs.ext4', '-q', '-E', MKFS_EXTENDED_OPTIONS, '-L', FILESYSTEM_LABEL, devicePath],
-  });
+  yield* stdoutOf({ command: ['mkfs.ext4', '-q', '-L', FILESYSTEM_LABEL, devicePath] });
   return true;
 });

--- a/apps/agent/src/services/reconciler.service.ts
+++ b/apps/agent/src/services/reconciler.service.ts
@@ -4,7 +4,12 @@ import { readExportReports } from '#lib/exports/manager.ts';
 import { readJsonFile, writeJsonFile } from '#lib/json-store.ts';
 import { applyCheckpoints } from '#lib/reconcile/checkpoints.ts';
 import { applyExports } from '#lib/reconcile/exports.ts';
-import { refreshStates, startInstance, stopInstance } from '#lib/reconcile/instances.ts';
+import {
+  prefetchArtifacts,
+  refreshStates,
+  startInstance,
+  stopInstance,
+} from '#lib/reconcile/instances.ts';
 import { applyNetwork, applyRoutes } from '#lib/reconcile/network.ts';
 import { hasDeferredWork, type ObservedState, planReconcile } from '#lib/reconcile/plan.ts';
 import { applyTeardowns, applyVolumes } from '#lib/reconcile/volumes.ts';
@@ -13,6 +18,7 @@ import * as Systemd from '#lib/vm/systemd.ts';
 import { UNKNOWN_UNIT } from '#lib/vm/unit-status.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
+import { ReportSignal } from '#services/report-signal.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { VmManager } from '#services/vm-manager.service.ts';
 import { VolumeManager } from '#services/volume-manager.service.ts';
@@ -193,7 +199,10 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       }));
       yield* syncDesired(desired);
 
-      yield* applyStops(plan).pipe(Effect.withSpan('reconcile.stops'));
+      yield* Effect.all(
+        [prefetchArtifacts(plan), applyStops(plan).pipe(Effect.withSpan('reconcile.stops'))],
+        { concurrency: 'unbounded', discard: true },
+      );
       yield* applyVolumes({ plan, observed }).pipe(Effect.withSpan('reconcile.volumes'));
       // Before anything boots: nothing persists the ruleset across a reboot, so a host that
       // started its VMs first would serve tenants through a kernel with no `nibrun` table.
@@ -210,6 +219,9 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       yield* persist.pipe(Effect.withSpan('reconcile.persist'));
 
       yield* AgentState.modify((current) => ({ ...current, converged: true }));
+      // Everything a reconcile touches is something the control plane is waiting to hear about:
+      // the instance it just asked for, a volume it may now delete, a bundle it can hand over.
+      yield* ReportSignal.raise;
     });
 
     return {

--- a/apps/agent/src/services/report-signal.service.ts
+++ b/apps/agent/src/services/report-signal.service.ts
@@ -1,0 +1,22 @@
+import { Effect, Queue } from 'effect';
+
+const ONE_PENDING = 1;
+
+/**
+ * Says a report is worth sending before the interval is up.
+ *
+ * The report is the only channel carrying an instance's state to the control plane, and it is
+ * what turns a deployment `active` — so on the interval alone every deploy pays for a tenant
+ * that answered just after the last one went out. Sliding and one deep, because what a raise
+ * says is "something moved", and two of them say nothing more than one.
+ */
+export class ReportSignal extends Effect.Service<ReportSignal>()('ReportSignal', {
+  accessors: true,
+  effect: Effect.gen(function* () {
+    const news = yield* Queue.sliding<void>(ONE_PENDING);
+    return {
+      raise: Effect.asVoid(Queue.offer(news, undefined)),
+      awaited: Queue.take(news),
+    };
+  }),
+}) {}

--- a/apps/agent/tests/lib/health/state.test.ts
+++ b/apps/agent/tests/lib/health/state.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import { DEFAULT_HEALTH_CHECK, type HealthCheck } from '@repo/protocol';
-import { applyProbe, evaluateInstanceState, initialTracker } from '#lib/health/state.ts';
+import {
+  applyProbe,
+  evaluateInstanceState,
+  initialTracker,
+  nextProbeDelayMs,
+  STARTUP_PROBE_INTERVAL_MS,
+} from '#lib/health/state.ts';
 import type { UnitStatus } from '#lib/vm/unit-status.ts';
 import { OBSERVED_AT } from '#tests/support/fixtures.ts';
 
@@ -96,6 +102,54 @@ function evaluate({
     nowMs,
   });
 }
+
+/**
+ * The interval is what stands between a binary starting to listen and the deploy that is waiting
+ * on it being called done, so the boot and the liveness cadence are deliberately not the same
+ * number — and the point of the grace bound is that a slow starter is still failed on the old one.
+ */
+describe('how soon a tenant is asked again', () => {
+  function delay({
+    tracker,
+    nowMs,
+    healthCheck = check(),
+  }: {
+    tracker: Tracker;
+    nowMs: number;
+    healthCheck?: HealthCheck;
+  }) {
+    return nextProbeDelayMs({ tracker, healthCheck, startedAtMs: STARTED_AT_MS, nowMs });
+  }
+
+  test('a tenant that has never answered is asked on the startup grid', () => {
+    expect(delay({ tracker: initialTracker(), nowMs: WITHIN_GRACE_MS })).toBe(
+      STARTUP_PROBE_INTERVAL_MS,
+    );
+  });
+
+  test('one that has answered falls back to the liveness interval', () => {
+    expect(delay({ tracker: healthyThen(0), nowMs: WITHIN_GRACE_MS })).toBe(
+      DEFAULT_HEALTH_CHECK.intervalMs,
+    );
+  });
+
+  test('past the grace period the startup grid is over, so a slow starter fails as it always did', () => {
+    expect(delay({ tracker: initialTracker(), nowMs: PAST_GRACE_MS })).toBe(
+      DEFAULT_HEALTH_CHECK.intervalMs,
+    );
+  });
+
+  test('an interval configured below the startup grid is not slowed to it', () => {
+    const intervalMs = STARTUP_PROBE_INTERVAL_MS - 1;
+    expect(
+      delay({
+        tracker: initialTracker(),
+        nowMs: WITHIN_GRACE_MS,
+        healthCheck: check({ intervalMs }),
+      }),
+    ).toBe(intervalMs);
+  });
+});
 
 describe('probe accounting', () => {
   test('a success resets the failure run and records when it happened', () => {

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -7,8 +7,12 @@ import type { RunOptions } from '#lib/plan.ts';
 import type { Ui } from '#lib/ui.ts';
 
 const SETTLING_STATES = new Set<DeploymentState>(['pending', 'starting']);
-const POLL_INTERVAL_MS = 2_000;
+// A host now tells the api the moment a tenant answers rather than on its next report, so this
+// is what stands between that and the owner being told — and the whole wait is a few seconds.
+const POLL_INTERVAL_MS = 500;
 const SERVING_TIMEOUT_MS = 300_000;
+const MS_PER_SECOND = 1_000;
+const ELAPSED_DECIMALS = 1;
 
 export type DeployInput = RunOptions & {
   api: Api;
@@ -57,6 +61,7 @@ export async function deploy({
     return;
   }
 
+  const startedAt = Date.now();
   const state = await ui.waitingFor({
     message: `starting deployment ${deployment.id}`,
     task: () => awaitSettled({ api, appId: app.id, deploymentId: deployment.id }),
@@ -64,7 +69,11 @@ export async function deploy({
   if (state !== 'active') {
     throw new ApiError(`Deployment ${deployment.id} is ${state}.`);
   }
-  ui.done(url);
+  ui.done(`${url} — ready in ${elapsed(Date.now() - startedAt)}`);
+}
+
+function elapsed(ms: number): string {
+  return `${(ms / MS_PER_SECOND).toFixed(ELAPSED_DECIMALS)}s`;
 }
 
 // A `File` rather than the `Bun.file` handle it came from: the multipart filename is read off


### PR DESCRIPTION
Time to ready was mostly polling, not infrastructure. The report a deployment turns `active` on went out on a 15s timer, the probe producing it landed on a 5s grid, and the cli asked again every 2s — roughly 12s mean of waiting after the binary was already listening.

Reports are now raised on an instance state change (the interval becomes the longest a host stays quiet), a tenant that has never answered is probed on a 250ms grid until its grace period is up, and the artifact is fetched while the outgoing microVM is still serving. Expected saving: ~12s mean of fixed overhead down to ~1.4s.

The remaining first-deploy cost is building the artifact's squashfs, so that now runs at gzip level 1 rather than the default: 0.56s against 2.6s for a 57 MiB binary, for an image 8% larger. It is built once per digest, on the path a deploy waits on, and read back off local disk by one guest.

Measured on a throwaway m7i-flex.large running the real ZeroFS v2.2.1 against S3, rather than reasoned from the code:

| | |
|---|---|
| `mksquashfs` gzip default | 2.6–2.9s (25M image) |
| `mksquashfs` gzip level 1 | **0.56s** (27M image) |
| `mksquashfs` lzo | 4.2–4.7s — slower, and zstd is not built into the host's squashfs-tools |
| `mksquashfs` uncompressed | 0.034s (57M image) — rejected, it doubles the artifact cache |
| `mkfs.ext4` on an 8 GiB volume | 0.10s, a few hundred KiB reaching S3 |

That last row killed an earlier version of this branch that tuned `mkfs.ext4`. The estimate behind it — a whole-device discard and hundreds of MiB of zeroed metadata through S3 — is wrong: ZeroFS is log-structured and compresses, and a fresh filesystem is almost all zeroes. Of the 0.10s, 0.09s was recoverable only via `lazy_journal_init`, which narrows what survives an unclean shutdown. Those flags are gone.

Two behaviour changes worth knowing: `nib run` now ends with `<url> — ready in 6.2s` rather than a bare url, and a deploy makes ~4x the cli polls it used to (500ms rather than 2s, over a much shorter wait).

Agent and cli only — no api change, no migration, no protocol bump — so this rolls out and reverts independently.

Left alone: the 1s desired-state poll, which wants long-polling rather than tuning.