### PR TITLE
refactor(app-operations): deploying an app is one sequence wherever it starts

### DIFF
--- a/packages/app-operations/src/deploy.ts
+++ b/packages/app-operations/src/deploy.ts
@@ -1,0 +1,216 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { ApiError, unwrap } from '@repo/api-client/unwrap';
+import {
+  type DeploymentState,
+  type Filename,
+  GuestPortSchema,
+  type TenantArguments,
+  Value,
+} from '@repo/protocol';
+import { appBySlug } from '#apps.ts';
+import { pause } from '#wait.ts';
+
+const SETTLING_STATES = new Set<DeploymentState>(['pending', 'starting']);
+// A host now tells the api the moment a tenant answers rather than on its next report, so this
+// is what stands between that and the owner being told — and the whole wait is a few seconds.
+const POLL_INTERVAL_MS = 500;
+const SERVING_TIMEOUT_MS = 300_000;
+const SIZE_DECIMALS = 1;
+const BYTES_PER_MEBIBYTE = 1_048_576;
+
+type RequestBody = NonNullable<RequestInit['body']>;
+
+export type UploadableBinary = {
+  name: Filename;
+  sizeBytes: number;
+  body: RequestBody;
+};
+
+export type DeployStep =
+  | { kind: 'app'; appId: string; slug: string }
+  | { kind: 'artifact'; artifactId: string; digest: string }
+  | { kind: 'deployment'; deploymentId: string };
+
+export type UploadWait = (input: { message: string; task: () => Promise<void> }) => Promise<void>;
+
+export type DeployInput = {
+  api: PublicApiClient;
+  binary: UploadableBinary;
+  args: TenantArguments;
+  app?: string | undefined;
+  name?: string | undefined;
+  port?: number | undefined;
+  onStep?: ((step: DeployStep) => void) | undefined;
+  whileUploading?: UploadWait | undefined;
+};
+
+export type Deployed = {
+  appId: string;
+  slug: string;
+  deploymentId: string;
+  url: string;
+};
+
+/**
+ * Upload a binary and make it the app's live release.
+ *
+ * Config is written before the deployment rather than sent with it: a deployment snapshots the
+ * app's config as it stands, so this is the only order in which the flags a caller just typed
+ * are the ones that run.
+ */
+export async function deploy({
+  api,
+  binary,
+  args,
+  app: slug,
+  name,
+  port,
+  onStep,
+  whileUploading = unwatched,
+}: DeployInput): Promise<Deployed> {
+  const target = slug === undefined ? null : await appBySlug({ api, slug });
+  const config = configPatch({ args, port });
+
+  const app =
+    target === null
+      ? unwrap(await api.api.apps.post({ name: name ?? binary.name, config }))
+      : unwrap(await api.api.apps({ appId: target.id }).patch(config));
+  onStep?.({ kind: 'app', appId: app.id, slug: app.slug });
+
+  const artifact = await uploadBinary({ api, appId: app.id, binary, whileUploading });
+  onStep?.({ kind: 'artifact', artifactId: artifact.id, digest: artifact.digest });
+
+  const deployment = unwrap(
+    await api.api.apps({ appId: app.id }).deployments.post({ artifactId: artifact.id }),
+  );
+  onStep?.({ kind: 'deployment', deploymentId: deployment.id });
+
+  return {
+    appId: app.id,
+    slug: app.slug,
+    deploymentId: deployment.id,
+    url: `https://${platformHostname(app.hostnames)}`,
+  };
+}
+
+/**
+ * The bytes go to the object store, not to the api: a binary is far larger than anything else
+ * sent here, and everything between this end and the api — proxies, CDNs — has an opinion about
+ * how large a request body may be. The api creates the artifact, says where to put the bytes,
+ * and is told afterwards how that went.
+ *
+ * It is told either way. Only this end watched the upload happen, so an artifact whose bytes
+ * never arrived is one nothing else can ever find out about.
+ */
+async function uploadBinary({
+  api,
+  appId,
+  binary,
+  whileUploading,
+}: {
+  api: PublicApiClient;
+  appId: string;
+  binary: UploadableBinary;
+  whileUploading: UploadWait;
+}) {
+  const { artifactId, url } = unwrap(
+    await api.api.apps({ appId }).artifacts.post({
+      filename: binary.name,
+      sizeBytes: binary.sizeBytes,
+    }),
+  );
+  const artifact = api.api.apps({ appId }).artifacts({ artifactId });
+
+  try {
+    await whileUploading({
+      message: `uploading ${binary.name} (${mebibytes(binary.sizeBytes)})`,
+      task: () => putBinary({ url, body: binary.body }),
+    });
+  } catch (failure) {
+    await artifact.patch({ upload: 'failed' });
+    throw failure;
+  }
+
+  // The same endpoint answers an abandoned upload with no body at all, so what comes back is
+  // only typed as an artifact once this has said it is one.
+  const completed = unwrap(await artifact.patch({ upload: 'complete' }));
+  if (!completed) {
+    throw new ApiError('The api accepted the upload without saying what it stored.');
+  }
+  return completed;
+}
+
+/**
+ * The whole binary as the body, never held here: something that has to hold a binary to send it
+ * is something that cannot send a large one.
+ *
+ * The url was signed for this exact length, so the store refuses anything else — which is also
+ * why a file that changed since it was measured comes back as a signature that does not match.
+ */
+async function putBinary({ url, body }: { url: string; body: RequestBody }): Promise<void> {
+  const response = await fetch(url, { method: 'PUT', body });
+  if (!response.ok) {
+    throw new ApiError(
+      `The store refused the upload: ${response.status} ${await storeError(response)}`,
+    );
+  }
+}
+
+// S3 answers in XML, and the one part of it worth repeating is the sentence it puts in Message.
+async function storeError(response: Response): Promise<string> {
+  const body = await response.text();
+  return /<Message>(?<message>[^<]*)<\/Message>/.exec(body)?.groups?.message ?? response.statusText;
+}
+
+function unwatched({ task }: { message: string; task: () => Promise<void> }): Promise<void> {
+  return task();
+}
+
+function mebibytes(bytes: number): string {
+  return `${(bytes / BYTES_PER_MEBIBYTE).toFixed(SIZE_DECIMALS)} MB`;
+}
+
+/**
+ * `args` is always written, empty included: what the caller typed is what the binary is asked to
+ * run with, and carrying over the last deploy's arguments because none were given this time
+ * would run something nobody asked for.
+ */
+function configPatch({ args, port }: { args: TenantArguments; port: number | undefined }) {
+  return {
+    args,
+    ...(port !== undefined && { guestPort: Value.Parse(GuestPortSchema, port) }),
+  };
+}
+
+export async function awaitDeploymentSettled({
+  api,
+  appId,
+  deploymentId,
+  signal,
+}: {
+  api: PublicApiClient;
+  appId: string;
+  deploymentId: string;
+  signal?: AbortSignal | undefined;
+}): Promise<DeploymentState> {
+  const deadline = Date.now() + SERVING_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    signal?.throwIfAborted();
+    const deployment = unwrap(await api.api.apps({ appId }).deployments({ deploymentId }).get());
+    if (!SETTLING_STATES.has(deployment.state)) {
+      return deployment.state;
+    }
+    await pause(POLL_INTERVAL_MS);
+  }
+  throw new ApiError(
+    `Deployment ${deploymentId} was still starting after ${SERVING_TIMEOUT_MS}ms.`,
+  );
+}
+
+function platformHostname(hostnames: ReadonlyArray<{ hostname: string; kind: string }>): string {
+  const platform = hostnames.find((entry) => entry.kind === 'platform') ?? hostnames[0];
+  if (!platform) {
+    throw new ApiError('The app was created without a hostname.');
+  }
+  return platform.hostname;
+}

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -1,6 +1,15 @@
 /** biome-ignore-all lint/performance/noBarrelFile: index is the only allowed file where we can export other files */
 
 export { addressedDeployment, appBySlug, latestDeployment } from '#apps.ts';
