### PR TITLE
feat(cli): an owner who named no app is asked which one

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -52,6 +52,10 @@ the layout under `src/commands/` is the command tree.
   (`isInteractive()`). A command must work without one: whatever the flags left
   open still needs a default. `ctx.print` stays the plain-output path, clack the
   interactive one — see `src/lib/ui.ts`.
+- **A command under `apps` reached without `--app` asks which one**, through
+  `selectApp` in `src/lib/apps.ts` so that the question is one question wherever
+  it is asked. An app is not something that can be defaulted to, so without a
+  terminal to ask at that is where the flag is demanded instead.
 - **A command that destroys something is the exception**, because the only
   default it could take is the destruction. Without a terminal it is refused
   rather than answered on the owner's behalf, so `--yes` is the one way to mean

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -17,7 +17,7 @@ export const command = defineCommand('apps', {
     [APP_OPTION]: {
       schema: z.string().min(1).optional(),
       forwardToChildren: true,
-      description: 'Slug of the app to work with.',
+      description: 'Slug of the app to work with. Asked for when omitted.',
     },
   },
 });

--- a/packages/cli/src/commands/apps/delete.ts
+++ b/packages/cli/src/commands/apps/delete.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
-import { requireAppSlug } from '#lib/apps.ts';
+import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { deleteApp } from '#lib/delete.ts';
 import { createUi, isInteractive } from '#lib/ui.ts';
@@ -17,18 +17,16 @@ export const command = defineCommand('apps delete', {
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ options, parents, context, print }) => {
-    // Elsewhere a terminal decides how the output looks. Here it also decides whether the question
-    // can be asked at all, which is why the handler keeps the answer rather than only the `ui`.
+    const { api } = context;
+    // A terminal decides more here than how the output looks — which app, when the flag named
+    // none, and whether the confirmation can be asked at all — so the handler keeps the answer
+    // rather than only the `ui` built from it.
     const interactive = isInteractive();
     const ui = createUi({ print, interactive });
 
     ui.open('nib apps delete');
-    await deleteApp({
-      api: context.api,
-      slug: requireAppSlug(parents.apps.options.app),
-      ui,
-      yes: options.yes === true,
-      interactive,
-    });
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
+
+    await deleteApp({ api, slug, ui, yes: options.yes === true, interactive });
   },
 });

--- a/packages/cli/src/commands/apps/export/[destination].ts
+++ b/packages/cli/src/commands/apps/export/[destination].ts
@@ -1,6 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
-import { requireAppSlug } from '#lib/apps.ts';
+import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { exportApp } from '#lib/exports.ts';
 import { createUi, isInteractive } from '#lib/ui.ts';
@@ -17,16 +17,12 @@ export const command = defineCommand('apps export [destination]', {
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ params, parents, context, print }) => {
     const { api } = context;
-    // Nothing to ask about — the destination is the one thing this needs and it was typed — so a
-    // terminal only decides how the waiting looks.
-    const ui = createUi({ print, interactive: isInteractive() });
+    const interactive = isInteractive();
+    const ui = createUi({ print, interactive });
 
     ui.open('nib apps export');
-    await exportApp({
-      api,
-      slug: requireAppSlug(parents.apps.options.app),
-      destination: params.destination,
-      ui,
-    });
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
+
+    await exportApp({ api, slug, destination: params.destination, ui });
   },
 });

--- a/packages/cli/src/commands/apps/logs.ts
+++ b/packages/cli/src/commands/apps/logs.ts
@@ -1,9 +1,10 @@
 import { defineCommand } from '@parshjs/core';
 import { DEFAULT_LOG_TIMERANGE, LOG_TIMERANGE_PATTERN } from '@repo/protocol';
 import { z } from 'zod';
