### PR TITLE
refactor(app-operations): an export is asked for and waited on the same way

### DIFF
--- a/packages/app-operations/src/exports.ts
+++ b/packages/app-operations/src/exports.ts
@@ -1,0 +1,68 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { ApiError, unwrap } from '@repo/api-client/unwrap';
+import type { ExportState } from '@repo/protocol';
+import { pause } from '#wait.ts';
+
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * Longer between polls than a deployment takes, because the wait is a different kind: a
+ * deployment is a guest starting, an export is a filesystem being read with no bound on how much
+ * is in it.
+ */
+const POLL_INTERVAL_MS = 5_000;
+
+/**
+ * The host allows itself an hour to read one tenant's filesystem, so giving up sooner would be
+ * giving up on an export that is still coming. Giving up costs little either way: the request
+ * stays in flight, and asking again is answered with it rather than with a second read.
+ */
+const READY_TIMEOUT_MINUTES = 60;
+
+const STILL_COMING: ReadonlySet<ExportState> = new Set<ExportState>(['pending', 'preparing']);
+
+export type ExportBundle = { downloadUrl: string; sizeBytes: number | undefined };
+
+export async function requestExport({
+  api,
+  appId,
+}: {
+  api: PublicApiClient;
+  appId: string;
+}): Promise<{ id: string; state: ExportState }> {
+  return unwrap(await api.api.apps({ appId }).exports.post());
+}
+
+/**
+ * Poll until the host has written the bundle.
+ *
+ * A download URL rather than a state is what says it is there: the URL is signed for the response
+ * it arrives in and outlives it by minutes, so the one that is read is the one the download uses.
+ */
+export async function awaitExportBundle({
+  api,
+  appId,
+  exportId,
+  signal,
+}: {
+  api: PublicApiClient;
+  appId: string;
+  exportId: string;
+  signal?: AbortSignal | undefined;
+}): Promise<ExportBundle> {
+  const deadline = Date.now() + READY_TIMEOUT_MINUTES * MS_PER_MINUTE;
+  while (Date.now() < deadline) {
+    signal?.throwIfAborted();
+    const found = unwrap(await api.api.apps({ appId }).exports({ exportId }).get());
+    if (found.downloadUrl !== undefined) {
+      return { downloadUrl: found.downloadUrl, sizeBytes: found.sizeBytes };
+    }
+    if (!STILL_COMING.has(found.state)) {
+      throw new ApiError(`Export ${exportId} is ${found.state}.`);
+    }
+    await pause(POLL_INTERVAL_MS);
+  }
+  throw new ApiError(
+    `Export ${exportId} was still being prepared after ${READY_TIMEOUT_MINUTES} minutes. Asking again is answered with this one until it is ready.`,
+  );
+}

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -11,5 +11,6 @@ export {
   type UploadWait,
 } from '#deploy.ts';
 export { InvalidPathError } from '#errors.ts';
+export { awaitExportBundle, type ExportBundle, requestExport } from '#exports.ts';
 export { guestPath, readDirectory } from '#filesystem.ts';
 export { type FollowInput, followLogs } from '#logs.ts';

--- a/packages/app-operations/tests/exports.test.ts
+++ b/packages/app-operations/tests/exports.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'bun:test';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { awaitExportBundle, requestExport } from '#exports.ts';
+
+const APP_ID = 'app-1';
+const EXPORT_ID = 'export-1';
+const DOWNLOAD_URL = 'https://bundles.example/export-1?signature=x';
+const SIZE_BYTES = 4096;
+
+type Found = { state: string; downloadUrl?: string; sizeBytes?: number };
+
+function apiHolding({ found, asked }: { found: Found; asked?: string[] }): PublicApiClient {
+  function underApp({ appId }: { appId: string }) {
+    function addressed({ exportId }: { exportId: string }) {
+      return {
+        get: () => {
+          asked?.push(exportId);
+          return Promise.resolve({ data: { id: exportId, ...found }, error: null });
+        },
+      };
+    }
+    return {
+      exports: Object.assign(addressed, {
+        post: () => {
+          asked?.push(appId);
+          return Promise.resolve({ data: { id: EXPORT_ID, state: 'pending' }, error: null });
+        },
+      }),
+    };
+  }
+
+  return { api: { apps: underApp } } as unknown as PublicApiClient;
+}
+
+test('the app an export is asked for is the app it is asked under', async () => {
+  const asked: string[] = [];
+
+  const requested = await requestExport({
+    api: apiHolding({ found: { state: 'pending' }, asked }),
+    appId: APP_ID,
+  });
+
+  expect(asked).toEqual([APP_ID]);
+  expect(requested).toMatchObject({ id: EXPORT_ID, state: 'pending' });
+});
+
+// The url is signed for the response it arrives in, so it is what says the bundle is there.
+test('a download url is what the wait is waiting for', async () => {
+  const api = apiHolding({
+    found: { state: 'ready', downloadUrl: DOWNLOAD_URL, sizeBytes: SIZE_BYTES },
+  });
+
+  await expect(awaitExportBundle({ api, appId: APP_ID, exportId: EXPORT_ID })).resolves.toEqual({
+    downloadUrl: DOWNLOAD_URL,
+    sizeBytes: SIZE_BYTES,
+  });
+});
+
+test('a size the host did not report is not waited for either', async () => {
+  const api = apiHolding({ found: { state: 'ready', downloadUrl: DOWNLOAD_URL } });
+
+  await expect(awaitExportBundle({ api, appId: APP_ID, exportId: EXPORT_ID })).resolves.toEqual({
+    downloadUrl: DOWNLOAD_URL,
+    sizeBytes: undefined,
+  });
+});
+
+test('an export that will never arrive is said rather than waited on', async () => {
+  const api = apiHolding({ found: { state: 'failed' } });
+
+  await expect(awaitExportBundle({ api, appId: APP_ID, exportId: EXPORT_ID })).rejects.toThrow(
+    `Export ${EXPORT_ID} is failed.`,
+  );
+});

