### PR TITLE
fix(infra): the edge stays up across a deploy and holds what it cannot reach

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,13 +30,20 @@ services:
   # No depends_on: it makes compose restart Caddy whenever an upstream is
   # recreated, which every deploy does to the api, taking the edge down for the
   # upstream's health-gate window. The Caddyfile's lb_try_duration already rides
-  # out an api that is not accepting yet, on cold boot and during a recreate.
+  # out an upstream that is not accepting yet, on cold boot and during a
+  # recreate.
   #
   # Nothing here changes between deploys, so the container is left running and
-  # the edge never blinks; new config and re-issued certificates arrive through
-  # the reload in on_box_deploy.sh rather than a recreate. The whole directory
-  # is mounted, not the files in it, so replacing a file cannot leave the
-  # container holding the old inode.
+  # the edge never blinks; new config, re-issued certificates and the log
+  # dashboard's password hash all arrive through the mounted directory and the
+  # reload in on_box_deploy.sh rather than a recreate. The whole directory is
+  # mounted, not the files in it, so replacing a file cannot leave the container
+  # holding the old inode.
+  #
+  # Anything added below that varies per deploy takes the whole origin down for
+  # the length of a recreate, with no proxy left alive to hold the requests that
+  # land in it — the log dashboard's bcrypt hash sat here and did exactly that,
+  # since bcrypt re-salts on every run.
   caddy:
     image: caddy:2.11-alpine
     container_name: caddy
@@ -60,10 +67,6 @@ services:
       - API_HOSTNAME
       - DOZZLE_HOSTNAME
       - VICTORIALOGS_HOSTNAME
