### PR TITLE
fix: an export captures everything the tenant wrote

### DIFF
--- a/apps/agent/src/lib/exports/bundle.ts
+++ b/apps/agent/src/lib/exports/bundle.ts
@@ -70,27 +70,43 @@ export function bundleBinaryName(artifact: DesiredArtifact): Either.Either<strin
 }
 
 /**
- * The binary is fetched from the artifact bucket rather than lifted out of the local squashfs
- * cache, because the download proves the digest on the way past.
+ * Kept apart from the archive step because this is the only part of an export a frozen tenant
+ * pays for. Everything after it reads the staging tree rather than the device, so holding the
+ * guest still through a binary download and a `tar` of the whole dataset would block writes for
+ * several times as long as reading the device does.
  */
-export const writeBundle = Effect.fn('writeBundle')(function* ({
-  artifact,
+export const dumpVolume = Effect.fn('dumpVolume')(function* ({
   devicePath,
   stagingDir,
 }: {
-  artifact: DesiredArtifact;
   devicePath: string;
   stagingDir: string;
 }) {
   yield* Effect.annotateCurrentSpan({ devicePath });
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const binaryName = yield* bundleBinaryName(artifact);
 
   yield* fs.remove(stagingDir, { recursive: true, force: true });
   yield* fs.makeDirectory(stagingDir, { recursive: true, mode: STAGING_MODE });
 
   yield* dumpFilesystem({ devicePath, destination: path.join(stagingDir, DATA_DIRECTORY) });
+});
+
+/**
+ * The binary is fetched from the artifact bucket rather than lifted out of the local squashfs
+ * cache, because the download proves the digest on the way past.
+ */
+export const writeBundle = Effect.fn('writeBundle')(function* ({
+  artifact,
+  stagingDir,
+}: {
+  artifact: DesiredArtifact;
+  stagingDir: string;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const binaryName = yield* bundleBinaryName(artifact);
+
   const binaryPath = path.join(stagingDir, binaryName);
   yield* downloadAndVerify({ artifact, destination: binaryPath });
   // A transfer writes what a transfer writes, and `tar` records the mode it finds. Without this

--- a/apps/agent/src/lib/exports/freeze.ts
+++ b/apps/agent/src/lib/exports/freeze.ts
@@ -1,0 +1,197 @@
+import type { AppId } from '@repo/protocol';
+import { Data, Duration, Effect, Option } from 'effect';
+import {
+  connectRequest,
+  GUEST_CONTROL_VSOCK_PORT,
+  guestVsockPath,
+  readConnectReply,
+  vmWorkingDir,
+} from '#lib/vm/vsock.ts';
+
+const FREEZE_REQUEST = 'FREEZE\n';
+const FREEZE_HELD = 'OK';
+/** The guest answers a freeze once ext4 has checkpointed its journal, which is work, not a round trip. */
+const REPLY_TIMEOUT_SECONDS = 30;
+const REPLY_TIMEOUT = Duration.seconds(REPLY_TIMEOUT_SECONDS);
+
+export class GuestUnreachable extends Data.TaggedError('GuestUnreachable')<{
+  readonly socketPath: string;
+  readonly cause: unknown;
+}> {
+  override get message() {
+    return `no VMM is listening on ${this.socketPath}`;
+  }
+}
+
+export class GuestSilent extends Data.TaggedError('GuestSilent')<{
+  readonly socketPath: string;
+}> {
+  override get message() {
+    return `${this.socketPath} took the request and never answered`;
+  }
+}
+
+export class FreezeRefused extends Data.TaggedError('FreezeRefused')<{
+  readonly appId: AppId;
+  readonly reply: string;
+}> {
+  override get message() {
+    return `the guest running ${this.appId} would not freeze its filesystem: ${this.reply}`;
+  }
+}
+
+/**
+ * The guest thaws itself if a freeze is held past its ceiling, and a bundle read across that
+ * moment is one whose tail the tenant was free to change underneath. Reported as a failed export
+ * rather than uploaded, because the point of freezing is that nobody has to wonder afterwards.
+ */
+export class FreezeLost extends Data.TaggedError('FreezeLost')<{
+  readonly appId: AppId;
+}> {
+  override get message() {
+    return `the guest running ${this.appId} thawed before the bundle was finished`;
+  }
+}
+
+type Wire = {
+  readonly send: (text: string) => void;
+  readonly readLine: () => Promise<string>;
+  readonly isOpen: () => boolean;
+  readonly close: () => void;
+};
+
+async function dial(socketPath: string): Promise<Wire> {
+  let buffered = '';
+  let open = true;
+  let waiting: (() => void) | undefined;
+
+  const socket = await Bun.connect({
+    unix: socketPath,
+    socket: {
+      // biome-ignore lint/complexity/useMaxParams: Bun hands a socket handler its own socket
+      data: (_socket, chunk) => {
+        buffered += chunk.toString();
+        waiting?.();
+      },
+      close: () => {
+        open = false;
+        waiting?.();
+      },
+      error: () => {
+        open = false;
+        waiting?.();
+      },
+    },
+  });
+
+  function takeLine(): string | undefined {
+    const end = buffered.indexOf('\n');
+    if (end < 0) {
+      return undefined;
+    }
+    const line = buffered.slice(0, end);
+    buffered = buffered.slice(end + 1);
+    return line;
+  }
+
+  return {
+    send: (text) => {
+      socket.write(text);
+    },
+    isOpen: () => open,
+    close: () => {
+      socket.end();
+    },
+    readLine: () =>
+      // biome-ignore lint/complexity/useMaxParams: an executor settles two ways
+      new Promise((resolve, reject) => {
+        function attempt() {
+          const line = takeLine();
+          if (line !== undefined) {
+            waiting = undefined;
+            resolve(line);
+            return;
+          }
+          if (!open) {
+            waiting = undefined;
+            reject(new Error(`${socketPath} closed before it answered`));
+          }
+        }
+        waiting = attempt;
+        attempt();
+      }),
+  };
+}
+
+const readLine = ({ wire, socketPath }: { wire: Wire; socketPath: string }) =>
+  Effect.tryPromise({
+    try: () => wire.readLine(),
+    catch: () => new GuestSilent({ socketPath }),
+  }).pipe(
+    Effect.timeoutFail({
+      duration: REPLY_TIMEOUT,
+      onTimeout: () => new GuestSilent({ socketPath }),
+    }),
+  );
+
+/**
+ * A held freeze, for as long as the scope lives. The connection *is* the lease: dropping it is
+ * what tells the guest to thaw, so an agent that dies mid-export cannot leave a tenant's
+ * filesystem wedged behind it.
+ */
+export type FreezeLease = {
+  /** Fails if the guest let go before the caller did. Ask before trusting what was read. */
+  readonly assertHeld: Effect.Effect<void, FreezeLost>;
+};
+
+const NOTHING_TO_HOLD: FreezeLease = { assertHeld: Effect.void };
+
+/**
+ * A stopped app has no VMM to ask and needs none: its guest unmounted the filesystem on the way
+ * down, which is the same journal checkpoint under another name. A VMM that is running and does
+ * not answer is the case that must not be waved through — that is a guest whose journal still
+ * holds writes the bundle would otherwise miss without saying so.
+ */
+export const frozen = Effect.fn('frozen')(function* ({
+  appId,
+  vmDir,
+}: {
+  appId: AppId;
+  vmDir: string;
+}) {
+  const socketPath = guestVsockPath({ workingDir: vmWorkingDir({ vmDir, appId }) });
+  const dialled = yield* Effect.acquireRelease(
+    Effect.tryPromise({
+      try: () => dial(socketPath),
+      catch: (cause) => new GuestUnreachable({ socketPath, cause }),
+    }),
+    (wire) => Effect.sync(() => wire.close()),
+  ).pipe(Effect.option);
+
+  if (Option.isNone(dialled)) {
+    yield* Effect.logInfo('no running guest to freeze; reading the volume as it lies').pipe(
+      Effect.annotateLogs({ appId, socketPath }),
+    );
+    return NOTHING_TO_HOLD;
+  }
+
+  const wire = dialled.value;
+  wire.send(connectRequest(GUEST_CONTROL_VSOCK_PORT));
+  yield* readConnectReply({
+    reply: yield* readLine({ wire, socketPath }),
+    port: GUEST_CONTROL_VSOCK_PORT,
+  });
+
+  wire.send(FREEZE_REQUEST);
+  const reply = yield* readLine({ wire, socketPath });
+  if (reply !== FREEZE_HELD) {
+    return yield* new FreezeRefused({ appId, reply });
+  }
+  yield* Effect.logInfo('the guest froze its filesystem').pipe(Effect.annotateLogs({ appId }));
+
+  return {
+    assertHeld: Effect.suspend(() =>
+      wire.isOpen() ? Effect.void : new FreezeLost({ appId }),
+    ) satisfies Effect.Effect<void, FreezeLost>,
+  };
+});

--- a/apps/agent/src/lib/logs/vsock.ts
+++ b/apps/agent/src/lib/logs/vsock.ts
@@ -1,8 +1,8 @@
 import { join } from 'node:path';
 import type { AppId, DeploymentId } from '@repo/protocol';
+import { GUEST_VSOCK_FILENAME } from '#lib/vm/vsock.ts';
 
 export const TENANT_LOG_VSOCK_PORT = 51000;
-export const TENANT_LOG_VSOCK_FILENAME = 'logs.vsock';
 
 export type TenantLogSource = {
   readonly appId: AppId;
@@ -10,4 +10,4 @@ export type TenantLogSource = {
 };
 
 export const tenantLogSocketPath = ({ workingDir }: { workingDir: string }): string =>
-  join(workingDir, `${TENANT_LOG_VSOCK_FILENAME}_${TENANT_LOG_VSOCK_PORT}`);
+  join(workingDir, `${GUEST_VSOCK_FILENAME}_${TENANT_LOG_VSOCK_PORT}`);

--- a/apps/agent/src/lib/vm/vsock.ts
+++ b/apps/agent/src/lib/vm/vsock.ts
@@ -1,0 +1,55 @@
+import { join } from 'node:path';
+import type { AppId } from '@repo/protocol';
+import { Data, Either } from 'effect';
+
+/**
+ * One vsock device per microVM, and every port multiplexes over it — which is why this names the
+ * device rather than what any one port carries. The host dials a guest port by connecting here
+ * and asking; the guest's own outbound connections arrive on `<path>_<port>` instead.
+ *
+ * The value is what the tenant log port made it before anything else shared the device, and it
+ * stays: a guest booted by an earlier agent is listening on this path, and renaming it would make
+ * an export of that VM find nothing, conclude no VMM was running, and read the volume unfrozen —
+ * the one outcome the freeze exists to prevent.
+ */
+export const GUEST_VSOCK_FILENAME = 'logs.vsock';
+
+/** Answered by the control process in the guest's PID 1. `apps/runtime/src/vsock.h` is the other end. */
+export const GUEST_CONTROL_VSOCK_PORT = 51001;
+
+export const vmWorkingDir = ({ vmDir, appId }: { vmDir: string; appId: AppId }): string =>
+  join(vmDir, appId);
+
+export const guestVsockPath = ({ workingDir }: { workingDir: string }): string =>
+  join(workingDir, GUEST_VSOCK_FILENAME);
+
+export class GuestPortUnreachable extends Data.TaggedError('GuestPortUnreachable')<{
+  readonly port: number;
+  readonly reply: string;
+}> {
+  override get message() {
+    return `nothing in the guest answered vsock port ${this.port}: ${this.reply}`;
+  }
+}
+
+/**
+ * Firecracker's host-initiated leg is a text handshake before the stream becomes the guest's:
+ * `CONNECT <port>` in, `OK <host-side port>` back. Anything else means the VMM is there and the
+ * guest is not listening, which is a different thing from no VMM at all — the socket refusing the
+ * connection outright is what says that.
+ */
+export const connectRequest = (port: number): string => `CONNECT ${port}\n`;
+
+const CONNECT_ACCEPTED = 'OK ';
+
+export function readConnectReply({
+  reply,
+  port,
+}: {
+  reply: string;
+  port: number;
+}): Either.Either<void, GuestPortUnreachable> {
+  return reply.startsWith(CONNECT_ACCEPTED)
+    ? Either.right(undefined)
+    : Either.left(new GuestPortUnreachable({ port, reply }));
+}

--- a/apps/agent/src/services/export-manager.service.ts
+++ b/apps/agent/src/services/export-manager.service.ts
@@ -3,7 +3,8 @@ import type { DesiredArtifact, DesiredExport, ReportedExport } from '@repo/proto
 import { Effect } from 'effect';
 import { s3Credentials } from '#lib/aws/credentials.ts';
 import { nowTimestamp } from '#lib/clock.ts';
-import { writeBundle } from '#lib/exports/bundle.ts';
+import { dumpVolume, writeBundle } from '#lib/exports/bundle.ts';
+import { frozen } from '#lib/exports/freeze.ts';
 import { flush } from '#lib/volumes/zerofs.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AwsCredentialProvider } from '#services/aws-credential-provider.service.ts';
@@ -71,10 +72,24 @@ export class ExportManager extends Effect.Service<ExportManager>()('ExportManage
       const stagingDir = path.join(config.exportStagingDir, desired.exportId);
       return yield* Effect.ensuring(
         Effect.gen(function* () {
-          // Under `ignore_fsync` the guest's barriers are not durability points, so this is what
-          // turns its acknowledged writes into bytes the device will hand back.
-          yield* flush(topology.place().admin);
-          const bundle = yield* writeBundle({ artifact, devicePath, stagingDir });
+          // Two layers of staleness sit between a tenant's last write and the device this reads,
+          // and each needs the side that owns it to act. The guest's kernel goes first: only it
+          // can checkpoint the ext4 journal that `debugfs` never replays, and staying frozen is
+          // also what stops the device changing mid-read. Then ZeroFS, where under
+          // `ignore_fsync` the guest's barriers are not durability points, so this is what turns
+          // acknowledged writes into bytes the device will hand back.
+          //
+          // The scope ends where the reading does. Archiving what was read needs the tenant no
+          // more than uploading it does, and both take longer.
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const lease = yield* frozen({ appId: desired.appId, vmDir: config.vmDir });
+              yield* flush(topology.place().admin);
+              yield* dumpVolume({ devicePath, stagingDir });
+              yield* lease.assertHeld;
+            }),
+          );
+          const bundle = yield* writeBundle({ artifact, stagingDir });
           yield* upload({ bundlePath: bundle.path, objectKey: desired.objectKey });
           yield* Effect.logInfo('export written').pipe(
             Effect.annotateLogs({

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -2,13 +2,14 @@ import { FileSystem, Path } from '@effect/platform';
 import type { AppId, DesiredInstance } from '@repo/protocol';
 import { Effect } from 'effect';
 import { writeJsonFile } from '#lib/json-store.ts';
-import { TENANT_LOG_VSOCK_FILENAME, tenantLogSocketPath } from '#lib/logs/vsock.ts';
+import { tenantLogSocketPath } from '#lib/logs/vsock.ts';
 import type { AppSlot } from '#lib/network/slot.ts';
 import { ensureTap } from '#lib/network/tap.ts';
 import * as Artifacts from '#lib/vm/artifacts.ts';
 import { renderFirecrackerConfig } from '#lib/vm/firecracker-config.ts';
 import { buildInstanceConfigImage } from '#lib/vm/instance-env.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
+import { GUEST_VSOCK_FILENAME, vmWorkingDir } from '#lib/vm/vsock.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { TenantLogReceiver } from '#services/tenant-log-receiver.service.ts';
 
@@ -26,7 +27,7 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
     const fs = yield* FileSystem.FileSystem;
     const logs = yield* TenantLogReceiver;
 
-    const workingDir = (appId: AppId) => path.join(config.vmDir, appId);
+    const workingDir = (appId: AppId) => vmWorkingDir({ vmDir: config.vmDir, appId });
 
     /**
      * The agent never becomes the VM's parent: it stages the files, asks init to start the unit,
@@ -82,7 +83,7 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
           },
           vsock: {
             guestCid: FIRST_GUEST_CID + slot.slot,
-            path: TENANT_LOG_VSOCK_FILENAME,
+            path: GUEST_VSOCK_FILENAME,
           },
         }),
       });

--- a/apps/agent/tests/lib/exports/bundle.test.ts
+++ b/apps/agent/tests/lib/exports/bundle.test.ts
@@ -3,7 +3,7 @@ import { mkdir, readdir, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { type Filename, FilenameSchema, Value } from '@repo/protocol';
 import { Effect, Either, Layer } from 'effect';
-import { bundleBinaryName, writeBundle } from '#lib/exports/bundle.ts';
+import { bundleBinaryName, dumpVolume, writeBundle } from '#lib/exports/bundle.ts';
 import { artifactStore } from '#tests/support/artifacts.ts';
 import { recordingCommands, succeeding } from '#tests/support/commands.ts';
 import { artifact } from '#tests/support/fixtures.ts';
@@ -52,7 +52,9 @@ function bundling({ dumps = 'tenant' }: { dumps?: keyof typeof DUMPS } = {}) {
 
     const result = yield* Effect.either(
       Effect.provide(
-        writeBundle({ artifact: artifact(), devicePath: DEVICE_PATH, stagingDir }),
+        Effect.flatMap(dumpVolume({ devicePath: DEVICE_PATH, stagingDir }), () =>
+          writeBundle({ artifact: artifact(), stagingDir }),
+        ),
         layer,
       ),
     );

--- a/apps/agent/tests/lib/exports/freeze.test.ts
+++ b/apps/agent/tests/lib/exports/freeze.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { type AppId, AppIdSchema, Value } from '@repo/protocol';
+import { Effect } from 'effect';
+import { frozen } from '#lib/exports/freeze.ts';
+import { GUEST_VSOCK_FILENAME } from '#lib/vm/vsock.ts';
+import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
+
+const APP_ID: AppId = Value.Parse(AppIdSchema, 'pocketbase-8zv0ch');
+
+const run = provided(platform);
+
+type GuestBehaviour = {
+  readonly onConnect?: string;
+  readonly onFreeze?: string;
+  readonly hangUpAfterFreezing?: boolean;
+};
+
+/**
+ * Firecracker's end of the vsock device, which is a plain unix socket speaking a text handshake
+ * before the stream becomes the guest's. Standing it up for real is the only way to cover the
+ * part that matters: what the agent does when the answer is not the one it wanted.
+ */
+const fakeVmm = ({ vmDir, behaviour }: { vmDir: string; behaviour: GuestBehaviour }) =>
+  Effect.acquireRelease(
+    Effect.promise(async () => {
+      const workingDir = join(vmDir, APP_ID);
+      await mkdir(workingDir, { recursive: true });
+      const { onConnect = 'OK 1024\n', onFreeze = 'OK\n', hangUpAfterFreezing = false } = behaviour;
+      return Bun.listen({
+        unix: join(workingDir, GUEST_VSOCK_FILENAME),
+        socket: {
+          // biome-ignore lint/complexity/useMaxParams: Bun hands a socket handler its own socket
+          data: (socket, chunk) => {
+            const request = chunk.toString();
+            if (request.startsWith('CONNECT')) {
+              socket.write(onConnect);
+              return;
+            }
+            socket.write(onFreeze);
+            if (hangUpAfterFreezing) {
+              socket.end();
+            }
+          },
+        },
+      });
+    }),
+    (server) => Effect.sync(() => server.stop(true)),
+  );
+
+const HELD = 'held';
+const BUNDLE_TIME = '50 millis';
+
+/**
+ * What the export would do with the lease: take it, spend time on the bundle, and ask whether it
+ * still holds before trusting a byte of what it read. The pause is what gives a guest that hangs
+ * up the chance to, so the answer is about the lease rather than about scheduling.
+ */
+const outcome = ({ vmDir }: { vmDir: string }) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const lease = yield* frozen({ appId: APP_ID, vmDir });
+      yield* Effect.sleep(BUNDLE_TIME);
+      yield* lease.assertHeld;
+      return HELD;
+    }),
+  ).pipe(Effect.catchAll((error) => Effect.succeed(error._tag)));
+describe('freezing a tenant filesystem before it is read', () => {
+  test('holds the freeze the guest granted', async () => {
+    const held = await run(
+      Effect.gen(function* () {
+        const vmDir = yield* temporaryDirectory;
+        yield* fakeVmm({ vmDir, behaviour: {} });
+        return yield* outcome({ vmDir });
+      }),
+    );
+
+    expect(held).toBe(HELD);
+  });
+
+  /* A guest that thawed on its own deadline leaves a bundle nobody can vouch for, and the export
+   * has to say so rather than upload it. */
+  test('reports the freeze lost when the guest thawed before the bundle was finished', async () => {
+    const held = await run(
+      Effect.gen(function* () {
+        const vmDir = yield* temporaryDirectory;
+        yield* fakeVmm({ vmDir, behaviour: { hangUpAfterFreezing: true } });
+        return yield* outcome({ vmDir });
+      }),
+    );
+
+    expect(held).toBe('FreezeLost');
+  });
+
+  test('reports a guest that would not freeze at all', async () => {
+    const held = await run(
+      Effect.gen(function* () {
+        const vmDir = yield* temporaryDirectory;
+        yield* fakeVmm({ vmDir, behaviour: { onFreeze: 'ERR the data filesystem is gone\n' } });
+        return yield* outcome({ vmDir });
+      }),
+    );
+
+    expect(held).toBe('FreezeRefused');
+  });
+
+  /* The VMM is there, so the tenant is writing; nothing answering the control port is a guest
+   * whose journal the bundle would miss without saying so. */
+  test('refuses a running VMM with nothing listening on the control port', async () => {
+    const held = await run(
+      Effect.gen(function* () {
+        const vmDir = yield* temporaryDirectory;
+        yield* fakeVmm({ vmDir, behaviour: { onConnect: 'FAILED\n' } });
+        return yield* outcome({ vmDir });
+      }),
+    );
+
+    expect(held).toBe('GuestPortUnreachable');
+  });
+
+  /* A stopped app unmounted its filesystem on the way down, which empties the journal for the
+   * same reason a freeze does. */
+  test('reads the volume as it lies when no VMM is running', async () => {
+    const held = await run(
+      Effect.gen(function* () {
+        const vmDir = yield* temporaryDirectory;
+        return yield* outcome({ vmDir });
+      }),
+    );
+
+    expect(held).toBe(HELD);
+  });
+});

--- a/apps/agent/tests/lib/vm/vsock.test.ts
+++ b/apps/agent/tests/lib/vm/vsock.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { type AppId, AppIdSchema, Value } from '@repo/protocol';
+import { Either } from 'effect';
+import { tenantLogSocketPath } from '#lib/logs/vsock.ts';
+import {
+  connectRequest,
+  GUEST_CONTROL_VSOCK_PORT,
+  guestVsockPath,
+  readConnectReply,
+  vmWorkingDir,
+} from '#lib/vm/vsock.ts';
+
+const APP_ID: AppId = Value.Parse(AppIdSchema, 'pocketbase-8zv0ch');
+
+describe('the VM vsock device', () => {
+  test('the host dials the device itself and the guest answers on a suffixed path', () => {
+    const workingDir = vmWorkingDir({ vmDir: '/var/lib/nibrun/vm', appId: APP_ID });
+
+    expect(guestVsockPath({ workingDir })).toBe('/var/lib/nibrun/vm/pocketbase-8zv0ch/logs.vsock');
+    expect(tenantLogSocketPath({ workingDir })).toBe(
+      '/var/lib/nibrun/vm/pocketbase-8zv0ch/logs.vsock_51000',
+    );
+  });
+});
+
+describe("Firecracker's host-initiated handshake", () => {
+  test('asks for the control port by number', () => {
+    expect(connectRequest(GUEST_CONTROL_VSOCK_PORT)).toBe('CONNECT 51001\n');
+  });
+
+  test('accepts the reply that names the port it bound', () => {
+    const accepted = readConnectReply({ reply: 'OK 1234', port: GUEST_CONTROL_VSOCK_PORT });
+
+    expect(Either.isRight(accepted)).toBe(true);
+  });
+
+  /* A VMM that is there and a guest that is not listening: the export must fail rather than read a
+   * device whose journal still holds the tenant's last writes. */
+  test('refuses anything else, so an unlistened port is not mistaken for a stopped app', () => {
+    for (const reply of ['FAILED', '', 'OK', 'NOT OK 1234']) {
+      const refused = readConnectReply({ reply, port: GUEST_CONTROL_VSOCK_PORT });
+
+      expect(Either.isLeft(refused)).toBe(true);
+    }
+  });
+});

--- a/apps/runtime/AGENTS.md
+++ b/apps/runtime/AGENTS.md
@@ -2,11 +2,20 @@
 
 The guest's PID 1. It boots and supervises the tenant binary inside one microVM, and is the only
 other thing that ever executes there. `src/init.c` is the sequence in order, `src/paths.h` is the
-boot contract shared with the host agent, and `src/config.h` is the `/instance.env` format.
+boot contract shared with the host agent, `src/vsock.h` is the port contract, and `src/config.h`
+is the `/instance.env` format.
+
+`src/guest-control.c` is the one thing here the host drives rather than reads. An export is built
+by reading the block device from outside, and what has only reached ext4's journal is not in the
+blocks that reader sees — so the host asks this side to freeze, which is what makes ext4
+checkpoint. It answers in a child of PID 1, not on the supervisor's poll loop, which does not run
+while the tenant is between restarts. The connection is the lease: dropping it thaws.
 
 C, static, musl, because this is resident in every microVM and its cost is multiplied by how many
-a host packs: measured **1.3 MiB RSS, 65 KiB on disk**. Only the tenant's binary needs glibc,
-which is why the rootfs carries it and this does not link against it.
+a host packs: measured **1.3 MiB RSS, 65 KiB on disk**. The control channel is a fork of PID 1
+rather than a second binary, so what it adds is its own private pages and not another copy — the
+pair measures **1.05 MiB PSS** between them. Only the tenant's binary needs glibc, which is why
+the rootfs carries it and this does not link against it.
 
 ## Building
 
@@ -27,6 +36,9 @@ budget ending the VM with Firecracker exiting 0, and a graceful stop over `SendC
 works only because the guest kernel enables the i8042 path, and that belongs to
 `infra/guest-image`.
 
-The stdout/stderr framing and non-blocking capture are exercised in Docker. The AF_VSOCK
-connection itself still needs a Firecracker integration test; a container has no Firecracker
-vsock backend to connect it to.
+The stdout/stderr framing and non-blocking capture are exercised in Docker, and so is freeze and
+thaw against a real ext4 loop device — a frozen filesystem cannot be asked whether it is frozen,
+so what the mount suite asserts is the pair of refusals, EBUSY on a second freeze and EINVAL on a
+second thaw. Neither AF_VSOCK leg is covered: a container has no Firecracker vsock backend, so
+the log connection and the control channel's handshake both still need a Firecracker integration
+test. The host's half of that handshake is covered in `apps/agent`, against a fake VMM.

--- a/apps/runtime/Dockerfile
+++ b/apps/runtime/Dockerfile
@@ -21,7 +21,7 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources; \
 # multiplied by how many VMs a host packs. Only the tenant's own binary needs glibc,
 # and the rootfs carries glibc for exactly that reason.
 ENV CFLAGS="-std=c11 -D_GNU_SOURCE -Os -static -Wall -Wextra -Werror -Wshadow -Wvla -fno-common -Wl,--build-id=none"
-ENV RUNTIME_SOURCES="/build/src/config.c /build/src/guest-logs.c /build/src/log.c /build/src/mounts.c /build/src/supervise.c"
+ENV RUNTIME_SOURCES="/build/src/clock.c /build/src/config.c /build/src/guest-control.c /build/src/guest-logs.c /build/src/log.c /build/src/mounts.c /build/src/supervise.c"
 WORKDIR /build
 COPY src/ /build/src/
 

--- a/apps/runtime/src/clock.c
+++ b/apps/runtime/src/clock.c
@@ -1,0 +1,19 @@
+#include "clock.h"
+
+#include <limits.h>
+#include <time.h>
+
+#define MS_PER_SECOND 1000
+#define NS_PER_MS 1000000L
+
+uint64_t clock_monotonic_ms(void) {
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+  return (uint64_t)now.tv_sec * MS_PER_SECOND + (uint64_t)now.tv_nsec / (uint64_t)NS_PER_MS;
+}
+
+int clock_remaining_ms(uint64_t deadline_ms) {
+  uint64_t now = clock_monotonic_ms();
+  uint64_t left = deadline_ms > now ? deadline_ms - now : 0;
+  return left > INT_MAX ? INT_MAX : (int)left;
+}

--- a/apps/runtime/src/clock.h
+++ b/apps/runtime/src/clock.h
@@ -1,0 +1,13 @@
+#ifndef NIBRUN_CLOCK_H
+#define NIBRUN_CLOCK_H
+
+#include <stdint.h>
+
+/* CLOCK_MONOTONIC, so a guest whose wall clock is stepped by NTP does not shorten
+ * or extend a deadline it is already waiting on. */
+uint64_t clock_monotonic_ms(void);
+
+/* What is left until `deadline_ms`, clamped to what poll(2) takes. */
+int clock_remaining_ms(uint64_t deadline_ms);
+
+#endif

--- a/apps/runtime/src/guest-control.c
+++ b/apps/runtime/src/guest-control.c
@@ -1,0 +1,233 @@
+#include "guest-control.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "clock.h"
+#include "log.h"
+#include "vsock.h"
+
+/* _IOWR('X', 119, int) and its pair, spelled out for the same reason the vsock
+ * address is: the musl toolchain carries no linux/fs.h. */
+#define FIFREEZE _IOWR('X', 119, int)
+#define FITHAW _IOWR('X', 120, int)
+
+/* One export at a time. A second one waits here rather than meeting an EBUSY from a
+ * filesystem the first has already frozen. */
+#define CONNECTION_BACKLOG 1
+#define REQUEST_MAX_BYTES 32
+#define REQUEST_TIMEOUT_MS 5000
+
+/* A frozen filesystem is a tenant whose writes are blocked, and the host holds the
+ * freeze for as long as it takes to read the whole device. This is the ceiling on
+ * that: past it the guest thaws and drops the connection, which is how the host
+ * learns the bundle it just built cannot be trusted. */
+#define MAX_FREEZE_HOLD_MS 900000U
+
+static const char FREEZE_REQUEST[] = "FREEZE\n";
+static const char FREEZE_HELD[] = "OK\n";
+static const char FREEZE_REFUSED[] = "ERR the data filesystem could not be frozen\n";
+static const char UNKNOWN_REQUEST[] = "ERR unknown request\n";
+
+bool guest_control_freeze(const char *mount_point) {
+  int mount_descriptor = open(mount_point, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (mount_descriptor < 0) {
+    return false;
+  }
+  bool frozen = ioctl(mount_descriptor, FIFREEZE, 0) == 0;
+  int failure = errno;
+  close(mount_descriptor);
+  errno = failure;
+  return frozen;
+}
+
+bool guest_control_thaw(const char *mount_point) {
+  int mount_descriptor = open(mount_point, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (mount_descriptor < 0) {
+    return false;
+  }
+  bool thawed = ioctl(mount_descriptor, FITHAW, 0) == 0;
+  int failure = errno;
+  close(mount_descriptor);
+  errno = failure;
+  return thawed;
+}
+
+static int listen_on_control_port(void) {
+  int listener = socket(AF_VSOCK, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (listener < 0) {
+    log_errno("could not open the control socket");
+    return -1;
+  }
+  struct vsock_address address = {
+      .family = AF_VSOCK,
+      .port = GUEST_CONTROL_VSOCK_PORT,
+      .cid = VMADDR_CID_ANY,
+  };
+  if (bind(listener, (const struct sockaddr *)&address, sizeof(address)) < 0) {
+    log_errno("could not bind the control socket");
+    close(listener);
+    return -1;
+  }
+  if (listen(listener, CONNECTION_BACKLOG) < 0) {
+    log_errno("could not listen on the control socket");
+    close(listener);
+    return -1;
+  }
+  return listener;
+}
+
+static bool reply(int connection, const char *line) {
+  size_t length = strlen(line);
+  size_t written = 0;
+  while (written < length) {
+    ssize_t sent = send(connection, line + written, length - written, MSG_NOSIGNAL);
+    if (sent < 0 && errno == EINTR) {
+      continue;
+    }
+    if (sent <= 0) {
+      return false;
+    }
+    written += (size_t)sent;
+  }
+  return true;
+}
+
+/* One byte at a time, which for a seven-byte request costs less than the state a
+ * buffered reader would need to carry between connections. */
+static bool read_request(int connection, char *buffer, size_t capacity) {
+  size_t filled = 0;
+  while (filled + 1 < capacity) {
+    struct pollfd waiting = {.fd = connection, .events = POLLIN};
+    int ready = poll(&waiting, 1, REQUEST_TIMEOUT_MS);
+    if (ready < 0 && errno == EINTR) {
+      continue;
+    }
+    if (ready <= 0) {
+      return false;
+    }
+    ssize_t seen = recv(connection, buffer + filled, 1, 0);
+    if (seen < 0 && errno == EINTR) {
+      continue;
+    }
+    if (seen <= 0) {
+      return false;
+    }
+    filled += (size_t)seen;
+    if (buffer[filled - 1] == '\n') {
+      buffer[filled] = '\0';
+      return true;
+    }
+  }
+  return false;
+}
+
+/* The connection is the lease. A host that finishes, crashes or is killed drops it,
+ * and the filesystem thaws without anybody having to ask — which is what keeps a
+ * dead agent from leaving a tenant wedged. The deadline covers the host that
+ * neither finishes nor lets go. */
+static bool wait_until_released(int connection) {
+  uint64_t deadline_ms = clock_monotonic_ms() + MAX_FREEZE_HOLD_MS;
+  for (;;) {
+    struct pollfd waiting = {.fd = connection, .events = POLLIN};
+    int ready = poll(&waiting, 1, clock_remaining_ms(deadline_ms));
+    if (ready < 0 && errno == EINTR) {
+      continue;
+    }
+    if (ready <= 0) {
+      return false;
+    }
+    char unexpected;
+    ssize_t seen = recv(connection, &unexpected, sizeof(unexpected), 0);
+    if (seen == 0) {
+      return true;
+    }
+    if (seen < 0 && errno != EINTR) {
+      return false;
+    }
+  }
+}
+
+static void answer(int connection, const char *mount_point) {
+  char request[REQUEST_MAX_BYTES];
+  if (!read_request(connection, request, sizeof(request))) {
+    return;
+  }
+  if (strcmp(request, FREEZE_REQUEST) != 0) {
+    reply(connection, UNKNOWN_REQUEST);
+    return;
+  }
+  if (!guest_control_freeze(mount_point)) {
+    log_errno("could not freeze %s", mount_point);
+    reply(connection, FREEZE_REFUSED);
+    return;
+  }
+  if (reply(connection, FREEZE_HELD) && !wait_until_released(connection)) {
+    log_line("the host held %s frozen for %ums without letting go; thawing it", mount_point,
+             MAX_FREEZE_HOLD_MS);
+  }
+  if (!guest_control_thaw(mount_point)) {
+    log_errno("could not thaw %s", mount_point);
+  }
+}
+
+static void serve(const char *mount_point) {
+  int listener = listen_on_control_port();
+  if (listener < 0) {
+    return;
+  }
+  log_line("the control channel is listening on vsock port %u", GUEST_CONTROL_VSOCK_PORT);
+  for (;;) {
+    int connection = accept(listener, NULL, NULL);
+    if (connection < 0) {
+      if (errno == EINTR || errno == ECONNABORTED) {
+        continue;
+      }
+      log_errno("could not accept a control connection");
+      break;
+    }
+    answer(connection, mount_point);
+    close(connection);
+  }
+  close(listener);
+}
+
+void guest_control_start(struct guest_control *control) {
+  pid_t process = fork();
+  if (process < 0) {
+    log_errno("could not start the control channel");
+    control->process = -1;
+    return;
+  }
+  if (process == 0) {
+    serve(control->mount_point);
+    _exit(0);
+  }
+  control->process = process;
+}
+
+void guest_control_stop(const struct guest_control *control) {
+  /* Nothing froze the filesystem if nothing was ever listening, and a boot that failed
+   * before the mount would have nothing to open either. */
+  if (control->process <= 0) {
+    return;
+  }
+  /* SIGKILL, not SIGTERM: PID 1 blocked the supervised signals before this process was
+   * forked, so it inherited a mask that would swallow anything catchable. */
+  kill(control->process, SIGKILL);
+  while (waitpid(control->process, NULL, 0) < 0 && errno == EINTR) {
+  }
+  /* EINVAL is the filesystem saying it was not frozen, which is the ordinary case: the
+   * host holds a freeze only for as long as it is reading. */
+  if (!guest_control_thaw(control->mount_point) && errno != EINVAL) {
+    log_errno("could not thaw %s", control->mount_point);
+  }
+}

--- a/apps/runtime/src/guest-control.h
+++ b/apps/runtime/src/guest-control.h
@@ -1,0 +1,41 @@
+#ifndef NIBRUN_GUEST_CONTROL_H
+#define NIBRUN_GUEST_CONTROL_H
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+/* The host asks for the tenant's filesystem to be held still while it reads the
+ * block device underneath. It cannot do that from its own side: the guest holds the
+ * same filesystem mounted read-write, and what has only reached ext4's journal is
+ * not yet in the place the host reads. Only the kernel that owns the mount can put
+ * it there. */
+
+struct guest_control {
+  pid_t process;
+  const char *mount_point;
+};
+
+/* Answers the host in a child of PID 1 rather than on the supervisor's poll loop,
+ * which does not run while the tenant is between restarts. Failing to start is not
+ * fatal: the tenant still runs, and an export that cannot freeze fails on the host.
+ *
+ * The guest kernel is built without CONFIG_VSOCKETS_LOOPBACK, so the tenant cannot
+ * reach this listener — the only peer a guest vsock port has is the host. */
+void guest_control_start(struct guest_control *control);
+
+/* Ends the control process and leaves the filesystem thawed. Both halves are
+ * needed: a freeze is superblock state that outlives whoever asked for it, so
+ * killing the process does not lift it, and unmounting a frozen filesystem blocks
+ * for as long as it stays frozen. */
+void guest_control_stop(const struct guest_control *control);
+
+/* ext4 answers a freeze by checkpointing its journal, which is the whole point: it
+ * moves every committed change out of a log the host never replays and into the
+ * blocks the host does read. */
+bool guest_control_freeze(const char *mount_point);
+
+/* False with errno set, so a caller can tell a filesystem that refused to thaw from
+ * one that was never frozen (EINVAL). */
+bool guest_control_thaw(const char *mount_point);
+
+#endif

--- a/apps/runtime/src/guest-logs.c
+++ b/apps/runtime/src/guest-logs.c
@@ -9,33 +9,14 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
-#include <time.h>
 #include <unistd.h>
 
-#define MS_PER_SECOND 1000
-#define NS_PER_MS 1000000L
+#include "clock.h"
+#include "vsock.h"
+
 #define RECONNECT_DELAY_MS 250
 #define FRAME_HEADER_BYTES 9
 #define GAP_PAYLOAD_BYTES 8
-
-#ifndef AF_VSOCK
-#define AF_VSOCK 40
-#endif
-#define VMADDR_CID_HOST 2U
-
-/* The static musl toolchain deliberately carries no Linux header bundle. This is
- * the stable 16-byte UAPI address, kept local so adding one socket family does not
- * add kernel headers to the guest runtime's build input. */
-struct vsock_address {
-  sa_family_t family;
-  unsigned short reserved;
-  uint32_t port;
-  uint32_t cid;
-  unsigned char zero[sizeof(struct sockaddr) - sizeof(sa_family_t) - sizeof(unsigned short) -
-                     sizeof(uint32_t) - sizeof(uint32_t)];
-};
-
-_Static_assert(sizeof(struct vsock_address) == sizeof(struct sockaddr), "vsock address has the wrong ABI");
 
 enum connection_state {
   CONNECTION_DISCONNECTED,
@@ -51,29 +32,23 @@ enum frame_kind {
 
 static const unsigned char FRAME_MAGIC[] = {'N', 'B', 'L', '1'};
 
-static uint64_t monotonic_ms(void) {
-  struct timespec now;
-  clock_gettime(CLOCK_MONOTONIC, &now);
-  return (uint64_t)now.tv_sec * MS_PER_SECOND + (uint64_t)now.tv_nsec / (uint64_t)NS_PER_MS;
-}
-
 static void disconnect(struct guest_log_forwarder *forwarder) {
   if (forwarder->descriptor >= 0) {
     close(forwarder->descriptor);
   }
   forwarder->descriptor = -1;
   forwarder->connection_state = CONNECTION_DISCONNECTED;
-  forwarder->retry_after_ms = monotonic_ms() + RECONNECT_DELAY_MS;
+  forwarder->retry_after_ms = clock_monotonic_ms() + RECONNECT_DELAY_MS;
 }
 
 static void start_connection(struct guest_log_forwarder *forwarder) {
-  if (monotonic_ms() < forwarder->retry_after_ms) {
+  if (clock_monotonic_ms() < forwarder->retry_after_ms) {
     return;
   }
 
   int descriptor = socket(AF_VSOCK, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
   if (descriptor < 0) {
-    forwarder->retry_after_ms = monotonic_ms() + RECONNECT_DELAY_MS;
+    forwarder->retry_after_ms = clock_monotonic_ms() + RECONNECT_DELAY_MS;
     return;
   }
 

--- a/apps/runtime/src/guest-logs.h
+++ b/apps/runtime/src/guest-logs.h
@@ -5,8 +5,6 @@
 
 #include "supervise.h"
 
-#define TENANT_LOG_VSOCK_PORT 51000
-
 struct guest_log_forwarder {
   int descriptor;
   int connection_state;

--- a/apps/runtime/src/init.c
+++ b/apps/runtime/src/init.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include "config.h"
+#include "guest-control.h"
 #include "guest-logs.h"
 #include "log.h"
 #include "mounts.h"
@@ -28,7 +29,9 @@
 #define SHUTDOWN_GRACE_MS 10000
 #define TENANT_UMASK 0022
 
-static _Noreturn void shutdown_guest(void) {
+static _Noreturn void shutdown_guest(const struct guest_control *control) {
+  /* Before the unmount, which a filesystem left frozen would never return from. */
+  guest_control_stop(control);
   /* Unmounted rather than only synced, so the next boot finds a clean filesystem
    * instead of replaying a journal. */
   if (umount(DATA_DIR) < 0 && errno != EINVAL && errno != ENOENT) {
@@ -143,8 +146,10 @@ static bool read_instance_config(struct instance_config *config) {
 int main(void) {
   umask(TENANT_UMASK);
 
+  struct guest_control control = {.process = -1, .mount_point = DATA_DIR};
+
   if (!mounts_dev()) {
-    shutdown_guest(); /* there is no console to say so on */
+    shutdown_guest(&control); /* there is no console to say so on */
   }
   adopt_console();
   log_line("guest runtime starting");
@@ -155,8 +160,13 @@ int main(void) {
   struct instance_config config;
   if (!mounts_pseudo_filesystems() || !read_instance_config(&config) || !write_resolv_conf(&config) ||
       !prepare_tenant_filesystem()) {
-    shutdown_guest();
+    shutdown_guest(&control);
   }
+
+  /* After the data filesystem exists and before the tenant does: the channel's only
+   * job is that filesystem, and the host may ask for it while the tenant is still
+   * starting. */
+  guest_control_start(&control);
 
   struct supervisor supervisor = {
       .tenant =
@@ -194,5 +204,5 @@ int main(void) {
       break;
   }
   guest_logs_close(&guest_logs);
-  shutdown_guest();
+  shutdown_guest(&control);
 }

--- a/apps/runtime/src/supervise.c
+++ b/apps/runtime/src/supervise.c
@@ -3,7 +3,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
-#include <limits.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -14,6 +13,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "clock.h"
 #include "log.h"
 
 #define MS_PER_SECOND 1000
@@ -59,22 +59,10 @@ void supervise_block_signals(void) {
   }
 }
 
-static uint64_t monotonic_ms(void) {
-  struct timespec now;
-  clock_gettime(CLOCK_MONOTONIC, &now);
-  return (uint64_t)now.tv_sec * MS_PER_SECOND + (uint64_t)now.tv_nsec / (uint64_t)NS_PER_MS;
-}
-
 static struct timespec remaining_until(uint64_t deadline_ms) {
-  uint64_t now = monotonic_ms();
+  uint64_t now = clock_monotonic_ms();
   uint64_t left = deadline_ms > now ? deadline_ms - now : 0;
   return (struct timespec){(time_t)(left / MS_PER_SECOND), (long)(left % MS_PER_SECOND) * NS_PER_MS};
-}
-
-static int remaining_ms(uint64_t deadline_ms) {
-  uint64_t now = monotonic_ms();
-  uint64_t left = deadline_ms > now ? deadline_ms - now : 0;
-  return left > INT_MAX ? INT_MAX : (int)left;
 }
 
 /* The tenant is a session leader, so its whole group can be signalled at once. The
@@ -211,8 +199,9 @@ static struct wait_result wait_for_tenant(pid_t tenant, uint32_t grace_ms, int s
         {.fd = stdout_descriptor, .events = POLLIN},
         {.fd = stderr_descriptor, .events = POLLIN},
     };
-    int ready = poll(polled, sizeof(polled) / sizeof(polled[0]),
-                     phase == PHASE_RUNNING ? OUTPUT_SERVICE_INTERVAL_MS : remaining_ms(deadline_ms));
+    int timeout_ms =
+        phase == PHASE_RUNNING ? OUTPUT_SERVICE_INTERVAL_MS : clock_remaining_ms(deadline_ms);
+    int ready = poll(polled, sizeof(polled) / sizeof(polled[0]), timeout_ms);
     if (ready < 0 && errno == EINTR) {
       continue;
     }
@@ -237,7 +226,7 @@ static struct wait_result wait_for_tenant(pid_t tenant, uint32_t grace_ms, int s
         log_line("the tenant is still running %ums after SIGTERM; killing it", grace_ms);
         signal_tenant(tenant, SIGKILL);
         phase = PHASE_KILL_SENT;
-        deadline_ms = monotonic_ms() + SIGKILL_GRACE_MS;
+        deadline_ms = clock_monotonic_ms() + SIGKILL_GRACE_MS;
         continue;
       }
       log_line("the tenant survived SIGKILL; shutting the guest down without it");
@@ -287,7 +276,7 @@ static struct wait_result wait_for_tenant(pid_t tenant, uint32_t grace_ms, int s
         log_line("shutdown requested; asking the tenant to stop");
         signal_tenant(tenant, SIGTERM);
         phase = PHASE_TERM_SENT;
-        deadline_ms = monotonic_ms() + grace_ms;
+        deadline_ms = clock_monotonic_ms() + grace_ms;
       }
     }
   }
@@ -295,7 +284,7 @@ static struct wait_result wait_for_tenant(pid_t tenant, uint32_t grace_ms, int s
 
 static bool sleep_or_shutdown(uint32_t duration_ms) {
   sigset_t signals = supervised_signals();
-  uint64_t deadline_ms = monotonic_ms() + duration_ms;
+  uint64_t deadline_ms = clock_monotonic_ms() + duration_ms;
 
   for (;;) {
     struct timespec remaining = remaining_until(deadline_ms);
@@ -342,7 +331,7 @@ enum supervise_outcome supervise(const struct supervisor *supervisor) {
   uint32_t restarts = 0;
 
   for (;;) {
-    uint64_t started_ms = monotonic_ms();
+    uint64_t started_ms = clock_monotonic_ms();
     int stdout_pipe[2];
     int stderr_pipe[2];
     if (!open_output_pipe(stdout_pipe)) {
@@ -381,7 +370,7 @@ enum supervise_outcome supervise(const struct supervisor *supervisor) {
       return SUPERVISE_SHUTDOWN_REQUESTED;
     }
 
-    uint64_t uptime_ms = monotonic_ms() - started_ms;
+    uint64_t uptime_ms = clock_monotonic_ms() - started_ms;
     log_tenant_exit(result.status, uptime_ms);
 
     if (uptime_ms >= supervisor->policy.reset_after_ms && restarts > 0) {

--- a/apps/runtime/src/vsock.h
+++ b/apps/runtime/src/vsock.h
@@ -1,0 +1,33 @@
+#ifndef NIBRUN_VSOCK_H
+#define NIBRUN_VSOCK_H
+
+#include <stdint.h>
+#include <sys/socket.h>
+
+/* One Firecracker vsock device serves the whole VM, so every port below multiplexes
+ * over it. Tenant output goes out on TENANT_LOG_VSOCK_PORT; the host comes in on
+ * GUEST_CONTROL_VSOCK_PORT. The host agent's `lib/vm/vsock.ts` is the other end. */
+#define TENANT_LOG_VSOCK_PORT 51000U
+#define GUEST_CONTROL_VSOCK_PORT 51001U
+
+#ifndef AF_VSOCK
+#define AF_VSOCK 40
+#endif
+#define VMADDR_CID_HOST 2U
+#define VMADDR_CID_ANY 0xFFFFFFFFU
+
+/* The static musl toolchain deliberately carries no Linux header bundle. This is
+ * the stable 16-byte UAPI address, kept local so adding one socket family does not
+ * add kernel headers to the guest runtime's build input. */
+struct vsock_address {
+  sa_family_t family;
+  unsigned short reserved;
+  uint32_t port;
+  uint32_t cid;
+  unsigned char zero[sizeof(struct sockaddr) - sizeof(sa_family_t) - sizeof(unsigned short) -
+                     sizeof(uint32_t) - sizeof(uint32_t)];
+};
+
+_Static_assert(sizeof(struct vsock_address) == sizeof(struct sockaddr), "vsock address has the wrong ABI");
+
+#endif

--- a/apps/runtime/tests/test-mounts.c
+++ b/apps/runtime/tests/test-mounts.c
@@ -18,6 +18,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include "../src/guest-control.h"
 #include "../src/mounts.h"
 #include "../src/paths.h"
 #include "expect.h"
@@ -151,6 +152,16 @@ int main(int argc, char **argv) {
   /* Its own directory and nothing above it: /run stands in for the tmpfs the guest
    * mounts at /app, which the tenant must not be able to write. */
   EXPECT(!can_write_as_tenant("/run"));
+
+  /* A frozen filesystem cannot be asked whether it is frozen, and a write that proved
+   * it would be a write that never returns. What answers instead is the pair of
+   * refusals: a second freeze is EBUSY only while one is held, and a second thaw is
+   * EINVAL only once none is. */
+  EXPECT(guest_control_freeze(DATA_MOUNT));
+  EXPECT(!guest_control_freeze(DATA_MOUNT) && errno == EBUSY);
+  EXPECT(guest_control_thaw(DATA_MOUNT));
+  EXPECT(!guest_control_thaw(DATA_MOUNT) && errno == EINVAL);
+  EXPECT(can_write_as_tenant(DATA_MOUNT));
 
   EXPECT(!mounts_artifact("/dev/does-not-exist", "/run/test-missing"));
   EXPECT(!mounts_tenant_data(&(struct tenant_data_mount){


### PR DESCRIPTION
An export read the block device while the guest still held the filesystem mounted, and `debugfs` never replays the ext4 journal — so whatever the tenant's kernel had committed but not yet checkpointed was missing from the bundle, silently. The guest now answers a freeze over vsock and holds it while the host reads.

The freeze covers the device read only; the binary download and the `tar` that follow run thawed. A guest that thaws early or refuses fails the export rather than uploading a bundle nobody can vouch for.

### Notes for review

- **Needs a new guest image**, and VMs must be rebooted to get the listener. Until one is, exporting a still-running old VM fails loudly.
- The vsock socket filename stays `logs.vsock` even though the constant is now `GUEST_VSOCK_FILENAME` — renaming it would make an export of a pre-upgrade VM find nothing, conclude no VMM was running, and read unfrozen, which is exactly the bug being fixed. Reasoning is in the constant's comment.
- A tenant's writes block for the length of the device read. `MAX_FREEZE_HOLD_MS` is the ceiling.
- The AF_VSOCK leg itself is still untested — a container has no Firecracker vsock backend, the same gap the tenant-log connection already had. Freeze/thaw against real ext4 is covered in the mount suite, and the host's half of the handshake against a fake VMM.