+export {
+  awaitDeploymentSettled,
+  type Deployed,
+  type DeployInput,
+  type DeployStep,
+  deploy,
+  type UploadableBinary,
+  type UploadWait,
+} from '#deploy.ts';
 export { InvalidPathError } from '#errors.ts';
 export { guestPath, readDirectory } from '#filesystem.ts';
 export { type FollowInput, followLogs } from '#logs.ts';

--- a/packages/app-operations/src/logs.ts
+++ b/packages/app-operations/src/logs.ts
@@ -1,6 +1,7 @@
 import type { PublicApiClient } from '@repo/api-client/public';
 import { unwrap } from '@repo/api-client/unwrap';
 import { SeenTenantLogs, type TenantLogRecord } from '@repo/protocol';
+import { pause } from '#wait.ts';
 
 /**
  * How much of the gap a reconnect asks to be told about.
@@ -59,10 +60,4 @@ export async function* followLogs({
       throw failure;
     }
   }
-}
-
-function pause(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }

--- a/packages/app-operations/src/wait.ts
+++ b/packages/app-operations/src/wait.ts
@@ -1,0 +1,5 @@
+export function pause(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/app-operations/tests/deploy.test.ts
+++ b/packages/app-operations/tests/deploy.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { PublicApiClient } from '@repo/api-client/public';
+import type { Filename } from '@repo/protocol';
+import { type DeployStep, deploy } from '#deploy.ts';
+
+const SLUG = 'quiet-otter';
+const APP_ID = 'app-1';
+const ARTIFACT_ID = 'artifact-1';
+const DIGEST = 'sha256:abcd';
+const PUT_URL = 'https://store.example/artifact-1?signature=x';
+const PORT = 8080;
+const SIZE_BYTES = 1_048_576;
+const REFUSED = 403;
+
+type Sent = { what: string; body?: unknown };
+
+function apiHolding({
+  apps,
+  sent,
+  completed = { id: ARTIFACT_ID, digest: DIGEST },
+}: {
+  apps: Array<{ id: string; slug: string }>;
+  sent: Sent[];
+  completed?: { id: string; digest: string } | null;
+}): PublicApiClient {
+  function addressed({ appId }: { appId: string }) {
+    function artifact() {
+      return {
+        patch: (body: unknown) => {
+          sent.push({ what: 'artifact patch', body });
+          return Promise.resolve({ data: completed, error: null });
+        },
+      };
+    }
+    return {
+      patch: (body: unknown) => {
+        sent.push({ what: 'app patch', body });
+        return Promise.resolve({ data: app(appId), error: null });
+      },
+      artifacts: Object.assign(artifact, {
+        post: (body: unknown) => {
+          sent.push({ what: 'artifact', body });
+          return Promise.resolve({ data: { artifactId: ARTIFACT_ID, url: PUT_URL }, error: null });
+        },
+      }),
+      deployments: {
+        post: (body: unknown) => {
+          sent.push({ what: 'deployment', body });
+          return Promise.resolve({ data: { id: 'deployment-1' }, error: null });
+        },
+      },
+    };
+  }
+
+  const route = Object.assign(addressed, {
+    get: () => Promise.resolve({ data: { apps }, error: null }),
+    post: (body: unknown) => {
+      sent.push({ what: 'create', body });
+      return Promise.resolve({ data: app(APP_ID), error: null });
+    },
+  });
+  return { api: { apps: route } } as unknown as PublicApiClient;
+}
+
+function app(id: string) {
+  return {
+    id,
+    slug: SLUG,
+    hostnames: [
+      { hostname: 'someone-else.example', kind: 'custom' },
+      { hostname: `${SLUG}.nibrun.app`, kind: 'platform' },
+    ],
+  };
+}
+
+function binary() {
+  return { name: 'my-server' as Filename, sizeBytes: SIZE_BYTES, body: 'a compiled thing' };
+}
+
+const REAL_FETCH = globalThis.fetch;
+
+/** The object store the presigned url points at, and what every request to it is answered with. */
+function storeAnswering({ refuses, sent }: { refuses?: boolean; sent: Sent[] }): void {
+  globalThis.fetch = ((url: string) => {
+    sent.push({ what: 'put', body: url });
+    if (refuses === true) {
+      return Promise.resolve(
+        new Response('<Error><Message>the length is not what was signed</Message></Error>', {
+          status: REFUSED,
+        }),
+      );
+    }
+    return Promise.resolve(new Response(''));
+  }) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  globalThis.fetch = REAL_FETCH;
+});
+
+test('a slug names the app the release lands on', async () => {
+  const sent: Sent[] = [];
+  storeAnswering({ sent });
+
+  const deployed = await deploy({
+    api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent }),
+    binary: binary(),
+    args: [],
+    app: SLUG,
+  });
+
+  expect(sent.map((each) => each.what)).toEqual([
+    'app patch',
+    'artifact',
+    'put',
+    'artifact patch',
+    'deployment',
+  ]);
+  expect(deployed).toEqual({
+    appId: APP_ID,
+    slug: SLUG,
+    deploymentId: 'deployment-1',
+    url: `https://${SLUG}.nibrun.app`,
+  });
+});
+
+test('naming no app creates one, named after the binary when nothing else says', async () => {
+  const sent: Sent[] = [];
+  storeAnswering({ sent });
+
+  await deploy({ api: apiHolding({ apps: [], sent }), binary: binary(), args: [] });
+
+  expect(sent[0]).toMatchObject({ what: 'create', body: { name: 'my-server' } });
+});
+
+// A deployment snapshots the app's config as it stands, so the flags a caller just typed only run
+// if they were written first.
+test('config is written before the deployment that snapshots it', async () => {
+  const sent: Sent[] = [];
+  storeAnswering({ sent });
+
+  await deploy({
+    api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent }),
+    binary: binary(),
+    args: ['serve'],
+    app: SLUG,
+    port: PORT,
+  });
+
+  expect(sent[0]).toEqual({ what: 'app patch', body: { args: ['serve'], guestPort: PORT } });
+  expect(sent.at(-1)?.what).toBe('deployment');
+});
+
+describe('the bytes go to the store, and the api is told how that went', () => {
+  test('the length is said before the url is asked for, and the bytes go there', async () => {
+    const sent: Sent[] = [];
+    storeAnswering({ sent });
+
+    await deploy({
+      api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent }),
+      binary: binary(),
+      args: [],
+      app: SLUG,
+    });
+
+    expect(sent[1]).toEqual({
+      what: 'artifact',
+      body: { filename: 'my-server', sizeBytes: SIZE_BYTES },
+    });
+    expect(sent[2]).toEqual({ what: 'put', body: PUT_URL });
+    expect(sent[3]).toEqual({ what: 'artifact patch', body: { upload: 'complete' } });
+  });
+
+  // Only this end watched the upload happen, so an artifact whose bytes never arrived is one
+  // nothing else can find out about.
+  test('a refused upload is reported as failed and still raised', async () => {
+    const sent: Sent[] = [];
+    storeAnswering({ refuses: true, sent });
+
+    const attempt = deploy({
+      api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent }),
+      binary: binary(),
+      args: [],
+      app: SLUG,
+    });
+
+    await expect(attempt).rejects.toThrow('the length is not what was signed');
+    expect(sent.at(-1)).toEqual({ what: 'artifact patch', body: { upload: 'failed' } });
+  });
+
+  test('an upload the api abandoned is not read as an artifact', async () => {
+    const sent: Sent[] = [];
+    storeAnswering({ sent });
+
+    const attempt = deploy({
+      api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent, completed: null }),
+      binary: binary(),
+      args: [],
+      app: SLUG,
+    });
+
+    await expect(attempt).rejects.toThrow(
+      'The api accepted the upload without saying what it stored.',
+    );
+  });
+});
+
+describe('what a caller is told as it happens', () => {
+  test('each step, in the order it was taken', async () => {
+    const steps: DeployStep[] = [];
+    storeAnswering({ sent: [] });
+
+    await deploy({
+      api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent: [] }),
+      binary: binary(),
+      args: [],
+      app: SLUG,
+      onStep: (step) => steps.push(step),
+    });
+
+    expect(steps).toEqual([
+      { kind: 'app', appId: APP_ID, slug: SLUG },
+      { kind: 'artifact', artifactId: ARTIFACT_ID, digest: DIGEST },
+      { kind: 'deployment', deploymentId: 'deployment-1' },
+    ]);
+  });
+
+  // A surface shows the wait its own way, and the upload is the only part long enough to need one.
+  test('the upload is handed to whoever is showing the wait', async () => {
+    const waits: string[] = [];
+    storeAnswering({ sent: [] });
+
+    await deploy({
+      api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent: [] }),
+      binary: binary(),
+      args: [],
+      app: SLUG,
+      whileUploading: ({ message, task }) => {
+        waits.push(message);
+        return task();
+      },
+    });
+
+    expect(waits).toEqual(['uploading my-server (1.0 MB)']);
+  });
+});

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -1,28 +1,18 @@
 import { basename } from 'node:path';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { ApiError, unwrap } from '@repo/api-client/unwrap';
