### PR TITLE
refactor(cli): listing inside an app is spelled apps files ls

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -22,12 +22,15 @@ the layout under `src/commands/` is the command tree.
   lists what is under it, and the flag stays optional — a required one would make
   that listing an error. parsh spells a flag exactly as its key, so `--app` is
   the key `'app'` — and a flag two unrelated commands both take is a
-  `SharedOption` member in `src/config.ts`, so they cannot drift apart. When
-  those commands also mean the same thing by it, the whole declaration is shared
-  from there (`DEPLOYMENT_ID_OPTION`) and the site adds only
-  `forwardToChildren`. `defineCommand` infers its options `const`, so an enum
-  key and a spread both survive as literals — `parents['<path>'].options` stays
-  typed either way.
+  `SHARED_OPTIONS` entry in `src/config.ts`, holding that name and the
+  declaration it points at, so neither half can drift. A site writes
+  `[SHARED_OPTIONS.x.name]: { ...SHARED_OPTIONS.x.option, … }` and adds only
+  what differs there — whether it forwards, and a description where the same
+  value means a different thing per command. `defineCommand` infers its options
+  through a `const` type parameter, so the key and the spread both survive as
+  literals and `parents['<path>'].options` stays typed. The `satisfies` on
+  `SHARED_OPTIONS` is what makes a mistyped field an error where it is written
+  rather than an overload failure at every command taking it.
 - A positional is a path segment, so a command taking one lives at
   `commands/<…>/[name].ts` and its path string ends in `[name]`. Leaving it out
   prints the parent's usage rather than a missing-argument error, because the

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -29,11 +29,12 @@ the layout under `src/commands/` is the command tree.
   walk stops at the node above the param — that listing is the only place the
   command's description is read, so it has to say what the value is for.
 - An **optional** positional is that node given a command of its own:
-  `commands/apps/ls.ts` beside `commands/apps/ls/[path].ts` makes `nib apps ls`
-  and `nib apps ls <path>` two commands, and the walk picks whichever the
-  positional it was handed reaches. There is no other spelling — a param is how
-  routing gets there, so a command reached without one is a different command.
-  Flags they share go on the `ls` node with `forwardToChildren: true`.
+  `commands/apps/files/ls.ts` beside `commands/apps/files/ls/[path].ts` makes
+  `nib apps files ls` and `nib apps files ls <path>` two commands, and the walk
+  picks whichever the positional it was handed reaches. There is no other
+  spelling — a param is how routing gets there, so a command reached without one
+  is a different command. Flags they share go on the `ls` node with
+  `forwardToChildren: true`.
 - **`options` is required by `defineCommand` even when a command has none.**
   Omitting it matches the alias overload instead, whose errors talk about
   `undefined` and never mention options. `options: {}` is the fix.
@@ -57,9 +58,7 @@ the layout under `src/commands/` is the command tree.
   it is asked. An app is not something that can be defaulted to, so without a
   terminal to ask at that is where the flag is demanded instead. `apps list` is
   the exception and the reason the rule is not enforced anywhere central: it
-  lists the apps themselves, so asking which one would be circular. `apps ls`
-  lists inside one — the two are a letter apart and neither name is free to
-  change, so check which you mean before adding to either.
+  lists the apps themselves, so asking which one would be circular.
 - **A command that destroys something is the exception**, because the only
   default it could take is the destruction. Without a terminal it is refused
   rather than answered on the owner's behalf, so `--yes` is the one way to mean

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -21,8 +21,13 @@ the layout under `src/commands/` is the command tree.
   redeclared per child. The parent is then a group: no handler, so `nib apps`
   lists what is under it, and the flag stays optional — a required one would make
   that listing an error. parsh spells a flag exactly as its key, so `--app` is
