### PR TITLE
feat(api): a deleted app takes its binaries and bundles with it

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -24,6 +24,13 @@ Every feature is a repository, a service, and a controller. Do not collapse them
 Every statement touching a tenant row takes an `ownerId` and scopes on it in the
 `WHERE` clause. Never filter by owner after the row comes back.
 
+Deleting an object from a bucket and deleting the row naming it cannot be one
+transaction, so the row goes **last**: a row removed first leaves bytes nothing
+names, while an object removed first leaves work the next pass finds and repeats.
+Work spanning the two is driven off a relation saying what is still outstanding
+— `nibrun.purgeable_apps` — rather than off the event that created it, which is
+what makes retrying the same code path as doing it the first time.
+
 Controllers call services; services call repositories. Never skip a layer — a
 controller must not touch a repository. Wire the graph once in
 `src/services/plugins.ts` and expose each service via an Elysia `.decorate`

--- a/apps/api/src/db/migrations/0015_create_nibrun_purgeable_apps.sql
+++ b/apps/api/src/db/migrations/0015_create_nibrun_purgeable_apps.sql
@@ -1,0 +1,20 @@
+-- What an app leaves behind once its filesystem is gone: the binaries it was deployed from and
+-- the bundles it was exported into. Both outlive the app until something removes them, and the
+-- objects behind them are a tenant's code and a tenant's whole dataset.
+--
+-- A relation rather than a flag on the app, so a purge that fails half way is retried by being
+-- asked again rather than by remembering it was owed. An app leaves this view by having nothing
+-- left, which is the same sentence as the work being done.
+--
+-- Membership is `deleted` rather than `deleting`: until a host says the filesystem is gone the
+-- app is still being torn down, and an export the host is still writing would be a row deleted
+-- out from under the write.
+
+CREATE INDEX apps_deleted_idx ON nibrun.apps (id) WHERE state = 'deleted';
+
+CREATE VIEW nibrun.purgeable_apps AS
+  SELECT a.id AS app_id
+  FROM nibrun.apps a
+  WHERE a.state = 'deleted'
+    AND (EXISTS (SELECT 1 FROM nibrun.artifacts ar WHERE ar.app_id = a.id)
+      OR EXISTS (SELECT 1 FROM nibrun.exports e WHERE e.app_id = a.id));

--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -226,6 +226,35 @@ export interface IFinishDeletingAppResult {
     id: import("@repo/protocol").AppId;
 }
 
