### PR TITLE
fix(api): an export downloads under the name of the app it was taken from

### DIFF
--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -481,6 +481,7 @@ export interface ISelectExportsByAppResult {
     /** When the bucket's lifecycle rule removes the bundle. The api refuses to sign past it. */
     expires_at: Date;
     created_at: Date;
+    app_slug: import("@repo/protocol").DnsLabel;
 }
 
 /** Result of query `SelectExportById`. */
@@ -497,6 +498,7 @@ export interface ISelectExportByIdResult {
     /** When the bucket's lifecycle rule removes the bundle. The api refuses to sign past it. */
     expires_at: Date;
     created_at: Date;
+    app_slug: import("@repo/protocol").DnsLabel;
 }
 
 /** Result of query `ApplyReportedExport`. */
@@ -521,6 +523,7 @@ export interface ISelectInFlightExportResult {
     /** When the bucket's lifecycle rule removes the bundle. The api refuses to sign past it. */
     expires_at: Date;
     created_at: Date;
+    app_slug: import("@repo/protocol").DnsLabel;
 }
 
 /** Result of query `SelectHealthPing`. */

--- a/apps/api/src/repositories/export-storage.repository.ts
+++ b/apps/api/src/repositories/export-storage.repository.ts
@@ -8,8 +8,10 @@ import type { ObjectKey } from '@repo/protocol';
  */
 const DOWNLOAD_URL_TTL_SECONDS = 300;
 
+export type SignDownloadInput = { objectKey: ObjectKey; filename: string };
+
 export abstract class ExportStorageRepositoryContract {
-  abstract signDownload(input: { objectKey: ObjectKey }): string;
+  abstract signDownload(input: SignDownloadInput): string;
   abstract remove(input: { objectKey: ObjectKey }): Promise<void>;
 }
 
@@ -27,10 +29,11 @@ export class ExportStorageRepository implements ExportStorageRepositoryContract 
    * The signature carries this end's permissions, which are read on the export bucket and
    * nothing else — so a leaked URL is a leaked bundle rather than a leaked bucket.
    */