-  the key `'app'` — and a flag two unrelated commands both take is that key held
-  in `src/config.ts` (`APP_OPTION`), so they cannot drift apart.
+  the key `'app'` — and a flag two unrelated commands both take is a
+  `SharedOption` member in `src/config.ts`, so they cannot drift apart. When
+  those commands also mean the same thing by it, the whole declaration is shared
+  from there (`DEPLOYMENT_ID_OPTION`) and the site adds only
+  `forwardToChildren`. `defineCommand` infers its options `const`, so an enum
+  key and a spread both survive as literals — `parents['<path>'].options` stays
+  typed either way.
 - A positional is a path segment, so a command taking one lives at
   `commands/<…>/[name].ts` and its path string ends in `[name]`. Leaving it out
   prints the parent's usage rather than a missing-argument error, because the

--- a/packages/cli/src/command-tree.gen.ts
+++ b/packages/cli/src/command-tree.gen.ts
@@ -4,10 +4,10 @@ import type { InferForwardedOptions, InferParams, RuntimeNode } from '@parshjs/c
 import type { command as appsCmd } from './commands/apps.ts';
 import type { command as appsDeleteCmd } from './commands/apps/delete.ts';
 import type { command as appsExportDestinationCmd } from './commands/apps/export/[destination].ts';
+import type { command as appsFilesLsCmd } from './commands/apps/files/ls.ts';
+import type { command as appsFilesLsPathCmd } from './commands/apps/files/ls/[path].ts';
 import type { command as appsListCmd } from './commands/apps/list.ts';
 import type { command as appsLogsCmd } from './commands/apps/logs.ts';
-import type { command as appsLsCmd } from './commands/apps/ls.ts';
-import type { command as appsLsPathCmd } from './commands/apps/ls/[path].ts';
 import type { command as loginCmd } from './commands/login.ts';
 import type { command as runCommandCmd } from './commands/run/[command].ts';
 
@@ -29,6 +29,19 @@ declare module '@parshjs/core' {
       };
       rootOptions: {};
     };
+    'apps files ls': {
+      parents: {
+        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+      };
+      rootOptions: {};
+    };
+    'apps files ls [path]': {
+      parents: {
+        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+        'apps files ls': { options: InferForwardedOptions<typeof appsFilesLsCmd.options>; params: InferParams<typeof appsFilesLsCmd.params> };
+      };
+      rootOptions: {};
+    };
     'apps list': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
@@ -38,19 +51,6 @@ declare module '@parshjs/core' {
     'apps logs': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
-      };
-      rootOptions: {};
-    };
-    'apps ls': {
-      parents: {
-        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
-      };
-      rootOptions: {};
-    };
-    'apps ls [path]': {
-      parents: {
-        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
-        'apps ls': { options: InferForwardedOptions<typeof appsLsCmd.options>; params: InferParams<typeof appsLsCmd.params> };
       };
       rootOptions: {};
     };
@@ -90,6 +90,24 @@ export const commandTree: RuntimeNode = {
             paramChild: null,
           },
         },
+        'files': {
+          segment: { kind: 'literal', value: 'files' },
+          command: null,
+          literalChildren: {
+            'ls': {
+              segment: { kind: 'literal', value: 'ls' },
+              command: { path: 'apps files ls', load: () => import('./commands/apps/files/ls.ts').then((m) => m.command) },
+              literalChildren: {},
+              paramChild: {
+                segment: { kind: 'param', name: 'path' },
+                command: { path: 'apps files ls [path]', load: () => import('./commands/apps/files/ls/[path].ts').then((m) => m.command) },
+                literalChildren: {},
+                paramChild: null,
+              },
+            },
+          },
+          paramChild: null,
+        },
         'list': {
           segment: { kind: 'literal', value: 'list' },
           command: { path: 'apps list', load: () => import('./commands/apps/list.ts').then((m) => m.command) },
@@ -101,17 +119,6 @@ export const commandTree: RuntimeNode = {
           command: { path: 'apps logs', load: () => import('./commands/apps/logs.ts').then((m) => m.command) },
           literalChildren: {},
           paramChild: null,
-        },
-        'ls': {
-          segment: { kind: 'literal', value: 'ls' },
-          command: { path: 'apps ls', load: () => import('./commands/apps/ls.ts').then((m) => m.command) },
-          literalChildren: {},
-          paramChild: {
-            segment: { kind: 'param', name: 'path' },
-            command: { path: 'apps ls [path]', load: () => import('./commands/apps/ls/[path].ts').then((m) => m.command) },
-            literalChildren: {},
-            paramChild: null,
-          },
         },
       },
       paramChild: null,

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -1,6 +1,5 @@
 import { defineCommand } from '@parshjs/core';
