### PR TITLE
fix: a tenant gets its filesystem back however an export ends

### DIFF
--- a/apps/runtime/AGENTS.md
+++ b/apps/runtime/AGENTS.md
@@ -36,9 +36,15 @@ budget ending the VM with Firecracker exiting 0, and a graceful stop over `SendC
 works only because the guest kernel enables the i8042 path, and that belongs to
 `infra/guest-image`.
 
-The stdout/stderr framing and non-blocking capture are exercised in Docker, and so is freeze and
-thaw against a real ext4 loop device — a frozen filesystem cannot be asked whether it is frozen,
-so what the mount suite asserts is the pair of refusals, EBUSY on a second freeze and EINVAL on a
-second thaw. Neither AF_VSOCK leg is covered: a container has no Firecracker vsock backend, so
-the log connection and the control channel's handshake both still need a Firecracker integration
-test. The host's half of that handshake is covered in `apps/agent`, against a fake VMM.
+The stdout/stderr framing and non-blocking capture are exercised in Docker, and so is the control
+channel against a real ext4 loop device. A frozen filesystem cannot be asked whether it is
+frozen, and a write that proved it would be a write that never returns, so what the mount suite
+asserts is the pair of refusals: EBUSY on a second freeze, EINVAL on a second thaw. The lease
+loop is driven over a socketpair standing in for the vsock — a host that lets go, one that never
+does, and one that asks for something else — because the property worth proving is that the
+tenant gets its filesystem back however the connection ended.
+
+What that leaves uncovered is the AF_VSOCK transport itself, for both legs: a container has no
+Firecracker vsock backend, so the log connection and the control channel's `CONNECT` handshake
+still need a Firecracker integration test. The host's half of that handshake is covered in
+`apps/agent`, against a fake VMM.

--- a/apps/runtime/src/guest-control.c
+++ b/apps/runtime/src/guest-control.c
@@ -134,8 +134,8 @@ static bool read_request(int connection, char *buffer, size_t capacity) {
  * and the filesystem thaws without anybody having to ask — which is what keeps a
  * dead agent from leaving a tenant wedged. The deadline covers the host that
  * neither finishes nor lets go. */
-static bool wait_until_released(int connection) {
-  uint64_t deadline_ms = clock_monotonic_ms() + MAX_FREEZE_HOLD_MS;
+static bool wait_until_released(int connection, uint32_t max_hold_ms) {
+  uint64_t deadline_ms = clock_monotonic_ms() + max_hold_ms;
   for (;;) {
     struct pollfd waiting = {.fd = connection, .events = POLLIN};
     int ready = poll(&waiting, 1, clock_remaining_ms(deadline_ms));
@@ -156,27 +156,39 @@ static bool wait_until_released(int connection) {
   }
 }
 
-static void answer(int connection, const char *mount_point) {
-  char request[REQUEST_MAX_BYTES];
-  if (!read_request(connection, request, sizeof(request))) {
-    return;
-  }
-  if (strcmp(request, FREEZE_REQUEST) != 0) {
-    reply(connection, UNKNOWN_REQUEST);
-    return;
-  }
-  if (!guest_control_freeze(mount_point)) {
-    log_errno("could not freeze %s", mount_point);
-    reply(connection, FREEZE_REFUSED);
-    return;
-  }
-  if (reply(connection, FREEZE_HELD) && !wait_until_released(connection)) {
-    log_line("the host held %s frozen for %ums without letting go; thawing it", mount_point,
-             MAX_FREEZE_HOLD_MS);
-  }
+/* The one way out of a freeze, so that every path that took one goes through here. */
+static enum guest_control_outcome thawing(const char *mount_point,
+                                          enum guest_control_outcome outcome) {
   if (!guest_control_thaw(mount_point)) {
     log_errno("could not thaw %s", mount_point);
   }
+  return outcome;
+}
+
+enum guest_control_outcome guest_control_answer(const struct guest_control_request *request) {
+  char asked[REQUEST_MAX_BYTES];
+  if (!read_request(request->connection, asked, sizeof(asked))) {
+    return GUEST_CONTROL_IGNORED;
+  }
+  if (strcmp(asked, FREEZE_REQUEST) != 0) {
+    reply(request->connection, UNKNOWN_REQUEST);
+    return GUEST_CONTROL_IGNORED;
+  }
+  if (!guest_control_freeze(request->mount_point)) {
+    log_errno("could not freeze %s", request->mount_point);
+    reply(request->connection, FREEZE_REFUSED);
+    return GUEST_CONTROL_REFUSED;
+  }
+  /* A host that is gone before it hears the answer has already let go. */
+  if (!reply(request->connection, FREEZE_HELD)) {
+    return thawing(request->mount_point, GUEST_CONTROL_RELEASED);
+  }
+  if (!wait_until_released(request->connection, request->max_hold_ms)) {
+    log_line("the host held %s frozen for %ums without letting go; thawing it",
+             request->mount_point, request->max_hold_ms);
+    return thawing(request->mount_point, GUEST_CONTROL_TIMED_OUT);
+  }
+  return thawing(request->mount_point, GUEST_CONTROL_RELEASED);
 }
 
 static void serve(const char *mount_point) {
@@ -194,10 +206,28 @@ static void serve(const char *mount_point) {
       log_errno("could not accept a control connection");
       break;
     }
-    answer(connection, mount_point);
+    guest_control_answer(&(struct guest_control_request){
+        .connection = connection, .mount_point = mount_point, .max_hold_ms = MAX_FREEZE_HOLD_MS});
     close(connection);
   }
   close(listener);
+}
+
+/* A freeze outlives the process that took it, so this one being reaped mid-lease
+ * would leave the tenant's filesystem frozen until the VM shut down — the deadline
+ * dies with the process waiting on it. The tenant is what should be killed under
+ * memory pressure instead: it is the only thing in this guest that allocates. */
+static void refuse_the_oom_killer(void) {
+  static const char NEVER[] = "-1000";
+  int descriptor = open("/proc/self/oom_score_adj", O_WRONLY | O_CLOEXEC);
+  if (descriptor < 0) {
+    log_errno("could not opt the control channel out of the oom killer");
+    return;
+  }
+  if (write(descriptor, NEVER, sizeof(NEVER) - 1) < 0) {
+    log_errno("could not opt the control channel out of the oom killer");
+  }
+  close(descriptor);
 }
 
 void guest_control_start(struct guest_control *control) {
@@ -208,6 +238,7 @@ void guest_control_start(struct guest_control *control) {
     return;
   }
   if (process == 0) {
+    refuse_the_oom_killer();
     serve(control->mount_point);
     _exit(0);
   }

--- a/apps/runtime/src/guest-control.h
+++ b/apps/runtime/src/guest-control.h
@@ -2,6 +2,7 @@
 #define NIBRUN_GUEST_CONTROL_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 /* The host asks for the tenant's filesystem to be held still while it reads the
@@ -37,5 +38,31 @@ bool guest_control_freeze(const char *mount_point);
 /* False with errno set, so a caller can tell a filesystem that refused to thaw from
  * one that was never frozen (EINVAL). */
 bool guest_control_thaw(const char *mount_point);
+
+enum guest_control_outcome {
+  /* Nothing was asked, or something this side does not answer. Nothing was frozen. */
+  GUEST_CONTROL_IGNORED,
+  GUEST_CONTROL_REFUSED,
+  /* The host let go, or stopped being there — which this side cannot tell apart, and
+   * has no reason to. */
+  GUEST_CONTROL_RELEASED,
+  GUEST_CONTROL_TIMED_OUT,
+};
+
+struct guest_control_request {
+  int connection;
+  const char *mount_point;
+  /* How long a freeze may be held before this side takes it back. */
+  uint32_t max_hold_ms;
+};
+
+/* Answers one connection and returns with the filesystem thawed, however that
+ * connection ended.
+ *
+ * Exposed rather than left private so a test can drive it over a socketpair: a vsock
+ * and a unix socket are both SOCK_STREAM, and the property worth proving is that no
+ * path out of here leaves a tenant frozen — which is exactly the path a container
+ * cannot arrange over vsock, having no Firecracker to carry it. */
+enum guest_control_outcome guest_control_answer(const struct guest_control_request *request);
 
 #endif

--- a/apps/runtime/tests/test-mounts.c
+++ b/apps/runtime/tests/test-mounts.c
@@ -10,10 +10,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sched.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -25,6 +27,45 @@
 
 #define SQUASHFS_MOUNT "/run/test-artifact"
 #define DATA_MOUNT "/run/test-data"
+#define FREEZE_HOLD_TEST_MS 200
+#define GRANT_BYTES 8
+
+/**
+ * Drives the real control-channel loop over a socketpair, standing in for the vsock a
+ * container has no Firecracker to carry. Both are SOCK_STREAM, so the code deciding when
+ * a lease has ended is the same code either way.
+ *
+ * The host runs in a child because the loop blocks until the lease ends: `release` closes
+ * the connection once the freeze is granted, and its absence is a host that took the
+ * freeze and never came back.
+ */
+static enum guest_control_outcome answering(const char *request, bool release) {
+  int pair[2];
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, pair) < 0) {
+    return GUEST_CONTROL_REFUSED;
+  }
+  pid_t host = fork();
+  if (host == 0) {
+    close(pair[0]);
+    if (write(pair[1], request, strlen(request)) < 0) {
+      _exit(1);
+    }
+    if (release) {
+      char granted[GRANT_BYTES];
+      /* Exiting closes the connection, which is the only way a host lets go. */
+      _exit(read(pair[1], granted, sizeof(granted)) < 0 ? 1 : 0);
+    }
+    pause();
+    _exit(0);
+  }
+  close(pair[1]);
+  enum guest_control_outcome outcome = guest_control_answer(&(struct guest_control_request){
+      .connection = pair[0], .mount_point = DATA_MOUNT, .max_hold_ms = FREEZE_HOLD_TEST_MS});
+  close(pair[0]);
+  kill(host, SIGKILL);
+  waitpid(host, NULL, 0);
+  return outcome;
+}
 
 static bool mounted_with(const char *target, const char *option) {
   FILE *table = fopen("/proc/self/mounts", "r");
@@ -160,6 +201,24 @@ int main(int argc, char **argv) {
   EXPECT(guest_control_freeze(DATA_MOUNT));
   EXPECT(!guest_control_freeze(DATA_MOUNT) && errno == EBUSY);
   EXPECT(guest_control_thaw(DATA_MOUNT));
+  EXPECT(!guest_control_thaw(DATA_MOUNT) && errno == EINVAL);
+  EXPECT(can_write_as_tenant(DATA_MOUNT));
+
+  /* However the connection ends, the tenant gets its filesystem back. A freeze is a lease
+   * on something live and not a flag somebody has to remember to clear, so the EINVAL after
+   * each of these is the whole point: it is the filesystem saying it is no longer frozen. */
+  EXPECT(answering("FREEZE\n", true) == GUEST_CONTROL_RELEASED);
+  EXPECT(!guest_control_thaw(DATA_MOUNT) && errno == EINVAL);
+  EXPECT(can_write_as_tenant(DATA_MOUNT));
+
+  /* The host that takes a freeze and never lets go: an agent wedged rather than gone, which
+   * no closed connection will ever report. */
+  EXPECT(answering("FREEZE\n", false) == GUEST_CONTROL_TIMED_OUT);
+  EXPECT(!guest_control_thaw(DATA_MOUNT) && errno == EINVAL);
+  EXPECT(can_write_as_tenant(DATA_MOUNT));
+
+  /* Anything else is answered without touching the filesystem at all. */
+  EXPECT(answering("THAW\n", true) == GUEST_CONTROL_IGNORED);
   EXPECT(!guest_control_thaw(DATA_MOUNT) && errno == EINVAL);
   EXPECT(can_write_as_tenant(DATA_MOUNT));
 


### PR DESCRIPTION
Follow-up to #140. A freeze outlives the process that took it, so how an export *ends* decides whether the tenant keeps running. The lease already handled that — the guest thaws when the connection drops — but that path was verified by reading the code, because arranging it over vsock needs a Firecracker a container doesn't have.

The lease loop now takes its connection and ceiling as arguments, so the mount suite drives it over a socketpair against real ext4: a host that lets go, one that never does, and a request it doesn't answer. Each asserts the filesystem is thawed afterwards and the tenant can write again. Mount suite goes 31 → 40 checks.

Also closes the one remaining way to strand a freeze: the OOM killer reaping the process holding it, taking the deadline with it. The control channel opts out — it allocates nothing, and the tenant is what should be reaped under memory pressure.

Still uncovered, unchanged: the AF_VSOCK transport itself, for both the log and control legs.

### Adopting the guest image

Neither this nor #140 reaches a host yet — `guestImage` in `infra/app-host/versions.json` still pins `6.1.180-26eb600e8e86`, and publishing is deliberately not adopting. Once this merges and CD publishes, the value to adopt in a separate commit is:

```
6.1.180-858fce9d6123
```

Worth waiting for this PR rather than adopting main's `6.1.180-a02aca5ca2b6` — it's one host rollout instead of two, and this is the one with the safety net proven.