### PR TITLE
feat(dashboard): an app's hostnames open the app

### DIFF
--- a/apps/dashboard/src/components/apps/app-overview-card.tsx
+++ b/apps/dashboard/src/components/apps/app-overview-card.tsx
@@ -1,3 +1,4 @@
+import { ExternalLinkIcon } from 'lucide-react';
 import { AppStateBadge } from '#components/apps/app-state-badge.tsx';
 import { Badge } from '#components/ui/badge.tsx';
 import { Card, CardContent, CardHeader, CardTitle } from '#components/ui/card.tsx';
@@ -24,8 +25,16 @@ export function AppOverviewCard({ app }: { app: AppSummary }) {
           <ul className="flex flex-col gap-2">
             {app.hostnames.map((hostname) => (
               <li key={hostname.hostname} className="flex items-center justify-between gap-4">
-                <span className="truncate font-mono">{hostname.hostname}</span>
-                <Badge variant="outline">{hostname.kind}</Badge>
+                <a
+                  href={`https://${hostname.hostname}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex min-w-0 items-center gap-1.5 font-mono hover:underline"
+                >
+                  <span className="truncate">{hostname.hostname}</span>
+                  <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
+                </a>
+                {hostname.kind === 'custom' ? <Badge variant="outline">Custom</Badge> : null}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
The overview tab linked nothing and badged every hostname with its kind. A hostname is now a link to the app, and only a custom domain is worth calling out.