### PR TITLE
feat(app-operations): the flows the cli and the dashboard both drive

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,17 @@
         "typescript": "catalog:",
       },
     },
+    "packages/app-operations": {
+      "name": "@repo/app-operations",
+      "dependencies": {
+        "@repo/api-client": "workspace:*",
+        "@repo/protocol": "workspace:*",
+      },
+      "devDependencies": {
+        "@repo/typescript-config": "workspace:*",
+        "typescript": "catalog:",
+      },
+    },
     "packages/cli": {
       "name": "@repo/cli",
       "dependencies": {
@@ -100,6 +111,7 @@
         "@parshjs/env": "^0.0.3",
         "@parshjs/files": "^0.0.4",
         "@repo/api-client": "workspace:*",
+        "@repo/app-operations": "workspace:*",
         "@repo/protocol": "workspace:*",
         "better-auth": "catalog:",
         "zod": "^4.4.3",
@@ -468,6 +480,8 @@
     "@repo/api": ["@repo/api@workspace:apps/api"],
 
     "@repo/api-client": ["@repo/api-client@workspace:packages/api-client"],
+
+    "@repo/app-operations": ["@repo/app-operations@workspace:packages/app-operations"],
 
     "@repo/cli": ["@repo/cli@workspace:packages/cli"],
 
@@ -1235,9 +1249,9 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
-    "seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
+    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
 
-    "seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
+    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -1409,6 +1423,10 @@
 
     "@tanstack/router-cli/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
+    "@tanstack/router-core/seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
+
+    "@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
+
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "conf/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
@@ -1448,10 +1466,6 @@
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "solid-js/seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
-
-    "solid-js/seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/packages/app-operations/package.json
+++ b/packages/app-operations/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@repo/app-operations",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "imports": {
+    "#*": "./src/*"
+  },
+  "scripts": {
+    "test": "bun test",
+    "check:types": "bun run --bun tsc"
+  },
+  "dependencies": {
+    "@repo/api-client": "workspace:*",
+    "@repo/protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/app-operations/src/apps.ts
+++ b/packages/app-operations/src/apps.ts
@@ -1,0 +1,54 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { ApiError, unwrap } from '@repo/api-client/unwrap';
+
+const NO_DEPLOYMENTS = 'This app has never been deployed.';
+
+// Apps are addressed by id and listed by slug; the slug is the half a person sees, so it is the
+// half the CLI takes and this is where the two meet.
+export async function appBySlug({ api, slug }: { api: PublicApiClient; slug: string }) {
+  const { apps } = unwrap(await api.api.apps.get());
+  const found = apps.find((app) => app.slug === slug);
+  if (!found) {
+    throw new ApiError(`No app with slug ${slug}.`);
+  }
+  return found;
+}
+
+/**
+ * The deployment a reader means by not naming one. The api lists them newest first, so this is
+ * the head of the list rather than a search through it.
+ */
+export async function latestDeployment({
+  api,
+  appId,
+}: {
+  api: PublicApiClient;
+  appId: string;
+}): Promise<string> {
+  const { deployments } = unwrap(await api.api.apps({ appId }).deployments.get());
+  const newest = deployments[0];
+  if (!newest) {
+    throw new ApiError(NO_DEPLOYMENTS);
+  }
+  return newest.id;
+}
+
+/**
+ * The deployment a command was pointed at.
+ *
+ * The app is looked up either way — a deployment is addressed under the app that owns it — so
+ * what naming one skips is only the question of which deployment is current.
+ */
+export async function addressedDeployment({
+  api,
+  slug,
+  deploymentId,
+}: {
+  api: PublicApiClient;
+  slug: string;
+  deploymentId: string | undefined;
+}): Promise<{ appId: string; deploymentId: string; slug: string }> {
+  const app = await appBySlug({ api, slug });
+  const addressed = deploymentId ?? (await latestDeployment({ api, appId: app.id }));
+  return { appId: app.id, deploymentId: addressed, slug: app.slug };
+}

--- a/packages/app-operations/src/errors.ts
+++ b/packages/app-operations/src/errors.ts
@@ -1,0 +1,6 @@
+export class InvalidPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidPathError';
+  }
+}