-import { z } from 'zod';
-import { SharedOption } from '#config.ts';
+import { SHARED_OPTIONS } from '#config.ts';
 
 /**
  * A group rather than a command. Naming an app is what everything under here has in common, so
@@ -14,8 +13,8 @@ import { SharedOption } from '#config.ts';
 export const command = defineCommand('apps', {
   description: 'Work with one of your apps.',
   options: {
-    [SharedOption.App]: {
-      schema: z.string().min(1).optional(),
+    [SHARED_OPTIONS.app.name]: {
+      ...SHARED_OPTIONS.app.option,
       forwardToChildren: true,
       description: 'Slug of the app to work with. Asked for when omitted.',
     },

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
-import { APP_OPTION } from '#config.ts';
+import { SharedOption } from '#config.ts';
 
 /**
  * A group rather than a command. Naming an app is what everything under here has in common, so
@@ -14,7 +14,7 @@ import { APP_OPTION } from '#config.ts';
 export const command = defineCommand('apps', {
   description: 'Work with one of your apps.',
   options: {
-    [APP_OPTION]: {
+    [SharedOption.App]: {
       schema: z.string().min(1).optional(),
       forwardToChildren: true,
       description: 'Slug of the app to work with. Asked for when omitted.',

--- a/packages/cli/src/commands/apps/files/ls.ts
+++ b/packages/cli/src/commands/apps/files/ls.ts
@@ -7,12 +7,12 @@ import { listDirectory } from '#lib/filesystem.ts';
 import { isInteractive } from '#lib/ui.ts';
 
 /**
- * A command and the parent of `apps ls [path]` at once, which is how an optional positional is
- * spelled: the walk stops here when nothing follows, and the volume's root is what listing
+ * A command and the parent of `apps files ls [path]` at once, which is how an optional positional
+ * is spelled: the walk stops here when nothing follows, and the volume's root is what listing
  * without naming a directory means. `--deployment-id` is declared here and forwarded, so both
  * spellings take it the same way.
  */
