### PR TITLE
fix(dashboard): the latest deployment is invalidated with the deployments it comes from

### DIFF
--- a/apps/dashboard/src/queries/deployments.ts
+++ b/apps/dashboard/src/queries/deployments.ts
@@ -18,7 +18,7 @@ export function deploymentsQueryOptions(appId: string | undefined) {
 
 export function latestDeploymentQueryOptions(appId: string) {
   return queryOptions({
-    queryKey: ['latest-deployment', appId],
+    queryKey: ['deployments', appId, 'latest'],
     queryFn: () => latestDeployment({ api, appId }),
   });
 }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>