--- a/packages/app-operations/src/filesystem.ts
+++ b/packages/app-operations/src/filesystem.ts
@@ -1,0 +1,39 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
+import { type DirectoryListing, type GuestPath, GuestPathSchema, Value } from '@repo/protocol';
+import { InvalidPathError } from '#errors.ts';
+
+/**
+ * What was typed, as a path the api will take.
+ *
+ * A path here is absolute because there is nothing for it to be relative to — the volume's root
+ * is the only place it can start — so a leading slash is spelling rather than meaning, and one
+ * left off is supplied rather than refused. A trailing one is the same. Nothing else is repaired:
+ * `.` and `..` are refused by the schema on purpose, and resolving them here is exactly what
+ * would put a caller outside the filesystem they were scoped to.
+ */
+export function guestPath(typed: string): GuestPath {
+  const absolute = typed.startsWith('/') ? typed : `/${typed}`;
+  const spelled = absolute.length > 1 ? absolute.replace(/\/$/, '') : absolute;
+  try {
+    return Value.Parse(GuestPathSchema, spelled);
+  } catch {
+    throw new InvalidPathError(`${typed} is not a path inside an app filesystem.`);
+  }
+}
+
+export async function readDirectory({
+  api,
+  appId,
+  deploymentId,
+  path,
+}: {
+  api: PublicApiClient;
+  appId: string;
+  deploymentId: string;
+  path: GuestPath;
+}): Promise<DirectoryListing> {
+  return unwrap(
+    await api.api.apps({ appId }).deployments({ deploymentId }).filesystem.get({ query: { path } }),
+  );
+}

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -1,0 +1,6 @@
+/** biome-ignore-all lint/performance/noBarrelFile: index is the only allowed file where we can export other files */
+
+export { addressedDeployment, appBySlug, latestDeployment } from '#apps.ts';
+export { InvalidPathError } from '#errors.ts';
+export { guestPath, readDirectory } from '#filesystem.ts';
+export { type FollowInput, followLogs } from '#logs.ts';

