### PR TITLE
feat(dashboard): how far back the logs tab starts reading

### DIFF
--- a/apps/dashboard/src/components/apps/app-tabs.tsx
+++ b/apps/dashboard/src/components/apps/app-tabs.tsx
@@ -1,4 +1,4 @@
-import { GUEST_PATH_ROOT } from '@repo/protocol';
+import { DEFAULT_LOG_TIMERANGE, GUEST_PATH_ROOT } from '@repo/protocol';
 import { Link } from '@tanstack/react-router';
 import { Tabs, TabsList, TabsTrigger } from '#components/ui/tabs.tsx';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
@@ -17,7 +17,16 @@ export function AppTabs() {
         <TabsTrigger value="overview" render={<Link to={AppRoute.to} params={{ appId }} />}>
           Overview
         </TabsTrigger>
-        <TabsTrigger value="logs" render={<Link to={LogsRoute.to} params={{ appId }} />}>
+        <TabsTrigger
+          value="logs"
+          render={
+            <Link
+              to={LogsRoute.to}
+              params={{ appId }}
+              search={{ timerange: DEFAULT_LOG_TIMERANGE }}
+            />
+          }
+        >
           Logs
         </TabsTrigger>
         <TabsTrigger

--- a/apps/dashboard/src/components/logs/deployment-logs.tsx
+++ b/apps/dashboard/src/components/logs/deployment-logs.tsx
@@ -1,6 +1,7 @@
 import { DeploymentLine } from '#components/apps/deployment-line.tsx';
 import { FailureEmpty } from '#components/failure-empty.tsx';
 import { LogStream } from '#components/logs/log-stream.tsx';
+import { LogTimerangeMenu } from '#components/logs/log-timerange-menu.tsx';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
 import { useDeploymentLogs } from '#lib/hooks/use-deployment-logs.ts';
 import { useFailureToast } from '#lib/hooks/use-failure-toast.ts';
@@ -17,11 +18,14 @@ export function DeploymentLogs() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
-      {logs.deploymentId === undefined ? (
-        <p className="text-muted-foreground text-xs">Finding the current deployment…</p>
-      ) : (
-        <DeploymentLine deploymentId={logs.deploymentId} />
-      )}
+      <div className="flex items-center justify-between gap-4">
+        {logs.deploymentId === undefined ? (
+          <p className="text-muted-foreground text-xs">Finding the current deployment…</p>
+        ) : (
+          <DeploymentLine deploymentId={logs.deploymentId} />
+        )}
+        <LogTimerangeMenu />
+      </div>
       <LogStream records={logs.records} />
     </div>
   );

