### PR TITLE
refactor(api-client): move uwrap to api client

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -4,12 +4,14 @@
   "type": "module",
   "exports": {
     "./public": "./src/public.ts",
-    "./internal": "./src/internal.ts"
+    "./internal": "./src/internal.ts",
+    "./unwrap": "./src/unwrap.ts"
   },
   "imports": {
     "#*": "./src/*"
   },
   "scripts": {
+    "test": "bun test",
     "check:types": "bun run --bun tsc"
   },
   "dependencies": {

--- a/packages/api-client/src/public.ts
+++ b/packages/api-client/src/public.ts
@@ -2,7 +2,7 @@ import type { Treaty } from '@elysiajs/eden';
 import type { PublicApp } from '@repo/api/types';
 import { type ApiClientOptions, createClient } from '#client.ts';
 
-type PublicApiClient = Treaty.Create<PublicApp>;
+export type PublicApiClient = Treaty.Create<PublicApp>;
 
 // The return annotation is required: the type Eden infers isn't portable across packages. Only
 // declaration emit says so, and this package is consumed as source, so nothing here reports it.

--- a/packages/api-client/src/unwrap.test.ts
+++ b/packages/api-client/src/unwrap.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'bun:test';
+import { ApiError, describeFailure, unwrap } from '#unwrap.ts';
+
+test('a reply that carries no failure is the data it carries', () => {
+  expect(unwrap({ data: { apps: [] }, error: null })).toEqual({ apps: [] });
+});
+
+test('a failure Eden handed back rather than threw is raised here', () => {
+  const failure = Object.assign(new Error('[object Object]'), {
+    status: 404,
+    value: { error: 'Not Found' },
+  });
+
+  expect(() => unwrap({ data: null, error: failure })).toThrow(ApiError);
+});
+
+test('a refusal is reported as the api answering, not as this program deciding', () => {
+  const failure = Object.assign(new Error('[object Object]'), {
+    status: 404,
+    value: { error: 'Not Found' },
+  });
+
+  expect(describeFailure(failure)).toBe('The api answered 404: Not Found');
+});
+
+test('a body that names no error is still worth repeating', () => {
+  const failure = Object.assign(new Error('nope'), { status: 500, value: 'nope' });
+
+  expect(describeFailure(failure)).toBe('The api answered 500: nope');
+});
+
+// Eden reports a request it never sent as a 503 of its own, and saying the api answered it would
+// blame a server that was never reached.
+test('an api that could not be reached is not one that answered', () => {
+  const failure = Object.assign(new Error('unreachable'), {
+    status: 503,
+    value: new TypeError('Unable to connect'),
+  });
+
+  expect(describeFailure(failure)).toBe('Unable to connect');
+});

--- a/packages/api-client/src/unwrap.ts
+++ b/packages/api-client/src/unwrap.ts
@@ -1,0 +1,49 @@
+export class ApiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+type Reply = { data: unknown; error: unknown };
+
+/**
+ * Eden hands back a failure rather than rejecting, and reports one it never sent as a 503 of its
+ * own — so a refusal and an unreachable api arrive the same way, and both have to be raised here
+ * or every call site reads as if it succeeded.
+ */
+export function unwrap<R extends Reply>(reply: R): NonNullable<R['data']> {
+  if (reply.error !== null) {
+    throw new ApiError(describeFailure(reply.error));
+  }
+  return reply.data as NonNullable<R['data']>;
+}
+
+/**
+ * Eden wraps the body it was given in an `Error` whose message is that body stringified, which
+ * for the api's `{ error }` shape reads as `[object Object]`.
+ *
+ * The status is said as well as the body, because the body alone reads as this program's own
+ * verdict: `Not Found` sounds like a binary that could not be opened rather than a route that
+ * does not exist.
+ */
+export function describeFailure(failure: unknown): string {
+  if (typeof failure !== 'object' || failure === null || !('value' in failure)) {
+    return String(failure);
+  }
+  const { value } = failure;
+  // Eden reports a request it never managed to send as a 503 of its own, so a thrown value is
+  // this end failing to reach the api rather than the api answering.
+  if (value instanceof Error) {
+    return value.message;
+  }
+  const status = 'status' in failure ? String(failure.status) : 'no status';
+  return `The api answered ${status}: ${bodyMessage(value)}`;
+}
+
+function bodyMessage(value: unknown): string {
+  if (typeof value === 'object' && value !== null && 'error' in value) {
+    return String(value.error);
+  }
+  return String(value);
+}

--- a/packages/cli/src/lib/api.test.ts
+++ b/packages/cli/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { authHeaders, describeFailure } from '#lib/api.ts';
+import { authHeaders } from '#lib/api.ts';
 
 const API_URL = 'http://localhost:3000';
 
@@ -25,30 +25,4 @@ test('a token issued by another api is not sent to this one', () => {
 // nothing to authenticate with.
 test('being signed out builds a client rather than refusing to', () => {
   expect(authHeaders({ baseUrl: API_URL, credentials: null })).toEqual({});
-});
-
-test('a refusal is reported as the api answering, not as this program deciding', () => {
-  const failure = Object.assign(new Error('[object Object]'), {
-    status: 404,
-    value: { error: 'Not Found' },
-  });
-
-  expect(describeFailure(failure)).toBe('The api answered 404: Not Found');
-});
-
-test('a body that names no error is still worth repeating', () => {
-  const failure = Object.assign(new Error('nope'), { status: 500, value: 'nope' });
-
-  expect(describeFailure(failure)).toBe('The api answered 500: nope');
-});
-
-// Eden reports a request it never sent as a 503 of its own, and saying the api answered it would
-// blame a server that was never reached.
-test('an api that could not be reached is not one that answered', () => {
-  const failure = Object.assign(new Error('unreachable'), {
-    status: 503,
-    value: new TypeError('Unable to connect'),
-  });
-
-  expect(describeFailure(failure)).toBe('Unable to connect');
 });

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -1,15 +1,12 @@
-import { createPublicApiClient } from '@repo/api-client/public';
+import { createPublicApiClient, type PublicApiClient } from '@repo/api-client/public';
 import type { Credentials } from '#lib/credentials.ts';
-import { ApiError } from '#lib/errors.ts';
-
-export type Api = ReturnType<typeof createPublicApiClient>;
 
 export type ApiInput = {
   baseUrl: string;
   credentials: Credentials | null;
 };
 
-export function createApi({ baseUrl, credentials }: ApiInput): Api {
+export function createApi({ baseUrl, credentials }: ApiInput): PublicApiClient {
   return createPublicApiClient({ baseUrl, headers: authHeaders({ baseUrl, credentials }) });
 }
 
@@ -26,47 +23,4 @@ export function authHeaders({ baseUrl, credentials }: ApiInput): Record<string, 
     return {};
   }
   return { authorization: `Bearer ${credentials.accessToken}` };
-}
-
-type Reply = { data: unknown; error: unknown };
-
-/**
- * Eden hands back a failure rather than rejecting, and reports one it never sent as a 503 of its
- * own — so a refusal and an unreachable api arrive the same way, and both have to be raised here
- * or every call site reads as if it succeeded.
- */
-export function unwrap<R extends Reply>(reply: R): NonNullable<R['data']> {
-  if (reply.error !== null) {
-    throw new ApiError(describeFailure(reply.error));
-  }
-  return reply.data as NonNullable<R['data']>;
-}
-
-/**
- * Eden wraps the body it was given in an `Error` whose message is that body stringified, which
- * for the api's `{ error }` shape reads as `[object Object]`.
- *
- * The status is said as well as the body, because the body alone reads as this program's own
- * verdict: `Not Found` sounds like a binary that could not be opened rather than a route that
- * does not exist.
- */
-export function describeFailure(failure: unknown): string {
-  if (typeof failure !== 'object' || failure === null || !('value' in failure)) {
-    return String(failure);
-  }
-  const { value } = failure;
-  // Eden reports a request it never managed to send as a 503 of its own, so a thrown value is
-  // this end failing to reach the api rather than the api answering.
-  if (value instanceof Error) {
-    return value.message;
-  }
-  const status = 'status' in failure ? String(failure.status) : 'no status';
-  return `The api answered ${status}: ${bodyMessage(value)}`;
-}
-
-function bodyMessage(value: unknown): string {
-  if (typeof value === 'object' && value !== null && 'error' in value) {
-    return String(value.error);
-  }
-  return String(value);
 }

--- a/packages/cli/src/lib/app-list.ts
+++ b/packages/cli/src/lib/app-list.ts
@@ -1,6 +1,7 @@
 import type { Print } from '@parshjs/core';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
 import { APP_STATES, type App } from '@repo/protocol';
-import { type Api, unwrap } from '#lib/api.ts';
 import { NO_APPS } from '#lib/apps.ts';
 import { dayAndMinute } from '#lib/timestamp.ts';
 
@@ -17,7 +18,13 @@ const COLUMN_GAP = '  ';
 const STATE_WIDTH = Math.max(HEADINGS.state.length, ...APP_STATES.map((state) => state.length));
 
 /** Print what the owner has, one app to a line. */
-export async function listApps({ api, print }: { api: Api; print: Print }): Promise<void> {
+export async function listApps({
+  api,
+  print,
+}: {
+  api: PublicApiClient;
+  print: Print;
+}): Promise<void> {
   const { apps } = unwrap(await api.api.apps.get());
   if (apps.length === 0) {
     print.dim(NO_APPS);

--- a/packages/cli/src/lib/apps.test.ts
+++ b/packages/cli/src/lib/apps.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, expect, mock, test } from 'bun:test';
-import type { Api } from '#lib/api.ts';
+import type { PublicApiClient } from '@repo/api-client/public';
 
 type Asked = {
   message: string;
@@ -25,7 +25,7 @@ const { selectApp } = await import('#lib/apps.ts');
 
 let listings = 0;
 
-function apiListing(apps: Array<{ slug: string; state: string }>): Api {
+function apiListing(apps: Array<{ slug: string; state: string }>): PublicApiClient {
   return {
     api: {
       apps: {
@@ -35,7 +35,7 @@ function apiListing(apps: Array<{ slug: string; state: string }>): Api {
         },
       },
     },
-  } as unknown as Api;
+  } as unknown as PublicApiClient;
 }
 
 beforeEach(() => {

--- a/packages/cli/src/lib/apps.ts
+++ b/packages/cli/src/lib/apps.ts
@@ -1,8 +1,9 @@
 import { select } from '@clack/prompts';
 import type { Print } from '@parshjs/core';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { ApiError, unwrap } from '@repo/api-client/unwrap';
 import { SHARED_OPTIONS } from '#config.ts';
-import { type Api, unwrap } from '#lib/api.ts';
-import { ApiError, UsageError } from '#lib/errors.ts';
+import { UsageError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
 
 const NO_APP_NAMED = `Which app? Name one with --${SHARED_OPTIONS.app.name}.`;
@@ -22,7 +23,7 @@ export async function selectApp({
   slug,
   interactive,
 }: {
-  api: Api;
+  api: PublicApiClient;
   slug: string | undefined;
   interactive: boolean;
 }): Promise<string> {
@@ -40,7 +41,7 @@ export async function selectApp({
  * the listing again: a slug is what an owner calls an app by and what every command under `apps`
  * takes, and the second read falls only on somebody already sat at the prompt.
  */
-async function chooseApp({ api }: { api: Api }): Promise<string> {
+async function chooseApp({ api }: { api: PublicApiClient }): Promise<string> {
   const { apps } = unwrap(await api.api.apps.get());
   if (apps.length === 0) {
     throw new UsageError(NO_APPS);
@@ -61,7 +62,7 @@ async function chooseApp({ api }: { api: Api }): Promise<string> {
 
 // Apps are addressed by id and listed by slug; the slug is the half a person sees, so it is the
 // half the CLI takes and this is where the two meet.
-export async function appBySlug({ api, slug }: { api: Api; slug: string }) {
+export async function appBySlug({ api, slug }: { api: PublicApiClient; slug: string }) {
   const { apps } = unwrap(await api.api.apps.get());
   const found = apps.find((app) => app.slug === slug);
   if (!found) {
@@ -74,7 +75,13 @@ export async function appBySlug({ api, slug }: { api: Api; slug: string }) {
  * The deployment a reader means by not naming one. The api lists them newest first, so this is
  * the head of the list rather than a search through it.
  */
-async function latestDeployment({ api, appId }: { api: Api; appId: string }): Promise<string> {
+async function latestDeployment({
+  api,
+  appId,
+}: {
+  api: PublicApiClient;
+  appId: string;
+}): Promise<string> {
   const { deployments } = unwrap(await api.api.apps({ appId }).deployments.get());
   const newest = deployments[0];
   if (!newest) {
@@ -97,7 +104,7 @@ export async function addressedDeployment({
   deploymentId,
   print,
 }: {
-  api: Api;
+  api: PublicApiClient;
   slug: string;
   deploymentId: string | undefined;
   print: Print;

--- a/packages/cli/src/lib/delete.test.ts
+++ b/packages/cli/src/lib/delete.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { Api } from '#lib/api.ts';
+import type { PublicApiClient } from '@repo/api-client/public';
 import { deleteApp, saysDeletePermanently } from '#lib/delete.ts';
 import type { Ui } from '#lib/ui.ts';
 
@@ -18,7 +18,7 @@ function listed(overrides: Partial<Listed> = {}): Listed {
 }
 
 /** The apps an owner has, and the ids the run asked the api to delete. */
-function apiHolding({ apps, deleted }: { apps: Listed[]; deleted: string[] }): Api {
+function apiHolding({ apps, deleted }: { apps: Listed[]; deleted: string[] }): PublicApiClient {
   function addressed({ appId }: { appId: string }) {
     return {
       delete: () => {
@@ -32,7 +32,7 @@ function apiHolding({ apps, deleted }: { apps: Listed[]; deleted: string[] }): A
   const route = Object.assign(addressed, {
     get: () => Promise.resolve({ data: { apps }, error: null }),
   });
-  return { api: { apps: route } } as unknown as Api;
+  return { api: { apps: route } } as unknown as PublicApiClient;
 }
 
 function ui(): Ui & { said: string[] } {

--- a/packages/cli/src/lib/delete.ts
+++ b/packages/cli/src/lib/delete.ts
@@ -1,5 +1,6 @@
 import { note, text } from '@clack/prompts';
-import { type Api, unwrap } from '#lib/api.ts';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
 import { appBySlug } from '#lib/apps.ts';
 import { UsageError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
@@ -13,7 +14,7 @@ import type { Ui } from '#lib/ui.ts';
 const CONFIRMATION_PHRASE = 'delete permanently';
 
 export type DeleteInput = {
-  api: Api;
+  api: PublicApiClient;
   slug: string;
   ui: Ui;
   yes: boolean;

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -1,8 +1,9 @@
 import { basename } from 'node:path';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { ApiError, unwrap } from '@repo/api-client/unwrap';
 import { type DeploymentState, GuestPortSchema, type TenantArguments, Value } from '@repo/protocol';
-import { type Api, unwrap } from '#lib/api.ts';
 import { appBySlug } from '#lib/apps.ts';
-import { ApiError, UsageError } from '#lib/errors.ts';
+import { UsageError } from '#lib/errors.ts';
 import type { RunOptions } from '#lib/plan.ts';
 import type { Ui } from '#lib/ui.ts';
 
@@ -15,7 +16,7 @@ const MS_PER_SECOND = 1_000;
 const ELAPSED_DECIMALS = 1;
 
 export type DeployInput = RunOptions & {
-  api: Api;
+  api: PublicApiClient;
   ui: Ui;
   binary: File;
   args: TenantArguments;
@@ -103,7 +104,7 @@ async function awaitSettled({
   appId,
   deploymentId,
 }: {
-  api: Api;
+  api: PublicApiClient;
   appId: string;
   deploymentId: string;
 }): Promise<DeploymentState> {

--- a/packages/cli/src/lib/device-login.ts
+++ b/packages/cli/src/lib/device-login.ts
@@ -1,6 +1,7 @@
+import { ApiError } from '@repo/api-client/unwrap';
 import { createAuthClient } from 'better-auth/client';
 import { deviceAuthorizationClient } from 'better-auth/client/plugins';
-import { ApiError, UsageError } from '#lib/errors.ts';
+import { UsageError } from '#lib/errors.ts';
 
 // Sent so the record of a pending login says what asked for it. Not a secret and not a
 // credential: a public client has nothing to prove, which is the whole reason this flow exists.

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -1,10 +1,3 @@
-export class ApiError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'ApiError';
-  }
-}
-
 /** Something wrong with what was typed, decided here rather than by sending it and being told. */
 export class UsageError extends Error {
   constructor(message: string) {

--- a/packages/cli/src/lib/exports.ts
+++ b/packages/cli/src/lib/exports.ts
@@ -1,9 +1,10 @@
 import { rename, rm, stat } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { ApiError, unwrap } from '@repo/api-client/unwrap';
 import type { ExportState } from '@repo/protocol';
-import { type Api, unwrap } from '#lib/api.ts';
 import { appBySlug } from '#lib/apps.ts';
-import { ApiError, UsageError } from '#lib/errors.ts';
+import { UsageError } from '#lib/errors.ts';
 import type { Ui } from '#lib/ui.ts';
 
 /** What the host writes, so what the file is called when the caller left the naming to us. */
@@ -37,7 +38,7 @@ const BYTES_PER_MIB = 1_048_576;
 const MIB_DECIMALS = 1;
 
 export type ExportInput = {
-  api: Api;
+  api: PublicApiClient;
   slug: string;
   destination: string;
   ui: Ui;
@@ -109,7 +110,7 @@ async function awaitBundle({
   appId,
   exportId,
 }: {
-  api: Api;
+  api: PublicApiClient;
   appId: string;
   exportId: string;
 }): Promise<{ downloadUrl: string; sizeBytes: number | undefined }> {

--- a/packages/cli/src/lib/filesystem.ts
+++ b/packages/cli/src/lib/filesystem.ts
@@ -1,4 +1,6 @@
 import type { Print } from '@parshjs/core';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
 import {
   DIRECTORY_ENTRY_LIMIT,
   FILESYSTEM_ENTRY_KINDS,
@@ -7,7 +9,6 @@ import {
   GuestPathSchema,
   Value,
 } from '@repo/protocol';
-import { type Api, unwrap } from '#lib/api.ts';
 import { addressedDeployment } from '#lib/apps.ts';
 import { UsageError } from '#lib/errors.ts';
 import { dayAndMinute } from '#lib/timestamp.ts';
@@ -34,7 +35,7 @@ export function guestPath(typed: string): GuestPath {
 }
 
 export type ListInput = {
-  api: Api;
+  api: PublicApiClient;
   slug: string;
   deploymentId: string | undefined;
   path: GuestPath;

--- a/packages/cli/src/lib/logs.ts
+++ b/packages/cli/src/lib/logs.ts
@@ -1,6 +1,7 @@
 import type { Print } from '@parshjs/core';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
 import { SeenTenantLogs, type TenantLogRecord, type TenantLogStream } from '@repo/protocol';
-import { type Api, unwrap } from '#lib/api.ts';
 
 /**
  * How much of the gap a reconnect asks to be told about.
@@ -28,7 +29,7 @@ export function untilInterrupted(): AbortSignal {
 }
 
 export type FollowInput = {
-  api: Api;
+  api: PublicApiClient;
   appId: string;
   deploymentId: string;
   timerange: string;

--- a/packages/cli/src/lib/plan.test.ts
+++ b/packages/cli/src/lib/plan.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, expect, mock, test } from 'bun:test';
-import type { Api } from '#lib/api.ts';
+import type { PublicApiClient } from '@repo/api-client/public';
 
 const asked: string[] = [];
 const notes: string[] = [];
@@ -38,10 +38,10 @@ beforeEach(() => {
   confirmed = true;
 });
 
-function apiListing(apps: Array<{ slug: string; state: string }>): Api {
+function apiListing(apps: Array<{ slug: string; state: string }>): PublicApiClient {
   return {
     api: { apps: { get: () => Promise.resolve({ data: { apps }, error: null }) } },
-  } as unknown as Api;
+  } as unknown as PublicApiClient;
 }
 
 test('an owner with no apps is asked what to call one, not which to use', async () => {

--- a/packages/cli/src/lib/plan.ts
+++ b/packages/cli/src/lib/plan.ts
@@ -1,7 +1,8 @@
 import { basename } from 'node:path';
 import { confirm, note, select, text } from '@clack/prompts';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
 import { DEFAULT_GUEST_PORT, type TenantArguments } from '@repo/protocol';
-import { type Api, unwrap } from '#lib/api.ts';
 import { CancelledError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
 
@@ -23,7 +24,12 @@ type Plan = {
  * Only the answers that decide where a first deploy lands are asked for — a question asked on
  * every run is one that gets answered without reading it.
  */
-export async function completeOptions({ api, options, binaryPath, args }: Plan & { api: Api }) {
+export async function completeOptions({
+  api,
+  options,
+  binaryPath,
+  args,
+}: Plan & { api: PublicApiClient }) {
   const completed = await fillGaps({ api, options, binaryPath });
   await confirmPlan({ options: completed, binaryPath, args });
   return completed;
@@ -33,7 +39,7 @@ async function fillGaps({
   api,
   options,
   binaryPath,
-}: Omit<Plan, 'args'> & { api: Api }): Promise<RunOptions> {
+}: Omit<Plan, 'args'> & { api: PublicApiClient }): Promise<RunOptions> {
   const app = options.app ?? (await chooseApp({ api }));
   if (app !== undefined) {
     return { ...options, app };
@@ -52,7 +58,7 @@ async function fillGaps({
  * the one case where guessing is expensive: taken literally they get a second app every run,
  * and taken generously they overwrite one they never named.
  */
-async function chooseApp({ api }: { api: Api }): Promise<string | undefined> {
+async function chooseApp({ api }: { api: PublicApiClient }): Promise<string | undefined> {
   const { apps } = unwrap(await api.api.apps.get());
   const deployable = apps.filter((app) => app.state === 'active');
   if (deployable.length === 0) {


### PR DESCRIPTION
`unwrap` and `describeFailure` are about Eden's reply shape rather than about apps, so they move to the client that produces those replies. `ApiError` moves with them and stays one class, so `instanceof` and the CLI's exit codes are unchanged.