### PR TITLE
feat: a binary reaches the store without passing through the api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,8 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1105.0",
+    "@aws-sdk/s3-presigned-post": "^3.1105.0",
     "@ilbertt/better-auth-bun-sql": "^0.2.0",
     "@ilbertt/bun-sqlgen": "^0.4.0",
     "@repo/protocol": "workspace:*",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1105.0",
-    "@aws-sdk/s3-presigned-post": "^3.1105.0",
+    "@aws-sdk/s3-request-presigner": "^3.1105.0",
     "@ilbertt/better-auth-bun-sql": "^0.2.0",
     "@ilbertt/bun-sqlgen": "^0.4.0",
     "@repo/protocol": "workspace:*",

--- a/apps/api/src/db/migrations/0017_artifacts_await_their_bytes.sql
+++ b/apps/api/src/db/migrations/0017_artifacts_await_their_bytes.sql
@@ -1,0 +1,27 @@
+-- An artifact row is now written before its bytes exist, which is the opposite of what 0008
+-- says. The upload no longer passes through the api: a caller is handed somewhere to put the
+-- binary and says afterwards that it landed, so the row is what that upload is addressed by and
+-- has to exist first.
+--
+-- What the bytes decide cannot be known until they are there. The digest is taken from them, the
+-- size is counted off them, and the key is the digest — so all three are absent until the api has
+-- read the object back, and none of them is a claim the uploader was believed about.
+--
+-- `digest IS NULL` is the whole of "still coming". No state column: a row is complete when what
+-- completes it is present, which is the same sentence as the work being done, and there is no
+-- second place for that answer to disagree with itself. Every read filters on it, so a pending
+-- row is invisible rather than deployable.
+
+ALTER TABLE nibrun.artifacts
+  ALTER COLUMN digest DROP NOT NULL,
+  ALTER COLUMN size_bytes DROP NOT NULL,
+  ALTER COLUMN object_key DROP NOT NULL;
+
+COMMENT ON COLUMN nibrun.artifacts.digest IS $c$Absent until the api has hashed the uploaded object; its presence is what makes the row an artifact. @type import('@repo/protocol').Sha256Digest$c$;
+COMMENT ON COLUMN nibrun.artifacts.size_bytes IS 'Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number.';
+COMMENT ON COLUMN nibrun.artifacts.object_key IS $c$Where the verified bytes came to rest, so absent while they are still in a staging slot. Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. @type import('@repo/protocol').ObjectKey$c$;
+
+-- An upload nobody ever completes leaves this row behind, and the bucket rule that expires the
+-- staged object cannot reach it. Partial, because the rows worth sweeping are always the few
+-- still pending rather than the many that are done.
+CREATE INDEX artifacts_pending_idx ON nibrun.artifacts (id) WHERE digest IS NULL;