--- a/apps/dashboard/src/components/logs/log-timerange-menu.tsx
+++ b/apps/dashboard/src/components/logs/log-timerange-menu.tsx
@@ -1,0 +1,42 @@
+import { useNavigate } from '@tanstack/react-router';
+import { ChevronDownIcon } from 'lucide-react';
+import { Button } from '#components/ui/button.tsx';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '#components/ui/dropdown-menu.tsx';
+import { useLogTimerange } from '#lib/hooks/use-log-timerange.ts';
+import { LOG_TIMERANGES, type LogTimerangeChoice } from '#lib/log-timeranges.ts';
+import { Route as LogsRoute } from '#routes/(dashboard)/apps/$appId/logs.tsx';
+
+export function LogTimerangeMenu() {
+  const timerange = useLogTimerange();
+  const navigate = useNavigate({ from: LogsRoute.fullPath });
+  const selected = LOG_TIMERANGES.find((choice) => choice.value === timerange);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger render={<Button variant="outline" size="sm" />}>
+        {selected?.label}
+        <ChevronDownIcon />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-44" align="end">
+        <DropdownMenuRadioGroup
+          value={timerange}
+          onValueChange={(value: LogTimerangeChoice) => {
+            void navigate({ search: { timerange: value } });
+          }}
+        >
+          {LOG_TIMERANGES.map((choice) => (
+            <DropdownMenuRadioItem key={choice.value} value={choice.value}>
+              {choice.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/dashboard/src/lib/hooks/use-deployment-logs.ts
+++ b/apps/dashboard/src/lib/hooks/use-deployment-logs.ts
@@ -1,6 +1,7 @@
 import type { TenantLogRecord } from '@repo/protocol';
 import { useQuery } from '@tanstack/react-query';
 import { useLatestDeployment } from '#lib/hooks/use-latest-deployment.ts';
+import { useLogTimerange } from '#lib/hooks/use-log-timerange.ts';
 import { deploymentLogsQueryOptions } from '#queries/logs.ts';
 
 export type DeploymentLogsView = {
@@ -13,7 +14,8 @@ export type DeploymentLogsView = {
 export function useDeploymentLogs(appId: string): DeploymentLogsView {
   const latest = useLatestDeployment(appId);
   const deploymentId = latest.data;
-  const logs = useQuery(deploymentLogsQueryOptions({ appId, deploymentId }));
+  const timerange = useLogTimerange();
+  const logs = useQuery(deploymentLogsQueryOptions({ appId, deploymentId, timerange }));
   const records = logs.data ?? [];
 
   if (latest.isError) {

--- a/apps/dashboard/src/lib/hooks/use-log-timerange.ts
+++ b/apps/dashboard/src/lib/hooks/use-log-timerange.ts
@@ -1,0 +1,6 @@
+import type { LogTimerangeChoice } from '#lib/log-timeranges.ts';
+import { Route as LogsRoute } from '#routes/(dashboard)/apps/$appId/logs.tsx';
+
+export function useLogTimerange(): LogTimerangeChoice {
+  return LogsRoute.useSearch().timerange;
+}

--- a/apps/dashboard/src/lib/log-timeranges.ts
+++ b/apps/dashboard/src/lib/log-timeranges.ts
@@ -1,0 +1,14 @@
+export const LOG_TIMERANGES = [
+  { value: '5m', label: 'Last 5 minutes' },
+  { value: '15m', label: 'Last 15 minutes' },
+  { value: '1h', label: 'Last hour' },
+  { value: '6h', label: 'Last 6 hours' },
+  { value: '12h', label: 'Last 12 hours' },
+  { value: '24h', label: 'Last 24 hours' },
+] as const;
+
+export type LogTimerangeChoice = (typeof LOG_TIMERANGES)[number]['value'];
+
+export function isLogTimerangeChoice(value: unknown): value is LogTimerangeChoice {
+  return LOG_TIMERANGES.some((timerange) => timerange.value === value);
+}

--- a/apps/dashboard/src/queries/logs.ts
+++ b/apps/dashboard/src/queries/logs.ts
@@ -1,5 +1,5 @@
 import { followLogs } from '@repo/app-operations';
-import { DEFAULT_LOG_TIMERANGE, type TenantLogRecord } from '@repo/protocol';
+import type { LogTimerange, TenantLogRecord } from '@repo/protocol';
 import {
   queryOptions,
   skipToken,
@@ -16,12 +16,14 @@ function keptTail(records: readonly TenantLogRecord[]): readonly TenantLogRecord
 export function deploymentLogsQueryOptions({
   appId,
   deploymentId,
+  timerange,
 }: {
   appId: string;
   deploymentId: string | undefined;
+  timerange: LogTimerange;
 }) {
   return queryOptions({
-    queryKey: ['deployments', appId, deploymentId, 'logs'],
+    queryKey: ['deployments', appId, deploymentId, 'logs', timerange],
     queryFn:
       deploymentId === undefined
         ? skipToken
@@ -31,7 +33,7 @@ export function deploymentLogsQueryOptions({
                 api,
                 appId,
                 deploymentId,
-                timerange: DEFAULT_LOG_TIMERANGE,
+                timerange,
                 signal,
               }),
             // biome-ignore lint/complexity/useMaxParams: a reducer folds a chunk into what it has

--- a/apps/dashboard/src/routes/(dashboard)/apps/$appId/logs.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/apps/$appId/logs.tsx
@@ -1,7 +1,14 @@
+import { DEFAULT_LOG_TIMERANGE } from '@repo/protocol';
 import { createFileRoute } from '@tanstack/react-router';
 import { DeploymentLogs } from '#components/logs/deployment-logs.tsx';
+import { isLogTimerangeChoice, type LogTimerangeChoice } from '#lib/log-timeranges.ts';
+
+export type LogsSearch = { timerange: LogTimerangeChoice };
 
 export const Route = createFileRoute('/(dashboard)/apps/$appId/logs')({
+  validateSearch: (search: Record<string, unknown>): LogsSearch => ({
+    timerange: isLogTimerangeChoice(search.timerange) ? search.timerange : DEFAULT_LOG_TIMERANGE,
+  }),
   component: RouteComponent,
 });
 


### PR DESCRIPTION
The logs tab always started five minutes back. It now offers the range as a menu, from five minutes to a day, and carries the choice in the URL.