-import { appBySlug } from '@repo/app-operations';
+import { ApiError } from '@repo/api-client/unwrap';
 import {
-  type DeploymentState,
-  type Filename,
-  FilenameSchema,
-  GuestPortSchema,
-  type TenantArguments,
-  Value,
-} from '@repo/protocol';
+  awaitDeploymentSettled,
+  type DeployStep,
+  deploy as startDeployment,
+} from '@repo/app-operations';
+import { type Filename, FilenameSchema, type TenantArguments, Value } from '@repo/protocol';
 import { UsageError } from '#lib/errors.ts';
 import type { RunOptions } from '#lib/plan.ts';
 import type { Ui } from '#lib/ui.ts';
 
-const SETTLING_STATES = new Set<DeploymentState>(['pending', 'starting']);
-// A host now tells the api the moment a tenant answers rather than on its next report, so this
-// is what stands between that and the owner being told — and the whole wait is a few seconds.
-const POLL_INTERVAL_MS = 500;
-const SERVING_TIMEOUT_MS = 300_000;
 const MS_PER_SECOND = 1_000;
 const ELAPSED_DECIMALS = 1;
-const SIZE_DECIMALS = 1;
-const BYTES_PER_MEBIBYTE = 1_048_576;
 
 /** The binary as this end knows it: where to read it from, not the bytes themselves. */
 export type LocalBinary = {
@@ -39,127 +29,55 @@ export type DeployInput = RunOptions & {
   detach?: boolean | undefined;
 };
 
-/**
- * Upload a binary and make it the app's live release.
- *
- * Config is written before the deployment rather than sent with it: a deployment snapshots the
- * app's config as it stands, so this is the only order in which the flags a caller just typed
- * are the ones that run.
- */
 export async function deploy({
   api,
   ui,
   binary,
   args,
-  app: slug,
+  app,
   name,
   port,
   detach,
 }: DeployInput): Promise<void> {
-  const target = slug === undefined ? null : await appBySlug({ api, slug });
-  const config = configPatch({ args, port });
+  const deployed = await startDeployment({
+    api,
+    binary: { name: binary.name, sizeBytes: binary.sizeBytes, body: Bun.file(binary.path) },
+    args,
+    app,
+    name,
+    port,
+    onStep: (step) => announce({ step, ui }),
+    whileUploading: ui.waitingFor,
+  });
 
-  const app =
-    target === null
-      ? unwrap(await api.api.apps.post({ name: name ?? binary.name, config }))
-      : unwrap(await api.api.apps({ appId: target.id }).patch(config));
-  ui.step(`app ${app.slug}`);
-
-  const artifact = await uploadBinary({ api, ui, appId: app.id, binary });
-  ui.step(`artifact ${artifact.digest}`);
-
-  const deployment = unwrap(
-    await api.api.apps({ appId: app.id }).deployments.post({ artifactId: artifact.id }),
-  );
-
-  const url = `https://${platformHostname(app.hostnames)}`;
   if (detach === true) {
-    ui.done(`${url} — deployment ${deployment.id} is starting`);
+    ui.done(`${deployed.url} — deployment ${deployed.deploymentId} is starting`);
     return;
   }
 
   const startedAt = Date.now();
   const state = await ui.waitingFor({
-    message: `starting deployment ${deployment.id}`,
-    task: () => awaitSettled({ api, appId: app.id, deploymentId: deployment.id }),
+    message: `starting deployment ${deployed.deploymentId}`,
+    task: () =>
+      awaitDeploymentSettled({
+        api,
+        appId: deployed.appId,
+        deploymentId: deployed.deploymentId,
+      }),
   });
   if (state !== 'active') {
-    throw new ApiError(`Deployment ${deployment.id} is ${state}.`);
+    throw new ApiError(`Deployment ${deployed.deploymentId} is ${state}.`);
   }
-  ui.done(`${url} — ready in ${elapsed(Date.now() - startedAt)}`);
+  ui.done(`${deployed.url} — ready in ${elapsed(Date.now() - startedAt)}`);
 }
 
-/**
- * The bytes go to the object store, not to the api: a binary is far larger than anything else
- * sent here, and everything between this end and the api — proxies, CDNs — has an opinion about
- * how large a request body may be. The api creates the artifact, says where to put the bytes,
- * and is told afterwards how that went.
- *
- * It is told either way. Only this end watched the upload happen, so an artifact whose bytes
- * never arrived is one nothing else can ever find out about.
- */
-async function uploadBinary({
-  api,
-  ui,
-  appId,
-  binary,
-}: {
-  api: PublicApiClient;
-  ui: Ui;
-  appId: string;
-  binary: LocalBinary;
-}) {
-  const { artifactId, url } = unwrap(
-    await api.api.apps({ appId }).artifacts.post({
-      filename: binary.name,
-      sizeBytes: binary.sizeBytes,
-    }),
-  );
-  const artifact = api.api.apps({ appId }).artifacts({ artifactId });
-
-  try {
-    await ui.waitingFor({
-      message: `uploading ${binary.name} (${mebibytes(binary.sizeBytes)})`,
-      task: () => putBinary({ url, binary }),
-    });
-  } catch (failure) {
-    await artifact.patch({ upload: 'failed' });
-    throw failure;
+function announce({ step, ui }: { step: DeployStep; ui: Ui }): void {
+  if (step.kind === 'app') {
+    ui.step(`app ${step.slug}`);
   }
-
-  // The same endpoint answers an abandoned upload with no body at all, so what comes back is
-  // only typed as an artifact once this has said it is one.
-  const completed = unwrap(await artifact.patch({ upload: 'complete' }));
-  if (!completed) {
-    throw new ApiError('The api accepted the upload without saying what it stored.');
+  if (step.kind === 'artifact') {
+    ui.step(`artifact ${step.digest}`);
   }
-  return completed;
-}
-
-/**
- * The whole file as the body, streamed from disk: a process that has to hold a binary to send it
- * is a process that cannot send a large one.
- *
- * The url was signed for this exact length, so the store refuses anything else — which is also
- * why a file that changed since it was measured comes back as a signature that does not match.
- */
-async function putBinary({ url, binary }: { url: string; binary: LocalBinary }): Promise<void> {
-  const response = await fetch(url, { method: 'PUT', body: Bun.file(binary.path) });
-  if (!response.ok) {
-    throw new ApiError(
-      `The store refused the upload: ${response.status} ${await storeError(response)}`,
-    );
-  }
-}
-
-// S3 answers in XML, and the one part of it worth repeating is the sentence it puts in Message.
-async function storeError(response: Response): Promise<string> {
-  const body = await response.text();
-  return /<Message>(?<message>[^<]*)<\/Message>/.exec(body)?.groups?.message ?? response.statusText;
-}
-
-function mebibytes(bytes: number): string {
-  return `${(bytes / BYTES_PER_MEBIBYTE).toFixed(SIZE_DECIMALS)} MB`;
 }
 
 function elapsed(ms: number): string {
@@ -191,46 +109,4 @@ function asFilename(name: string): Filename {
       `A binary's name must start with a letter or digit and hold only letters, digits, dots, dashes or underscores: ${name}`,
     );
   }
-}
-
-/**
- * `args` is always written, empty included: what the caller typed is what the binary is asked to
- * run with, and carrying over the last deploy's arguments because none were given this time
- * would run something nobody asked for.
- */
-function configPatch({ args, port }: Pick<RunOptions, 'port'> & { args: TenantArguments }) {
-  return {
-    args,
-    ...(port !== undefined && { guestPort: Value.Parse(GuestPortSchema, port) }),
-  };
-}
-
-async function awaitSettled({
-  api,
-  appId,
-  deploymentId,
-}: {
-  api: PublicApiClient;
-  appId: string;
-  deploymentId: string;
-}): Promise<DeploymentState> {
-  const deadline = Date.now() + SERVING_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    const deployment = unwrap(await api.api.apps({ appId }).deployments({ deploymentId }).get());
-    if (!SETTLING_STATES.has(deployment.state)) {
-      return deployment.state;
-    }
-    await Bun.sleep(POLL_INTERVAL_MS);
-  }
-  throw new ApiError(
-    `Deployment ${deploymentId} was still starting after ${SERVING_TIMEOUT_MS}ms.`,
-  );
-}
-
-function platformHostname(hostnames: ReadonlyArray<{ hostname: string; kind: string }>): string {
-  const platform = hostnames.find((entry) => entry.kind === 'platform') ?? hostnames[0];
-  if (!platform) {
-    throw new ApiError('The app was created without a hostname.');
-  }
-  return platform.hostname;
 }


### PR DESCRIPTION
The dashboard deploys the same way `nib run` does, so the sequence moves to the package both drive: config before the deployment, the three upload steps, and the failed-upload report that only the uploading end can make.

Reading the binary stays where it can happen — a path in the cli, a picked file in the browser.