### PR TITLE
refactor(app-operations): deleting an app is the same request from either surface

### DIFF
--- a/packages/app-operations/src/delete.ts
+++ b/packages/app-operations/src/delete.ts
@@ -1,0 +1,18 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
+import type { AppState } from '@repo/protocol';
+
+/**
+ * Delete an app: the hostnames it answered on, everything its binary ever wrote, every deployment
+ * of it, and — once the api has torn it down — every binary uploaded to it and every export taken
+ * of it.
+ */
+export async function deleteApp({
+  api,
+  appId,
+}: {
+  api: PublicApiClient;
+  appId: string;
+}): Promise<{ slug: string; state: AppState }> {
+  return unwrap(await api.api.apps({ appId }).delete());
+}

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -1,6 +1,7 @@
 /** biome-ignore-all lint/performance/noBarrelFile: index is the only allowed file where we can export other files */
 
 export { addressedDeployment, appBySlug, latestDeployment } from '#apps.ts';
+export { deleteApp } from '#delete.ts';
 export {
   awaitDeploymentSettled,
   type Deployed,

--- a/packages/app-operations/tests/delete.test.ts
+++ b/packages/app-operations/tests/delete.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { deleteApp } from '#delete.ts';
+
+const SLUG = 'quiet-otter';
+
+function apiHolding({ deleted }: { deleted: string[] }): PublicApiClient {
+  function addressed({ appId }: { appId: string }) {
+    return {
+      delete: () => {
+        deleted.push(appId);
+        return Promise.resolve({ data: { slug: SLUG, state: 'deleting' }, error: null });
+      },
+    };
+  }
+  return { api: { apps: addressed } } as unknown as PublicApiClient;
+}
+
+test('the app named is the app the api is asked to tear down', async () => {
+  const deleted: string[] = [];
+
+  const deleting = await deleteApp({ api: apiHolding({ deleted }), appId: 'app-1' });
+
+  expect(deleted).toEqual(['app-1']);
+  expect(deleting).toEqual({ slug: SLUG, state: 'deleting' });
+});

--- a/packages/cli/src/lib/delete.ts
+++ b/packages/cli/src/lib/delete.ts
@@ -1,7 +1,6 @@
 import { note, text } from '@clack/prompts';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { unwrap } from '@repo/api-client/unwrap';
-import { appBySlug } from '@repo/app-operations';
+import { appBySlug, deleteApp as requestDeletion } from '@repo/app-operations';
 import { UsageError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
 import type { Ui } from '#lib/ui.ts';
@@ -45,7 +44,7 @@ export async function deleteApp({ api, slug, ui, yes, interactive }: DeleteInput
     });
   }
 
-  const deleting = unwrap(await api.api.apps({ appId: app.id }).delete());
+  const deleting = await requestDeletion({ api, appId: app.id });
   ui.done(
     `${deleting.slug} is ${deleting.state}. What is on the volume goes when the host holding it says so.`,
   );


### PR DESCRIPTION
Only the request moves. How an owner is asked to mean it stays where it is asked — a typed phrase in the terminal, a typed phrase in the dialog.