### PR TITLE
feat(cli): an owner reads what apps they have and what state each is in

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -55,7 +55,11 @@ the layout under `src/commands/` is the command tree.
 - **A command under `apps` reached without `--app` asks which one**, through
   `selectApp` in `src/lib/apps.ts` so that the question is one question wherever
   it is asked. An app is not something that can be defaulted to, so without a
-  terminal to ask at that is where the flag is demanded instead.
+  terminal to ask at that is where the flag is demanded instead. `apps list` is
+  the exception and the reason the rule is not enforced anywhere central: it
+  lists the apps themselves, so asking which one would be circular. `apps ls`
+  lists inside one — the two are a letter apart and neither name is free to
+  change, so check which you mean before adding to either.
 - **A command that destroys something is the exception**, because the only
   default it could take is the destruction. Without a terminal it is refused
   rather than answered on the owner's behalf, so `--yes` is the one way to mean

--- a/packages/cli/src/command-tree.gen.ts
+++ b/packages/cli/src/command-tree.gen.ts
@@ -4,6 +4,7 @@ import type { InferForwardedOptions, InferParams, RuntimeNode } from '@parshjs/c
 import type { command as appsCmd } from './commands/apps.ts';
 import type { command as appsDeleteCmd } from './commands/apps/delete.ts';
 import type { command as appsExportDestinationCmd } from './commands/apps/export/[destination].ts';
+import type { command as appsListCmd } from './commands/apps/list.ts';
 import type { command as appsLogsCmd } from './commands/apps/logs.ts';
 import type { command as appsLsCmd } from './commands/apps/ls.ts';
 import type { command as appsLsPathCmd } from './commands/apps/ls/[path].ts';
@@ -23,6 +24,12 @@ declare module '@parshjs/core' {
       rootOptions: {};
     };
     'apps export [destination]': {
+      parents: {
+        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+      };
+      rootOptions: {};
+    };
+    'apps list': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
@@ -82,6 +89,12 @@ export const commandTree: RuntimeNode = {
             literalChildren: {},
             paramChild: null,
           },
