### PR TITLE
ci: build runs only on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: build
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
`cd` already compiles every buildable package on its way out — `@repo/api` and `@repo/dashboard` in the api image, `@repo/agent` for the app hosts, `@repo/runtime` for the guest image — so the build job on main proves nothing the deploy doesn't. Follows #143, which did the same for `checks` and `infra`.