--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -6,10 +6,11 @@ export interface ISelectDesiredDeploymentsResult {
     id: import("@repo/protocol").DeploymentId;
     app_id: import("@repo/protocol").AppId;
     state: import("@repo/protocol").AppState;
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row an artifact. */
     digest: import("@repo/protocol").Sha256Digest;
-    /** A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    /** Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number. */
     size_bytes: string;
-    /** Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
+    /** Where the verified bytes came to rest, so absent while they are still in a staging slot. Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
     object_key: import("@repo/protocol").ObjectKey;
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: import("@repo/protocol").Filename;
@@ -50,10 +51,11 @@ export interface ISelectDesiredExportsResult {
     /** Where the host writes the bundle and the api signs its download URL. */
     object_key: import("@repo/protocol").ObjectKey;
     state: import("@repo/protocol").ExportState;
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row an artifact. */
     digest: import("@repo/protocol").Sha256Digest;
-    /** A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    /** Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number. */
     size_bytes: string;
-    /** Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
+    /** Where the verified bytes came to rest, so absent while they are still in a staging slot. Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
     artifact_object_key: import("@repo/protocol").ObjectKey;
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: import("@repo/protocol").Filename;
@@ -243,7 +245,7 @@ export interface ISelectPurgeableAppsResult {
 
 /** Result of query `SelectUnsharedArtifactKeys`. */
 export interface ISelectUnsharedArtifactKeysResult {
-    /** Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
+    /** Where the verified bytes came to rest, so absent while they are still in a staging slot. Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
     object_key: import("@repo/protocol").ObjectKey;
 }
 
@@ -295,28 +297,62 @@ export interface ISelectAppAfterStateChangeResult {
     restart_reset_after_ms: number;
 }
 
-/** Result of query `InsertArtifact`. */
-export interface IInsertArtifactResult {
+/** Result of query `InsertPendingArtifact`. */
+export interface IInsertPendingArtifactResult {
     id: import("@repo/protocol").ArtifactId;
     app_id: import("@repo/protocol").AppId;
+    /** The name the binary was uploaded under; a content-addressed key carries none. */
+    original_file_name: import("@repo/protocol").Filename;
+    created_at: Date;
+}
+
+/** Result of query `CompleteArtifact`. */
+export interface ICompleteArtifactResult {
+    id: import("@repo/protocol").ArtifactId;
+    app_id: import("@repo/protocol").AppId;
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row an artifact. */
     digest: import("@repo/protocol").Sha256Digest;
-    /** A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    /** Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number. */
     size_bytes: string;
-    /** Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
+    /** Where the verified bytes came to rest, so absent while they are still in a staging slot. Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
     object_key: import("@repo/protocol").ObjectKey;
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: import("@repo/protocol").Filename;
     created_at: Date;
 }
 
+/** Result of query `DeleteArtifact`. */
+export interface IDeleteArtifactResult {
+}
+
+/** Result of query `SelectPendingArtifact`. */
+export interface ISelectPendingArtifactResult {
+    id: import("@repo/protocol").ArtifactId;
+    app_id: import("@repo/protocol").AppId;
+    /** The name the binary was uploaded under; a content-addressed key carries none. */
+    original_file_name: import("@repo/protocol").Filename;
+    created_at: Date;
+}
+
+/** Result of query `SelectAbandonedArtifacts`. */
+export interface ISelectAbandonedArtifactsResult {
+    id: import("@repo/protocol").ArtifactId;
+    app_id: import("@repo/protocol").AppId;
+}
+
+/** Result of query `DeleteAbandonedArtifact`. */
+export interface IDeleteAbandonedArtifactResult {
+}
+
 /** Result of query `SelectArtifactsByApp`. */
 export interface ISelectArtifactsByAppResult {
     id: import("@repo/protocol").ArtifactId;
     app_id: import("@repo/protocol").AppId;
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row an artifact. */
     digest: import("@repo/protocol").Sha256Digest;
-    /** A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    /** Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number. */
     size_bytes: string;
-    /** Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
+    /** Where the verified bytes came to rest, so absent while they are still in a staging slot. Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
     object_key: import("@repo/protocol").ObjectKey;
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: import("@repo/protocol").Filename;
@@ -327,10 +363,11 @@ export interface ISelectArtifactsByAppResult {
 export interface ISelectArtifactByIdResult {
     id: import("@repo/protocol").ArtifactId;
     app_id: import("@repo/protocol").AppId;
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row an artifact. */
     digest: import("@repo/protocol").Sha256Digest;
-    /** A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    /** Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number. */
     size_bytes: string;
-    /** Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
+    /** Where the verified bytes came to rest, so absent while they are still in a staging slot. Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
     object_key: import("@repo/protocol").ObjectKey;
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: import("@repo/protocol").Filename;
@@ -560,7 +597,12 @@ export interface Queries {
     DeleteArtifactsByApp: IDeleteArtifactsByAppResult;
     UpdateAppState: IUpdateAppStateResult;
     SelectAppAfterStateChange: ISelectAppAfterStateChangeResult;
-    InsertArtifact: IInsertArtifactResult;
+    InsertPendingArtifact: IInsertPendingArtifactResult;
+    CompleteArtifact: ICompleteArtifactResult;
+    DeleteArtifact: IDeleteArtifactResult;
+    SelectPendingArtifact: ISelectPendingArtifactResult;
+    SelectAbandonedArtifacts: ISelectAbandonedArtifactsResult;
+    DeleteAbandonedArtifact: IDeleteAbandonedArtifactResult;
     SelectArtifactsByApp: ISelectArtifactsByAppResult;
     SelectArtifactById: ISelectArtifactByIdResult;
     SelectDeployableArtifact: ISelectDeployableArtifactResult;

--- a/apps/api/src/lib/artifact-digest.ts
+++ b/apps/api/src/lib/artifact-digest.ts
@@ -5,6 +5,7 @@ import {
   Sha256DigestSchema,
   Value,
 } from '@repo/protocol';
+import { ELF_MAGIC_LENGTH, isElfExecutable } from '#lib/elf.ts';
 
 const DIGEST_ALGORITHM = 'sha256';
 const HEX_ENCODING = 'hex';
@@ -15,21 +16,60 @@ export type ArtifactIdentity = {
   objectKey: ObjectKey;
 };
 
+export type ArtifactInspection =
+  | ({ outcome: 'stored' } & ArtifactIdentity)
+  | { outcome: 'not-executable' }
+  | { outcome: 'too-large' };
+
 /**
- * The digest a host will verify, taken from the bytes the api is about to store.
+ * The digest a host will verify, taken from the bytes the store now holds.
  *
  * An uploader-supplied digest could only ever fail out on the host, where it becomes a deploy
- * that never converges rather than a rejected upload.
+ * that never converges rather than a rejected upload — so the bytes are read back and hashed
+ * here even though the api never had them in hand.
+ *
+ * Executability and size are settled in the same pass because the pass is the expensive part:
+ * the object is a whole binary, and reading it three times to answer three questions about it
+ * would cost three times the bandwidth to reach the same verdict.
  */
-export function identifyArtifact(bytes: Uint8Array): ArtifactIdentity {
-  const digest = Value.Parse(
-    Sha256DigestSchema,
-    new Bun.CryptoHasher(DIGEST_ALGORITHM).update(bytes).digest(HEX_ENCODING),
-  );
+export async function inspectArtifact({
+  stream,
+  maxSizeBytes,
+}: {
+  stream: ReadableStream<Uint8Array>;
+  maxSizeBytes: number;
+}): Promise<ArtifactInspection> {
+  const hasher = new Bun.CryptoHasher(DIGEST_ALGORITHM);
+  const magic: number[] = [];
+  let sizeBytes = 0;
+
+  for await (const chunk of stream) {
+    magic.push(...chunk.slice(0, ELF_MAGIC_LENGTH - magic.length));
+    // Leaving the loop cancels the read, so something that was never a binary costs one chunk
+    // rather than the whole object.
+    if (magic.length >= ELF_MAGIC_LENGTH && !isElfExecutable(Uint8Array.from(magic))) {
+      return { outcome: 'not-executable' };
+    }
+
+    sizeBytes += chunk.byteLength;
+    if (sizeBytes > maxSizeBytes) {
+      return { outcome: 'too-large' };
+    }
+
+    hasher.update(chunk);
+  }
+
+  // Shorter than the magic itself, so the loop above never reached a verdict.
+  if (!isElfExecutable(Uint8Array.from(magic))) {
+    return { outcome: 'not-executable' };
+  }
+
+  const digest = Value.Parse(Sha256DigestSchema, hasher.digest(HEX_ENCODING));
 
   return {
+    outcome: 'stored',
     digest,
-    sizeBytes: bytes.byteLength,
+    sizeBytes,
     objectKey: Value.Parse(ObjectKeySchema, digest),
   };
 }

--- a/apps/api/src/lib/elf.ts
+++ b/apps/api/src/lib/elf.ts
@@ -2,6 +2,8 @@
 // bytes themselves — and the first four settle it.
 const ELF_MAGIC = Uint8Array.from('\x7fELF', (character) => character.charCodeAt(0));
 
+export const ELF_MAGIC_LENGTH = ELF_MAGIC.length;
+
 /**
  * Whether the upload is a Linux executable at all.
  *

--- a/apps/api/src/lib/s3/client.ts
+++ b/apps/api/src/lib/s3/client.ts
@@ -1,3 +1,4 @@
+import { S3Client } from '@aws-sdk/client-s3';
 import { env } from '#lib/env.ts';
 
 const credentials = {
@@ -10,3 +11,20 @@ const credentials = {
 export const artifactsS3 = new Bun.S3Client({ bucket: env.ARTIFACTS_BUCKET, ...credentials });
 
 export const exportsS3 = new Bun.S3Client({ bucket: env.EXPORTS_BUCKET, ...credentials });
+
+/**
+ * A client from another library for one thing Bun's cannot do: sign a POST policy, which is what
+ * holds an upload to a size when the api is not the one receiving it. Everything else still goes
+ * through the client above — see `signUpload` for why this one has to exist.
+ */
+export const artifactsPolicySigner = new S3Client({
+  region: env.S3_REGION,
+  endpoint: env.S3_ENDPOINT.origin,
+  credentials: {
+    accessKeyId: env.S3_ACCESS_KEY_ID,
+    secretAccessKey: env.S3_SECRET_ACCESS_KEY,
+  },
+  // The bucket goes in the path rather than the hostname: MinIO answers on a bare host, where a
+  // bucket cannot be a subdomain, and S3 serves either form.
+  forcePathStyle: true,
+});

--- a/apps/api/src/lib/s3/client.ts
+++ b/apps/api/src/lib/s3/client.ts
@@ -13,11 +13,11 @@ export const artifactsS3 = new Bun.S3Client({ bucket: env.ARTIFACTS_BUCKET, ...c
 export const exportsS3 = new Bun.S3Client({ bucket: env.EXPORTS_BUCKET, ...credentials });
 
 /**
- * A client from another library for one thing Bun's cannot do: sign a POST policy, which is what
- * holds an upload to a size when the api is not the one receiving it. Everything else still goes
- * through the client above — see `signUpload` for why this one has to exist.
+ * A client from another library for one thing Bun's cannot do: name `content-length` among the
+ * headers a signature covers, which is what holds an upload to a size when the api is not the one
+ * receiving it. Everything else still goes through the client above — see `signUpload`.
  */
-export const artifactsPolicySigner = new S3Client({
+export const artifactsSigner = new S3Client({
   region: env.S3_REGION,
   endpoint: env.S3_ENDPOINT.origin,
   credentials: {

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -39,7 +39,12 @@ export class AgentRepository extends Repository implements AgentRepositoryContra
    * so a host can only be told to do one once something has recorded that someone asked.
    */
   async desiredState({ hostId }: { hostId: HostId }): Promise<HostDesiredState> {
+    // An artifact still awaiting its upload cannot be deployed or exported — the deployment
+    // that would name it is refused — so what reaches a host here always has its bytes.
     const deployments = await this.sql.SelectDesiredDeployments`
+      /* @notNull digest */
+      /* @notNull size_bytes */
+      /* @notNull object_key */
       SELECT id, app_id, state,
              digest, size_bytes, object_key, original_file_name,
              guest_port, args, vcpu_count, memory_mib,
@@ -61,6 +66,8 @@ export class AgentRepository extends Repository implements AgentRepositoryContra
     const exports = await this.sql.SelectDesiredExports`
       /* @notNull object_key */
       /* @notNull artifact_object_key */
+      /* @notNull digest */
+      /* @notNull size_bytes */
       SELECT id, app_id, object_key, state,
              digest, size_bytes, artifact_object_key, original_file_name
       FROM nibrun.desired_exports

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -342,9 +342,12 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
   async listLeftovers({ appId }: { appId: AppId }): Promise<Leftovers> {
     const [artifacts, exports] = await Promise.all([
       this.sql.SelectUnsharedArtifactKeys`
+        /* @notNull object_key */
         SELECT DISTINCT ar.object_key
         FROM nibrun.artifacts ar
         WHERE ar.app_id = ${appId}
+          -- An upload that never completed named no object, so there is nothing of it to remove.
+          AND ar.object_key IS NOT NULL
           AND NOT EXISTS (
             SELECT 1 FROM nibrun.artifacts other
             WHERE other.object_key = ar.object_key AND other.app_id <> ${appId}

--- a/apps/api/src/repositories/artifact-storage.repository.ts
+++ b/apps/api/src/repositories/artifact-storage.repository.ts
@@ -1,29 +1,113 @@
+import type { S3Client } from '@aws-sdk/client-s3';
+import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
 import type { ObjectKey } from '@repo/protocol';
 
 const ARTIFACT_CONTENT_TYPE = 'application/octet-stream';
 
-// A transient 5xx from the store would otherwise fail an upload the caller has already paid to
-// send, so the client retries before the request does.
+// A transient 5xx from the store would otherwise fail a promotion the caller has already paid to
+// upload, so the client retries before the request does.
 const UPLOAD_RETRIES = 3;
 
+/**
+ * The window an upload has to *begin* in, not to finish in — S3 checks the signature when the
+ * request arrives, so a slow link spends this budget once and then has as long as it needs.
+ *
+ * A presigned URL is a bearer token for the one key it names, and that key is a staging slot
+ * inside one app's prefix: a leaked URL can overwrite an upload nobody has registered yet, and
+ * reaches nothing that has been.
+ */
+const UPLOAD_URL_TTL_SECONDS = 900;
+
+/**
+ * Everything the caller has to send for the store to accept the upload. `fields` carries the
+ * policy and its signature, and goes in the form ahead of the file.
+ */
+export type SignedUpload = {
+  url: string;
+  fields: Record<string, string>;
+};
+
 export abstract class ArtifactStorageRepositoryContract {
-  abstract put(input: { objectKey: ObjectKey; bytes: Uint8Array }): Promise<void>;
+  abstract signUpload(input: { objectKey: ObjectKey; maxSizeBytes: number }): Promise<SignedUpload>;
+  abstract read(input: { objectKey: ObjectKey }): ReadableStream<Uint8Array>;
+  abstract copy(input: { from: ObjectKey; to: ObjectKey }): Promise<void>;
   abstract exists(input: { objectKey: ObjectKey }): Promise<boolean>;
   abstract remove(input: { objectKey: ObjectKey }): Promise<void>;
 }
 
 export class ArtifactStorageRepository implements ArtifactStorageRepositoryContract {
   private readonly client: Bun.S3Client;
+  private readonly policySigner: S3Client;
+  private readonly bucket: string;
 
-  constructor(client: Bun.S3Client) {
+  constructor({
+    client,
+    policySigner,
+    bucket,
+  }: {
+    client: Bun.S3Client;
+    policySigner: S3Client;
+    bucket: string;
+  }) {
     this.client = client;
+    this.policySigner = policySigner;
+    this.bucket = bucket;
   }
 
-  async put({ objectKey, bytes }: { objectKey: ObjectKey; bytes: Uint8Array }): Promise<void> {
-    await this.client.write(objectKey, bytes, {
+  /**
+   * Signed rather than proxied: a binary is far larger than anything else this api handles, and
+   * taking delivery of one would spend the control plane's memory and bandwidth on every deploy
+   * — and put every upload under whatever body limit the edge in front of it enforces.
+   *
+   * The signature carries this end's permissions, which are this bucket and nothing else.
+   *
+   * A POST policy rather than a presigned PUT, because only a policy can name a size the store
+   * itself will hold the upload to. SigV4 binds the headers it lists and no others, and Bun's
+   * `presign` offers no way to add one — https://github.com/oven-sh/bun/issues/18240, still open,
+   * with an attempt at it closed unmerged. Signing this with Bun would leave the limit to be
+   * discovered after the bytes were already stored, which is the upload it exists to refuse.
+   */
+  async signUpload({
+    objectKey,
+    maxSizeBytes,
+  }: {
+    objectKey: ObjectKey;
+    maxSizeBytes: number;
+  }): Promise<SignedUpload> {
+    return await createPresignedPost(this.policySigner, {
+      Bucket: this.bucket,
+      Key: objectKey,
+      Conditions: [['content-length-range', 0, maxSizeBytes]],
+      Expires: UPLOAD_URL_TTL_SECONDS,
+    });
+  }
+
+  read({ objectKey }: { objectKey: ObjectKey }): ReadableStream<Uint8Array> {
+    return this.client.file(objectKey).stream();
+  }
+
+  /**
+   * Streamed rather than buffered: this runs on an object as large as a whole binary, and holding
+   * one in memory is the cost that signing the upload away was meant to avoid.
+   *
+   * Nothing else writes the content-addressed namespace. That is what lets a key found there be
+   * trusted without reading it again — the bytes under it were hashed by this process, on their
+   * way to it.
+   */
+  async copy({ from, to }: { from: ObjectKey; to: ObjectKey }): Promise<void> {
+    const writer = this.client.file(to).writer({
       type: ARTIFACT_CONTENT_TYPE,
       retry: UPLOAD_RETRIES,
     });
+    try {
+      for await (const chunk of this.client.file(from).stream()) {
+        await writer.write(chunk);
+      }
+      await writer.end();
+    } catch (failure) {
+      await abandon({ writer, failure });
+      throw failure;
+    }
   }
 
   exists({ objectKey }: { objectKey: ObjectKey }): Promise<boolean> {
@@ -36,5 +120,26 @@ export class ArtifactStorageRepository implements ArtifactStorageRepositoryContr
    */
   async remove({ objectKey }: { objectKey: ObjectKey }): Promise<void> {
     await this.client.delete(objectKey);
+  }
+}
+
+/**
+ * An object this size is uploaded in parts, and one left half way holds every part already sent
+ * under a key that names none of them. The bucket's rule is what guarantees they go; this is what
+ * makes the ordinary failure immediate rather than a day later.
+ *
+ * How the abandoning went is not the error worth raising — the copy failing is.
+ */
+async function abandon({
+  writer,
+  failure,
+}: {
+  writer: Bun.NetworkSink;
+  failure: unknown;
+}): Promise<void> {
+  try {
+    await writer.end(failure instanceof Error ? failure : new Error(String(failure)));
+  } catch {
+    return;
   }
 }

--- a/apps/api/src/repositories/artifact-storage.repository.ts
+++ b/apps/api/src/repositories/artifact-storage.repository.ts
@@ -1,5 +1,5 @@
-import type { S3Client } from '@aws-sdk/client-s3';
-import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
+import { PutObjectCommand, type S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import type { ObjectKey } from '@repo/protocol';
 
 const ARTIFACT_CONTENT_TYPE = 'application/octet-stream';
@@ -18,17 +18,8 @@ const UPLOAD_RETRIES = 3;
  */
 const UPLOAD_URL_TTL_SECONDS = 900;
 
-/**
- * Everything the caller has to send for the store to accept the upload. `fields` carries the
- * policy and its signature, and goes in the form ahead of the file.
- */
-export type SignedUpload = {
-  url: string;
-  fields: Record<string, string>;
-};
-
 export abstract class ArtifactStorageRepositoryContract {
-  abstract signUpload(input: { objectKey: ObjectKey; maxSizeBytes: number }): Promise<SignedUpload>;
+  abstract signUpload(input: { objectKey: ObjectKey; sizeBytes: number }): Promise<string>;
   abstract read(input: { objectKey: ObjectKey }): ReadableStream<Uint8Array>;
   abstract copy(input: { from: ObjectKey; to: ObjectKey }): Promise<void>;
   abstract exists(input: { objectKey: ObjectKey }): Promise<boolean>;
@@ -37,20 +28,20 @@ export abstract class ArtifactStorageRepositoryContract {
 
 export class ArtifactStorageRepository implements ArtifactStorageRepositoryContract {
   private readonly client: Bun.S3Client;
-  private readonly policySigner: S3Client;
+  private readonly signer: S3Client;
   private readonly bucket: string;
 
   constructor({
     client,
-    policySigner,
+    signer,
     bucket,
   }: {
     client: Bun.S3Client;
-    policySigner: S3Client;
+    signer: S3Client;
     bucket: string;
   }) {
     this.client = client;
-    this.policySigner = policySigner;
+    this.signer = signer;
     this.bucket = bucket;
   }
 
@@ -59,27 +50,31 @@ export class ArtifactStorageRepository implements ArtifactStorageRepositoryContr
    * taking delivery of one would spend the control plane's memory and bandwidth on every deploy
    * — and put every upload under whatever body limit the edge in front of it enforces.
    *
-   * The signature carries this end's permissions, which are this bucket and nothing else.
+   * The signature carries this end's permissions, which are this bucket and nothing else, and it
+   * covers the length as well as the key: a signature holds whatever headers it names, so naming
+   * `content-length` is what makes the store refuse a body of any other size. Bun's `presign` has
+   * no way to name one — https://github.com/oven-sh/bun/issues/18240 — which is the whole reason
+   * the signing here is not its.
    *
-   * A POST policy rather than a presigned PUT, because only a policy can name a size the store
-   * itself will hold the upload to. SigV4 binds the headers it lists and no others, and Bun's
-   * `presign` offers no way to add one — https://github.com/oven-sh/bun/issues/18240, still open,
-   * with an attempt at it closed unmerged. Signing this with Bun would leave the limit to be
-   * discovered after the bytes were already stored, which is the upload it exists to refuse.
+   * Exactly the size that was declared rather than at most it: this end was told what it is being
+   * offered, and a body of any other length is not the upload it agreed to.
    */
   async signUpload({
     objectKey,
-    maxSizeBytes,
+    sizeBytes,
   }: {
     objectKey: ObjectKey;
-    maxSizeBytes: number;
-  }): Promise<SignedUpload> {
-    return await createPresignedPost(this.policySigner, {
-      Bucket: this.bucket,
-      Key: objectKey,
-      Conditions: [['content-length-range', 0, maxSizeBytes]],
-      Expires: UPLOAD_URL_TTL_SECONDS,
-    });
+    sizeBytes: number;
+  }): Promise<string> {
+    return await getSignedUrl(
+      this.signer,
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: objectKey,
+        ContentLength: sizeBytes,
+      }),
+      { expiresIn: UPLOAD_URL_TTL_SECONDS, signableHeaders: new Set(['content-length']) },
+    );
   }
 
   read({ objectKey }: { objectKey: ObjectKey }): ReadableStream<Uint8Array> {

--- a/apps/api/src/repositories/artifacts.repository.ts
+++ b/apps/api/src/repositories/artifacts.repository.ts
@@ -3,18 +3,33 @@ import type { Queries } from '#db/queries.gen.d.ts';
 import { Repository } from '#repositories/repository.ts';
 
 export type ArtifactRow = Queries['SelectArtifactById'];
+export type PendingArtifactRow = Queries['SelectPendingArtifact'];
+export type AbandonedArtifactRow = Queries['SelectAbandonedArtifacts'];
 
-export type InsertArtifactInput = {
+export type CompleteArtifactInput = {
   appId: AppId;
+  artifactId: ArtifactId;
   ownerId: OwnerId;
   digest: Sha256Digest;
   sizeBytes: number;
   objectKey: ObjectKey;
-  originalFileName: Filename;
 };
 
 export abstract class ArtifactsRepositoryContract {
-  abstract insert(input: InsertArtifactInput): Promise<ArtifactRow | null>;
+  abstract insertPending(input: {
+    appId: AppId;
+    ownerId: OwnerId;
+    originalFileName: Filename;
+  }): Promise<PendingArtifactRow | null>;
+  abstract complete(input: CompleteArtifactInput): Promise<ArtifactRow | null>;
+  abstract remove(input: { appId: AppId; artifactId: ArtifactId; ownerId: OwnerId }): Promise<void>;
+  abstract findPending(input: {
+    appId: AppId;
+    artifactId: ArtifactId;
+    ownerId: OwnerId;
+  }): Promise<PendingArtifactRow | null>;
+  abstract listAbandoned(input: { olderThanSeconds: number }): Promise<AbandonedArtifactRow[]>;
+  abstract removeAbandoned(input: { artifactId: ArtifactId }): Promise<void>;
   abstract listByApp(input: { appId: AppId; ownerId: OwnerId }): Promise<ArtifactRow[]>;
   abstract findById(input: {
     appId: AppId;
@@ -23,34 +38,136 @@ export abstract class ArtifactsRepositoryContract {
   }): Promise<ArtifactRow | null>;
 }
 
+/**
+ * `digest IS NOT NULL` is what separates an artifact from an upload still in flight, so every
+ * read that returns one carries it. A row without it names bytes that may never arrive.
+ */
 export class ArtifactsRepository extends Repository implements ArtifactsRepositoryContract {
-  async insert({
+  async insertPending({
     appId,
+    ownerId,
+    originalFileName,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    originalFileName: Filename;
+  }): Promise<PendingArtifactRow | null> {
+    const [row] = await this.sql.InsertPendingArtifact`
+      /* @notNull created_at */
+      INSERT INTO nibrun.artifacts (app_id, original_file_name)
+      SELECT a.id, ${originalFileName}
+      FROM nibrun.live_apps a
+      WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
+      RETURNING id, app_id, original_file_name, created_at
+    `;
+    return row ?? null;
+  }
+
+  /**
+   * Only ever the first time: the guard is what stops a second report of the same upload from
+   * rewriting an artifact a deployment already points at.
+   */
+  async complete({
+    appId,
+    artifactId,
     ownerId,
     digest,
     sizeBytes,
     objectKey,
-    originalFileName,
-  }: InsertArtifactInput): Promise<ArtifactRow | null> {
-    const [row] = await this.sql.InsertArtifact`
+  }: CompleteArtifactInput): Promise<ArtifactRow | null> {
+    const [row] = await this.sql.CompleteArtifact`
       /* @notNull created_at */
-      INSERT INTO nibrun.artifacts (app_id, digest, size_bytes, object_key, original_file_name)
-      SELECT a.id, ${digest}, ${sizeBytes}, ${objectKey}, ${originalFileName}
+      /* @notNull digest */
+      /* @notNull size_bytes */
+      /* @notNull object_key */
+      UPDATE nibrun.artifacts ar
+      SET digest = ${digest}, size_bytes = ${sizeBytes}, object_key = ${objectKey}
       FROM nibrun.live_apps a
-      WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
-      RETURNING id, app_id, digest, size_bytes, object_key, original_file_name, created_at
+      WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.id = ar.app_id
+        AND a.owner_id = ${ownerId} AND ar.digest IS NULL
+      RETURNING ar.id, ar.app_id, ar.digest, ar.size_bytes, ar.object_key, ar.original_file_name,
+                ar.created_at
     `;
     return row ?? null;
+  }
+
+  async remove({
+    appId,
+    artifactId,
+    ownerId,
+  }: {
+    appId: AppId;
+    artifactId: ArtifactId;
+    ownerId: OwnerId;
+  }): Promise<void> {
+    await this.sql.DeleteArtifact`
+      DELETE FROM nibrun.artifacts ar
+      USING nibrun.live_apps a
+      WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.id = ar.app_id
+        AND a.owner_id = ${ownerId} AND ar.digest IS NULL
+    `;
+  }
+
+  async findPending({
+    appId,
+    artifactId,
+    ownerId,
+  }: {
+    appId: AppId;
+    artifactId: ArtifactId;
+    ownerId: OwnerId;
+  }): Promise<PendingArtifactRow | null> {
+    const [row] = await this.sql.SelectPendingArtifact`
+      /* @notNull created_at */
+      SELECT ar.id, ar.app_id, ar.original_file_name, ar.created_at
+      FROM nibrun.artifacts ar
+      JOIN nibrun.live_apps a ON a.id = ar.app_id
+      WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.owner_id = ${ownerId}
+        AND ar.digest IS NULL
+    `;
+    return row ?? null;
+  }
+
+  /**
+   * An upload nobody ever reported on. Old enough that the signed URL it was handed has long
+   * expired, so nothing is still on its way to the key this row is addressed by.
+   */
+  listAbandoned({
+    olderThanSeconds,
+  }: {
+    olderThanSeconds: number;
+  }): Promise<AbandonedArtifactRow[]> {
+    return this.sql.SelectAbandonedArtifacts`
+      SELECT ar.id, ar.app_id
+      FROM nibrun.artifacts ar
+      WHERE ar.digest IS NULL
+        AND ar.created_at < now() - make_interval(secs => ${olderThanSeconds})
+    `;
+  }
+
+  /**
+   * No owner, because no owner asked: this is the sweep, and the row it names came from a listing
+   * of what is still pending rather than from anybody's request. `digest IS NULL` is carried
+   * anyway, so a row completed since that listing is left alone.
+   */
+  async removeAbandoned({ artifactId }: { artifactId: ArtifactId }): Promise<void> {
+    await this.sql.DeleteAbandonedArtifact`
+      DELETE FROM nibrun.artifacts ar
+      WHERE ar.id = ${artifactId} AND ar.digest IS NULL
+    `;
   }
 
   listByApp({ appId, ownerId }: { appId: AppId; ownerId: OwnerId }): Promise<ArtifactRow[]> {
     return this.sql.SelectArtifactsByApp`
       /* @notNull created_at */
+      /* @notNull digest */
+      /* @notNull size_bytes */
+      /* @notNull object_key */
       SELECT ar.id, ar.app_id, ar.digest, ar.size_bytes, ar.object_key, ar.original_file_name,
              ar.created_at
       FROM nibrun.artifacts ar
       JOIN nibrun.live_apps a ON a.id = ar.app_id
-      WHERE ar.app_id = ${appId} AND a.owner_id = ${ownerId}
+      WHERE ar.app_id = ${appId} AND a.owner_id = ${ownerId} AND ar.digest IS NOT NULL
       ORDER BY ar.id DESC
     `;
   }
@@ -66,11 +183,15 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
   }): Promise<ArtifactRow | null> {
     const [row] = await this.sql.SelectArtifactById`
       /* @notNull created_at */
+      /* @notNull digest */
+      /* @notNull size_bytes */
+      /* @notNull object_key */
       SELECT ar.id, ar.app_id, ar.digest, ar.size_bytes, ar.object_key, ar.original_file_name,
              ar.created_at
       FROM nibrun.artifacts ar
       JOIN nibrun.live_apps a ON a.id = ar.app_id
       WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.owner_id = ${ownerId}
+        AND ar.digest IS NOT NULL
     `;
     return row ?? null;
   }

--- a/apps/api/src/repositories/deployments.repository.ts
+++ b/apps/api/src/repositories/deployments.repository.ts
@@ -82,11 +82,14 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
       // Asked before anything is superseded: returning from this callback commits, so an
       // artifact this owner does not have must leave the running deployment alone rather than
       // stand it down on behalf of a request that goes on to write nothing.
+      // `digest IS NOT NULL` is what makes an artifact one: a row without it is an upload still
+      // in flight, and a host sent to fetch it would find a key that names nothing yet.
       const [deployable] = await tx.SelectDeployableArtifact`
         SELECT ar.id
         FROM nibrun.artifacts ar
         JOIN nibrun.live_apps a ON a.id = ar.app_id
         WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.owner_id = ${ownerId}
+          AND ar.digest IS NOT NULL
       `;
       if (!deployable) {
         return null;
@@ -105,6 +108,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
           WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1
         ) c ON true
         WHERE a.id = ${appId} AND a.owner_id = ${ownerId} AND ar.id = ${artifactId}
+          AND ar.digest IS NOT NULL
         RETURNING id
       `;
       return inserted ? await this.selectDeployment({ tx, deploymentId: inserted.id }) : null;

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
@@ -5,8 +5,9 @@ import {
   OwnerIdSchema,
   Value,
 } from '@repo/protocol';
-import { Elysia, StatusMap } from 'elysia';
+import { Elysia, StatusMap, t } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
+import { UpdateArtifactBodySchema } from '#routes/api/apps/[appId]/artifacts/model.ts';
 import { ArtifactsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdArtifactsArtifactIdController = new Elysia()
@@ -26,5 +27,28 @@ export const AppsAppIdArtifactsArtifactIdController = new Elysia()
     },
     {
       response: { [StatusMap.OK]: ArtifactSchema },
+    },
+  )
+  .patch(
+    '/apps/:appId/artifacts/:artifactId',
+    async ({ artifactsService, params, body, user, status }) => {
+      const appId = Value.Parse(AppIdSchema, params.appId);
+      const artifactId = Value.Parse(ArtifactIdSchema, params.artifactId);
+      const ownerId = Value.Parse(OwnerIdSchema, user.id);
+
+      if (body.upload === 'failed') {
+        await artifactsService.failUpload({ appId, artifactId, ownerId });
+        return status(StatusMap['No Content'], undefined);
+      }
+
+      const artifact = await artifactsService.completeUpload({ appId, artifactId, ownerId });
+      return status(StatusMap.OK, artifact);
+    },
+    {
+      body: UpdateArtifactBodySchema,
+      response: {
+        [StatusMap.OK]: ArtifactSchema,
+        [StatusMap['No Content']]: t.Void(),
+      },
     },
   );

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
@@ -1,8 +1,9 @@
-import { AppIdSchema, ArtifactSchema, OwnerIdSchema, Value } from '@repo/protocol';
+import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
 import { authPlugin } from '#lib/auth/plugin.ts';
 import {
   CreateArtifactBodySchema,
+  CreateArtifactResponseSchema,
   ListArtifactsResponseSchema,
 } from '#routes/api/apps/[appId]/artifacts/model.ts';
 import { ArtifactsServicePlugin, loggerPlugin } from '#services/plugins.ts';
@@ -25,18 +26,21 @@ export const AppsAppIdArtifactsController = new Elysia()
       response: { [StatusMap.OK]: ListArtifactsResponseSchema },
     },
   )
+  // Created rather than OK: the artifact exists from here on, and the upload it is waiting for is
+  // what the response says where to send.
   .post(
     '/apps/:appId/artifacts',
     async ({ artifactsService, params, body, user, status }) => {
-      const artifact = await artifactsService.create({
+      const upload = await artifactsService.create({
         appId: Value.Parse(AppIdSchema, params.appId),
         ownerId: Value.Parse(OwnerIdSchema, user.id),
-        binary: body.binary,
+        filename: body.filename,
+        sizeBytes: body.sizeBytes,
       });
-      return status(StatusMap.Created, artifact);
+      return status(StatusMap.Created, upload);
     },
     {
       body: CreateArtifactBodySchema,
-      response: { [StatusMap.Created]: ArtifactSchema },
+      response: { [StatusMap.Created]: CreateArtifactResponseSchema },
     },
   );

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
@@ -5,8 +5,8 @@ import { t } from 'elysia';
 // what a host writes into an export archive. Refused here as a shape rather than sanitised into
 // a different name — see FilenameSchema.
 //
-// The size is only a claim, answered before anything is signed. What holds the upload to it is
-// the policy in the response.
+// The size is answered before anything is signed, and then signed into the url: the store holds
+// the upload to exactly it.
 export const CreateArtifactBodySchema = t.Object({
   filename: FilenameSchema,
   sizeBytes: ByteSizeSchema,
@@ -14,10 +14,7 @@ export const CreateArtifactBodySchema = t.Object({
 
 export const CreateArtifactResponseSchema = t.Object({
   artifactId: ArtifactIdSchema,
-  url: t.String({ description: 'Where to post the binary.' }),
-  fields: t.Record(t.String(), t.String(), {
-    description: 'Form fields to send before the file, which must be the last part.',
-  }),
+  url: t.String({ description: 'Where to PUT the binary, as the whole request body.' }),
 });
 
 // Said by the only end that knows: the upload happened between the caller and the store, so the

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
@@ -1,12 +1,29 @@
-import { ArtifactSchema } from '@repo/protocol';
+import { ArtifactIdSchema, ArtifactSchema, ByteSizeSchema, FilenameSchema } from '@repo/protocol';
 import { t } from 'elysia';
 
-// The api buffers the upload to hash it, so this bound is what a single request may cost the
-// control plane's memory, not a judgement about how large a binary may be.
-const MAX_ARTIFACT_SIZE = '256m';
-
+// The name is the caller's, not the store's: a content-addressed key carries none, and this is
+// what a host writes into an export archive. Refused here as a shape rather than sanitised into
+// a different name — see FilenameSchema.
+//
+// The size is only a claim, answered before anything is signed. What holds the upload to it is
+// the policy in the response.
 export const CreateArtifactBodySchema = t.Object({
-  binary: t.File({ maxSize: MAX_ARTIFACT_SIZE }),
+  filename: FilenameSchema,
+  sizeBytes: ByteSizeSchema,
+});
+
+export const CreateArtifactResponseSchema = t.Object({
+  artifactId: ArtifactIdSchema,
+  url: t.String({ description: 'Where to post the binary.' }),
+  fields: t.Record(t.String(), t.String(), {
+    description: 'Form fields to send before the file, which must be the last part.',
+  }),
+});
+
+// Said by the only end that knows: the upload happened between the caller and the store, so the
+// api learns how it went by being told.
+export const UpdateArtifactBodySchema = t.Object({
+  upload: t.Union([t.Literal('complete'), t.Literal('failed')]),
 });
 
 export const ListArtifactsResponseSchema = t.Object({

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -13,6 +13,7 @@ import {
 import { UnauthorizedError } from '#lib/errors.ts';
 import type { AgentRepositoryContract } from '#repositories/agent.repository.ts';
 import type { AppsService } from '#services/apps.service.ts';
+import type { ArtifactsService } from '#services/artifacts.service.ts';
 import type { DeploymentsService } from '#services/deployments.service.ts';
 import type { ExportsService } from '#services/exports.service.ts';
 import { Service } from '#services/service.ts';
@@ -21,28 +22,35 @@ const MS_PER_SECOND = 1000;
 const SECONDS_PER_HOUR = 60 * 60;
 const SESSION_LIFETIME_MS = SECONDS_PER_HOUR * MS_PER_SECOND;
 
+/** What a report is borrowed for, and nothing else artifacts can do. */
+export type UploadSweep = Pick<ArtifactsService, 'sweepAbandoned'>;
+
 export class AgentService extends Service {
   private readonly agentRepo: AgentRepositoryContract;
   private readonly deploymentsService: DeploymentsService;
   private readonly appsService: AppsService;
   private readonly exportsService: ExportsService;
+  private readonly artifactsService: UploadSweep;
 
   constructor({
     agentRepo,
     deploymentsService,
     appsService,
     exportsService,
+    artifactsService,
   }: {
     agentRepo: AgentRepositoryContract;
     deploymentsService: DeploymentsService;
     appsService: AppsService;
     exportsService: ExportsService;
+    artifactsService: UploadSweep;
   }) {
     super();
     this.agentRepo = agentRepo;
     this.deploymentsService = deploymentsService;
     this.appsService = appsService;
     this.exportsService = exportsService;
+    this.artifactsService = artifactsService;
   }
 
   /**
@@ -115,5 +123,8 @@ export class AgentService extends Service {
     // filesystem is gone — and `completeDeletions` above is where this report says so.
     await this.appsService.finishDeletions();
     await this.appsService.purgeDeleted();
+    // Nothing to do with this report. A report is simply the clock this process has, and an
+    // upload nobody ever came back about is work that needs one.
+    await this.artifactsService.sweepAbandoned();
   }
 }

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -16,7 +16,6 @@ import type {
   AppsRepositoryContract,
 } from '#repositories/apps.repository.ts';
 import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
-import type { ExportStorageRepositoryContract } from '#repositories/export-storage.repository.ts';
 import type { ExportsRepositoryContract } from '#repositories/exports.repository.ts';
 import { Service } from '#services/service.ts';
 
@@ -37,6 +36,13 @@ const MAX_SLUG_ATTEMPTS = 5;
 /** What deleting an app needs from the exports it leaves behind, and nothing else. */
 export type ExportCancellation = Pick<ExportsRepositoryContract, 'failInFlight'>;
 
+/**
+ * Likewise for the buckets: purging only ever takes objects out of them. Narrowed so that a
+ * service holding the whole of one — able to sign an upload, or read a tenant's binary back —
+ * is not what a reader has to rule out here.
+ */
+export type ObjectRemoval = Pick<ArtifactStorageRepositoryContract, 'remove'>;
+
 const APP_DELETED = 'The app was deleted while this export was still being written.';
 
 /**
@@ -55,8 +61,8 @@ const FINISH_BATCH = 8;
 export class AppsService extends Service {
   private readonly appsRepo: AppsRepositoryContract;
   private readonly exportsRepo: ExportCancellation;
-  private readonly artifactStorageRepo: ArtifactStorageRepositoryContract;
-  private readonly exportStorageRepo: ExportStorageRepositoryContract;
+  private readonly artifactStorageRepo: ObjectRemoval;
+  private readonly exportStorageRepo: ObjectRemoval;
   private readonly appHostDomain: string;
 
   constructor({
@@ -68,8 +74,8 @@ export class AppsService extends Service {
   }: {
     appsRepo: AppsRepositoryContract;
     exportsRepo: ExportCancellation;
-    artifactStorageRepo: ArtifactStorageRepositoryContract;
-    exportStorageRepo: ExportStorageRepositoryContract;
+    artifactStorageRepo: ObjectRemoval;
+    exportStorageRepo: ObjectRemoval;
     appHostDomain: string;
   }) {
     super();

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -12,10 +12,7 @@ import { inspectArtifact } from '#lib/artifact-digest.ts';
 import { BadRequestError, NotFoundError } from '#lib/errors.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
 import type { AppsRepositoryContract } from '#repositories/apps.repository.ts';
-import type {
-  ArtifactStorageRepositoryContract,
-  SignedUpload,
-} from '#repositories/artifact-storage.repository.ts';
+import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
 import type {
   ArtifactRow,
   ArtifactsRepositoryContract,
@@ -36,10 +33,11 @@ const MAX_ARTIFACT_MEBIBYTES = 256;
 /**
  * What a host has to pull before a tenant can start, and what this api has to read back to hash.
  *
- * Said three times over, each catching what the one before it cannot: to the caller before a byte
- * moves, so an oversized binary costs a request; to the store in the upload policy, which is the
- * only one that can refuse the bytes as they arrive; and here again while hashing, because the
- * store is not this api and a bucket that let something through is not an argument for storing it.
+ * Refused here before a byte moves, which is also what bounds the signature: an upload is signed
+ * for exactly the size it declared, so a binary larger than this cannot be declared and a body
+ * larger than the declaration is not the request that was signed. Checked once more while hashing,
+ * because the store is not this api and a bucket that let something through is not an argument for
+ * storing it.
  */
 export const MAX_ARTIFACT_SIZE_BYTES = MAX_ARTIFACT_MEBIBYTES * BYTES_PER_MEBIBYTE;
 const TOO_LARGE = `A binary may be at most ${MAX_ARTIFACT_MEBIBYTES} MB.`;
@@ -58,8 +56,9 @@ const UPLOAD_PREFIX = 'uploads';
 
 export type AppOwnership = Pick<AppsRepositoryContract, 'isOwnedBy'>;
 
-export type ArtifactUpload = SignedUpload & {
+export type ArtifactUpload = {
   artifactId: ArtifactId;
+  url: string;
 };
 
 function toArtifact(row: ArtifactRow): Artifact {
@@ -132,12 +131,12 @@ export class ArtifactsService extends Service {
       throw new NotFoundError(NO_SUCH_APP);
     }
 
-    const upload = await this.storageRepo.signUpload({
+    const url = await this.storageRepo.signUpload({
       objectKey: stagingKey({ appId, artifactId: pending.id }),
-      maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES,
+      sizeBytes,
     });
 
-    return { artifactId: pending.id, ...upload };
+    return { artifactId: pending.id, url };
   }
 
   /**

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -3,16 +3,19 @@ import {
   type Artifact,
   type ArtifactId,
   type Filename,
-  FilenameSchema,
+  type ObjectKey,
+  ObjectKeySchema,
   type OwnerId,
   Value,
 } from '@repo/protocol';
-import { identifyArtifact } from '#lib/artifact-digest.ts';
-import { isElfExecutable } from '#lib/elf.ts';
+import { inspectArtifact } from '#lib/artifact-digest.ts';
 import { BadRequestError, NotFoundError } from '#lib/errors.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
 import type { AppsRepositoryContract } from '#repositories/apps.repository.ts';
-import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
+import type {
+  ArtifactStorageRepositoryContract,
+  SignedUpload,
+} from '#repositories/artifact-storage.repository.ts';
 import type {
   ArtifactRow,
   ArtifactsRepositoryContract,
@@ -23,20 +26,41 @@ import { Service } from '#services/service.ts';
 // 403 confirms the app to a stranger.
 const NO_SUCH_APP = 'App not found.';
 const NO_SUCH_ARTIFACT = 'Artifact not found.';
+const NO_SUCH_UPLOAD = 'No upload is awaiting that artifact.';
+const NOTHING_UPLOADED = 'Nothing was uploaded against that artifact.';
 const NOT_AN_EXECUTABLE = 'The artifact is not a Linux executable.';
-const NOT_A_FILENAME = 'The uploaded file must be named as a single path segment.';
+
+const BYTES_PER_MEBIBYTE = 1_048_576;
+const MAX_ARTIFACT_MEBIBYTES = 256;
+
+/**
+ * What a host has to pull before a tenant can start, and what this api has to read back to hash.
+ *
+ * Said three times over, each catching what the one before it cannot: to the caller before a byte
+ * moves, so an oversized binary costs a request; to the store in the upload policy, which is the
+ * only one that can refuse the bytes as they arrive; and here again while hashing, because the
+ * store is not this api and a bucket that let something through is not an argument for storing it.
+ */
+export const MAX_ARTIFACT_SIZE_BYTES = MAX_ARTIFACT_MEBIBYTES * BYTES_PER_MEBIBYTE;
+const TOO_LARGE = `A binary may be at most ${MAX_ARTIFACT_MEBIBYTES} MB.`;
+
+/**
+ * Long enough that no upload is still on its way to a row this old — the signed policy expires
+ * far sooner — and no longer than the bucket rule that expires the staged object, so a row and
+ * the bytes it was waiting for are not left outliving each other.
+ */
+const ABANDONED_AFTER_SECONDS = 86_400;
+
+// One slot per upload, under the app it belongs to. The app is in the key so that a signed policy
+// can only ever be spent inside the app whose ownership was checked to obtain it, and the
+// artifact's own id is in it so that two uploads never write over each other.
+const UPLOAD_PREFIX = 'uploads';
 
 export type AppOwnership = Pick<AppsRepositoryContract, 'isOwnedBy'>;
 
-// A host writes this name into an export archive, so a browser-supplied one that is not a
-// single path segment has to be refused here rather than sanitised into something else.
-function asFilename(name: string): Filename {
-  try {
-    return Value.Parse(FilenameSchema, name);
-  } catch {
-    throw new BadRequestError(NOT_A_FILENAME);
-  }
-}
+export type ArtifactUpload = SignedUpload & {
+  artifactId: ArtifactId;
+};
 
 function toArtifact(row: ArtifactRow): Artifact {
   return {
@@ -71,51 +95,151 @@ export class ArtifactsService extends Service {
   }
 
   /**
-   * The row is written last, so an artifact that exists is one whose bytes are readable —
-   * there is no state to consult and no way to name an object that was never stored.
+   * Begin an artifact: a row with nothing the bytes decide, and somewhere to put them.
    *
-   * Ownership is asked before the upload only so that an app the caller does not own costs a
-   * rejected request instead of the bytes; the insert carries the same predicate and is what
-   * actually decides.
+   * The row comes first because it is what the upload is addressed by — there is no second
+   * identifier for a binary on its way in, and inventing one would be a name for the same thing.
+   * What the bytes decide stays absent until they are read, so nothing here is the uploader's
+   * word about its own upload.
+   *
+   * The declared size is refused before anything is signed, so a binary over the limit costs a
+   * request rather than the upload; the policy is what holds the upload to it afterwards.
    */
   async create({
     appId,
     ownerId,
-    binary,
+    filename,
+    sizeBytes,
   }: {
     appId: AppId;
     ownerId: OwnerId;
-    binary: File;
-  }): Promise<Artifact> {
+    filename: Filename;
+    sizeBytes: number;
+  }): Promise<ArtifactUpload> {
     if (!(await this.appsRepo.isOwnedBy({ appId, ownerId }))) {
       throw new NotFoundError(NO_SUCH_APP);
     }
-
-    const originalFileName = asFilename(binary.name);
-
-    const bytes = new Uint8Array(await binary.arrayBuffer());
-    if (!isElfExecutable(bytes)) {
-      throw new BadRequestError(NOT_AN_EXECUTABLE);
+    if (sizeBytes > MAX_ARTIFACT_SIZE_BYTES) {
+      throw new BadRequestError(TOO_LARGE);
     }
 
-    const identity = identifyArtifact(bytes);
-
-    // Content-addressed, so an object already under this key is these bytes: re-uploading it
-    // would spend the bandwidth to write what is already there.
-    if (!(await this.storageRepo.exists({ objectKey: identity.objectKey }))) {
-      await this.storageRepo.put({ objectKey: identity.objectKey, bytes });
-    }
-
-    const stored = await this.artifactsRepo.insert({
+    const pending = await this.artifactsRepo.insertPending({
       appId,
       ownerId,
-      originalFileName,
-      ...identity,
+      originalFileName: filename,
     });
-    if (!stored) {
+    if (!pending) {
       throw new NotFoundError(NO_SUCH_APP);
     }
+
+    const upload = await this.storageRepo.signUpload({
+      objectKey: stagingKey({ appId, artifactId: pending.id }),
+      maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES,
+    });
+
+    return { artifactId: pending.id, ...upload };
+  }
+
+  /**
+   * Take the caller's word that the bytes are there, and nothing else about them.
+   *
+   * They are read back and hashed rather than trusted, because the digest is what a host verifies
+   * before it will run one: a wrong digest accepted here becomes a deployment that never
+   * converges, which is the failure this end exists to turn into a rejected request.
+   *
+   * That read is also what keeps the content-addressed namespace honest. Only this process writes
+   * it, and only from bytes it has just hashed — so a key already there is bytes that were
+   * verified on their way in, and copying them again would spend the bandwidth to write what is
+   * already stored.
+   *
+   * The digest is written last, and writing it is what makes the row an artifact.
+   */
+  async completeUpload({
+    appId,
+    ownerId,
+    artifactId,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    artifactId: ArtifactId;
+  }): Promise<Artifact> {
+    const pending = await this.artifactsRepo.findPending({ appId, artifactId, ownerId });
+    if (!pending) {
+      throw new NotFoundError(NO_SUCH_UPLOAD);
+    }
+
+    const staged = stagingKey({ appId, artifactId });
+    if (!(await this.storageRepo.exists({ objectKey: staged }))) {
+      throw new BadRequestError(NOTHING_UPLOADED);
+    }
+
+    const inspection = await inspectArtifact({
+      stream: this.storageRepo.read({ objectKey: staged }),
+      maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES,
+    });
+    if (inspection.outcome !== 'stored') {
+      await this.abandon({ appId, artifactId, ownerId });
+      throw new BadRequestError(inspection.outcome === 'too-large' ? TOO_LARGE : NOT_AN_EXECUTABLE);
+    }
+
+    const { digest, sizeBytes, objectKey } = inspection;
+    if (!(await this.storageRepo.exists({ objectKey }))) {
+      await this.storageRepo.copy({ from: staged, to: objectKey });
+    }
+
+    const stored = await this.artifactsRepo.complete({
+      appId,
+      artifactId,
+      ownerId,
+      digest,
+      sizeBytes,
+      objectKey,
+    });
+    if (!stored) {
+      throw new NotFoundError(NO_SUCH_UPLOAD);
+    }
+
+    await this.discard({ objectKey: staged });
+
     return toArtifact(stored);
+  }
+
+  /**
+   * The caller says the upload will not be coming. Taken at face value: they are the only one who
+   * knows, and the row is theirs — so it goes now rather than waiting a day to be swept.
+   */
+  async failUpload({
+    appId,
+    ownerId,
+    artifactId,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    artifactId: ArtifactId;
+  }): Promise<void> {
+    const pending = await this.artifactsRepo.findPending({ appId, artifactId, ownerId });
+    if (!pending) {
+      throw new NotFoundError(NO_SUCH_UPLOAD);
+    }
+    await this.abandon({ appId, artifactId, ownerId });
+  }
+
+  /**
+   * Uploads nobody ever came back about. Driven off the rows still waiting rather than off the
+   * moment one was signed, so a pass that fails part way is retried by the next one finding the
+   * same rows — and rows left by anything that happened before this existed are swept too.
+   *
+   * Objects before rows, as everywhere else: a row removed first leaves bytes nothing names.
+   */
+  async sweepAbandoned(): Promise<void> {
+    const abandoned = await this.artifactsRepo.listAbandoned({
+      olderThanSeconds: ABANDONED_AFTER_SECONDS,
+    });
+    for (const row of abandoned) {
+      await this.discard({ objectKey: stagingKey({ appId: row.app_id, artifactId: row.id }) });
+      await this.artifactsRepo.removeAbandoned({ artifactId: row.id });
+      this.logger.info('abandoned upload swept', { appId: row.app_id, artifactId: row.id });
+    }
   }
 
   async list({ appId, ownerId }: { appId: AppId; ownerId: OwnerId }): Promise<Artifact[]> {
@@ -138,4 +262,34 @@ export class ArtifactsService extends Service {
     }
     return toArtifact(row);
   }
+
+  private async abandon({
+    appId,
+    artifactId,
+    ownerId,
+  }: {
+    appId: AppId;
+    artifactId: ArtifactId;
+    ownerId: OwnerId;
+  }): Promise<void> {
+    await this.discard({ objectKey: stagingKey({ appId, artifactId }) });
+    await this.artifactsRepo.remove({ appId, artifactId, ownerId });
+  }
+
+  /**
+   * A staging slot is spent either way, and the bucket's own expiry is what guarantees it goes.
+   * Failing the request over it would report an upload that did not happen — the artifact is
+   * stored and the row is written — so this is logged and left to the rule.
+   */
+  private async discard({ objectKey }: { objectKey: ObjectKey }): Promise<void> {
+    try {
+      await this.storageRepo.remove({ objectKey });
+    } catch (error) {
+      this.logger.warn('a staged upload could not be removed', { objectKey, error });
+    }
+  }
+}
+
+function stagingKey({ appId, artifactId }: { appId: AppId; artifactId: ArtifactId }): ObjectKey {
+  return Value.Parse(ObjectKeySchema, `${UPLOAD_PREFIX}/${appId}/${artifactId}`);
 }

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -2,7 +2,7 @@ import { Elysia } from 'elysia';
 import { sql } from '#db/client.ts';
 import { env } from '#lib/env.ts';
 import { createLogger } from '#lib/logger.ts';
-import { artifactsPolicySigner, artifactsS3, exportsS3 } from '#lib/s3/client.ts';
+import { artifactsS3, artifactsSigner, exportsS3 } from '#lib/s3/client.ts';
 import { VictoriaLogsClient } from '#lib/victorialogs/client.ts';
 import { AgentRepository } from '#repositories/agent.repository.ts';
 import { AppsRepository } from '#repositories/apps.repository.ts';
@@ -32,7 +32,7 @@ const artifactsRepository = new ArtifactsRepository(sql);
 const deploymentsRepository = new DeploymentsRepository(sql);
 const artifactStorageRepository = new ArtifactStorageRepository({
   client: artifactsS3,
-  policySigner: artifactsPolicySigner,
+  signer: artifactsSigner,
   bucket: env.ARTIFACTS_BUCKET,
 });
 const exportsRepository = new ExportsRepository(sql);

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -2,7 +2,7 @@ import { Elysia } from 'elysia';
 import { sql } from '#db/client.ts';
 import { env } from '#lib/env.ts';
 import { createLogger } from '#lib/logger.ts';
-import { artifactsS3, exportsS3 } from '#lib/s3/client.ts';
+import { artifactsPolicySigner, artifactsS3, exportsS3 } from '#lib/s3/client.ts';
 import { VictoriaLogsClient } from '#lib/victorialogs/client.ts';
 import { AgentRepository } from '#repositories/agent.repository.ts';
 import { AppsRepository } from '#repositories/apps.repository.ts';
@@ -30,7 +30,11 @@ const healthRepository = new HealthRepository(sql);
 const appsRepository = new AppsRepository(sql);
 const artifactsRepository = new ArtifactsRepository(sql);
 const deploymentsRepository = new DeploymentsRepository(sql);
-const artifactStorageRepository = new ArtifactStorageRepository(artifactsS3);
+const artifactStorageRepository = new ArtifactStorageRepository({
+  client: artifactsS3,
+  policySigner: artifactsPolicySigner,
+  bucket: env.ARTIFACTS_BUCKET,
+});
 const exportsRepository = new ExportsRepository(sql);
 const exportStorageRepository = new ExportStorageRepository(exportsS3);
 const logsRepository = new LogsRepository(new VictoriaLogsClient(env.VICTORIALOGS_ENDPOINT));
@@ -49,12 +53,7 @@ const exportsService = new ExportsService({
   appsRepo: appsRepository,
   retentionDays: env.EXPORT_RETENTION_DAYS,
 });
-const agentService = new AgentService({
-  agentRepo: agentRepository,
-  deploymentsService,
-  appsService,
-  exportsService,
-});
+
 const assetsService = new AssetsService(assetsRepository);
 const healthService = new HealthService(healthRepository);
 const filesystemService = new FilesystemService({ deploymentsRepo: deploymentsRepository });
@@ -62,6 +61,13 @@ const artifactsService = new ArtifactsService({
   artifactsRepo: artifactsRepository,
   storageRepo: artifactStorageRepository,
   appsRepo: appsRepository,
+});
+const agentService = new AgentService({
+  agentRepo: agentRepository,
+  deploymentsService,
+  appsService,
+  exportsService,
+  artifactsService,
 });
 const logsService = new LogsService({
   logsRepo: logsRepository,

--- a/apps/api/tests/controllers/artifacts.test.ts
+++ b/apps/api/tests/controllers/artifacts.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, test } from 'bun:test';
 import { StatusMap } from 'elysia';
-import { ORIGIN, send } from '#tests/controllers/support/api.ts';
+import { ORIGIN, send, sendJson } from '#tests/controllers/support/api.ts';
 
 const APP_ID = '0199c0de-0000-7000-8000-000000000001';
 const ARTIFACT_ID = '0199c0de-0000-7000-8000-000000000002';
 const ARTIFACTS_URL = `${ORIGIN}/api/apps/${APP_ID}/artifacts`;
 
-function upload(body: FormData) {
-  return send({ method: 'POST', url: ARTIFACTS_URL, body });
+function create(body: unknown) {
+  return sendJson({ method: 'POST', url: ARTIFACTS_URL, body });
+}
+
+function report(body: unknown) {
+  return sendJson({ method: 'PATCH', url: `${ARTIFACTS_URL}/${ARTIFACT_ID}`, body });
 }
 
 // Nothing here presents a session: better-auth needs a database and this suite has none. What
@@ -24,16 +28,40 @@ describe('an app is not somewhere strangers can read from or write to', () => {
     expect(response.status).toBe(StatusMap.Unauthorized);
   });
 
-  test('uploading an artifact requires a session', async () => {
-    const form = new FormData();
-    form.set('binary', new Blob([new TextEncoder().encode('#!/bin/true')]), 'server');
+  test('being given somewhere to upload requires a session', async () => {
+    const response = await create({ filename: 'server', sizeBytes: 1 });
 
-    expect((await upload(form)).status).toBe(StatusMap.Unauthorized);
+    expect(response.status).toBe(StatusMap.Unauthorized);
   });
 
-  // Body validation runs ahead of the session check, so this one answers 400 rather than 401 —
-  // it says nothing about the app, only that the request was never an upload.
-  test('a request carrying no binary is not an upload', async () => {
-    expect((await upload(new FormData())).status).toBe(StatusMap['Bad Request']);
+  test('saying how an upload went requires a session', async () => {
+    expect((await report({ upload: 'complete' })).status).toBe(StatusMap.Unauthorized);
+  });
+});
+
+// Body validation runs ahead of the session check, so these answer 400 rather than 401 — they
+// say nothing about the app, only that the request was never what it claimed.
+describe('a request that could not name a binary is not one', () => {
+  test('asking for somewhere to upload without saying what or how large is not asking', async () => {
+    expect((await create({})).status).toBe(StatusMap['Bad Request']);
+  });
+
+  test('a size that is not a size is not one', async () => {
+    const response = await create({ filename: 'server', sizeBytes: 'large' });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
+  // The name is written into an export archive, so one carrying a path is refused at the edge
+  // rather than sanitised into a different name.
+  test('a filename that is a path is not a filename', async () => {
+    const response = await create({ filename: '../../etc/passwd', sizeBytes: 1 });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
+  test('an upload went one of two ways, and nothing else is an answer', async () => {
+    expect((await report({ upload: 'probably' })).status).toBe(StatusMap['Bad Request']);
+    expect((await report({})).status).toBe(StatusMap['Bad Request']);
   });
 });

--- a/apps/api/tests/lib/artifact-digest.test.ts
+++ b/apps/api/tests/lib/artifact-digest.test.ts
@@ -1,59 +1,149 @@
 import { describe, expect, test } from 'bun:test';
 import { isValidMessage, ObjectKeySchema, Sha256DigestSchema, Value } from '@repo/protocol';
-import { identifyArtifact } from '#lib/artifact-digest.ts';
+import { type ArtifactInspection, inspectArtifact } from '#lib/artifact-digest.ts';
 
-// From the SHA-256 test vectors: the digest of the empty input and of "abc".
-const EMPTY_DIGEST = Value.Parse(
+// The api refuses anything that is not a Linux executable, so every fixture that is meant to be
+// read to the end opens with the ELF magic the way a real upload does.
+const BINARY = '\x7fELFnibrun-test-binary';
+const OTHER_BINARY = '\x7fELFnibrun-other-binary';
+
+const BINARY_DIGEST = Value.Parse(
   Sha256DigestSchema,
-  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-);
-const ABC_DIGEST = Value.Parse(
-  Sha256DigestSchema,
-  'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+  'd9403d88cdf0684fbb9d8e97cf3508e9fb4506cf309a34e42653a1c2bc04a298',
 );
 
-// One character, two bytes — which is the whole point of the size test below.
-const MULTI_BYTE_CHARACTER = 'é';
-const MULTI_BYTE_CHARACTER_SIZE = 2;
+// Larger than anything here, so a test only meets the limit when it is the limit being tested.
+const NO_LIMIT = 1024;
 
 function bytesOf(text: string): Uint8Array {
-  return new TextEncoder().encode(text);
+  return Uint8Array.from(text, (character) => character.charCodeAt(0));
+}
+
+/**
+ * Counts what was pulled, because half of what this reads is how much it declines to read.
+ *
+ * Nothing is queued ahead of a read, so a chunk in `delivered` is one the inspection asked for
+ * rather than one a buffer helped itself to.
+ */
+function streamOf(chunks: Uint8Array[]) {
+  const delivered: Uint8Array[] = [];
+  let index = 0;
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        const chunk = chunks[index++];
+        if (chunk === undefined) {
+          controller.close();
+          return;
+        }
+        delivered.push(chunk);
+        controller.enqueue(chunk);
+      },
+    },
+    { highWaterMark: 0 },
+  );
+  return { stream, delivered };
+}
+
+function inspect({
+  text,
+  maxSizeBytes = NO_LIMIT,
+}: {
+  text: string;
+  maxSizeBytes?: number;
+}): Promise<ArtifactInspection> {
+  return inspectArtifact({ stream: streamOf([bytesOf(text)]).stream, maxSizeBytes });
+}
+
+async function identityOf(text: string) {
+  const inspection = await inspect({ text });
+  if (inspection.outcome !== 'stored') {
+    throw new Error(`expected ${text} to be storable, got ${inspection.outcome}`);
+  }
+  return inspection;
 }
 
 describe('an artifact is identified by what was stored, not by what was claimed', () => {
-  test('the digest is the SHA-256 of the bytes', () => {
-    expect(identifyArtifact(bytesOf('abc')).digest).toBe(ABC_DIGEST);
-    expect(identifyArtifact(new Uint8Array()).digest).toBe(EMPTY_DIGEST);
+  test('the digest is the SHA-256 of the bytes', async () => {
+    expect((await identityOf(BINARY)).digest).toBe(BINARY_DIGEST);
   });
 
-  test('the size is the byte length, not the character count', () => {
-    expect(identifyArtifact(bytesOf(MULTI_BYTE_CHARACTER)).sizeBytes).toBe(
-      MULTI_BYTE_CHARACTER_SIZE,
+  test('the size is the byte length', async () => {
+    expect((await identityOf(BINARY)).sizeBytes).toBe(BINARY.length);
+  });
+
+  test('the same bytes always land on the same object key', async () => {
+    expect((await identityOf(BINARY)).objectKey).toBe((await identityOf(BINARY)).objectKey);
+  });
+
+  test('bytes that differ anywhere land somewhere else', async () => {
+    expect((await identityOf(BINARY)).objectKey).not.toBe(
+      (await identityOf(OTHER_BINARY)).objectKey,
     );
   });
 
-  test('the same bytes always land on the same object key', () => {
-    expect(identifyArtifact(bytesOf('abc')).objectKey).toBe(
-      identifyArtifact(bytesOf('abc')).objectKey,
-    );
+  test('the key names the digest, so a future algorithm cannot alias this object', async () => {
+    expect((await identityOf(BINARY)).objectKey).toBe(Value.Parse(ObjectKeySchema, BINARY_DIGEST));
   });
 
-  test('bytes that differ anywhere land somewhere else', () => {
-    expect(identifyArtifact(bytesOf('abc')).objectKey).not.toBe(
-      identifyArtifact(bytesOf('abd')).objectKey,
-    );
-  });
-
-  test('the key names the digest algorithm, so a future one cannot alias this object', () => {
-    expect(identifyArtifact(bytesOf('abc')).objectKey).toBe(
-      Value.Parse(ObjectKeySchema, ABC_DIGEST),
-    );
-  });
-
-  test('the identity satisfies the schemas the agent will read it back through', () => {
-    const { digest, objectKey } = identifyArtifact(bytesOf('abc'));
+  test('the identity satisfies the schemas the agent will read it back through', async () => {
+    const { digest, objectKey } = await identityOf(BINARY);
 
     expect(isValidMessage({ schema: Sha256DigestSchema, value: digest })).toBe(true);
     expect(isValidMessage({ schema: ObjectKeySchema, value: objectKey })).toBe(true);
+  });
+
+  // The object arrives in whatever pieces the store sends it in, and none of them are the
+  // boundaries of anything this reads: the magic alone can span two.
+  test('where the chunks fall makes no difference to any of it', async () => {
+    const split = streamOf([...bytesOf(BINARY)].map((byte) => Uint8Array.of(byte)));
+
+    const inspection = await inspectArtifact({ stream: split.stream, maxSizeBytes: NO_LIMIT });
+
+    expect(inspection).toEqual(await identityOf(BINARY));
+  });
+});
+
+describe('what the guest could never exec is not read to the end', () => {
+  test('an upload that is not a Linux executable is refused', async () => {
+    expect(await inspect({ text: '#!/bin/sh' })).toEqual({ outcome: 'not-executable' });
+  });
+
+  // Nothing to compare against is not something to wave through: the loop reaches no verdict on
+  // a stream this short, so the decision is the one made after it.
+  test('an upload shorter than the magic is refused', async () => {
+    expect(await inspect({ text: '\x7fEL' })).toEqual({ outcome: 'not-executable' });
+  });
+
+  test('the rest of it is never pulled', async () => {
+    const chunks = [bytesOf('#!/bin/sh'), bytesOf('and a great deal more')];
+    const { stream, delivered } = streamOf(chunks);
+
+    await inspectArtifact({ stream, maxSizeBytes: NO_LIMIT });
+
+    expect(delivered).toEqual([chunks[0] as Uint8Array]);
+  });
+});
+
+describe('a size the store accepted is still a size this api will not', () => {
+  // The store takes whatever it is handed, so a caller that declared one size and sent another
+  // is caught here or not at all.
+  test('an object past the limit is refused however large it turned out to be', async () => {
+    expect(await inspect({ text: BINARY, maxSizeBytes: BINARY.length - 1 })).toEqual({
+      outcome: 'too-large',
+    });
+  });
+
+  test('one exactly at the limit is stored', async () => {
+    expect((await inspect({ text: BINARY, maxSizeBytes: BINARY.length })).outcome).toBe('stored');
+  });
+
+  test('the rest of it is never pulled', async () => {
+    const chunks = [bytesOf(BINARY), bytesOf('and a great deal more')];
+    const { stream, delivered } = streamOf(chunks);
+
+    await inspectArtifact({ stream, maxSizeBytes: BINARY.length - 1 });
+
+    expect(delivered).toEqual([chunks[0] as Uint8Array]);
   });
 });

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@repo/protocol';
 import { UnauthorizedError } from '#lib/errors.ts';
 import type { AgentRepositoryContract } from '#repositories/agent.repository.ts';
-import { AgentService } from '#services/agent.service.ts';
+import { AgentService, type UploadSweep } from '#services/agent.service.ts';
 import type { AppsService } from '#services/apps.service.ts';
 import type { DeploymentsService } from '#services/deployments.service.ts';
 import type { ExportsService } from '#services/exports.service.ts';
@@ -89,19 +89,32 @@ class FakeExportsService {
   }
 }
 
+/** A report is the only clock this process has, so the sweep rides along on one. */
+class FakeUploadSweep implements UploadSweep {
+  swept = 0;
+
+  sweepAbandoned(): Promise<void> {
+    this.swept += 1;
+    return Promise.resolve();
+  }
+}
+
 function build() {
   const deployments = new FakeDeploymentsService();
   const apps = new FakeAppsService();
   const exports = new FakeExportsService();
+  const artifacts = new FakeUploadSweep();
   return {
     apps,
     deployments,
     exports,
+    artifacts,
     service: new AgentService({
       agentRepo: new FakeAgentRepository(),
       deploymentsService: deployments as unknown as DeploymentsService,
       appsService: apps as unknown as AppsService,
       exportsService: exports as unknown as ExportsService,
+      artifactsService: artifacts,
     }),
   };
 }

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -25,9 +25,11 @@ import type {
   Leftovers,
   OwnedAppHostnameRow,
 } from '#repositories/apps.repository.ts';
-import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
-import type { ExportStorageRepositoryContract } from '#repositories/export-storage.repository.ts';
-import { AppsService, type ExportCancellation } from '#services/apps.service.ts';
+import {
+  AppsService,
+  type ExportCancellation,
+  type ObjectRemoval,
+} from '#services/apps.service.ts';
 import {
   APP_HOST_DOMAIN,
   APP_ID,
@@ -222,22 +224,6 @@ class StubObjectStorage {
   }
 }
 
-class StubArtifactStorage extends StubObjectStorage implements ArtifactStorageRepositoryContract {
-  put(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-}
-
-class StubExportStorage extends StubObjectStorage implements ExportStorageRepositoryContract {
-  signDownload(): string {
-    return '';
-  }
-}
-
 function objectKey(key: string): ObjectKey {
   return Value.Parse(ObjectKeySchema, key);
 }
@@ -257,13 +243,13 @@ class StubExportCancellation implements ExportCancellation {
 function serviceWith({
   appsRepo,
   exportsRepo = new StubExportCancellation(),
-  artifactStorageRepo = new StubArtifactStorage({ trace: [] }),
-  exportStorageRepo = new StubExportStorage({ trace: [] }),
+  artifactStorageRepo = new StubObjectStorage({ trace: [] }),
+  exportStorageRepo = new StubObjectStorage({ trace: [] }),
 }: {
   appsRepo: AppsRepositoryContract;
   exportsRepo?: ExportCancellation;
-  artifactStorageRepo?: ArtifactStorageRepositoryContract;
-  exportStorageRepo?: ExportStorageRepositoryContract;
+  artifactStorageRepo?: ObjectRemoval;
+  exportStorageRepo?: ObjectRemoval;
 }) {
   return new AppsService({
     appsRepo,
@@ -510,8 +496,8 @@ function purgeableApp({
 describe('what a deleted app leaves behind is removed after it', () => {
   test('the binaries and the bundles both go', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
-    const artifacts = new StubArtifactStorage({ trace: appsRepo.trace });
-    const exports = new StubExportStorage({ trace: appsRepo.trace });
+    const artifacts = new StubObjectStorage({ trace: appsRepo.trace });
+    const exports = new StubObjectStorage({ trace: appsRepo.trace });
     purgeableApp({
       appsRepo,
       appId: APP_ID,
@@ -532,8 +518,8 @@ describe('what a deleted app leaves behind is removed after it', () => {
   // work the next pass reads again. Only one of those two orders is recoverable.
   test('every object goes before the rows naming it', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
-    const artifacts = new StubArtifactStorage({ trace: appsRepo.trace });
-    const exports = new StubExportStorage({ trace: appsRepo.trace });
+    const artifacts = new StubObjectStorage({ trace: appsRepo.trace });
+    const exports = new StubObjectStorage({ trace: appsRepo.trace });
     purgeableApp({
       appsRepo,
       appId: APP_ID,
@@ -573,7 +559,7 @@ describe('what a deleted app leaves behind is removed after it', () => {
 describe('a purge that cannot finish leaves the work to be found again', () => {
   test('a bucket refusing one object keeps the rows that name it', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
-    const artifacts = new StubArtifactStorage({
+    const artifacts = new StubObjectStorage({
       trace: appsRepo.trace,
       refuse: new Set([SOLO_BINARY]),
     });
@@ -593,7 +579,7 @@ describe('a purge that cannot finish leaves the work to be found again', () => {
   // or the apps queued behind the app it failed on.
   test('the app after the one that failed is still purged', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
-    const artifacts = new StubArtifactStorage({
+    const artifacts = new StubObjectStorage({
       trace: appsRepo.trace,
       refuse: new Set([SOLO_BINARY]),
     });

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -4,6 +4,7 @@ import {
   type ArtifactId,
   ArtifactIdSchema,
   ArtifactSchema,
+  type Filename,
   FilenameSchema,
   isValidMessage,
   type ObjectKey,
@@ -14,68 +15,180 @@ import {
   Value,
 } from '@repo/protocol';
 import { BadRequestError, NotFoundError } from '#lib/errors.ts';
-import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
 import type {
+  ArtifactStorageRepositoryContract,
+  SignedUpload,
+} from '#repositories/artifact-storage.repository.ts';
+import type {
+  AbandonedArtifactRow,
   ArtifactRow,
   ArtifactsRepositoryContract,
-  InsertArtifactInput,
+  CompleteArtifactInput,
+  PendingArtifactRow,
 } from '#repositories/artifacts.repository.ts';
-import { type AppOwnership, ArtifactsService } from '#services/artifacts.service.ts';
+import {
+  type AppOwnership,
+  ArtifactsService,
+  MAX_ARTIFACT_SIZE_BYTES,
+} from '#services/artifacts.service.ts';
 import { APP_ID, OTHER_OWNER_ID, OWNER_ID } from '#tests/services/support/fixtures.ts';
 
 // The api refuses anything that is not a Linux executable, so the fixture opens with the ELF
 // magic the way a real upload does.
 const BINARY_TEXT = '\x7fELFnibrun-test-binary';
-const UPLOADED_NAME = 'pocketbase';
 const BINARY_DIGEST = 'd9403d88cdf0684fbb9d8e97cf3508e9fb4506cf309a34e42653a1c2bc04a298';
-
-function bytesOf(text: string): Uint8Array {
-  return Uint8Array.from(text, (character) => character.charCodeAt(0));
-}
-
-function binary(name = UPLOADED_NAME): File {
-  return new File([bytesOf(BINARY_TEXT)], name);
-}
+const UPLOADED_NAME = Value.Parse(FilenameSchema, 'pocketbase');
 
 const SEEDED_DIGEST = Value.Parse(Sha256DigestSchema, 'a'.repeat(BINARY_DIGEST.length));
 const SEEDED_SIZE_BYTES = 4096;
 const SEEDED_CREATED_AT = new Date('2026-01-02T03:04:05.000Z');
 
+const A_DAY_SECONDS = 86_400;
+const AN_HOUR_MS = 3_600_000;
+const MS_PER_SECOND = 1_000;
+const PAST_THE_SWEEP_MS = A_DAY_SECONDS * MS_PER_SECOND + AN_HOUR_MS;
+
+function bytesOf(text: string): Uint8Array {
+  return Uint8Array.from(text, (character) => character.charCodeAt(0));
+}
+
+type StoredRow = Omit<ArtifactRow, 'digest' | 'size_bytes' | 'object_key'> & {
+  digest: ArtifactRow['digest'] | null;
+  size_bytes: ArtifactRow['size_bytes'] | null;
+  object_key: ArtifactRow['object_key'] | null;
+};
+
 /**
- * The ownership predicate lives in the SQL, so this fake answers nothing for an owner it was
- * not built for — a fake that resolved rows and left the caller to compare owners afterwards
- * would be testing a repository this service never talks to.
+ * A row is an artifact once it has a digest and an upload still in flight until then, which is
+ * the distinction the SQL draws — so this fake draws it too rather than answering every read the
+ * same way and leaving the service to sort them out.
  */
 class FakeArtifactsRepository implements ArtifactsRepositoryContract {
-  readonly inserted: InsertArtifactInput[] = [];
-  private readonly rows = new Map<ArtifactId, ArtifactRow>();
+  readonly rows = new Map<ArtifactId, StoredRow>();
   private readonly ownedBy: OwnerId;
 
   constructor(ownedBy: OwnerId) {
     this.ownedBy = ownedBy;
   }
 
-  insert(input: InsertArtifactInput): Promise<ArtifactRow | null> {
-    this.inserted.push(input);
-    if (input.ownerId !== this.ownedBy) {
+  insertPending({
+    appId,
+    ownerId,
+    originalFileName,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    originalFileName: Filename;
+  }): Promise<PendingArtifactRow | null> {
+    if (ownerId !== this.ownedBy) {
       return Promise.resolve(null);
     }
+    const row: StoredRow = {
+      id: Value.Parse(ArtifactIdSchema, `artifact-${this.rows.size}`),
+      app_id: appId,
+      digest: null,
+      size_bytes: null,
+      object_key: null,
+      original_file_name: originalFileName,
+      created_at: SEEDED_CREATED_AT,
+    };
+    this.rows.set(row.id, row);
+    return Promise.resolve({
+      id: row.id,
+      app_id: row.app_id,
+      original_file_name: row.original_file_name,
+      created_at: row.created_at,
+    });
+  }
+
+  complete({
+    appId,
+    artifactId,
+    ownerId,
+    digest,
+    sizeBytes,
+    objectKey,
+  }: CompleteArtifactInput): Promise<ArtifactRow | null> {
+    const row = this.rows.get(artifactId);
+    if (!row || row.app_id !== appId || ownerId !== this.ownedBy || row.digest !== null) {
+      return Promise.resolve(null);
+    }
+    const completed: StoredRow = {
+      ...row,
+      digest,
+      size_bytes: String(sizeBytes),
+      object_key: objectKey,
+    };
+    this.rows.set(artifactId, completed);
+    return Promise.resolve(completed as ArtifactRow);
+  }
+
+  remove({
+    appId,
+    artifactId,
+    ownerId,
+  }: {
+    appId: AppId;
+    artifactId: ArtifactId;
+    ownerId: OwnerId;
+  }): Promise<void> {
+    const row = this.rows.get(artifactId);
+    if (row && row.app_id === appId && ownerId === this.ownedBy && row.digest === null) {
+      this.rows.delete(artifactId);
+    }
+    return Promise.resolve();
+  }
+
+  findPending({
+    appId,
+    artifactId,
+    ownerId,
+  }: {
+    appId: AppId;
+    artifactId: ArtifactId;
+    ownerId: OwnerId;
+  }): Promise<PendingArtifactRow | null> {
+    const row = this.rows.get(artifactId);
+    if (!row || row.app_id !== appId || ownerId !== this.ownedBy || row.digest !== null) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve({
+      id: row.id,
+      app_id: row.app_id,
+      original_file_name: row.original_file_name,
+      created_at: row.created_at,
+    });
+  }
+
+  listAbandoned({
+    olderThanSeconds,
+  }: {
+    olderThanSeconds: number;
+  }): Promise<AbandonedArtifactRow[]> {
+    const cutoff = Date.now() - olderThanSeconds * MS_PER_SECOND;
     return Promise.resolve(
-      this.remember({
-        app_id: input.appId,
-        digest: input.digest,
-        size_bytes: String(input.sizeBytes),
-        object_key: input.objectKey,
-        original_file_name: input.originalFileName,
-      }),
+      [...this.rows.values()]
+        .filter((row) => row.digest === null && row.created_at.getTime() < cutoff)
+        .map((row) => ({ id: row.id, app_id: row.app_id })),
     );
+  }
+
+  removeAbandoned({ artifactId }: { artifactId: ArtifactId }): Promise<void> {
+    if (this.rows.get(artifactId)?.digest === null) {
+      this.rows.delete(artifactId);
+    }
+    return Promise.resolve();
   }
 
   listByApp({ appId, ownerId }: { appId: AppId; ownerId: OwnerId }): Promise<ArtifactRow[]> {
     if (ownerId !== this.ownedBy) {
       return Promise.resolve([]);
     }
-    return Promise.resolve([...this.rows.values()].filter((row) => row.app_id === appId));
+    return Promise.resolve(
+      [...this.rows.values()].filter(
+        (row) => row.app_id === appId && row.digest !== null,
+      ) as ArtifactRow[],
+    );
   }
 
   findById({
@@ -88,67 +201,87 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
     ownerId: OwnerId;
   }): Promise<ArtifactRow | null> {
     const row = this.rows.get(artifactId);
-    if (ownerId !== this.ownedBy || row?.app_id !== appId) {
+    if (!row || row.app_id !== appId || ownerId !== this.ownedBy || row.digest === null) {
       return Promise.resolve(null);
     }
-    return Promise.resolve(row);
+    return Promise.resolve(row as ArtifactRow);
   }
 
   seed(): ArtifactRow {
-    return this.remember({
+    const row: StoredRow = {
+      id: Value.Parse(ArtifactIdSchema, `artifact-${this.rows.size}`),
       app_id: APP_ID,
       digest: SEEDED_DIGEST,
       size_bytes: String(SEEDED_SIZE_BYTES),
       object_key: Value.Parse(ObjectKeySchema, SEEDED_DIGEST),
-      original_file_name: Value.Parse(FilenameSchema, UPLOADED_NAME),
-    });
-  }
-
-  private remember(row: Omit<ArtifactRow, 'id' | 'created_at'>): ArtifactRow {
-    const stored: ArtifactRow = {
-      ...row,
-      id: Value.Parse(ArtifactIdSchema, `artifact-${this.rows.size}`),
+      original_file_name: UPLOADED_NAME,
       created_at: SEEDED_CREATED_AT,
     };
-    this.rows.set(stored.id, stored);
-    return stored;
+    this.rows.set(row.id, row);
+    return row as ArtifactRow;
+  }
+
+  age({ artifactId, byMs }: { artifactId: ArtifactId; byMs: number }): void {
+    const row = this.rows.get(artifactId);
+    if (row) {
+      this.rows.set(artifactId, { ...row, created_at: new Date(Date.now() - byMs) });
+    }
   }
 }
 
+const SIGNED_URL = 'https://store.test/nibrun';
+
+/** A bucket as a map, so what a signed policy wrote and what the api copied are both visible. */
 class FakeStorage implements ArtifactStorageRepositoryContract {
-  readonly written: { objectKey: ObjectKey; bytes: Uint8Array }[] = [];
-  #alreadyStored: boolean;
+  readonly objects = new Map<ObjectKey, Uint8Array>();
+  readonly signed: { objectKey: ObjectKey; maxSizeBytes: number }[] = [];
+  readonly copied: { from: ObjectKey; to: ObjectKey }[] = [];
 
-  constructor({ alreadyStored = false }: { alreadyStored?: boolean } = {}) {
-    this.#alreadyStored = alreadyStored;
+  signUpload(input: { objectKey: ObjectKey; maxSizeBytes: number }): Promise<SignedUpload> {
+    this.signed.push(input);
+    return Promise.resolve({ url: SIGNED_URL, fields: { key: input.objectKey } });
   }
 
-  put(input: { objectKey: ObjectKey; bytes: Uint8Array }): Promise<void> {
-    this.written.push(input);
+  read({ objectKey }: { objectKey: ObjectKey }): ReadableStream<Uint8Array> {
+    const bytes = this.objects.get(objectKey);
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (bytes !== undefined) {
+          controller.enqueue(bytes);
+        }
+        controller.close();
+      },
+    });
+  }
+
+  copy({ from, to }: { from: ObjectKey; to: ObjectKey }): Promise<void> {
+    this.copied.push({ from, to });
+    const bytes = this.objects.get(from);
+    if (bytes !== undefined) {
+      this.objects.set(to, bytes);
+    }
     return Promise.resolve();
   }
 
-  exists(): Promise<boolean> {
-    return Promise.resolve(this.#alreadyStored);
+  exists({ objectKey }: { objectKey: ObjectKey }): Promise<boolean> {
+    return Promise.resolve(this.objects.has(objectKey));
   }
 
-  remove(): Promise<void> {
+  remove({ objectKey }: { objectKey: ObjectKey }): Promise<void> {
+    this.objects.delete(objectKey);
     return Promise.resolve();
+  }
+
+  /** Stands in for the caller spending the signed policy. */
+  put({ objectKey, text }: { objectKey: ObjectKey; text: string }): void {
+    this.objects.set(objectKey, bytesOf(text));
   }
 }
 
 const BUCKET_REFUSED = 'the bucket said no';
 
-class RefusingStorage implements ArtifactStorageRepositoryContract {
-  put(): Promise<void> {
-    return Promise.reject(new Error(BUCKET_REFUSED));
-  }
-
-  exists(): Promise<boolean> {
-    return Promise.resolve(false);
-  }
-
-  remove(): Promise<void> {
+class RefusingStorage extends FakeStorage {
+  override copy(): Promise<void> {
     return Promise.reject(new Error(BUCKET_REFUSED));
   }
 }
@@ -157,105 +290,339 @@ const appsRepo: AppOwnership = {
   isOwnedBy: ({ ownerId }) => Promise.resolve(ownerId === OWNER_ID),
 };
 
-function build(storageRepo: ArtifactStorageRepositoryContract = new FakeStorage()) {
+function build(storageRepo: FakeStorage = new FakeStorage()) {
   const artifactsRepo = new FakeArtifactsRepository(OWNER_ID);
   return {
+    storage: storageRepo,
     artifactsRepo,
     service: new ArtifactsService({ artifactsRepo, storageRepo, appsRepo }),
   };
 }
 
-describe('the api records the digest of what it stored', () => {
-  test('the digest is taken from the bytes, and those same bytes are what land', async () => {
-    const storage = new FakeStorage();
-    const { artifactsRepo, service } = build(storage);
+/** Create the artifact, put the bytes where it points, and say so — one deploy's worth. */
+async function upload({
+  service,
+  storage,
+  text = BINARY_TEXT,
+  ownerId = OWNER_ID,
+  filename = UPLOADED_NAME,
+}: {
+  service: ArtifactsService;
+  storage: FakeStorage;
+  text?: string;
+  ownerId?: OwnerId;
+  filename?: Filename;
+}) {
+  const { artifactId } = await service.create({
+    appId: APP_ID,
+    ownerId,
+    filename,
+    sizeBytes: text.length,
+  });
+  storage.put({ objectKey: (storage.signed.at(-1) as { objectKey: ObjectKey }).objectKey, text });
+  return service.completeUpload({ appId: APP_ID, ownerId, artifactId });
+}
 
-    const artifact = await service.create({ appId: APP_ID, ownerId: OWNER_ID, binary: binary() });
+describe('an artifact begins before its bytes do', () => {
+  test('the slot is inside the app it belongs to, so a policy cannot be spent anywhere else', async () => {
+    const { service, storage } = build();
 
-    const [written] = storage.written;
-    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
-    expect(artifactsRepo.inserted[0]?.digest).toBe(artifact.digest);
-    expect(written?.objectKey).toBe(artifact.objectKey);
-    expect(written?.bytes).toEqual(bytesOf(BINARY_TEXT));
-    expect(artifact.sizeBytes).toBe(BINARY_TEXT.length);
+    const { artifactId } = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: BINARY_TEXT.length,
+    });
+
+    expect(storage.signed.at(-1)?.objectKey).toBe(
+      Value.Parse(ObjectKeySchema, `uploads/${APP_ID}/${artifactId}`),
+    );
   });
 
-  test('the key is derived, so two uploads of one binary share the bytes but not the row', async () => {
-    const { service } = build();
+  // The store is the only thing positioned to refuse the bytes as they arrive, and it will only
+  // do it if the size was part of what was signed.
+  test('the policy the store is handed carries the limit', async () => {
+    const { service, storage } = build();
 
-    const first = await service.create({ appId: APP_ID, ownerId: OWNER_ID, binary: binary() });
-    const second = await service.create({ appId: APP_ID, ownerId: OWNER_ID, binary: binary() });
+    await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: BINARY_TEXT.length,
+    });
 
-    expect(second.objectKey).toBe(first.objectKey);
-    expect(second.id).not.toBe(first.id);
+    expect(storage.signed.at(-1)?.maxSizeBytes).toBe(MAX_ARTIFACT_SIZE_BYTES);
   });
 
-  // The declared content type is whatever the uploader typed. Reaching a host with something
-  // the guest cannot exec turns a rejectable upload into a deploy that never converges.
-  test('an upload that is not a Linux executable is refused before anything is written', async () => {
-    const storage = new FakeStorage();
-    const { artifactsRepo, service } = build(storage);
+  test('two uploads of one app never share a slot', async () => {
+    const { service, storage } = build();
+    const input = {
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: BINARY_TEXT.length,
+    };
+
+    const first = await service.create(input);
+    const second = await service.create(input);
+
+    expect(second.artifactId).not.toBe(first.artifactId);
+    expect(new Set(storage.signed.map((entry) => entry.objectKey)).size).toBe(2);
+  });
+
+  test('a binary declared over the limit is refused before a row or a policy exists', async () => {
+    const { service, storage, artifactsRepo } = build();
 
     await expect(
       service.create({
         appId: APP_ID,
         ownerId: OWNER_ID,
-        binary: new File(['#!/bin/true'], UPLOADED_NAME),
+        filename: UPLOADED_NAME,
+        sizeBytes: MAX_ARTIFACT_SIZE_BYTES + 1,
       }),
     ).rejects.toBeInstanceOf(BadRequestError);
 
-    expect(artifactsRepo.inserted).toHaveLength(0);
-    expect(storage.written).toHaveLength(0);
+    expect(storage.signed).toEqual([]);
+    expect(artifactsRepo.rows.size).toBe(0);
   });
 
-  // A host writes this name into an export archive, so a name carrying a path is refused at
-  // the upload rather than sanitised into a different one.
-  test('an upload whose name is a path is refused before anything is written', async () => {
-    const storage = new FakeStorage();
-    const { artifactsRepo, service } = build(storage);
+  test('creating one in an app the caller does not own is refused', async () => {
+    const { service, storage } = build();
 
     await expect(
-      service.create({ appId: APP_ID, ownerId: OWNER_ID, binary: binary('../../etc/passwd') }),
+      service.create({
+        appId: APP_ID,
+        ownerId: OTHER_OWNER_ID,
+        filename: UPLOADED_NAME,
+        sizeBytes: 1,
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect(storage.signed).toEqual([]);
+  });
+
+  // Until the bytes are read there is nothing to deploy and nothing worth listing.
+  test('one still waiting for its upload is not an artifact anybody can see', async () => {
+    const { service, artifactsRepo } = build();
+
+    const { artifactId } = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: BINARY_TEXT.length,
+    });
+
+    expect(await service.list({ appId: APP_ID, ownerId: OWNER_ID })).toEqual([]);
+    await expect(
+      service.get({ appId: APP_ID, artifactId, ownerId: OWNER_ID }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+    expect(artifactsRepo.rows.size).toBe(1);
+  });
+});
+
+describe('the api records the digest of what was stored', () => {
+  test('the digest is taken from the bytes that arrived, not from what was claimed', async () => {
+    const { service, storage } = build();
+
+    const artifact = await upload({ service, storage });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+    expect(artifact.sizeBytes).toBe(BINARY_TEXT.length);
+    expect(storage.objects.get(artifact.objectKey)).toEqual(bytesOf(BINARY_TEXT));
+  });
+
+  test('the name is the caller’s, because a content-addressed key carries none', async () => {
+    const { service, storage } = build();
+    const filename = Value.Parse(FilenameSchema, 'openclaw');
+
+    expect((await upload({ service, storage, filename })).originalFileName).toBe(filename);
+  });
+
+  test('the key is derived, so two uploads of one binary share the bytes but not the row', async () => {
+    const { service, storage } = build();
+
+    const first = await upload({ service, storage });
+    const second = await upload({ service, storage });
+
+    expect(second.objectKey).toBe(first.objectKey);
+    expect(second.id).not.toBe(first.id);
+  });
+
+  // Copying them again would move bytes the store already holds under exactly this key.
+  test('bytes already under the key are not copied a second time', async () => {
+    const { service, storage } = build();
+
+    await upload({ service, storage });
+    const copiesAfterFirst = storage.copied.length;
+    await upload({ service, storage });
+
+    expect(storage.copied).toHaveLength(copiesAfterFirst);
+  });
+
+  test('the staging copy does not outlive the artifact it became', async () => {
+    const { service, storage } = build();
+
+    const artifact = await upload({ service, storage });
+
+    expect([...storage.objects.keys()]).toEqual([artifact.objectKey]);
+  });
+
+  test('and only then is it something to list and deploy', async () => {
+    const { service, storage } = build();
+
+    const artifact = await upload({ service, storage });
+
+    expect(await service.list({ appId: APP_ID, ownerId: OWNER_ID })).toEqual([artifact]);
+  });
+});
+
+describe('what the store accepted, this api still has to agree to', () => {
+  // The declared content type is whatever the uploader typed. Reaching a host with something the
+  // guest cannot exec turns a rejectable upload into a deploy that never converges.
+  test('an upload that is not a Linux executable leaves no row and no bytes', async () => {
+    const { service, storage, artifactsRepo } = build();
+
+    await expect(upload({ service, storage, text: '#!/bin/true' })).rejects.toBeInstanceOf(
+      BadRequestError,
+    );
+
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect([...storage.objects.keys()]).toEqual([]);
+  });
+
+  test('saying an upload landed when nothing did is not an artifact', async () => {
+    const { service, artifactsRepo } = build();
+    const { artifactId } = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: BINARY_TEXT.length,
+    });
+
+    await expect(
+      service.completeUpload({ appId: APP_ID, ownerId: OWNER_ID, artifactId }),
     ).rejects.toBeInstanceOf(BadRequestError);
 
-    expect(artifactsRepo.inserted).toHaveLength(0);
-    expect(storage.written).toHaveLength(0);
+    // Still pending rather than gone: the caller may yet finish the upload it was signed for.
+    expect(artifactsRepo.rows.size).toBe(1);
   });
 
-  // Writing them again would send bytes the store already holds under exactly this key.
-  test('bytes already under the key are not uploaded a second time', async () => {
-    const storage = new FakeStorage({ alreadyStored: true });
-    const { service } = build(storage);
-
-    await service.create({ appId: APP_ID, ownerId: OWNER_ID, binary: binary() });
-
-    expect(storage.written).toHaveLength(0);
-  });
-
-  // The row is what says the bytes are there, so it must not exist when they are not.
-  test('one that never reached the bucket leaves no row behind', async () => {
-    const { artifactsRepo, service } = build(new RefusingStorage());
+  test('an artifact nobody is waiting on cannot be completed twice', async () => {
+    const { service, storage } = build();
+    const artifact = await upload({ service, storage });
 
     await expect(
-      service.create({ appId: APP_ID, ownerId: OWNER_ID, binary: binary() }),
-    ).rejects.toThrow(BUCKET_REFUSED);
+      service.completeUpload({ appId: APP_ID, ownerId: OWNER_ID, artifactId: artifact.id }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
 
-    expect(artifactsRepo.inserted).toHaveLength(0);
+  // The row is what says the bytes are there, so it must not become an artifact when they are not.
+  test('one that never reached its resting place stays pending', async () => {
+    const { service, storage, artifactsRepo } = build(new RefusingStorage());
+
+    await expect(upload({ service, storage })).rejects.toThrow(BUCKET_REFUSED);
+
+    expect(await service.list({ appId: APP_ID, ownerId: OWNER_ID })).toEqual([]);
+    expect(artifactsRepo.rows.size).toBe(1);
+  });
+});
+
+describe('an upload the caller gave up on does not wait to be noticed', () => {
+  test('saying it failed takes the row and the bytes with it', async () => {
+    const { service, storage, artifactsRepo } = build();
+    const { artifactId } = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: BINARY_TEXT.length,
+    });
+    storage.put({
+      objectKey: (storage.signed.at(-1) as { objectKey: ObjectKey }).objectKey,
+      text: BINARY_TEXT,
+    });
+
+    await service.failUpload({ appId: APP_ID, ownerId: OWNER_ID, artifactId });
+
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect([...storage.objects.keys()]).toEqual([]);
+  });
+
+  test('an artifact that is already one is not an upload to abandon', async () => {
+    const { service, storage } = build();
+    const artifact = await upload({ service, storage });
+
+    await expect(
+      service.failUpload({ appId: APP_ID, ownerId: OWNER_ID, artifactId: artifact.id }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test('another owner cannot abandon an upload that is not theirs', async () => {
+    const { service, artifactsRepo } = build();
+    const { artifactId } = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: BINARY_TEXT.length,
+    });
+
+    await expect(
+      service.failUpload({ appId: APP_ID, ownerId: OTHER_OWNER_ID, artifactId }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect(artifactsRepo.rows.size).toBe(1);
+  });
+});
+
+describe('an upload nobody ever came back about is swept', () => {
+  test('one old enough that nothing can still be on its way goes', async () => {
+    const { service, storage, artifactsRepo } = build();
+    const { artifactId } = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: BINARY_TEXT.length,
+    });
+    storage.put({
+      objectKey: (storage.signed.at(-1) as { objectKey: ObjectKey }).objectKey,
+      text: BINARY_TEXT,
+    });
+    artifactsRepo.age({ artifactId, byMs: PAST_THE_SWEEP_MS });
+
+    await service.sweepAbandoned();
+
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect([...storage.objects.keys()]).toEqual([]);
+  });
+
+  test('one still within its window is left alone', async () => {
+    const { service, artifactsRepo } = build();
+    const { artifactId } = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: BINARY_TEXT.length,
+    });
+    artifactsRepo.age({ artifactId, byMs: AN_HOUR_MS });
+
+    await service.sweepAbandoned();
+
+    expect(artifactsRepo.rows.size).toBe(1);
+  });
+
+  test('an artifact is not an upload, however old it is', async () => {
+    const { service, storage, artifactsRepo } = build();
+    const artifact = await upload({ service, storage });
+    artifactsRepo.age({ artifactId: artifact.id, byMs: PAST_THE_SWEEP_MS });
+
+    await service.sweepAbandoned();
+
+    expect((await service.list({ appId: APP_ID, ownerId: OWNER_ID })).map((one) => one.id)).toEqual(
+      [artifact.id],
+    );
   });
 });
 
 describe('an artifact is reachable only through an app its owner owns', () => {
-  test('uploading into an app the caller does not own writes no bytes', async () => {
-    const storage = new FakeStorage();
-    const { service } = build(storage);
-
-    await expect(
-      service.create({ appId: APP_ID, ownerId: OTHER_OWNER_ID, binary: binary() }),
-    ).rejects.toBeInstanceOf(NotFoundError);
-
-    expect(storage.written).toEqual([]);
-  });
-
   test("another owner's artifact is missing rather than forbidden", async () => {
     const { artifactsRepo, service } = build();
     const seeded = artifactsRepo.seed();

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -15,10 +15,7 @@ import {
   Value,
 } from '@repo/protocol';
 import { BadRequestError, NotFoundError } from '#lib/errors.ts';
-import type {
-  ArtifactStorageRepositoryContract,
-  SignedUpload,
-} from '#repositories/artifact-storage.repository.ts';
+import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
 import type {
   AbandonedArtifactRow,
   ArtifactRow,
@@ -231,15 +228,15 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
 
 const SIGNED_URL = 'https://store.test/nibrun';
 
-/** A bucket as a map, so what a signed policy wrote and what the api copied are both visible. */
+/** A bucket as a map, so what a signed upload wrote and what the api copied are both visible. */
 class FakeStorage implements ArtifactStorageRepositoryContract {
   readonly objects = new Map<ObjectKey, Uint8Array>();
-  readonly signed: { objectKey: ObjectKey; maxSizeBytes: number }[] = [];
+  readonly signed: { objectKey: ObjectKey; sizeBytes: number }[] = [];
   readonly copied: { from: ObjectKey; to: ObjectKey }[] = [];
 
-  signUpload(input: { objectKey: ObjectKey; maxSizeBytes: number }): Promise<SignedUpload> {
+  signUpload(input: { objectKey: ObjectKey; sizeBytes: number }): Promise<string> {
     this.signed.push(input);
-    return Promise.resolve({ url: SIGNED_URL, fields: { key: input.objectKey } });
+    return Promise.resolve(`${SIGNED_URL}/${input.objectKey}`);
   }
 
   read({ objectKey }: { objectKey: ObjectKey }): ReadableStream<Uint8Array> {
@@ -272,7 +269,7 @@ class FakeStorage implements ArtifactStorageRepositoryContract {
     return Promise.resolve();
   }
 
-  /** Stands in for the caller spending the signed policy. */
+  /** Stands in for the caller spending the signed url. */
   put({ objectKey, text }: { objectKey: ObjectKey; text: string }): void {
     this.objects.set(objectKey, bytesOf(text));
   }
@@ -324,7 +321,7 @@ async function upload({
 }
 
 describe('an artifact begins before its bytes do', () => {
-  test('the slot is inside the app it belongs to, so a policy cannot be spent anywhere else', async () => {
+  test('the slot is inside the app it belongs to, so a url cannot be spent anywhere else', async () => {
     const { service, storage } = build();
 
     const { artifactId } = await service.create({
@@ -340,8 +337,8 @@ describe('an artifact begins before its bytes do', () => {
   });
 
   // The store is the only thing positioned to refuse the bytes as they arrive, and it will only
-  // do it if the size was part of what was signed.
-  test('the policy the store is handed carries the limit', async () => {
+  // do it if the size is part of what was signed.
+  test('the url is signed for the size that was declared', async () => {
     const { service, storage } = build();
 
     await service.create({
@@ -351,7 +348,7 @@ describe('an artifact begins before its bytes do', () => {
       sizeBytes: BINARY_TEXT.length,
     });
 
-    expect(storage.signed.at(-1)?.maxSizeBytes).toBe(MAX_ARTIFACT_SIZE_BYTES);
+    expect(storage.signed.at(-1)?.sizeBytes).toBe(BINARY_TEXT.length);
   });
 
   test('two uploads of one app never share a slot', async () => {
@@ -370,7 +367,7 @@ describe('an artifact begins before its bytes do', () => {
     expect(new Set(storage.signed.map((entry) => entry.objectKey)).size).toBe(2);
   });
 
-  test('a binary declared over the limit is refused before a row or a policy exists', async () => {
+  test('a binary declared over the limit is refused before a row or a url exists', async () => {
     const { service, storage, artifactsRepo } = build();
 
     await expect(

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,8 @@
     "apps/api": {
       "name": "@repo/api",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1105.0",
+        "@aws-sdk/s3-presigned-post": "^3.1105.0",
         "@ilbertt/better-auth-bun-sql": "^0.2.0",
         "@ilbertt/bun-sqlgen": "^0.4.0",
         "@repo/protocol": "workspace:*",
@@ -173,6 +175,44 @@
     "@actions/http-client": ["@actions/http-client@4.0.1", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^6.23.0" } }, "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg=="],
 
     "@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
+
+    "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.26", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CGznePoL+1oWCSzqmkvlYMpWQEZohPR3LntjKXXfVH+oh6Kd8d+yHLkjpiAGwPIHAxFe4OAq3aKfRnv/wqWIyA=="],
+
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1105.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.26", "@aws-sdk/core": "^3.977.6", "@aws-sdk/credential-provider-node": "^3.972.78", "@aws-sdk/middleware-sdk-s3": "^3.972.72", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-eiR289CNgH2atIh2zOSDSpXOmDVGCxFEk0S8jMHo599oTCjcnjmlNOVsFCWXx5jMPP83+c47Wl/1R7xgUVBzZw=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.6", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.67", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.69", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.12", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/credential-provider-env": "^3.972.67", "@aws-sdk/credential-provider-http": "^3.972.69", "@aws-sdk/credential-provider-login": "^3.972.74", "@aws-sdk/credential-provider-process": "^3.972.67", "@aws-sdk/credential-provider-sso": "^3.973.11", "@aws-sdk/credential-provider-web-identity": "^3.972.73", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.74", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.78", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.67", "@aws-sdk/credential-provider-http": "^3.972.69", "@aws-sdk/credential-provider-ini": "^3.973.12", "@aws-sdk/credential-provider-process": "^3.972.67", "@aws-sdk/credential-provider-sso": "^3.973.11", "@aws-sdk/credential-provider-web-identity": "^3.972.73", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.67", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.11", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/token-providers": "3.1103.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.73", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.72", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-lSAoVPvQxX1d8TOM6waKDBQrvvZcm4w6pCldFAsRUffEaXq6lYY0pPyew3KlLu6Xqb74DXI42hGvSsbGBLljlw=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.41", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ=="],
+
+    "@aws-sdk/s3-presigned-post": ["@aws-sdk/s3-presigned-post@3.1105.0", "", { "dependencies": { "@aws-sdk/client-s3": "3.1105.0", "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-W2hGeWPibCOdmXGUAITC+56nhxdUojDW+VvsG3ndCi7Gjnw/DQVQvZpSLZPlsWyNP/EqwM26yDEC3QonUbakRg=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.43", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1103.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.37", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -540,6 +580,18 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@smithy/core": ["@smithy/core@3.31.1", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.16", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.12", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
     "@solid-primitives/event-listener": ["@solid-primitives/event-listener@2.4.6", "", { "dependencies": { "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw=="],
 
     "@solid-primitives/keyboard": ["@solid-primitives/keyboard@1.3.7", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.6", "@solid-primitives/rootless": "^1.5.4", "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-558RPNYnXx4nGh537DSqAn4xMrC8iFipl/5+xzgzWoTNFst4RnUN3BOLmtDjJ0UGGoQXVMALYR3bNOHM0xnt1Q=="],
@@ -739,6 +791,8 @@
     "better-call": ["better-call@1.3.7", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w=="],
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
       "name": "@repo/api",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1105.0",
-        "@aws-sdk/s3-presigned-post": "^3.1105.0",
+        "@aws-sdk/s3-request-presigner": "^3.1105.0",
         "@ilbertt/better-auth-bun-sql": "^0.2.0",
         "@ilbertt/bun-sqlgen": "^0.4.0",
         "@repo/protocol": "workspace:*",
@@ -202,7 +202,7 @@
 
     "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.41", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ=="],
 
-    "@aws-sdk/s3-presigned-post": ["@aws-sdk/s3-presigned-post@3.1105.0", "", { "dependencies": { "@aws-sdk/client-s3": "3.1105.0", "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-W2hGeWPibCOdmXGUAITC+56nhxdUojDW+VvsG3ndCi7Gjnw/DQVQvZpSLZPlsWyNP/EqwM26yDEC3QonUbakRg=="],
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1105.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BaWEMVBsVHsJwpVnBmkzwzF7127hjELPNldXfJ0qiBvuco45ADDF1NbmaCrs93iFpSlFEhf+7mu4HmXS9nIlyw=="],
 
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.43", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA=="],
 
@@ -1304,9 +1304,9 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
-    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+    "seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
 
-    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
+    "seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -1478,10 +1478,6 @@
 
     "@tanstack/router-cli/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
-    "@tanstack/router-core/seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
-
-    "@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
-
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "conf/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
@@ -1521,6 +1517,10 @@
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "solid-js/seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "solid-js/seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -130,6 +130,48 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
   }
 }
 
+# A binary is uploaded straight here over a URL the api signs, landing under
+# uploads/ until the api has read it back, hashed it and copied it to the key its
+# digest names. The staging copy is deleted the moment that is done — this is for
+# the ones where it never happens: an upload nobody registers is bytes no row will
+# ever name, and without a rule they would sit here at full size forever.
+#
+# Scoped to the prefix, because everything outside it is what users deployed.
+#
+# Noncurrent versions too: the bucket is versioned, so deleting a staging object
+# leaves the object behind under a delete marker, and expiring only the current
+# version would keep exactly what this is meant to remove.
+resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    id     = "expire-staged-uploads"
+    status = "Enabled"
+    filter {
+      prefix = "uploads/"
+    }
+    expiration {
+      days = 1
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
+
+  # Every key, not just the staged ones: the api copies a verified binary to the key its digest
+  # names, in parts, and a copy that fails part way leaves those parts holding storage under a
+  # key that lists nothing. Unfiltered so that a prefix added later cannot be the one this was
+  # forgotten on.
+  rule {
+    id     = "abort-incomplete-uploads"
+    status = "Enabled"
+    filter {}
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
 # --- Tenant filesystems ---
 #
 # ZeroFS's backing store. Deliberately not a prefix inside artifacts.

--- a/packages/api-client/src/unwrap.ts
+++ b/packages/api-client/src/unwrap.ts
@@ -45,5 +45,16 @@ function bodyMessage(value: unknown): string {
   if (typeof value === 'object' && value !== null && 'error' in value) {
     return String(value.error);
   }
+  // A body Eden hands back unread, because it arrived chunked and as text: an error page from
+  // something between here and the api rather than the api's own answer. Reading it would make
+  // every call site async to quote a page of HTML, so the status is left to say it — and it is
+  // the status that identifies the hop, since the api answers in JSON.
+  if (isAsyncIterable(value)) {
+    return 'a page, not this api — something between here and it refused the request';
+  }
   return String(value);
+}
+
+function isAsyncIterable(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && Symbol.asyncIterator in value;
 }

--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { SHARED_OPTIONS } from '#config.ts';
 import { parseCommandLine } from '#lib/command-line.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { deploy, readBinary } from '#lib/deploy.ts';
+import { deploy, openBinary } from '#lib/deploy.ts';
 import { completeOptions } from '#lib/plan.ts';
 import { createUi, isInteractive } from '#lib/ui.ts';
 
@@ -43,7 +43,7 @@ export const command = defineCommand('run [command]', {
 
     // Before anything is asked, so a path nobody can read costs one line rather than a
     // questionnaire whose answers are then thrown away.
-    const binary = await readBinary(binaryPath);
+    const binary = await openBinary(binaryPath);
     ui.open('nib run');
 
     const resolved = interactive

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -2,7 +2,14 @@ import { basename } from 'node:path';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { ApiError, unwrap } from '@repo/api-client/unwrap';
 import { appBySlug } from '@repo/app-operations';
-import { type DeploymentState, GuestPortSchema, type TenantArguments, Value } from '@repo/protocol';
+import {
+  type DeploymentState,
+  type Filename,
+  FilenameSchema,
+  GuestPortSchema,
+  type TenantArguments,
+  Value,
+} from '@repo/protocol';
 import { UsageError } from '#lib/errors.ts';
 import type { RunOptions } from '#lib/plan.ts';
 import type { Ui } from '#lib/ui.ts';
@@ -14,11 +21,20 @@ const POLL_INTERVAL_MS = 500;
 const SERVING_TIMEOUT_MS = 300_000;
 const MS_PER_SECOND = 1_000;
 const ELAPSED_DECIMALS = 1;
+const SIZE_DECIMALS = 1;
+const BYTES_PER_MEBIBYTE = 1_048_576;
+
+/** The binary as this end knows it: where to read it from, not the bytes themselves. */
+export type LocalBinary = {
+  path: string;
+  name: Filename;
+  sizeBytes: number;
+};
 
 export type DeployInput = RunOptions & {
   api: PublicApiClient;
   ui: Ui;
-  binary: File;
+  binary: LocalBinary;
   args: TenantArguments;
   detach?: boolean | undefined;
 };
@@ -49,7 +65,7 @@ export async function deploy({
       : unwrap(await api.api.apps({ appId: target.id }).patch(config));
   ui.step(`app ${app.slug}`);
 
-  const artifact = unwrap(await api.api.apps({ appId: app.id }).artifacts.post({ binary }));
+  const artifact = await uploadBinary({ api, ui, appId: app.id, binary });
   ui.step(`artifact ${artifact.digest}`);
 
   const deployment = unwrap(
@@ -73,18 +89,125 @@ export async function deploy({
   ui.done(`${url} — ready in ${elapsed(Date.now() - startedAt)}`);
 }
 
+/**
+ * The bytes go to the object store, not to the api: a binary is far larger than anything else
+ * sent here, and everything between this end and the api — proxies, CDNs — has an opinion about
+ * how large a request body may be. The api creates the artifact, says where to put the bytes,
+ * and is told afterwards how that went.
+ *
+ * It is told either way. Only this end watched the upload happen, so an artifact whose bytes
+ * never arrived is one nothing else can ever find out about.
+ */
+async function uploadBinary({
+  api,
+  ui,
+  appId,
+  binary,
+}: {
+  api: PublicApiClient;
+  ui: Ui;
+  appId: string;
+  binary: LocalBinary;
+}) {
+  const { artifactId, url, fields } = unwrap(
+    await api.api.apps({ appId }).artifacts.post({
+      filename: binary.name,
+      sizeBytes: binary.sizeBytes,
+    }),
+  );
+  const artifact = api.api.apps({ appId }).artifacts({ artifactId });
+
+  try {
+    await ui.waitingFor({
+      message: `uploading ${binary.name} (${mebibytes(binary.sizeBytes)})`,
+      task: () => postBinary({ url, fields, binary }),
+    });
+  } catch (failure) {
+    await artifact.patch({ upload: 'failed' });
+    throw failure;
+  }
+
+  // The same endpoint answers an abandoned upload with no body at all, so what comes back is
+  // only typed as an artifact once this has said it is one.
+  const completed = unwrap(await artifact.patch({ upload: 'complete' }));
+  if (!completed) {
+    throw new ApiError('The api accepted the upload without saying what it stored.');
+  }
+  return completed;
+}
+
+/**
+ * A form post rather than a plain PUT, because the store will only hold an upload to a size when
+ * the size is part of what was signed, and that is a policy the form carries.
+ *
+ * The file goes last: the store reads the fields in order and applies the policy to what follows
+ * them, so a file sent before them is a file sent under no policy at all.
+ *
+ * Streamed from disk rather than read into memory — a process that has to hold a binary to send
+ * it is a process that cannot send a large one.
+ */
+async function postBinary({
+  url,
+  fields,
+  binary,
+}: {
+  url: string;
+  fields: Record<string, string>;
+  binary: LocalBinary;
+}): Promise<void> {
+  const form = new FormData();
+  for (const [name, value] of Object.entries(fields)) {
+    form.append(name, value);
+  }
+  form.append('file', Bun.file(binary.path), binary.name);
+
+  const response = await fetch(url, { method: 'POST', body: form });
+  if (!response.ok) {
+    throw new ApiError(
+      `The store refused the upload: ${response.status} ${await storeError(response)}`,
+    );
+  }
+}
+
+// S3 answers in XML, and the one part of it worth repeating is the sentence it puts in Message.
+async function storeError(response: Response): Promise<string> {
+  const body = await response.text();
+  return /<Message>(?<message>[^<]*)<\/Message>/.exec(body)?.groups?.message ?? response.statusText;
+}
+
+function mebibytes(bytes: number): string {
+  return `${(bytes / BYTES_PER_MEBIBYTE).toFixed(SIZE_DECIMALS)} MB`;
+}
+
 function elapsed(ms: number): string {
   return `${(ms / MS_PER_SECOND).toFixed(ELAPSED_DECIMALS)}s`;
 }
 
-// A `File` rather than the `Bun.file` handle it came from: the multipart filename is read off
-// `name`, and the api keeps it as what the binary is called again inside an export.
-export async function readBinary(path: string): Promise<File> {
+/**
+ * Opened rather than read: the bytes are streamed to the store when the time comes, and all
+ * that is wanted here is that there is a file, what it is called, and how large it is.
+ */
+export async function openBinary(path: string): Promise<LocalBinary> {
   const handle = Bun.file(path);
   if (!(await handle.exists())) {
     throw new UsageError(`No such file: ${path}`);
   }
-  return new File([await handle.arrayBuffer()], basename(path));
+  return { path, name: asFilename(basename(path)), sizeBytes: handle.size };
+}
+
+/**
+ * The name travels with the binary — it is what a host writes into an export archive, which the
+ * api will not take as anything but a single plain path segment. Said here so that a name it
+ * would refuse costs a line rather than the upload that preceded the refusal.
+ */
+function asFilename(name: string): Filename {
+  try {
+    return Value.Parse(FilenameSchema, name);
+  } catch {
+    throw new UsageError(
+      `A binary's name must start with a letter or digit and hold only letters, digits, dots, dashes or underscores: ${name}`,
+    );
+  }
 }
 
 /**

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -109,7 +109,7 @@ async function uploadBinary({
   appId: string;
   binary: LocalBinary;
 }) {
-  const { artifactId, url, fields } = unwrap(
+  const { artifactId, url } = unwrap(
     await api.api.apps({ appId }).artifacts.post({
       filename: binary.name,
       sizeBytes: binary.sizeBytes,
@@ -120,7 +120,7 @@ async function uploadBinary({
   try {
     await ui.waitingFor({
       message: `uploading ${binary.name} (${mebibytes(binary.sizeBytes)})`,
-      task: () => postBinary({ url, fields, binary }),
+      task: () => putBinary({ url, binary }),
     });
   } catch (failure) {
     await artifact.patch({ upload: 'failed' });
@@ -137,31 +137,14 @@ async function uploadBinary({
 }
 
 /**
- * A form post rather than a plain PUT, because the store will only hold an upload to a size when
- * the size is part of what was signed, and that is a policy the form carries.
+ * The whole file as the body, streamed from disk: a process that has to hold a binary to send it
+ * is a process that cannot send a large one.
  *
- * The file goes last: the store reads the fields in order and applies the policy to what follows
- * them, so a file sent before them is a file sent under no policy at all.
- *
- * Streamed from disk rather than read into memory — a process that has to hold a binary to send
- * it is a process that cannot send a large one.
+ * The url was signed for this exact length, so the store refuses anything else — which is also
+ * why a file that changed since it was measured comes back as a signature that does not match.
  */
-async function postBinary({
-  url,
-  fields,
-  binary,
-}: {
-  url: string;
-  fields: Record<string, string>;
-  binary: LocalBinary;
-}): Promise<void> {
-  const form = new FormData();
-  for (const [name, value] of Object.entries(fields)) {
-    form.append(name, value);
-  }
-  form.append('file', Bun.file(binary.path), binary.name);
-
-  const response = await fetch(url, { method: 'POST', body: form });
+async function putBinary({ url, binary }: { url: string; binary: LocalBinary }): Promise<void> {
+  const response = await fetch(url, { method: 'PUT', body: Bun.file(binary.path) });
   if (!response.ok) {
     throw new ApiError(
       `The store refused the upload: ${response.status} ${await storeError(response)}`,


### PR DESCRIPTION
Deploying a 180 MiB binary answered `413`: Cloudflare caps a request body at 100 MB, and Bun's own default would have refused it at 128 MB — so the `256m` the api declared was never reachable.

`POST /apps/:appId/artifacts` now creates the artifact and answers with a signed policy saying where to put the binary; `PATCH` on it says how that went. The bytes go straight to the store, and the api reads them back to hash them, check them and copy them to the key their digest names.

The 256 MB is said three times, each catching what the one before it cannot: to the caller before a byte moves, to the store in the policy — which is the only one that can refuse the bytes as they arrive — and again while hashing.

A row now exists before its bytes, which inverts what `0008` said. `digest IS NULL` is the whole of "still coming": every read filters on it, a deployment will not name one, and an upload nobody ever completes is swept.

`createPresignedPost` comes from the AWS SDK because Bun's `presign` cannot sign a `content-length` — https://github.com/oven-sh/bun/issues/18240.