--- a/packages/cli/src/lib/exports.ts
+++ b/packages/cli/src/lib/exports.ts
@@ -1,9 +1,8 @@
 import { rename, rm, stat } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { ApiError, unwrap } from '@repo/api-client/unwrap';
-import { appBySlug } from '@repo/app-operations';
-import type { ExportState } from '@repo/protocol';
+import { ApiError } from '@repo/api-client/unwrap';
+import { appBySlug, awaitExportBundle, requestExport } from '@repo/app-operations';
 import { UsageError } from '#lib/errors.ts';
 import type { Ui } from '#lib/ui.ts';
 
@@ -15,24 +14,6 @@ const BUNDLE_SUFFIX = '.tar.gz';
  * otherwise leave something that looks like the export and is not one.
  */
 const PARTIAL_SUFFIX = '.partial';
-
-const MS_PER_MINUTE = 60_000;
-
-/**
- * Longer between polls than a deployment takes, because the wait is a different kind: a
- * deployment is a guest starting, an export is a filesystem being read with no bound on how much
- * is in it.
- */
-const POLL_INTERVAL_MS = 5_000;
-
-/**
- * The host allows itself an hour to read one tenant's filesystem, so giving up sooner would be
- * giving up on an export that is still coming. Giving up costs little either way: the request
- * stays in flight, and asking again is answered with it rather than with a second read.
- */
-const READY_TIMEOUT_MINUTES = 60;
-
-const STILL_COMING: ReadonlySet<ExportState> = new Set<ExportState>(['pending', 'preparing']);
 
 const BYTES_PER_MIB = 1_048_576;
 const MIB_DECIMALS = 1;
@@ -56,12 +37,12 @@ export async function exportApp({ api, slug, destination, ui }: ExportInput): Pr
   const path = await bundlePath({ destination, slug });
   const app = await appBySlug({ api, slug });
 
-  const requested = unwrap(await api.api.apps({ appId: app.id }).exports.post());
+  const requested = await requestExport({ api, appId: app.id });
   ui.step(`export ${requested.id}`);
 
   const bundle = await ui.waitingFor({
     message: 'preparing the bundle',
-    task: () => awaitBundle({ api, appId: app.id, exportId: requested.id }),
+    task: () => awaitExportBundle({ api, appId: app.id, exportId: requested.id }),
   });
   await ui.waitingFor({
     message: describeDownload(bundle.sizeBytes),
@@ -97,37 +78,6 @@ export async function bundlePath({
     throw new UsageError(`${path} already exists.`);
   }
   return path;
-}
-
-/**
- * Poll until the host has written the bundle.
- *
- * A download URL rather than a state is what says it is there: the URL is signed for the response
- * it arrives in and outlives it by minutes, so the one that is read is the one the download uses.
- */
-async function awaitBundle({
-  api,
-  appId,
-  exportId,
-}: {
-  api: PublicApiClient;
-  appId: string;
-  exportId: string;
-}): Promise<{ downloadUrl: string; sizeBytes: number | undefined }> {
-  const deadline = Date.now() + READY_TIMEOUT_MINUTES * MS_PER_MINUTE;
-  while (Date.now() < deadline) {
-    const found = unwrap(await api.api.apps({ appId }).exports({ exportId }).get());
-    if (found.downloadUrl !== undefined) {
-      return { downloadUrl: found.downloadUrl, sizeBytes: found.sizeBytes };
-    }
-    if (!STILL_COMING.has(found.state)) {
-      throw new ApiError(`Export ${exportId} is ${found.state}.`);
-    }
-    await Bun.sleep(POLL_INTERVAL_MS);
-  }
-  throw new ApiError(
-    `Export ${exportId} was still being prepared after ${READY_TIMEOUT_MINUTES} minutes. Asking again is answered with this one until it is ready.`,
-  );
 }
 
 /**


### PR DESCRIPTION
Asking for a bundle and polling until it is written is the same wait from either surface. Writing it to disk stays in the cli; the browser is handed the url.