+        },
+        'list': {
+          segment: { kind: 'literal', value: 'list' },
+          command: { path: 'apps list', load: () => import('./commands/apps/list.ts').then((m) => m.command) },
+          literalChildren: {},
+          paramChild: null,
         },
         'logs': {
           segment: { kind: 'literal', value: 'logs' },

--- a/packages/cli/src/commands/apps/list.ts
+++ b/packages/cli/src/commands/apps/list.ts
@@ -1,0 +1,18 @@
+import { defineCommand } from '@parshjs/core';
+import { listApps } from '#lib/app-list.ts';
+import { requireSignedIn } from '#lib/credentials.ts';
+
+/**
+ * The one command under `apps` that names no app, so `--app` is the one thing forwarded here that
+ * it has nothing to do with: this is where an owner who cannot remember a slug goes to read one,
+ * and answering it with the question every sibling asks would be circular.
+ */
+export const command = defineCommand('apps list', {
+  description:
+    'List your apps: what each is called, what state it is in, and when it last changed.',
+  options: {},
+  beforeHandler: ({ context }) => requireSignedIn(context),
+  handler: async ({ context, print }) => {
+    await listApps({ api: context.api, print });
+  },
+});

--- a/packages/cli/src/lib/app-list.test.ts
+++ b/packages/cli/src/lib/app-list.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import { type AppListing, render } from '#lib/app-list.ts';
+
+// Plain strings rather than the branded ones the wire carries: what is pinned down here is how a
+// row is laid out, and a cast per field would be spelling rather than meaning.
+function app(overrides: Partial<Record<keyof AppListing, string>> = {}): AppListing {
+  return {
+    slug: 'quiet-otter',
+    state: 'active',
+    updatedAt: '2026-08-07T09:41:00.123Z',
+    ...overrides,
+  } as AppListing;
+}
+
+describe('a listing is read down a column', () => {
+  test('a heading says what each column is', () => {
+    expect(render([app()])).toEqual([
+      'SLUG         STATE      LAST CHANGE',
+      'quiet-otter  active     2026-08-07 09:41',
+    ]);
+  });
+
+  test('the widest slug is what the column is wide enough for', () => {
+    expect(render([app({ slug: 'a' }), app({ slug: 'considerably-longer' })])).toEqual([
+      'SLUG                 STATE      LAST CHANGE',
+      'a                    active     2026-08-07 09:41',
+      'considerably-longer  active     2026-08-07 09:41',
+    ]);
+  });
+
+  // The column is sized for every state an app can be in, so reading two listings side by side is
+  // reading the same shape twice.
+  test('a state wider than the one beside it does not shift the columns', () => {
+    expect(render([app({ state: 'suspended' }), app({ state: 'deleting' })])).toEqual([
+      'SLUG         STATE      LAST CHANGE',
+      'quiet-otter  suspended  2026-08-07 09:41',
+      'quiet-otter  deleting   2026-08-07 09:41',
+    ]);
+  });
+
+  test('the day is said as well as the minute, because an app may not have changed today', () => {
+    const lines = render([app({ updatedAt: '2026-01-02T23:05:59.999Z' })]);
+
+    expect(lines.at(-1)).toEndWith('2026-01-02 23:05');
+  });
+});
+
+// Newest first is the api's answer, and the order an owner made their apps in is the one they
+// remember them in.
+test('the order the api answered with is the order that is printed', () => {
+  const lines = render([app({ slug: 'newest' }), app({ slug: 'oldest' })]);
+
+  expect(lines.map((line) => line.split(' ')[0])).toEqual(['SLUG', 'newest', 'oldest']);
+});

--- a/packages/cli/src/lib/app-list.ts
+++ b/packages/cli/src/lib/app-list.ts
@@ -1,0 +1,51 @@
+import type { Print } from '@parshjs/core';
+import { APP_STATES, type App } from '@repo/protocol';
+import { type Api, unwrap } from '#lib/api.ts';
+import { NO_APPS } from '#lib/apps.ts';
+import { dayAndMinute } from '#lib/timestamp.ts';
+
+export type AppListing = Pick<App, 'slug' | 'state' | 'updatedAt'>;
+
+// `LAST CHANGE` rather than `UPDATED`, which reads as the owner having done it: the row moves on
+// a config patch or a state change, and a deploy leaves it alone entirely.
+const HEADINGS = { slug: 'SLUG', state: 'STATE', updated: 'LAST CHANGE' };
+
+const COLUMN_GAP = '  ';
+
+// Every state the column can ever hold, so a suspended app appearing in a later listing does not
+// move the columns of the one before it.
+const STATE_WIDTH = Math.max(HEADINGS.state.length, ...APP_STATES.map((state) => state.length));
+
+/** Print what the owner has, one app to a line. */
+export async function listApps({ api, print }: { api: Api; print: Print }): Promise<void> {
+  const { apps } = unwrap(await api.api.apps.get());
+  if (apps.length === 0) {
+    print.dim(NO_APPS);
+    return;
+  }
+
+  for (const line of render(apps)) {
+    print.info(line);
+  }
+}
+
+/**
+ * Left in the order the api answered with, which is newest first — the order an owner made these
+ * in is the one they remember them in, and sorting by slug would bury the app they just deployed
+ * somewhere in the middle.
+ *
+ * A heading, unlike the filesystem listing: there a name and a size say what they are, and here
+ * two of the three columns are words that would read as the app's own.
+ */
+export function render(apps: readonly AppListing[]): string[] {
+  const rows = [HEADINGS, ...apps.map(toRow)];
+  const slugWidth = Math.max(...rows.map((row) => row.slug.length));
+
+  return rows.map((row) =>
+    [row.slug.padEnd(slugWidth), row.state.padEnd(STATE_WIDTH), row.updated].join(COLUMN_GAP),
+  );
+}
+
+function toRow(app: AppListing) {
+  return { slug: app.slug, state: app.state, updated: dayAndMinute(app.updatedAt) };
+}

--- a/packages/cli/src/lib/apps.ts
+++ b/packages/cli/src/lib/apps.ts
@@ -6,7 +6,7 @@ import { ApiError, UsageError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
 
 const NO_APP_NAMED = `Which app? Name one with --${APP_OPTION}.`;
-const NO_APPS = 'You have no apps. `nib run` is what makes one.';
+export const NO_APPS = 'You have no apps. `nib run` is what makes one.';
 const NO_DEPLOYMENTS = 'This app has never been deployed.';
 
 /**

--- a/packages/cli/src/lib/filesystem.ts
+++ b/packages/cli/src/lib/filesystem.ts
@@ -10,10 +10,9 @@ import {
 import { type Api, unwrap } from '#lib/api.ts';
 import { addressedDeployment } from '#lib/apps.ts';
 import { UsageError } from '#lib/errors.ts';
+import { dayAndMinute } from '#lib/timestamp.ts';
 
 const KIND_WIDTH = Math.max(...FILESYSTEM_ENTRY_KINDS.map((kind) => kind.length));
-
-const DAY_AND_MINUTE_END = 16;
 
 /**
  * What was typed, as a path the api will take.
@@ -87,7 +86,7 @@ export function render(entries: readonly FilesystemEntry[]): string[] {
     [
       entry.kind.padEnd(KIND_WIDTH),
       String(entry.sizeBytes).padStart(sizeWidth),
-      modifiedAt(entry.modifiedAt),
+      dayAndMinute(entry.modifiedAt),
       entry.name,
     ].join(' '),
   );
@@ -96,12 +95,4 @@ export function render(entries: readonly FilesystemEntry[]): string[] {
 function byName(entries: readonly FilesystemEntry[]): FilesystemEntry[] {
   // biome-ignore lint/complexity/useMaxParams: a comparator compares two entries
   return [...entries].sort((left, right) => (left.name < right.name ? -1 : 1));
-}
-
-/**
- * The date as well as the time, unlike a log line: what a log holds is what just happened, and
- * what a filesystem holds may have been written months ago. UTC, as logs are.
- */
-function modifiedAt(instant: string): string {
-  return new Date(instant).toISOString().slice(0, DAY_AND_MINUTE_END).replace('T', ' ');
 }

--- a/packages/cli/src/lib/timestamp.ts
+++ b/packages/cli/src/lib/timestamp.ts
@@ -1,0 +1,9 @@
+const DAY_AND_MINUTE_END = 16;
+
+/**
+ * The date as well as the time, unlike a log line: what a log holds is what just happened, and
+ * what an app or a file holds may have been written months ago. UTC, as logs are.
+ */
+export function dayAndMinute(instant: string): string {
+  return new Date(instant).toISOString().slice(0, DAY_AND_MINUTE_END).replace('T', ' ');
+}


### PR DESCRIPTION
`nib apps list` prints one line per app — slug, state, and when that row last changed.

```
SLUG                        STATE      LAST CHANGE
billing-a3f9                active     2026-08-07 09:41
quiet-otter                 suspended  2026-08-06 17:02
a-considerably-longer-slug  deleting   2026-01-02 23:05
```

Two things that are decisions rather than diff:

- **No size column.** Nothing measures what an app has actually written. `config.volumeSizeBytes` is a constant and `ReportedVolume.sizeBytes` is the device file's provisioned size, so the column would read 8 GiB for every app forever.
- **`LAST CHANGE`, not `UPDATED`.** The apps row moves on a config patch or a state change and a deploy leaves it alone, so the participle would invite two wrong readings: that the owner did it, and that it is when the app was last released.