+/** Result of query `SelectPurgeableApps`. */
+export interface ISelectPurgeableAppsResult {
+    app_id: import("@repo/protocol").AppId;
+}
+
+/** Result of query `SelectUnsharedArtifactKeys`. */
+export interface ISelectUnsharedArtifactKeysResult {
+    /** Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
+    object_key: import("@repo/protocol").ObjectKey;
+}
+
+/** Result of query `SelectExportKeysByApp`. */
+export interface ISelectExportKeysByAppResult {
+    /** Where the host writes the bundle and the api signs its download URL. */
+    object_key: import("@repo/protocol").ObjectKey;
+}
+
+/** Result of query `DeleteExportsByApp`. */
+export interface IDeleteExportsByAppResult {
+}
+
+/** Result of query `DeleteDeploymentsByApp`. */
+export interface IDeleteDeploymentsByAppResult {
+}
+
+/** Result of query `DeleteArtifactsByApp`. */
+export interface IDeleteArtifactsByAppResult {
+}
+
 /** Result of query `UpdateAppState`. */
 export interface IUpdateAppStateResult {
     id: import("@repo/protocol").AppId;
@@ -508,6 +537,12 @@ export interface Queries {
     InsertPatchedAppConfig: IInsertPatchedAppConfigResult;
     TouchAppAfterConfigPatch: ITouchAppAfterConfigPatchResult;
     FinishDeletingApp: IFinishDeletingAppResult;
+    SelectPurgeableApps: ISelectPurgeableAppsResult;
+    SelectUnsharedArtifactKeys: ISelectUnsharedArtifactKeysResult;
+    SelectExportKeysByApp: ISelectExportKeysByAppResult;
+    DeleteExportsByApp: IDeleteExportsByAppResult;
+    DeleteDeploymentsByApp: IDeleteDeploymentsByAppResult;
+    DeleteArtifactsByApp: IDeleteArtifactsByAppResult;
     UpdateAppState: IUpdateAppStateResult;
     SelectAppAfterStateChange: ISelectAppAfterStateChangeResult;
     InsertArtifact: IInsertArtifactResult;

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -1,4 +1,12 @@
-import type { AppHostnameKind, AppId, AppState, DnsLabel, Hostname, OwnerId } from '@repo/protocol';
+import type {
+  AppHostnameKind,
+  AppId,
+  AppState,
+  DnsLabel,
+  Hostname,
+  ObjectKey,
+  OwnerId,
+} from '@repo/protocol';
 import type { ArrayType } from 'bun';
 import type { Queries } from '#db/queries.gen.d.ts';
 import { type AppConfigPatch, type PublicAppConfig, toAppConfig } from '#lib/app-config.ts';
@@ -17,6 +25,17 @@ export type OwnedAppHostnameRow = Queries['SelectAppHostnamesByOwner'];
 
 export type CreatedApp = { app: AppRow; hostnames: AppHostnameRow[] };
 
+/**
+ * The objects a deleted app still has behind it, ready to be removed before the rows naming them
+ * are.
+ *
+ * `artifacts` is only the keys no surviving app still names. An artifact key is the digest of the
+ * bytes and nothing else, so two apps that were deployed from the same binary are two rows over
+ * one object — and deleting it for the app that is going would take the binary out from under the
+ * one that stays. The last of them to be deleted is the one that finds it unreferenced.
+ */
+export type Leftovers = { artifacts: ObjectKey[]; exports: ObjectKey[] };
+
 type OwnedApp = { appId: AppId; ownerId: OwnerId };
 
 export abstract class AppsRepositoryContract {
@@ -34,6 +53,9 @@ export abstract class AppsRepositoryContract {
   abstract updateState(input: OwnedApp & { state: AppState }): Promise<AppRow | null>;
   abstract finishDeleting(input: { appId: AppId }): Promise<boolean>;
   abstract isOwnedBy(input: OwnedApp): Promise<boolean>;
+  abstract listPurgeable(input: { limit: number }): Promise<AppId[]>;
+  abstract listLeftovers(input: { appId: AppId }): Promise<Leftovers>;
+  abstract purge(input: { appId: AppId }): Promise<void>;
 }
 
 export const PLATFORM_KIND: AppHostnameKind = 'platform';
@@ -276,6 +298,64 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
       RETURNING id
     `;
     return rows.length > 0;
+  }
+
+  /**
+   * Apps whose filesystem is gone and whose binaries and bundles are not. Bounded, because this
+   * is asked on the way through a host report and the answer is almost always empty — a backlog
+   * is drained a batch per report rather than held open on one.
+   */
+  async listPurgeable({ limit }: { limit: number }): Promise<AppId[]> {
+    const rows = await this.sql.SelectPurgeableApps`
+      SELECT p.app_id FROM nibrun.purgeable_apps p LIMIT ${limit}
+    `;
+    return rows.map((row) => row.app_id);
+  }
+
+  /**
+   * Read while the rows still name them, so an object is only ever deleted on the strength of a
+   * row that says it should be — and read as one query per kind rather than one per row, because
+   * an app deployed a hundred times is a hundred rows over far fewer objects.
+   */
+  async listLeftovers({ appId }: { appId: AppId }): Promise<Leftovers> {
+    const [artifacts, exports] = await Promise.all([
+      this.sql.SelectUnsharedArtifactKeys`
+        SELECT DISTINCT ar.object_key
+        FROM nibrun.artifacts ar
+        WHERE ar.app_id = ${appId}
+          AND NOT EXISTS (
+            SELECT 1 FROM nibrun.artifacts other
+            WHERE other.object_key = ar.object_key AND other.app_id <> ${appId}
+          )
+      `,
+      this.sql.SelectExportKeysByApp`
+        SELECT e.object_key FROM nibrun.exports e WHERE e.app_id = ${appId}
+      `,
+    ]);
+    return {
+      artifacts: artifacts.map((row) => row.object_key),
+      exports: exports.map((row) => row.object_key),
+    };
+  }
+
+  /**
+   * Every row of the app's that names an object, in the order the foreign keys allow: exports and
+   * deployments both point at artifacts with `ON DELETE RESTRICT`, so the artifact rows are last.
+   * The app row itself stays — the slug must never be handed to a second app.
+   *
+   * A deployment made to replay an older one points at it, and one statement takes both: a
+   * rollback only ever names a deployment of the same app, so there is no row left behind to
+   * restrict the delete.
+   *
+   * One transaction, so an app is never half purged: what a second pass finds is either all of
+   * this still to do or none of it.
+   */
+  purge({ appId }: { appId: AppId }): Promise<void> {
+    return this.sql.begin(async (tx) => {
+      await tx.DeleteExportsByApp`DELETE FROM nibrun.exports WHERE app_id = ${appId}`;
+      await tx.DeleteDeploymentsByApp`DELETE FROM nibrun.deployments WHERE app_id = ${appId}`;
+      await tx.DeleteArtifactsByApp`DELETE FROM nibrun.artifacts WHERE app_id = ${appId}`;
+    });
   }
 
   updateState({ appId, ownerId, state }: OwnedApp & { state: AppState }) {

--- a/apps/api/src/repositories/artifact-storage.repository.ts
+++ b/apps/api/src/repositories/artifact-storage.repository.ts
@@ -9,6 +9,7 @@ const UPLOAD_RETRIES = 3;
 export abstract class ArtifactStorageRepositoryContract {
   abstract put(input: { objectKey: ObjectKey; bytes: Uint8Array }): Promise<void>;
   abstract exists(input: { objectKey: ObjectKey }): Promise<boolean>;
+  abstract remove(input: { objectKey: ObjectKey }): Promise<void>;
 }
 
 export class ArtifactStorageRepository implements ArtifactStorageRepositoryContract {
@@ -27,5 +28,13 @@ export class ArtifactStorageRepository implements ArtifactStorageRepositoryContr
 
   exists({ objectKey }: { objectKey: ObjectKey }): Promise<boolean> {
     return this.client.file(objectKey).exists();
+  }
+
+  /**
+   * A key already gone is the state this asks for, so S3 answering that it deleted nothing is
+   * this having succeeded — which is what lets a purge interrupted half way be run again.
+   */
+  async remove({ objectKey }: { objectKey: ObjectKey }): Promise<void> {
+    await this.client.delete(objectKey);
   }
 }

--- a/apps/api/src/repositories/export-storage.repository.ts
+++ b/apps/api/src/repositories/export-storage.repository.ts
@@ -10,6 +10,7 @@ const DOWNLOAD_URL_TTL_SECONDS = 300;
 
 export abstract class ExportStorageRepositoryContract {
   abstract signDownload(input: { objectKey: ObjectKey }): string;
+  abstract remove(input: { objectKey: ObjectKey }): Promise<void>;
 }
 
 export class ExportStorageRepository implements ExportStorageRepositoryContract {
@@ -31,5 +32,14 @@ export class ExportStorageRepository implements ExportStorageRepositoryContract 
       method: 'GET',
       expiresIn: DOWNLOAD_URL_TTL_SECONDS,
     });
+  }
+
+  /**
+   * The lifecycle rule would reach this bundle eventually, and eventually is the whole retention
+   * window: the app it was taken from is gone, so what is left is a tenant's dataset outliving
+   * every way of asking for it. Removing it early is what closes that window.
+   */
+  async remove({ objectKey }: { objectKey: ObjectKey }): Promise<void> {
+    await this.client.delete(objectKey);
   }
 }

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -111,5 +111,8 @@ export class AgentService extends Service {
     await this.deploymentsService.applyHostReport({ reported });
     await this.appsService.completeDeletions({ volumes: reported.volumes });
     await this.exportsService.applyHostReport({ reported });
+    // Last, because what an app leaves behind is only safe to remove once a host has said its
+    // filesystem is gone — and `completeDeletions` above is where this report says so.
+    await this.appsService.purgeDeleted();
   }
 }

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -15,6 +15,8 @@ import type {
   AppRow,
   AppsRepositoryContract,
 } from '#repositories/apps.repository.ts';
+import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
+import type { ExportStorageRepositoryContract } from '#repositories/export-storage.repository.ts';
 import type { ExportsRepositoryContract } from '#repositories/exports.repository.ts';
 import { Service } from '#services/service.ts';
 
@@ -37,23 +39,38 @@ export type ExportCancellation = Pick<ExportsRepositoryContract, 'failInFlight'>
 
 const APP_DELETED = 'The app was deleted while this export was still being written.';
 
+/**
+ * How many deleted apps one host report cleans up after. Small, because it is work done on the
+ * way through a request that a host is waiting on, and a backlog only ever grows by one app per
+ * deletion — the next report takes the next batch.
+ */
+const PURGE_BATCH = 8;
+
 export class AppsService extends Service {
   private readonly appsRepo: AppsRepositoryContract;
   private readonly exportsRepo: ExportCancellation;
+  private readonly artifactStorageRepo: ArtifactStorageRepositoryContract;
+  private readonly exportStorageRepo: ExportStorageRepositoryContract;
   private readonly appHostDomain: string;
 
   constructor({
     appsRepo,
     exportsRepo,
+    artifactStorageRepo,
+    exportStorageRepo,
     appHostDomain,
   }: {
     appsRepo: AppsRepositoryContract;
     exportsRepo: ExportCancellation;
+    artifactStorageRepo: ArtifactStorageRepositoryContract;
+    exportStorageRepo: ExportStorageRepositoryContract;
     appHostDomain: string;
   }) {
     super();
     this.appsRepo = appsRepo;
     this.exportsRepo = exportsRepo;
+    this.artifactStorageRepo = artifactStorageRepo;
+    this.exportStorageRepo = exportStorageRepo;
     this.appHostDomain = appHostDomain;
   }
 
@@ -143,6 +160,49 @@ export class AppsService extends Service {
       if (await this.appsRepo.finishDeleting({ appId: volume.appId })) {
         this.logger.info('app deleted', { appId: volume.appId, volumeId: volume.volumeId });
       }
+    }
+  }
+
+  /**
+   * Remove what a deleted app left behind: the binaries it was deployed from, the bundles it was
+   * exported into, and the rows naming them. The filesystem went with the host; these did not,
+   * and between them they are the tenant's code and every byte of their data.
+   *
+   * Driven off what is still there rather than off the moment an app became `deleted`, so a pass
+   * that fails part way is retried by the next host report finding the same app still listed —
+   * and so apps deleted before any of this existed are cleaned up by the first report after it.
+   */
+  async purgeDeleted(): Promise<void> {
+    const appIds = await this.appsRepo.listPurgeable({ limit: PURGE_BATCH });
+    for (const appId of appIds) {
+      await this.purgeApp({ appId });
+    }
+  }
+
+  /**
+   * Objects first, rows last, because the rows are what makes the objects findable: a row deleted
+   * before its object leaves bytes nothing names, while an object deleted before its row leaves a
+   * row that the next pass reads again and acts on again. Both halves are safe to repeat.
+   *
+   * One app failing is logged rather than thrown: this runs on the way through a host report, and
+   * a bucket refusing one delete is no reason to fail the report or to skip the apps after it.
+   */
+  private async purgeApp({ appId }: { appId: AppId }): Promise<void> {
+    try {
+      const leftovers = await this.appsRepo.listLeftovers({ appId });
+      await Promise.all([
+        ...leftovers.exports.map((objectKey) => this.exportStorageRepo.remove({ objectKey })),
+        ...leftovers.artifacts.map((objectKey) => this.artifactStorageRepo.remove({ objectKey })),
+      ]);
+      await this.appsRepo.purge({ appId });
+
+      this.logger.info('deleted app purged', {
+        appId,
+        artifacts: leftovers.artifacts.length,
+        exports: leftovers.exports.length,
+      });
+    } catch (error) {
+      this.logger.error('purging a deleted app failed', { appId, error });
     }
   }
 

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -39,6 +39,8 @@ const deploymentsService = new DeploymentsService({ deploymentsRepo: deployments
 const appsService = new AppsService({
   appsRepo: appsRepository,
   exportsRepo: exportsRepository,
+  artifactStorageRepo: artifactStorageRepository,
+  exportStorageRepo: exportStorageRepository,
   appHostDomain: env.APP_HOST_DOMAIN,
 });
 const exportsService = new ExportsService({

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -52,9 +52,16 @@ class FakeAgentRepository implements AgentRepositoryContract {
 
 class FakeAppsService {
   readonly volumes: ReportedVolume[][] = [];
+  readonly trace: string[] = [];
 
   completeDeletions({ volumes }: { volumes: readonly ReportedVolume[] }): Promise<void> {
     this.volumes.push([...volumes]);
+    this.trace.push('completeDeletions');
+    return Promise.resolve();
+  }
+
+  purgeDeleted(): Promise<void> {
+    this.trace.push('purgeDeleted');
     return Promise.resolve();
   }
 }
@@ -148,5 +155,21 @@ describe('a report is read by whatever owns what it talks about', () => {
 
     expect(deployments.reports).toEqual([reported]);
     expect(exports.reports).toEqual([reported]);
+  });
+
+  // What a deleted app left behind is only safe to remove once a host has said the filesystem is
+  // gone, and that is what taking the report in records.
+  test('and only then is what the deleted ones left behind cleaned up', async () => {
+    const { apps, service } = build();
+    const reported = {
+      hostId: Value.Parse(HostIdSchema, 'host-1'),
+      instances: [],
+      volumes: [],
+      exports: [],
+    } as unknown as HostReportedState;
+
+    await service.acceptReport({ reported });
+
+    expect(apps.trace).toEqual(['completeDeletions', 'purgeDeleted']);
   });
 });

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 import {
   type AppId,
+  AppIdSchema,
   type AppState,
   type DnsLabel,
   DnsLabelSchema,
   type Hostname,
   HostnameSchema,
+  type ObjectKey,
+  ObjectKeySchema,
   type OwnerId,
   type ReportedVolume,
   Value,
@@ -19,8 +22,11 @@ import type {
   AppRow,
   AppsRepositoryContract,
   CreatedApp,
+  Leftovers,
   OwnedAppHostnameRow,
 } from '#repositories/apps.repository.ts';
+import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
+import type { ExportStorageRepositoryContract } from '#repositories/export-storage.repository.ts';
 import { AppsService, type ExportCancellation } from '#services/apps.service.ts';
 import {
   APP_HOST_DOMAIN,
@@ -64,7 +70,10 @@ class StubAppsRepository implements AppsRepositoryContract {
   readonly offeredSlugs: DnsLabel[] = [];
   readonly offeredConfigs: PublicAppConfig[] = [];
   readonly deleted: AppId[] = [];
+  readonly trace: string[] = [];
+  readonly leftovers = new Map<AppId, Leftovers>();
   deleting: AppId[] = [];
+  purgeable: AppId[] = [];
   owns = false;
   #remainingFailures: number;
   readonly #failure: unknown;
@@ -144,6 +153,69 @@ class StubAppsRepository implements AppsRepositoryContract {
       this.owns ? { ...appRow(Value.Parse(DnsLabelSchema, APP_NAME)), state } : null,
     );
   }
+
+  listPurgeable({ limit }: { limit: number }): Promise<AppId[]> {
+    return Promise.resolve(this.purgeable.slice(0, limit));
+  }
+
+  listLeftovers({ appId }: { appId: AppId }): Promise<Leftovers> {
+    return Promise.resolve(this.leftovers.get(appId) ?? { artifacts: [], exports: [] });
+  }
+
+  // An app leaves the purgeable list by having nothing left, which is how the real view answers.
+  purge({ appId }: { appId: AppId }): Promise<void> {
+    this.trace.push(`rows:${appId}`);
+    this.purgeable = this.purgeable.filter((id) => id !== appId);
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Both buckets write into one trace, because what this has to pin down is that no object is
+ * deleted after the row naming it: a bucket refusing a delete has to leave work a later pass can
+ * still find.
+ */
+class StubObjectStorage {
+  readonly removed: ObjectKey[] = [];
+  readonly #trace: string[];
+  readonly #refuse: ReadonlySet<ObjectKey>;
+
+  constructor({
+    trace,
+    refuse = new Set<ObjectKey>(),
+  }: { trace: string[]; refuse?: Set<ObjectKey> }) {
+    this.#trace = trace;
+    this.#refuse = refuse;
+  }
+
+  remove({ objectKey }: { objectKey: ObjectKey }): Promise<void> {
+    if (this.#refuse.has(objectKey)) {
+      return Promise.reject(new Error(`the bucket refused ${objectKey}`));
+    }
+    this.#trace.push(`object:${objectKey}`);
+    this.removed.push(objectKey);
+    return Promise.resolve();
+  }
+}
+
+class StubArtifactStorage extends StubObjectStorage implements ArtifactStorageRepositoryContract {
+  put(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+}
+
+class StubExportStorage extends StubObjectStorage implements ExportStorageRepositoryContract {
+  signDownload(): string {
+    return '';
+  }
+}
+
+function objectKey(key: string): ObjectKey {
+  return Value.Parse(ObjectKeySchema, key);
 }
 
 const VOLUME_ID = Value.Parse(VolumeIdSchema, APP_ID);
@@ -161,11 +233,21 @@ class StubExportCancellation implements ExportCancellation {
 function serviceWith({
   appsRepo,
   exportsRepo = new StubExportCancellation(),
+  artifactStorageRepo = new StubArtifactStorage({ trace: [] }),
+  exportStorageRepo = new StubExportStorage({ trace: [] }),
 }: {
   appsRepo: AppsRepositoryContract;
   exportsRepo?: ExportCancellation;
+  artifactStorageRepo?: ArtifactStorageRepositoryContract;
+  exportStorageRepo?: ExportStorageRepositoryContract;
 }) {
-  return new AppsService({ appsRepo, exportsRepo, appHostDomain: APP_HOST_DOMAIN });
+  return new AppsService({
+    appsRepo,
+    exportsRepo,
+    artifactStorageRepo,
+    exportStorageRepo,
+    appHostDomain: APP_HOST_DOMAIN,
+  });
 }
 
 function createApp({
@@ -379,5 +461,131 @@ describe('an app is deleted when its filesystem is gone, not when it is asked fo
     await serviceWith({ appsRepo }).completeDeletions({ volumes: [reportedVolume('deleted')] });
 
     expect(appsRepo.deleted).toEqual([]);
+  });
+});
+
+const SECOND_APP_ID = Value.Parse(AppIdSchema, '01927e3a-0000-7000-8000-00000000beef');
+
+const SOLO_BINARY = objectKey('solo-binary-digest');
+const BUNDLE = objectKey('exports/app/bundle.tar.gz');
+
+function purgeableApp({
+  appsRepo,
+  appId,
+  leftovers,
+}: {
+  appsRepo: StubAppsRepository;
+  appId: AppId;
+  leftovers: Leftovers;
+}): void {
+  appsRepo.purgeable.push(appId);
+  appsRepo.leftovers.set(appId, leftovers);
+}
+
+describe('what a deleted app leaves behind is removed after it', () => {
+  test('the binaries and the bundles both go', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    const artifacts = new StubArtifactStorage({ trace: appsRepo.trace });
+    const exports = new StubExportStorage({ trace: appsRepo.trace });
+    purgeableApp({
+      appsRepo,
+      appId: APP_ID,
+      leftovers: { artifacts: [SOLO_BINARY], exports: [BUNDLE] },
+    });
+
+    await serviceWith({
+      appsRepo,
+      artifactStorageRepo: artifacts,
+      exportStorageRepo: exports,
+    }).purgeDeleted();
+
+    expect(artifacts.removed).toEqual([SOLO_BINARY]);
+    expect(exports.removed).toEqual([BUNDLE]);
+  });
+
+  // A row deleted before its object is bytes nothing names; an object deleted before its row is
+  // work the next pass reads again. Only one of those two orders is recoverable.
+  test('every object goes before the rows naming it', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    const artifacts = new StubArtifactStorage({ trace: appsRepo.trace });
+    const exports = new StubExportStorage({ trace: appsRepo.trace });
+    purgeableApp({
+      appsRepo,
+      appId: APP_ID,
+      leftovers: { artifacts: [SOLO_BINARY], exports: [BUNDLE] },
+    });
+
+    await serviceWith({
+      appsRepo,
+      artifactStorageRepo: artifacts,
+      exportStorageRepo: exports,
+    }).purgeDeleted();
+
+    expect(appsRepo.trace.at(-1)).toBe(`rows:${APP_ID}`);
+    expect(appsRepo.trace).toContain(`object:${SOLO_BINARY}`);
+  });
+
+  test('an app with nothing left is not asked about again', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    purgeableApp({ appsRepo, appId: APP_ID, leftovers: { artifacts: [], exports: [] } });
+    const apps = serviceWith({ appsRepo });
+
+    await apps.purgeDeleted();
+    await apps.purgeDeleted();
+
+    expect(appsRepo.trace).toEqual([`rows:${APP_ID}`]);
+  });
+
+  test('nothing to purge does nothing', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+
+    await serviceWith({ appsRepo }).purgeDeleted();
+
+    expect(appsRepo.trace).toEqual([]);
+  });
+});
+
+describe('a purge that cannot finish leaves the work to be found again', () => {
+  test('a bucket refusing one object keeps the rows that name it', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    const artifacts = new StubArtifactStorage({
+      trace: appsRepo.trace,
+      refuse: new Set([SOLO_BINARY]),
+    });
+    purgeableApp({
+      appsRepo,
+      appId: APP_ID,
+      leftovers: { artifacts: [SOLO_BINARY], exports: [] },
+    });
+
+    await serviceWith({ appsRepo, artifactStorageRepo: artifacts }).purgeDeleted();
+
+    expect(appsRepo.trace).toEqual([]);
+    expect(appsRepo.purgeable).toEqual([APP_ID]);
+  });
+
+  // This runs on the way through a host report, so one bucket failure must not cost the report
+  // or the apps queued behind the app it failed on.
+  test('the app after the one that failed is still purged', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    const artifacts = new StubArtifactStorage({
+      trace: appsRepo.trace,
+      refuse: new Set([SOLO_BINARY]),
+    });
+    purgeableApp({
+      appsRepo,
+      appId: APP_ID,
+      leftovers: { artifacts: [SOLO_BINARY], exports: [] },
+    });
+    purgeableApp({
+      appsRepo,
+      appId: SECOND_APP_ID,
+      leftovers: { artifacts: [], exports: [BUNDLE] },
+    });
+
+    await serviceWith({ appsRepo, artifactStorageRepo: artifacts }).purgeDeleted();
+
+    expect(appsRepo.trace).toContain(`rows:${SECOND_APP_ID}`);
+    expect(appsRepo.purgeable).toEqual([APP_ID]);
   });
 });

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -131,6 +131,10 @@ class FakeStorage implements ArtifactStorageRepositoryContract {
   exists(): Promise<boolean> {
     return Promise.resolve(this.#alreadyStored);
   }
+
+  remove(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 const BUCKET_REFUSED = 'the bucket said no';
@@ -142,6 +146,10 @@ class RefusingStorage implements ArtifactStorageRepositoryContract {
 
   exists(): Promise<boolean> {
     return Promise.resolve(false);
+  }
+
+  remove(): Promise<void> {
+    return Promise.reject(new Error(BUCKET_REFUSED));
   }
 }
 

--- a/apps/api/tests/services/exports.test.ts
+++ b/apps/api/tests/services/exports.test.ts
@@ -113,6 +113,10 @@ class FakeExportStorage implements ExportStorageRepositoryContract {
     this.signed.push(objectKey);
     return SIGNED_URL;
   }
+
+  remove(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 function build(exportsRepo = new FakeExportsRepository()) {

--- a/infra/terraform/iam_api.tf
+++ b/infra/terraform/iam_api.tf
@@ -38,9 +38,15 @@ data "aws_iam_policy_document" "api_s3" {
   # Read on the exports bucket is what lets the api sign a download URL: a
   # presigned URL carries the signer's own permissions, so it cannot grant a read
   # this policy does not.
+  #
+  # Delete is how a bundle goes when the app it was taken from is deleted. The
+  # lifecycle rule would reach it eventually, and eventually is the whole
+  # retention window — a tenant's entire dataset outliving every way of asking
+  # for it. Signing needs read, so read is already here; this adds only the
+  # removal.
   statement {
-    sid       = "ExportsRead"
-    actions   = ["s3:GetObject"]
+    sid       = "ExportsReadDelete"
+    actions   = ["s3:GetObject", "s3:DeleteObject"]
     resources = ["${aws_s3_bucket.exports.arn}/*"]
   }
 }


### PR DESCRIPTION
Deleting an app removed its filesystem and nothing else. The binaries it was deployed from stayed in the artifacts bucket permanently — that bucket is versioned with no lifecycle rule — and the export bundles stayed downloadable for the rest of the retention window. Both are a tenant's code and a tenant's whole dataset outliving every way of asking for them. Now they go when the app does.

**When.** On `deleted`, not `deleting`: until a host says the filesystem is gone the app is still being torn down, and an export the host is still writing would be a row deleted out from under the write.

**Driven off what is left, not off the moment it happened.** `nibrun.purgeable_apps` lists deleted apps that still have rows, and the sweep runs on the way through a host report. A pass that fails half way is retried by the next report finding the same app still listed, so retrying is the same code path as the first attempt — and apps deleted before this shipped are cleaned up by the first report after it, with no backfill.

**Objects first, rows last.** The two cannot be one transaction. A row removed first leaves bytes nothing names; an object removed first leaves work the next pass repeats harmlessly. Only one of those is recoverable.

Two things worth a look:

**Artifact objects are shared, so not every one can go.** The object key is the digest of the bytes and nothing else, so two apps deployed from the same binary are two rows over one object — across owners. Deleting it for the app that is going would take the binary out from under the one that stays. Only keys no surviving app still names are removed; the last app to be deleted is the one that finds it unreferenced.

**Deployments are deleted too.** They point at artifacts with `ON DELETE RESTRICT`, so the artifact rows cannot go without them. The app row itself still stays, so a slug is never handed to a second app.

The api already had `s3:DeleteObject` on artifacts; the exports bucket statement had read only, and now has both.