### PR TITLE
fix(cli): deleting an app says everything that goes with it

### DIFF
--- a/packages/cli/src/commands/apps/delete.ts
+++ b/packages/cli/src/commands/apps/delete.ts
@@ -7,7 +7,7 @@ import { createUi, isInteractive } from '#lib/ui.ts';
 
 export const command = defineCommand('apps delete', {
   description:
-    'Delete an app: every deployment of it and everything on its volume. There is no undo.',
+    'Delete an app: everything on its volume, every binary uploaded to it and every export taken of it. There is no undo.',
   options: {
     yes: {
       schema: z.boolean().optional(),

--- a/packages/cli/src/lib/delete.ts
+++ b/packages/cli/src/lib/delete.ts
@@ -7,8 +7,8 @@ import type { Ui } from '#lib/ui.ts';
 
 /**
  * A phrase rather than a y/n, because a y/n is answered by the muscle that has answered every
- * other one. There is nothing underneath this to undo it with: an export taken beforehand is the
- * only copy anyone gets to keep.
+ * other one. There is nothing underneath this to undo it with: an export goes with the app it
+ * was taken of, so not even a bundle downloaded first leaves a copy on the platform.
  */
 const CONFIRMATION_PHRASE = 'delete permanently';
 
@@ -21,8 +21,9 @@ export type DeleteInput = {
 };
 
 /**
- * Delete an app: every deployment of it, the hostnames it answered on, and everything its binary
- * ever wrote.
+ * Delete an app: the hostnames it answered on, everything its binary ever wrote, every deployment
+ * of it, and — once the api has torn it down — every binary uploaded to it and every export taken
+ * of it.
  *
  * The app is looked up before anything is asked, so a slug that names nothing costs one line
  * rather than a phrase typed out for an app that was never there.
@@ -70,9 +71,13 @@ async function confirmDeletion({
   }
 
   note(
-    [`app: ${slug}`, `hostnames: ${hostnames.join(' ')}`, 'data: everything on the volume'].join(
-      '\n',
-    ),
+    [
+      `app: ${slug}`,
+      `hostnames: ${hostnames.join(' ')}`,
+      'volume: everything on it',
+      'binaries: every one ever uploaded to this app',
+      'exports: every bundle ever taken of it',
+    ].join('\n'),
     'Deleted for good',
   );
   answered(


### PR DESCRIPTION
The confirmation dialog listed the app, its hostnames and `data: everything on the volume`. Since #135 a delete also takes every binary uploaded to the app and every export bundle taken of it — so the dialog someone types `delete permanently` into was understating what they were agreeing to.

```
app: quiet-otter
hostnames: quiet-otter.nibrun.app
volume: everything on it
binaries: every one ever uploaded to this app
exports: every bundle ever taken of it
```

The `--help` description follows the same change. Text only — no behaviour moves.