-export const command = defineCommand('apps ls', {
+export const command = defineCommand('apps files ls', {
   description: "List a directory of an app's filesystem. Without a path, the volume root.",
   options: {
     'deployment-id': {

--- a/packages/cli/src/commands/apps/files/ls.ts
+++ b/packages/cli/src/commands/apps/files/ls.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { GUEST_PATH_ROOT } from '@repo/protocol';
-import { DEPLOYMENT_ID_OPTION, SharedOption } from '#config.ts';
+import { SHARED_OPTIONS } from '#config.ts';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { listDirectory } from '#lib/filesystem.ts';
@@ -15,7 +15,10 @@ import { isInteractive } from '#lib/ui.ts';
 export const command = defineCommand('apps files ls', {
   description: "List a directory of an app's filesystem. Without a path, the volume root.",
   options: {
-    [SharedOption.DeploymentId]: { ...DEPLOYMENT_ID_OPTION, forwardToChildren: true },
+    [SHARED_OPTIONS.deploymentId.name]: {
+      ...SHARED_OPTIONS.deploymentId.option,
+      forwardToChildren: true,
+    },
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ options, parents, context, print }) => {
@@ -29,7 +32,7 @@ export const command = defineCommand('apps files ls', {
     await listDirectory({
       api,
       slug,
-      deploymentId: options[SharedOption.DeploymentId],
+      deploymentId: options[SHARED_OPTIONS.deploymentId.name],
       path: GUEST_PATH_ROOT,
       print,
     });

--- a/packages/cli/src/commands/apps/files/ls.ts
+++ b/packages/cli/src/commands/apps/files/ls.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { GUEST_PATH_ROOT } from '@repo/protocol';
-import { z } from 'zod';
+import { DEPLOYMENT_ID_OPTION, SharedOption } from '#config.ts';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { listDirectory } from '#lib/filesystem.ts';
@@ -15,11 +15,7 @@ import { isInteractive } from '#lib/ui.ts';
 export const command = defineCommand('apps files ls', {
   description: "List a directory of an app's filesystem. Without a path, the volume root.",
   options: {
-    'deployment-id': {
-      schema: z.string().min(1).optional(),
-      forwardToChildren: true,
-      description: 'Read this deployment instead of looking up the app latest.',
-    },
+    [SharedOption.DeploymentId]: { ...DEPLOYMENT_ID_OPTION, forwardToChildren: true },
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ options, parents, context, print }) => {
@@ -33,7 +29,7 @@ export const command = defineCommand('apps files ls', {
     await listDirectory({
       api,
       slug,
-      deploymentId: options['deployment-id'],
+      deploymentId: options[SharedOption.DeploymentId],
       path: GUEST_PATH_ROOT,
       print,
     });

--- a/packages/cli/src/commands/apps/files/ls/[path].ts
+++ b/packages/cli/src/commands/apps/files/ls/[path].ts
@@ -1,5 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
+import { SharedOption } from '#config.ts';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { guestPath, listDirectory } from '#lib/filesystem.ts';
@@ -29,7 +30,7 @@ export const command = defineCommand('apps files ls [path]', {
     await listDirectory({
       api,
       slug,
-      deploymentId: parents['apps files ls'].options['deployment-id'],
+      deploymentId: parents['apps files ls'].options[SharedOption.DeploymentId],
       path,
       print,
     });

--- a/packages/cli/src/commands/apps/files/ls/[path].ts
+++ b/packages/cli/src/commands/apps/files/ls/[path].ts
@@ -5,7 +5,7 @@ import { requireSignedIn } from '#lib/credentials.ts';
 import { guestPath, listDirectory } from '#lib/filesystem.ts';
 import { isInteractive } from '#lib/ui.ts';
 
-export const command = defineCommand('apps ls [path]', {
+export const command = defineCommand('apps files ls [path]', {
   description: 'Directory to list, as a path inside the app filesystem.',
   options: {},
   params: {
@@ -29,7 +29,7 @@ export const command = defineCommand('apps ls [path]', {
     await listDirectory({
       api,
       slug,
-      deploymentId: parents['apps ls'].options['deployment-id'],
+      deploymentId: parents['apps files ls'].options['deployment-id'],
       path,
       print,
     });

--- a/packages/cli/src/commands/apps/files/ls/[path].ts
+++ b/packages/cli/src/commands/apps/files/ls/[path].ts
@@ -1,6 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
-import { SharedOption } from '#config.ts';
+import { SHARED_OPTIONS } from '#config.ts';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { guestPath, listDirectory } from '#lib/filesystem.ts';
@@ -30,7 +30,7 @@ export const command = defineCommand('apps files ls [path]', {
     await listDirectory({
       api,
       slug,
-      deploymentId: parents['apps files ls'].options[SharedOption.DeploymentId],
+      deploymentId: parents['apps files ls'].options[SHARED_OPTIONS.deploymentId.name],
       path,
       print,
     });

--- a/packages/cli/src/commands/apps/logs.ts
+++ b/packages/cli/src/commands/apps/logs.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from '@parshjs/core';
 import { DEFAULT_LOG_TIMERANGE, LOG_TIMERANGE_PATTERN } from '@repo/protocol';
 import { z } from 'zod';
+import { DEPLOYMENT_ID_OPTION, SharedOption } from '#config.ts';
 import { addressedDeployment, selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { follow, untilInterrupted } from '#lib/logs.ts';
@@ -19,10 +20,7 @@ export const command = defineCommand('apps logs', {
         .default(DEFAULT_LOG_TIMERANGE),
       description: 'How much history to print before following.',
     },
-    'deployment-id': {
-      schema: z.string().min(1).optional(),
-      description: 'Read this deployment instead of looking up the app latest.',
-    },
+    [SharedOption.DeploymentId]: DEPLOYMENT_ID_OPTION,
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ options, parents, context, print }) => {
@@ -35,7 +33,7 @@ export const command = defineCommand('apps logs', {
     const { appId, deploymentId } = await addressedDeployment({
       api,
       slug,
-      deploymentId: options['deployment-id'],
+      deploymentId: options[SharedOption.DeploymentId],
       print,
     });
 

--- a/packages/cli/src/commands/apps/logs.ts
+++ b/packages/cli/src/commands/apps/logs.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from '@parshjs/core';
 import { DEFAULT_LOG_TIMERANGE, LOG_TIMERANGE_PATTERN } from '@repo/protocol';
 import { z } from 'zod';
-import { DEPLOYMENT_ID_OPTION, SharedOption } from '#config.ts';
+import { SHARED_OPTIONS } from '#config.ts';
 import { addressedDeployment, selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { follow, untilInterrupted } from '#lib/logs.ts';
@@ -20,7 +20,7 @@ export const command = defineCommand('apps logs', {
         .default(DEFAULT_LOG_TIMERANGE),
       description: 'How much history to print before following.',
     },
-    [SharedOption.DeploymentId]: DEPLOYMENT_ID_OPTION,
+    [SHARED_OPTIONS.deploymentId.name]: SHARED_OPTIONS.deploymentId.option,
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ options, parents, context, print }) => {
@@ -33,7 +33,7 @@ export const command = defineCommand('apps logs', {
     const { appId, deploymentId } = await addressedDeployment({
       api,
       slug,
-      deploymentId: options[SharedOption.DeploymentId],
+      deploymentId: options[SHARED_OPTIONS.deploymentId.name],
       print,
     });
 

--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -1,6 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
-import { APP_OPTION } from '#config.ts';
+import { SharedOption } from '#config.ts';
 import { parseCommandLine } from '#lib/command-line.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { deploy, readBinary } from '#lib/deploy.ts';
@@ -14,7 +14,7 @@ export const command = defineCommand('run [command]', {
     command: { schema: z.string().min(1) },
   },
   options: {
-    [APP_OPTION]: {
+    [SharedOption.App]: {
       schema: z.string().optional(),
       description: 'Slug of an existing app to deploy onto. Asked for when omitted.',
     },

--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -1,6 +1,6 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
-import { SharedOption } from '#config.ts';
+import { SHARED_OPTIONS } from '#config.ts';
 import { parseCommandLine } from '#lib/command-line.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { deploy, readBinary } from '#lib/deploy.ts';
@@ -14,8 +14,8 @@ export const command = defineCommand('run [command]', {
     command: { schema: z.string().min(1) },
   },
   options: {
-    [SharedOption.App]: {
-      schema: z.string().optional(),
+    [SHARED_OPTIONS.app.name]: {
+      ...SHARED_OPTIONS.app.option,
       description: 'Slug of an existing app to deploy onto. Asked for when omitted.',
     },
     name: {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,3 +1,4 @@
+import type { CommandOption } from '@parshjs/core';
 import { z } from 'zod';
 
 export const PROGRAM_NAME = 'nib';
@@ -5,20 +6,21 @@ export const PROGRAM_NAME = 'nib';
 export const DEFAULT_API_URL = 'https://app.nibrun.com';
 
 /**
- * Flags asked for by more than one command, spelled once so two commands cannot end up asking for
- * the same thing by different names.
+ * A flag more than one command takes, held as both the name parsh spells it by and the declaration
+ * that name points at, so neither half can drift between the commands taking it. A site adds only
+ * what genuinely differs there: whether it forwards, and a description where the same value means a
+ * different thing to each command.
  */
-export enum SharedOption {
-  App = 'app',
-  DeploymentId = 'deployment-id',
-}
-
-/**
- * Only the name of `--app` is shared, because what an app is to each command is not: `nib run`
- * deploys onto one, `nib apps` works with one. A deployment is the same deployment wherever it is
- * named, so this one is shared whole and a site adds nothing but whether it forwards.
- */
-export const DEPLOYMENT_ID_OPTION = {
-  schema: z.string().min(1).optional(),
-  description: 'Read this deployment instead of looking up the app latest.',
-};
+export const SHARED_OPTIONS = {
+  app: {
+    name: 'app',
+    option: { schema: z.string().min(1).optional() },
+  },
+  deploymentId: {
+    name: 'deployment-id',
+    option: {
+      schema: z.string().min(1).optional(),
+      description: 'Read this deployment instead of looking up the app latest.',
+    },
+  },
+} as const satisfies Record<string, { name: string; option: CommandOption }>;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,7 +1,24 @@
+import { z } from 'zod';
+
 export const PROGRAM_NAME = 'nib';
 
 export const DEFAULT_API_URL = 'https://app.nibrun.com';
 
-// `nib run` and `nib apps` both take the app to work on, and one name for it is what makes them
-// the same flag rather than two that happen to rhyme.
-export const APP_OPTION = 'app';
+/**
+ * Flags asked for by more than one command, spelled once so two commands cannot end up asking for
+ * the same thing by different names.
+ */
+export enum SharedOption {
+  App = 'app',
+  DeploymentId = 'deployment-id',
+}
+
+/**
+ * Only the name of `--app` is shared, because what an app is to each command is not: `nib run`
+ * deploys onto one, `nib apps` works with one. A deployment is the same deployment wherever it is
+ * named, so this one is shared whole and a site adds nothing but whether it forwards.
+ */
+export const DEPLOYMENT_ID_OPTION = {
+  schema: z.string().min(1).optional(),
+  description: 'Read this deployment instead of looking up the app latest.',
+};

--- a/packages/cli/src/lib/apps.ts
+++ b/packages/cli/src/lib/apps.ts
@@ -1,11 +1,11 @@
 import { select } from '@clack/prompts';
 import type { Print } from '@parshjs/core';
-import { SharedOption } from '#config.ts';
+import { SHARED_OPTIONS } from '#config.ts';
 import { type Api, unwrap } from '#lib/api.ts';
 import { ApiError, UsageError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
 
-const NO_APP_NAMED = `Which app? Name one with --${SharedOption.App}.`;
+const NO_APP_NAMED = `Which app? Name one with --${SHARED_OPTIONS.app.name}.`;
 export const NO_APPS = 'You have no apps. `nib run` is what makes one.';
 const NO_DEPLOYMENTS = 'This app has never been deployed.';
 

--- a/packages/cli/src/lib/apps.ts
+++ b/packages/cli/src/lib/apps.ts
@@ -1,11 +1,11 @@
 import { select } from '@clack/prompts';
 import type { Print } from '@parshjs/core';
-import { APP_OPTION } from '#config.ts';
+import { SharedOption } from '#config.ts';
 import { type Api, unwrap } from '#lib/api.ts';
 import { ApiError, UsageError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
 
-const NO_APP_NAMED = `Which app? Name one with --${APP_OPTION}.`;
+const NO_APP_NAMED = `Which app? Name one with --${SharedOption.App}.`;
 export const NO_APPS = 'You have no apps. `nib run` is what makes one.';
 const NO_DEPLOYMENTS = 'This app has never been deployed.';
 


### PR DESCRIPTION
`nib apps ls` sat one letter from `nib apps list` while meaning something else entirely — one lists your apps, the other lists inside one. Moving it under `files` says which is which by name, and gives the filesystem commands somewhere to be added.

Both spellings move together: `nib apps files ls` and `nib apps files ls <path>`. No behaviour changes.