-import { addressedDeployment, requireAppSlug } from '#lib/apps.ts';
+import { addressedDeployment, selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { follow, untilInterrupted } from '#lib/logs.ts';
+import { isInteractive } from '#lib/ui.ts';
 
 export const command = defineCommand('apps logs', {
   description: 'Print an app output and keep printing it. Ends when you do.',
@@ -26,9 +27,14 @@ export const command = defineCommand('apps logs', {
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ options, parents, context, print }) => {
     const { api } = context;
+    const slug = await selectApp({
+      api,
+      slug: parents.apps.options.app,
+      interactive: isInteractive(),
+    });
     const { appId, deploymentId } = await addressedDeployment({
       api,
-      slug: requireAppSlug(parents.apps.options.app),
+      slug,
       deploymentId: options['deployment-id'],
       print,
     });

--- a/packages/cli/src/commands/apps/ls.ts
+++ b/packages/cli/src/commands/apps/ls.ts
@@ -1,9 +1,10 @@
 import { defineCommand } from '@parshjs/core';
 import { GUEST_PATH_ROOT } from '@repo/protocol';
 import { z } from 'zod';
-import { requireAppSlug } from '#lib/apps.ts';
+import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { listDirectory } from '#lib/filesystem.ts';
+import { isInteractive } from '#lib/ui.ts';
 
 /**
  * A command and the parent of `apps ls [path]` at once, which is how an optional positional is
@@ -22,9 +23,16 @@ export const command = defineCommand('apps ls', {
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ options, parents, context, print }) => {
+    const { api } = context;
+    const slug = await selectApp({
+      api,
+      slug: parents.apps.options.app,
+      interactive: isInteractive(),
+    });
+
     await listDirectory({
-      api: context.api,
-      slug: requireAppSlug(parents.apps.options.app),
+      api,
+      slug,
       deploymentId: options['deployment-id'],
       path: GUEST_PATH_ROOT,
       print,

--- a/packages/cli/src/commands/apps/ls/[path].ts
+++ b/packages/cli/src/commands/apps/ls/[path].ts
@@ -1,8 +1,9 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
-import { requireAppSlug } from '#lib/apps.ts';
+import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { guestPath, listDirectory } from '#lib/filesystem.ts';
+import { isInteractive } from '#lib/ui.ts';
 
 export const command = defineCommand('apps ls [path]', {
   description: 'Directory to list, as a path inside the app filesystem.',
@@ -18,9 +19,16 @@ export const command = defineCommand('apps ls [path]', {
     // never have been read is worth one line now rather than one line half a minute from now.
     const path = guestPath(params.path);
 
+    const { api } = context;
+    const slug = await selectApp({
+      api,
+      slug: parents.apps.options.app,
+      interactive: isInteractive(),
+    });
+
     await listDirectory({
-      api: context.api,
-      slug: requireAppSlug(parents.apps.options.app),
+      api,
+      slug,
       deploymentId: parents['apps ls'].options['deployment-id'],
       path,
       print,

--- a/packages/cli/src/lib/apps.test.ts
+++ b/packages/cli/src/lib/apps.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import type { Api } from '#lib/api.ts';
+
+type Asked = {
+  message: string;
+  options: Array<{ value: string; label: string; hint?: string | undefined }>;
+};
+
+const asked: Asked[] = [];
+let chosen: unknown = null;
+
+// Replaced wholesale rather than reached through a port, as `plan.test.ts` does it: what is being
+// pinned down is which question an owner is asked and what it offers them. `mock.module` is
+// global, so this answers for clack for the rest of the run — only for what `#lib/apps.ts` asks of
+// it, which is why a file prompting for anything else stubs it itself.
+mock.module('@clack/prompts', () => ({
+  isCancel: (value: unknown) => typeof value === 'symbol',
+  select(opts: Asked) {
+    asked.push(opts);
+    return Promise.resolve(chosen);
+  },
+}));
+
+const { selectApp } = await import('#lib/apps.ts');
+
+let listings = 0;
+
+function apiListing(apps: Array<{ slug: string; state: string }>): Api {
+  return {
+    api: {
+      apps: {
+        get: () => {
+          listings += 1;
+          return Promise.resolve({ data: { apps }, error: null });
+        },
+      },
+    },
+  } as unknown as Api;
+}
+
+beforeEach(() => {
+  asked.length = 0;
+  listings = 0;
+  chosen = null;
+});
+
+test('a flag naming an app is the answer, and costs no listing to be one', async () => {
+  const slug = await selectApp({
+    api: apiListing([{ slug: 'quiet-otter', state: 'active' }]),
+    slug: 'loud-badger',
+    interactive: true,
+  });
+
+  expect(slug).toBe('loud-badger');
+  expect(listings).toBe(0);
+  expect(asked).toEqual([]);
+});
+
+test('an owner at a terminal is asked which app rather than told to name one', async () => {
+  chosen = 'quiet-otter';
+
+  const slug = await selectApp({
+    api: apiListing([
+      { slug: 'quiet-otter', state: 'active' },
+      { slug: 'loud-badger', state: 'suspended' },
+    ]),
+    slug: undefined,
+    interactive: true,
+  });
+
+  expect(slug).toBe('quiet-otter');
+  expect(asked[0]?.message).toBe('Which app?');
+  expect(asked[0]?.options).toEqual([
+    { value: 'quiet-otter', label: 'quiet-otter', hint: undefined },
+    { value: 'loud-badger', label: 'loud-badger', hint: 'suspended' },
+  ]);
+});
+
+test('a pipe has nobody to ask, so it is told which flag names one', async () => {
+  const attempt = selectApp({
+    api: apiListing([{ slug: 'quiet-otter', state: 'active' }]),
+    slug: undefined,
+    interactive: false,
+  });
+
+  await expect(attempt).rejects.toThrow('Which app? Name one with --app.');
+  expect(listings).toBe(0);
+});
+
+test('an owner with no apps is told what makes one, not shown an empty list', async () => {
+  const attempt = selectApp({ api: apiListing([]), slug: undefined, interactive: true });
+
+  await expect(attempt).rejects.toThrow('You have no apps.');
+  expect(asked).toEqual([]);
+});
+
+test('walking away from the question is not answering it', async () => {
+  chosen = Symbol('cancel');
+
+  const attempt = selectApp({
+    api: apiListing([{ slug: 'quiet-otter', state: 'active' }]),
+    slug: undefined,
+    interactive: true,
+  });
+
+  await expect(attempt).rejects.toThrow('Cancelled.');
+});

--- a/packages/cli/src/lib/apps.ts
+++ b/packages/cli/src/lib/apps.ts
@@ -1,21 +1,62 @@
+import { select } from '@clack/prompts';
 import type { Print } from '@parshjs/core';
 import { APP_OPTION } from '#config.ts';
 import { type Api, unwrap } from '#lib/api.ts';
 import { ApiError, UsageError } from '#lib/errors.ts';
+import { answered } from '#lib/prompts.ts';
 
 const NO_APP_NAMED = `Which app? Name one with --${APP_OPTION}.`;
+const NO_APPS = 'You have no apps. `nib run` is what makes one.';
 const NO_DEPLOYMENTS = 'This app has never been deployed.';
 
 /**
+ * The app a command was pointed at: the flag when it was given, and the question it stands for
+ * when it was not.
+ *
  * `--app` is optional on `apps` so that asking for nothing is answered with a listing rather
  * than an error, which leaves every command underneath to say what going without one means. They
  * all mean the same thing, so they say it from here.
  */
-export function requireAppSlug(slug: string | undefined): string {
-  if (slug === undefined) {
+export async function selectApp({
+  api,
+  slug,
+  interactive,
+}: {
+  api: Api;
+  slug: string | undefined;
+  interactive: boolean;
+}): Promise<string> {
+  if (slug !== undefined) {
+    return slug;
+  }
+  if (!interactive) {
     throw new UsageError(NO_APP_NAMED);
   }
-  return slug;
+  return await chooseApp({ api });
+}
+
+/**
+ * A slug rather than the app it was read from, even though whatever the answer is handed to reads
+ * the listing again: a slug is what an owner calls an app by and what every command under `apps`
+ * takes, and the second read falls only on somebody already sat at the prompt.
+ */
+async function chooseApp({ api }: { api: Api }): Promise<string> {
+  const { apps } = unwrap(await api.api.apps.get());
+  if (apps.length === 0) {
+    throw new UsageError(NO_APPS);
+  }
+  const chosen = await select({
+    message: 'Which app?',
+    options: apps.map((app) => ({
+      value: app.slug,
+      label: app.slug,
+      // Every app the api lists is offered — reading what a suspended one wrote is a reason to
+      // have kept it — so the state is said as well, an app being torn down answering differently
+      // and having chosen it being too late to find that out.
+      hint: app.state === 'active' ? undefined : app.state,
+    })),
+  });
+  return answered(chosen);
 }
 
 // Apps are addressed by id and listed by slug; the slug is the half a person sees, so it is the

--- a/packages/cli/src/lib/exports.ts
+++ b/packages/cli/src/lib/exports.ts
@@ -47,7 +47,7 @@ export type ExportInput = {
  * Ask for a copy of an app — its data and the binary that ran against it — and write it where the
  * caller said.
  *
- * Where it goes is settled before anything is asked for, because reading a tenant's whole
+ * Where it goes is settled before the export is asked for, because reading a tenant's whole
  * filesystem is the most expensive thing the platform does on an owner's behalf: a path that
  * cannot be written is worth one line now rather than one line several minutes from now.
  */


### PR DESCRIPTION
Every command under `nib apps` demanded `--app` and said so identically. They now share `selectApp`, which asks the question from the listing when the flag named nothing, and still demands the flag when there is no terminal to ask at.

Every app the api lists is offered, with its state alongside the slug when it is not active — an app being torn down answers a command differently, and having chosen it is too late to find that out.

`nib run` is untouched: what it asks is whether to make a new app, which is a different question.