### PR TITLE
refactor(dashboard): a size is read the same way wherever one is shown

### DIFF
--- a/apps/dashboard/src/components/apps/app-config-card.tsx
+++ b/apps/dashboard/src/components/apps/app-config-card.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardHeader, CardTitle } from '#components/ui/card.tsx';
+import { formatBytes } from '#lib/format-bytes.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
 export function AppConfigCard({ app }: { app: AppSummary }) {
@@ -16,7 +17,9 @@ export function AppConfigCard({ app }: { app: AppSummary }) {
         </div>
         <div className="flex items-center justify-between gap-4">
           <span className="text-muted-foreground">Volume size</span>
-          <span className="font-mono tabular-nums">{volumeSizeBytes} bytes</span>
+          <span className="font-mono tabular-nums" title={`${volumeSizeBytes} bytes`}>
+            {formatBytes(volumeSizeBytes)}
+          </span>
         </div>
         <div className="flex flex-col gap-2">
           <span className="text-muted-foreground">Arguments</span>

--- a/apps/dashboard/src/components/files/directory-table.tsx
+++ b/apps/dashboard/src/components/files/directory-table.tsx
@@ -8,6 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from '#components/ui/table.tsx';
+import { formatBytes } from '#lib/format-bytes.ts';
 import { dayAndMinute } from '#lib/format-timestamp.ts';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
 import { useDirectoryPath } from '#lib/hooks/use-directory-path.ts';
@@ -31,7 +32,12 @@ export function DirectoryTable({ entries }: { entries: readonly FilesystemEntry[
         {byName(entries).map((entry) => (
           <TableRow key={entry.name}>
             <TableCell className="text-muted-foreground">{entry.kind}</TableCell>
-            <TableCell className="text-right font-mono tabular-nums">{entry.sizeBytes}</TableCell>
+            <TableCell
+              className="text-right font-mono tabular-nums"
+              title={`${entry.sizeBytes} bytes`}
+            >
+              {formatBytes(entry.sizeBytes)}
+            </TableCell>
             <TableCell className="text-muted-foreground tabular-nums">
               {dayAndMinute(entry.modifiedAt)}
             </TableCell>


### PR DESCRIPTION
A volume size read as `10737418240 bytes`. The exact count stays on hover, which is what a terminal could not offer and why `nib apps files ls` prints digits.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>