--- a/packages/app-operations/src/logs.ts
+++ b/packages/app-operations/src/logs.ts
@@ -1,0 +1,68 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
+import { SeenTenantLogs, type TenantLogRecord } from '@repo/protocol';
+
+/**
+ * How much of the gap a reconnect asks to be told about.
+ *
+ * Only the first stream wants the range the reader asked for; a later one is picking up after a
+ * close and wants the seconds it was away, not that history again. Generous, because overlap is
+ * cheap here — `SeenTenantLogs` drops what has already been shown — and a gap is not recoverable.
+ */
+const RECONNECT_TIMERANGE = '30s';
+
+/** What a closed stream costs before we open another, so a refusing api is not hammered. */
+const RECONNECT_PAUSE_MS = 1_000;
+
+export type FollowInput = {
+  api: PublicApiClient;
+  appId: string;
+  deploymentId: string;
+  timerange: string;
+  signal: AbortSignal;
+};
+
+/**
+ * What a deployment has written, and what it writes from then on until stopped.
+ *
+ * The api closes a stream on its own clock so that who may read it is asked again rather than
+ * decided once, which makes reaching the end of one an instruction to open another rather than
+ * the end of the log. Opening another is why `SeenTenantLogs` outlives them all: a reconnect asks
+ * for the seconds it was away, and what it was not away for comes back a second time.
+ */
+export async function* followLogs({
+  api,
+  appId,
+  deploymentId,
+  timerange,
+  signal,
+}: FollowInput): AsyncGenerator<TenantLogRecord> {
+  const logs = api.api.apps({ appId }).deployments({ deploymentId }).logs;
+  const seen = new SeenTenantLogs();
+  let asked = timerange;
+
+  // Stopping part-way through a stream is the ordinary ending, and it arrives as a failed request
+  // rather than a last record. The signal is what says so, not the error.
+  try {
+    while (!signal.aborted) {
+      const stream = unwrap(await logs.get({ query: { timerange: asked }, fetch: { signal } }));
+      for await (const { data } of stream) {
+        if (seen.admit(data)) {
+          yield data;
+        }
+      }
+      asked = RECONNECT_TIMERANGE;
+      await pause(RECONNECT_PAUSE_MS);
+    }
+  } catch (failure) {
+    if (!signal.aborted) {
+      throw failure;
+    }
+  }
+}
+
+function pause(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/app-operations/tests/apps.test.ts
+++ b/packages/app-operations/tests/apps.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from 'bun:test';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { addressedDeployment, appBySlug, latestDeployment } from '#apps.ts';
+
+function apiHolding({
+  apps,
+  deployments = [],
+}: {
+  apps: Array<{ id: string; slug: string }>;
+  deployments?: Array<{ id: string }>;
+}): PublicApiClient {
+  function underApp() {
+    return {
+      deployments: { get: () => Promise.resolve({ data: { deployments }, error: null }) },
+    };
+  }
+
+  return {
+    api: {
+      apps: Object.assign(underApp, {
+        get: () => Promise.resolve({ data: { apps }, error: null }),
+      }),
+    },
+  } as unknown as PublicApiClient;
+}
+
+test('an app is found by the name its owner calls it', async () => {
+  const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter' }] });
+
+  expect(await appBySlug({ api, slug: 'quiet-otter' })).toMatchObject({ id: 'app-1' });
+});
+
+test('a slug naming nothing is said to name nothing', async () => {
+  const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter' }] });
+
+  await expect(appBySlug({ api, slug: 'loud-badger' })).rejects.toThrow(
+    'No app with slug loud-badger.',
+  );
+});
+
+// The api lists deployments newest first, so the head of the list is what naming none means.
+test('the deployment nobody named is the newest one', async () => {
+  const api = apiHolding({
+    apps: [{ id: 'app-1', slug: 'quiet-otter' }],
+    deployments: [{ id: 'deployment-2' }, { id: 'deployment-1' }],
+  });
+
+  expect(await latestDeployment({ api, appId: 'app-1' })).toBe('deployment-2');
+});
+
+test('an app that has never been deployed has no newest deployment', async () => {
+  const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter' }] });
+
+  await expect(latestDeployment({ api, appId: 'app-1' })).rejects.toThrow(
+    'This app has never been deployed.',
+  );
+});
+
+test('addressing without a deployment id resolves to the newest one', async () => {
+  const api = apiHolding({
+    apps: [{ id: 'app-1', slug: 'quiet-otter' }],
+    deployments: [{ id: 'deployment-2' }],
+  });
+
+  expect(await addressedDeployment({ api, slug: 'quiet-otter', deploymentId: undefined })).toEqual({
+    appId: 'app-1',
+    deploymentId: 'deployment-2',
+    slug: 'quiet-otter',
+  });
+});
+
+// The app is looked up either way, because a deployment is addressed under the app that owns it.
+test('a deployment named outright still comes back under its app', async () => {
+  const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter' }] });
+
+  expect(
+    await addressedDeployment({ api, slug: 'quiet-otter', deploymentId: 'deployment-9' }),
+  ).toEqual({ appId: 'app-1', deploymentId: 'deployment-9', slug: 'quiet-otter' });
+});

--- a/packages/app-operations/tests/filesystem.test.ts
+++ b/packages/app-operations/tests/filesystem.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { guestPath } from '#filesystem.ts';
+
+function spelled(typed: string): string {
+  return guestPath(typed);
+}
+
+describe('a path is absolute because there is nowhere else it could start', () => {
+  test('one already spelled that way is left alone', () => {
+    expect(spelled('/uploads/2026')).toBe('/uploads/2026');
+  });
+
+  test('a leading slash left off is supplied', () => {
+    expect(spelled('uploads')).toBe('/uploads');
+  });
+
+  test('a trailing slash is spelling too', () => {
+    expect(spelled('/uploads/')).toBe('/uploads');
+  });
+
+  test('the root survives being trimmed', () => {
+    expect(spelled('/')).toBe('/');
+  });
+});
+
+describe('what is refused rather than repaired', () => {
+  // Resolving these is what would let a caller walk out of the filesystem they were scoped to.
+  test('a traversal is not resolved', () => {
+    expect(() => guestPath('/uploads/../../etc')).toThrow(
+      '/uploads/../../etc is not a path inside an app filesystem.',
+    );
+  });
+
+  test('a quote the reader tooling would tokenise is refused', () => {
+    expect(() => guestPath("/it's")).toThrow("/it's is not a path inside an app filesystem.");
+  });
+});

--- a/packages/app-operations/tsconfig.json
+++ b/packages/app-operations/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules"]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
     "@parshjs/env": "^0.0.3",
     "@parshjs/files": "^0.0.4",
     "@repo/api-client": "workspace:*",
+    "@repo/app-operations": "workspace:*",
     "@repo/protocol": "workspace:*",
     "better-auth": "catalog:",
     "zod": "^4.4.3"

--- a/packages/cli/src/commands/apps/files/ls/[path].ts
+++ b/packages/cli/src/commands/apps/files/ls/[path].ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { SHARED_OPTIONS } from '#config.ts';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { guestPath, listDirectory } from '#lib/filesystem.ts';
+import { listDirectory, typedPath } from '#lib/filesystem.ts';
 import { isInteractive } from '#lib/ui.ts';
 
 export const command = defineCommand('apps files ls [path]', {
@@ -18,7 +18,7 @@ export const command = defineCommand('apps files ls [path]', {
   handler: async ({ params, parents, context, print }) => {
     // Parsed before anything is asked for: the read is a wait on a host, and a path that could
     // never have been read is worth one line now rather than one line half a minute from now.
-    const path = guestPath(params.path);
+    const path = typedPath(params.path);
 
     const { api } = context;
     const slug = await selectApp({

--- a/packages/cli/src/commands/apps/logs.ts
+++ b/packages/cli/src/commands/apps/logs.ts
@@ -2,7 +2,7 @@ import { defineCommand } from '@parshjs/core';
 import { DEFAULT_LOG_TIMERANGE, LOG_TIMERANGE_PATTERN } from '@repo/protocol';
 import { z } from 'zod';
 import { SHARED_OPTIONS } from '#config.ts';
-import { addressedDeployment, selectApp } from '#lib/apps.ts';
+import { announcedDeployment, selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { follow, untilInterrupted } from '#lib/logs.ts';
 import { isInteractive } from '#lib/ui.ts';
@@ -30,7 +30,7 @@ export const command = defineCommand('apps logs', {
       slug: parents.apps.options.app,
       interactive: isInteractive(),
     });
-    const { appId, deploymentId } = await addressedDeployment({
+    const { appId, deploymentId } = await announcedDeployment({
       api,
       slug,
       deploymentId: options[SHARED_OPTIONS.deploymentId.name],

--- a/packages/cli/src/lib/apps.test.ts
+++ b/packages/cli/src/lib/apps.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, mock, test } from 'bun:test';
+import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
 
 type Asked = {
@@ -21,7 +22,7 @@ mock.module('@clack/prompts', () => ({
   },
 }));
 
-const { selectApp } = await import('#lib/apps.ts');
+const { announcedDeployment, selectApp } = await import('#lib/apps.ts');
 
 let listings = 0;
 
@@ -104,4 +105,37 @@ test('walking away from the question is not answering it', async () => {
   });
 
   await expect(attempt).rejects.toThrow('Cancelled.');
+});
+
+test('which deployment a command settled on is said before it is read from', async () => {
+  const dimmed: string[] = [];
+  const api = {
+    api: {
+      apps: Object.assign(
+        () => ({
+          deployments: {
+            get: () =>
+              Promise.resolve({ data: { deployments: [{ id: 'deployment-2' }] }, error: null }),
+          },
+        }),
+        {
+          get: () =>
+            Promise.resolve({
+              data: { apps: [{ id: 'app-1', slug: 'quiet-otter' }] },
+              error: null,
+            }),
+        },
+      ),
+    },
+  } as unknown as PublicApiClient;
+
+  const addressed = await announcedDeployment({
+    api,
+    slug: 'quiet-otter',
+    deploymentId: undefined,
+    print: { dim: (line: string) => dimmed.push(line) } as unknown as Print,
+  });
+
+  expect(addressed).toEqual({ appId: 'app-1', deploymentId: 'deployment-2', slug: 'quiet-otter' });
+  expect(dimmed).toEqual(['quiet-otter · deployment deployment-2']);
 });

--- a/packages/cli/src/lib/apps.ts
+++ b/packages/cli/src/lib/apps.ts
@@ -1,14 +1,14 @@
 import { select } from '@clack/prompts';
 import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { ApiError, unwrap } from '@repo/api-client/unwrap';
+import { unwrap } from '@repo/api-client/unwrap';
+import { addressedDeployment } from '@repo/app-operations';
 import { SHARED_OPTIONS } from '#config.ts';
 import { UsageError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
 
 const NO_APP_NAMED = `Which app? Name one with --${SHARED_OPTIONS.app.name}.`;
 export const NO_APPS = 'You have no apps. `nib run` is what makes one.';
-const NO_DEPLOYMENTS = 'This app has never been deployed.';
 
 /**
  * The app a command was pointed at: the flag when it was given, and the question it stands for
@@ -60,45 +60,14 @@ async function chooseApp({ api }: { api: PublicApiClient }): Promise<string> {
   return answered(chosen);
 }
 
-// Apps are addressed by id and listed by slug; the slug is the half a person sees, so it is the
-// half the CLI takes and this is where the two meet.
-export async function appBySlug({ api, slug }: { api: PublicApiClient; slug: string }) {
-  const { apps } = unwrap(await api.api.apps.get());
-  const found = apps.find((app) => app.slug === slug);
-  if (!found) {
-    throw new ApiError(`No app with slug ${slug}.`);
-  }
-  return found;
-}
-
-/**
- * The deployment a reader means by not naming one. The api lists them newest first, so this is
- * the head of the list rather than a search through it.
- */
-async function latestDeployment({
-  api,
-  appId,
-}: {
-  api: PublicApiClient;
-  appId: string;
-}): Promise<string> {
-  const { deployments } = unwrap(await api.api.apps({ appId }).deployments.get());
-  const newest = deployments[0];
-  if (!newest) {
-    throw new ApiError(NO_DEPLOYMENTS);
-  }
-  return newest.id;
-}
-
 /**
  * The deployment a command was pointed at, and a line saying which one it turned out to be.
  *
- * The app is looked up either way — a deployment is addressed under the app that owns it — so
- * what naming one skips is only the question of which deployment is current. Which makes the line
+ * What naming one skips is only the question of which deployment is current. Which makes the line
  * worth printing: the answer to that question is the difference between reading the release
  * someone just made and reading the one before it.
  */
-export async function addressedDeployment({
+export async function announcedDeployment({
   api,
   slug,
   deploymentId,
@@ -108,9 +77,8 @@ export async function addressedDeployment({
   slug: string;
   deploymentId: string | undefined;
   print: Print;
-}): Promise<{ appId: string; deploymentId: string }> {
-  const app = await appBySlug({ api, slug });
-  const addressed = deploymentId ?? (await latestDeployment({ api, appId: app.id }));
-  print.dim(`${app.slug} · deployment ${addressed}`);
-  return { appId: app.id, deploymentId: addressed };
+}): Promise<{ appId: string; deploymentId: string; slug: string }> {
+  const addressed = await addressedDeployment({ api, slug, deploymentId });
+  print.dim(`${addressed.slug} · deployment ${addressed.deploymentId}`);
+  return addressed;
 }

--- a/packages/cli/src/lib/delete.ts
+++ b/packages/cli/src/lib/delete.ts
@@ -1,7 +1,7 @@
 import { note, text } from '@clack/prompts';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { unwrap } from '@repo/api-client/unwrap';
-import { appBySlug } from '#lib/apps.ts';
+import { appBySlug } from '@repo/app-operations';
 import { UsageError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
 import type { Ui } from '#lib/ui.ts';

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -1,8 +1,8 @@
 import { basename } from 'node:path';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { ApiError, unwrap } from '@repo/api-client/unwrap';
+import { appBySlug } from '@repo/app-operations';
 import { type DeploymentState, GuestPortSchema, type TenantArguments, Value } from '@repo/protocol';
-import { appBySlug } from '#lib/apps.ts';
 import { UsageError } from '#lib/errors.ts';
 import type { RunOptions } from '#lib/plan.ts';
 import type { Ui } from '#lib/ui.ts';

--- a/packages/cli/src/lib/exports.ts
+++ b/packages/cli/src/lib/exports.ts
@@ -2,8 +2,8 @@ import { rename, rm, stat } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { ApiError, unwrap } from '@repo/api-client/unwrap';
+import { appBySlug } from '@repo/app-operations';
 import type { ExportState } from '@repo/protocol';
-import { appBySlug } from '#lib/apps.ts';
 import { UsageError } from '#lib/errors.ts';
 import type { Ui } from '#lib/ui.ts';
 

--- a/packages/cli/src/lib/filesystem.test.ts
+++ b/packages/cli/src/lib/filesystem.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { FilesystemEntry } from '@repo/protocol';
-import { guestPath, render } from '#lib/filesystem.ts';
+import { UsageError } from '#lib/errors.ts';
+import { render, typedPath } from '#lib/filesystem.ts';
 
 function entry(overrides: Partial<FilesystemEntry> = {}): FilesystemEntry {
   return {
@@ -13,37 +14,19 @@ function entry(overrides: Partial<FilesystemEntry> = {}): FilesystemEntry {
 }
 
 function spelled(typed: string): string {
-  return guestPath(typed);
+  return typedPath(typed);
 }
 
-describe('a path is absolute because there is nowhere else it could start', () => {
-  test('one already spelled that way is left alone', () => {
-    expect(spelled('/uploads/2026')).toBe('/uploads/2026');
+describe('a path the filesystem cannot take is something that was typed wrong', () => {
+  test('one it can take is handed on as it stands', () => {
+    expect(spelled('uploads/')).toBe('/uploads');
   });
 
-  test('a leading slash left off is supplied', () => {
-    expect(spelled('uploads')).toBe('/uploads');
-  });
-
-  test('a trailing slash is spelling too', () => {
-    expect(spelled('/uploads/')).toBe('/uploads');
-  });
-
-  test('the root survives being trimmed', () => {
-    expect(spelled('/')).toBe('/');
-  });
-});
-
-describe('what is refused rather than repaired', () => {
-  // Resolving these is what would let a caller walk out of the filesystem they were scoped to.
-  test('a traversal is not resolved', () => {
-    expect(() => guestPath('/uploads/../../etc')).toThrow(
+  test('one it cannot is refused in the words `nib` refuses anything else in', () => {
+    expect(() => typedPath('/uploads/../../etc')).toThrow(UsageError);
+    expect(() => typedPath('/uploads/../../etc')).toThrow(
       '/uploads/../../etc is not a path inside an app filesystem.',
     );
-  });
-
-  test('a quote the reader tooling would tokenise is refused', () => {
-    expect(() => guestPath("/it's")).toThrow("/it's is not a path inside an app filesystem.");
   });
 });
 

--- a/packages/cli/src/lib/filesystem.ts
+++ b/packages/cli/src/lib/filesystem.ts
@@ -1,36 +1,26 @@
 import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { unwrap } from '@repo/api-client/unwrap';
+import { guestPath, InvalidPathError, readDirectory } from '@repo/app-operations';
 import {
   DIRECTORY_ENTRY_LIMIT,
   FILESYSTEM_ENTRY_KINDS,
   type FilesystemEntry,
   type GuestPath,
-  GuestPathSchema,
-  Value,
 } from '@repo/protocol';
-import { addressedDeployment } from '#lib/apps.ts';
+import { announcedDeployment } from '#lib/apps.ts';
 import { UsageError } from '#lib/errors.ts';
 import { dayAndMinute } from '#lib/timestamp.ts';
 
 const KIND_WIDTH = Math.max(...FILESYSTEM_ENTRY_KINDS.map((kind) => kind.length));
 
-/**
- * What was typed, as a path the api will take.
- *
- * A path here is absolute because there is nothing for it to be relative to — the volume's root
- * is the only place it can start — so a leading slash is spelling rather than meaning, and one
- * left off is supplied rather than refused. A trailing one is the same. Nothing else is repaired:
- * `.` and `..` are refused by the schema on purpose, and resolving them here is exactly what
- * would put a caller outside the filesystem they were scoped to.
- */
-export function guestPath(typed: string): GuestPath {
-  const absolute = typed.startsWith('/') ? typed : `/${typed}`;
-  const spelled = absolute.length > 1 ? absolute.replace(/\/$/, '') : absolute;
+export function typedPath(typed: string): GuestPath {
   try {
-    return Value.Parse(GuestPathSchema, spelled);
-  } catch {
-    throw new UsageError(`${typed} is not a path inside an app filesystem.`);
+    return guestPath(typed);
+  } catch (failure) {
+    if (failure instanceof InvalidPathError) {
+      throw new UsageError(failure.message);
+    }
+    throw failure;
   }
 }
 
@@ -55,13 +45,13 @@ export async function listDirectory({
   path,
   print,
 }: ListInput): Promise<void> {
-  const addressed = await addressedDeployment({ api, slug, deploymentId, print });
-  const listing = unwrap(
-    await api.api
-      .apps({ appId: addressed.appId })
-      .deployments({ deploymentId: addressed.deploymentId })
-      .filesystem.get({ query: { path } }),
-  );
+  const addressed = await announcedDeployment({ api, slug, deploymentId, print });
+  const listing = await readDirectory({
+    api,
+    appId: addressed.appId,
+    deploymentId: addressed.deploymentId,
+    path,
+  });
 
   for (const line of render(listing.entries)) {
     print.info(line);

--- a/packages/cli/src/lib/logs.ts
+++ b/packages/cli/src/lib/logs.ts
@@ -1,19 +1,7 @@
 import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { unwrap } from '@repo/api-client/unwrap';
-import { SeenTenantLogs, type TenantLogRecord, type TenantLogStream } from '@repo/protocol';
-
-/**
- * How much of the gap a reconnect asks to be told about.
- *
- * Only the first stream wants the range the reader asked for; a later one is picking up after a
- * close and wants the seconds it was away, not that history again. Generous, because overlap is
- * cheap here — `SeenTenantLogs` drops what has already been shown — and a gap is not recoverable.
- */
-const RECONNECT_TIMERANGE = '30s';
-
-/** What a closed stream costs before we open another, so a refusing api is not hammered. */
-const RECONNECT_PAUSE_MS = 1_000;
+import { followLogs } from '@repo/app-operations';
+import type { TenantLogRecord, TenantLogStream } from '@repo/protocol';
 
 /**
  * Ctrl-C, as something a loop can read rather than something that kills it mid-line.
@@ -37,14 +25,7 @@ export type FollowInput = {
   signal: AbortSignal;
 };
 
-/**
- * Print what a deployment has written, and keep printing what it writes until stopped.
- *
- * The api closes a stream on its own clock so that who may read it is asked again rather than
- * decided once, which makes reaching the end of one an instruction to open another rather than
- * the end of the log. Opening another is why `SeenTenantLogs` outlives them all: a reconnect asks
- * for the seconds it was away, and what it was not away for comes back a second time.
- */
+/** Print what a deployment has written, and keep printing what it writes until stopped. */
 export async function follow({
   api,
   appId,
@@ -53,27 +34,8 @@ export async function follow({
   print,
   signal,
 }: FollowInput): Promise<void> {
-  const logs = api.api.apps({ appId }).deployments({ deploymentId }).logs;
-  const printed = new SeenTenantLogs();
-  let asked = timerange;
-
-  // Stopping part-way through a stream is the ordinary ending, and it arrives as a failed request
-  // rather than a last record. The signal is what says so, not the error.
-  try {
-    while (!signal.aborted) {
-      const stream = unwrap(await logs.get({ query: { timerange: asked }, fetch: { signal } }));
-      for await (const { data } of stream) {
-        if (printed.admit(data)) {
-          show({ record: data, print });
-        }
-      }
-      asked = RECONNECT_TIMERANGE;
-      await Bun.sleep(RECONNECT_PAUSE_MS);
-    }
-  } catch (failure) {
-    if (!signal.aborted) {
-      throw failure;
-    }
+  for await (const record of followLogs({ api, appId, deploymentId, timerange, signal })) {
+    show({ record, print });
   }
 }
 


### PR DESCRIPTION
The dashboard is about to drive the same flows as `nib`, so the parts that are neither terminal nor browser move to a package both can import: app lookup, directory reads and the log follow loop with its reconnect and dedupe.

Rendering stays where it was — column padding and ANSI in the CLI. The package is browser-safe: no `node:`, no `Bun.*`.

The lockfile's `seroval` re-hoisting is `bun install` reacting to the new workspace package, not an intended dependency change.