### PR TITLE
chore(infra): adopt the guest image an export can freeze

### DIFF
--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -16,5 +16,5 @@
     "url": "https://github.com/caddyserver/caddy/releases/download/v2.11.4/caddy_2.11.4_linux_amd64.tar.gz",
     "sha256": "527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9"
   },
-  "guestImage": "6.1.180-26eb600e8e86"
+  "guestImage": "6.1.180-858fce9d6123"
 }


### PR DESCRIPTION
Adopts `6.1.180-858fce9d6123`, the image the tree at #141 digests to.

Publishing is not adopting — CD uploads and stops, and a host only moves once a commit like this one says so. #140 and #141 have both landed and neither has reached a host, so exports of running apps are still reading a device nobody froze.

**Do not merge until the `build-guest-image` job on #141's CD run has succeeded** — `ssm-deploy-app-hosts` and `build-guest-image` are independent jobs, so merging early points hosts at an object that isn't in the bucket yet.

Every microVM has to be restarted to pick it up. Until one is, its exports fail rather than quietly returning an incomplete bundle — the trade #140 chose.