-  signDownload({ objectKey }: { objectKey: ObjectKey }): string {
+  signDownload({ objectKey, filename }: SignDownloadInput): string {
     return this.client.presign(objectKey, {
       method: 'GET',
       expiresIn: DOWNLOAD_URL_TTL_SECONDS,
+      contentDisposition: `attachment; filename="${filename}"`,
     });
   }
 

--- a/apps/api/src/repositories/exports.repository.ts
+++ b/apps/api/src/repositories/exports.repository.ts
@@ -73,8 +73,9 @@ export class ExportsRepository extends Repository implements ExportsRepositoryCo
     return this.sql.SelectExportsByApp`
       /* @notNull created_at */
       /* @notNull object_key */
+      /* @notNull app_slug */
       SELECT e.id, e.app_id, e.state, e.object_key, e.size_bytes, e.message,
-             e.ready_at, e.expires_at, e.created_at
+             e.ready_at, e.expires_at, e.created_at, a.slug AS app_slug
       FROM nibrun.exports e
       JOIN nibrun.live_apps a ON a.id = e.app_id
       WHERE e.app_id = ${appId} AND a.owner_id = ${ownerId}
@@ -86,8 +87,9 @@ export class ExportsRepository extends Repository implements ExportsRepositoryCo
     const [row] = await this.sql.SelectExportById`
       /* @notNull created_at */
       /* @notNull object_key */
+      /* @notNull app_slug */
       SELECT e.id, e.app_id, e.state, e.object_key, e.size_bytes, e.message,
-             e.ready_at, e.expires_at, e.created_at
+             e.ready_at, e.expires_at, e.created_at, a.slug AS app_slug
       FROM nibrun.exports e
       JOIN nibrun.live_apps a ON a.id = e.app_id
       WHERE e.app_id = ${appId} AND e.id = ${exportId} AND a.owner_id = ${ownerId}
@@ -132,8 +134,9 @@ export class ExportsRepository extends Repository implements ExportsRepositoryCo
     const [row] = await this.sql.SelectInFlightExport`
       /* @notNull created_at */
       /* @notNull object_key */
+      /* @notNull app_slug */
       SELECT e.id, e.app_id, e.state, e.object_key, e.size_bytes, e.message,
-             e.ready_at, e.expires_at, e.created_at
+             e.ready_at, e.expires_at, e.created_at, a.slug AS app_slug
       FROM nibrun.exports e
       JOIN nibrun.live_apps a ON a.id = e.app_id
       WHERE e.app_id = ${appId} AND a.owner_id = ${ownerId}

--- a/apps/api/src/services/exports.service.ts
+++ b/apps/api/src/services/exports.service.ts
@@ -14,6 +14,8 @@ const NOTHING_TO_EXPORT = 'The app has never been deployed, so there is no binar
 
 const MS_PER_DAY = 86_400_000;
 
+const BUNDLE_SUFFIX = '.tar.gz';
+
 /** What the owner sees, plus the only way to actually reach the bytes. */
 export type OwnedExport = Omit<Export, 'objectKey'> & { downloadUrl?: string };
 
@@ -125,7 +127,10 @@ export class ExportsService extends Service {
       expiresAt: toTimestamp(expiresAt),
       downloadUrl:
         state === 'ready'
-          ? this.storageRepo.signDownload({ objectKey: row.object_key })
+          ? this.storageRepo.signDownload({
+              objectKey: row.object_key,
+              filename: `${row.app_slug}${BUNDLE_SUFFIX}`,
+            })
           : undefined,
     };
   }

--- a/apps/api/tests/services/exports.test.ts
+++ b/apps/api/tests/services/exports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   type AppId,
+  DnsLabelSchema,
   type ExportId,
   ExportIdSchema,
   type ExportState,
@@ -12,7 +13,10 @@ import {
   Value,
 } from '@repo/protocol';
 import { ConflictError, NotFoundError } from '#lib/errors.ts';
-import type { ExportStorageRepositoryContract } from '#repositories/export-storage.repository.ts';
+import type {
+  ExportStorageRepositoryContract,
+  SignDownloadInput,
+} from '#repositories/export-storage.repository.ts';
 import type {
   ExportRow,
   ExportsRepositoryContract,
@@ -25,6 +29,7 @@ import { APP_ID, OTHER_OWNER_ID, OWNER_ID } from '#tests/services/support/fixtur
 
 const EXPORT_ID = Value.Parse(ExportIdSchema, 'export-1');
 const OBJECT_KEY = Value.Parse(ObjectKeySchema, `exports/${APP_ID}/${EXPORT_ID}.tar.gz`);
+const APP_SLUG = Value.Parse(DnsLabelSchema, 'quiet-meadow');
 const SIGNED_URL = 'https://exports.test/signed';
 const RETENTION_DAYS = 1;
 const MS_PER_DAY = 86_400_000;
@@ -41,6 +46,7 @@ function exportRow(overrides: Partial<ExportRow> = {}): ExportRow {
     ready_at: null,
     expires_at: new Date(Date.now() + MS_PER_DAY),
     created_at: new Date('2026-01-02T03:04:05.000Z'),
+    app_slug: APP_SLUG,
     ...overrides,
   };
 }
@@ -108,9 +114,11 @@ class FakeExportsRepository implements ExportsRepositoryContract {
 
 class FakeExportStorage implements ExportStorageRepositoryContract {
   readonly signed: ObjectKey[] = [];
+  readonly filenames: string[] = [];
 
-  signDownload({ objectKey }: { objectKey: ObjectKey }): string {
+  signDownload({ objectKey, filename }: SignDownloadInput): string {
     this.signed.push(objectKey);
+    this.filenames.push(filename);
     return SIGNED_URL;
   }
 
@@ -202,6 +210,16 @@ describe('polling an export', () => {
     expect(found.downloadUrl).toBe(SIGNED_URL);
     expect(found.sizeBytes).toBe(BUNDLE_SIZE_BYTES);
     expect(storage.signed).toEqual([OBJECT_KEY]);
+  });
+
+  test('is signed for under the name of the app it was taken from', async () => {
+    const repo = new FakeExportsRepository();
+    repo.rows = [exportRow({ state: 'ready', ready_at: new Date() })];
+    const { service, storage } = build(repo);
+
+    await service.get({ appId: APP_ID, exportId: EXPORT_ID, ownerId: OWNER_ID });
+
+    expect(storage.filenames).toEqual([`${APP_SLUG}.tar.gz`]);
   });
 
   // The bucket's lifecycle rule is what removed the object; signing for it would hand over a URL


### PR DESCRIPTION
An export's object key is addressed by ids, so a browser saved every bundle under a uuid. The download URL is now signed with a content disposition naming the app, matching what `nib apps export` writes to disk.