-      # A bcrypt hash is full of `$`, and compose reads `$name` in .env as a
-      # variable — so the deploy escapes them and compose unescapes here. Passed
-      # in rather than mounted because basic_auth takes the hash inline.
-      - VICTORIALOGS_PASSWORD_HASH
       - INTERNAL_PORT
       # Without this the Caddyfile's `:{$LOG_INGEST_PORT}` site address expands
       # to a bare `:`, which Caddy drops silently rather than refusing — the

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -87,7 +87,13 @@ https://{$API_HOSTNAME} {
 :{$LOG_INGEST_PORT} {
 	@insert path /insert/*
 	handle @insert {
-		reverse_proxy victorialogs:9428
+		# Held rather than refused while the store is away: a shipper that gets an
+		# error here drops the lines it was carrying, and they are the record of
+		# what the fleet was doing at the one moment worth reading back.
+		reverse_proxy victorialogs:9428 {
+			lb_try_duration 30s
+			lb_try_interval 250ms
+		}
 	}
 
 	handle {
@@ -101,11 +107,13 @@ https://{$API_HOSTNAME} {
 https://{$DOZZLE_HOSTNAME} {
 	import origin_tls
 
-	# Log streaming is a websocket; reverse_proxy upgrades it as-is. No
-	# lb_try_duration: nothing recreates this container on deploy, so there is no
-	# gap to ride out, and holding a request open would only delay the 502 that
-	# says Dozzle is actually down.
-	reverse_proxy dozzle:8080
+	# Log streaming is a websocket; reverse_proxy upgrades it as-is, and the
+	# retries below sit before the upgrade, where a dial that never connected is
+	# safe to repeat.
+	reverse_proxy dozzle:8080 {
+		lb_try_duration 30s
+		lb_try_interval 250ms
+	}
 }
 
 # The fleet's logs. Unlike Dozzle, VictoriaLogs has no login of its own and no
@@ -115,12 +123,14 @@ https://{$DOZZLE_HOSTNAME} {
 https://{$VICTORIALOGS_HOSTNAME} {
 	import origin_tls
 
-	# The hash is written by on_box_deploy.sh from the SSM password, the way
-	# Dozzle's user list is. bcrypt is what basic_auth reads; nothing on the box
-	# holds the password itself.
-	basic_auth {
-		admin {$VICTORIALOGS_PASSWORD_HASH}
-	}
+	# Rendered by on_box_deploy.sh from the SSM password, the way Dozzle's user
+	# list is; bcrypt is what basic_auth reads, and nothing on the box holds the
+	# password itself. A file under the mounted directory rather than an
+	# environment variable because bcrypt re-salts on every run: the same
+	# password hashes differently each deploy, which through the environment
+	# would change the edge's compose config and recreate it every time. Here the
+	# new hash arrives through the reload and the container is never touched.
+	import /etc/caddy/auth/victorialogs.caddy
 
 	# Nothing is served at the bare hostname — the allowlist below starts at
 	# /select — so this is what makes typing the hostname land on the dashboard
@@ -137,7 +147,10 @@ https://{$VICTORIALOGS_HOSTNAME} {
 	# version page, /metrics and /flags are not published at all.
 	@select path /select/*
 	handle @select {
-		reverse_proxy victorialogs:9428
+		reverse_proxy victorialogs:9428 {
+			lb_try_duration 30s
+			lb_try_interval 250ms
+		}
 	}
 
 	handle {

--- a/infra/deploy/on_box_deploy.sh
+++ b/infra/deploy/on_box_deploy.sh
@@ -147,19 +147,19 @@ $compose run --rm --no-deps -T --entrypoint /dozzle dozzle generate \
   --password "$(secret dozzle_password)" admin > dozzle/data/users.yml.new
 mv dozzle/data/users.yml.new dozzle/data/users.yml
 
-# VictoriaLogs has no login, so Caddy holds the one for its dashboard — and
-# basic_auth takes the hash inline, which is why this lands in .env rather than
-# in a file beside the Caddyfile. Appended rather than written with the rest
-# because producing it needs compose, and compose needs the .env that was
-# written above. Over stdin so the password is never in a container's argv.
-#
-# Every `$` is doubled: compose reads `$name` in .env as a variable, and a
-# bcrypt hash is `$2a$14$<salt><digest>` — the salt is arbitrary and starts with
-# a letter often enough that leaving this alone truncates the hash silently.
-log "Hashing the log dashboard password"
+# VictoriaLogs has no login, so Caddy holds the one for its dashboard. Rendered
+# into the directory Caddy mounts rather than passed to the container, because
+# bcrypt re-salts on every run: as part of the edge's environment a hash that
+# differs on every deploy is a changed compose config, and compose answers that
+# by recreating the container — dropping the whole origin, every time. Produced
+# after the .env above because it takes compose, and before `up` because the
+# Caddyfile imports it and a missing file is a parse error on a cold box. Over
+# stdin so the password is never in a container's argv.
+log "Rendering the log dashboard login"
 victorialogs_hash=$(printf '%s\n' "$(secret victorialogs_password)" |
   $compose run --rm --no-deps -T --entrypoint caddy caddy hash-password)
-printf 'VICTORIALOGS_PASSWORD_HASH=%s\n' "${victorialogs_hash//\$/\$\$}" >> .env
+mkdir -p caddy/auth
+printf 'basic_auth {\n\tadmin %s\n}\n' "${victorialogs_hash}" > caddy/auth/victorialogs.caddy
 
 log "Starting services (up -d --remove-orphans)"
 $compose up -d --remove-orphans


### PR DESCRIPTION
Caddy was recreated on every deploy, so nothing was left alive to hold the requests landing in the gap and the whole origin went down with it — `lb_try_duration` cannot ride out a recreate the proxy itself is having.

The cause was the log dashboard's password. `caddy hash-password` re-salts on every run, so the same password hashed differently each deploy, and in the edge's environment that is a changed compose config, which compose answers by recreating the container. It now reaches Caddy as a file under the mounted directory, the way Dozzle's user list already did, so a new hash arrives through the reload instead.

Every upstream now carries `lb_try_duration`, not just the api, so a request that lands while something is restarting waits for it rather than taking a 502 — including log ingest, where the shipper's reply to an error is to drop the lines it was carrying.

The first deploy carrying this recreates Caddy once, since removing the environment variable is itself a config change. After that it stays put.