### PR TITLE
fix(dashboard): the apps list says what an app is running, not that it exists

### DIFF
--- a/apps/dashboard/src/components/apps/app-status-badge.tsx
+++ b/apps/dashboard/src/components/apps/app-status-badge.tsx
@@ -1,0 +1,34 @@
+import { AppStateBadge } from '#components/apps/app-state-badge.tsx';
+import { DeploymentStateBadge } from '#components/apps/deployment-state-badge.tsx';
+import { Badge } from '#components/ui/badge.tsx';
+import { Skeleton } from '#components/ui/skeleton.tsx';
+import { useDeployments } from '#lib/hooks/use-deployments.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+/**
+ * What an app is doing, which is what its newest deployment is doing: an app row is `active`
+ * from the moment it is created, so on its own it never says whether anything is serving.
+ *
+ * Its own state still wins when it is not `active` — an app being suspended or taken away is a
+ * truer answer than whatever release it was left holding.
+ */
+export function AppStatusBadge({ app }: { app: AppSummary }) {
+  const deployments = useDeployments(app.state === 'active' ? app.id : undefined);
+
+  if (app.state !== 'active') {
+    return <AppStateBadge state={app.state} />;
+  }
+  if (deployments.isPending) {
+    return <Skeleton className="h-5 w-20 rounded-2xl" />;
+  }
+  if (deployments.isError) {
+    return <Badge variant="outline">unknown</Badge>;
+  }
+
+  const latest = deployments.data[0];
+  return latest === undefined ? (
+    <Badge variant="outline">never deployed</Badge>
+  ) : (
+    <DeploymentStateBadge state={latest.state} />
+  );
+}

--- a/apps/dashboard/src/components/apps/apps-table.tsx
+++ b/apps/dashboard/src/components/apps/apps-table.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { AppStateBadge } from '#components/apps/app-state-badge.tsx';
+import { AppStatusBadge } from '#components/apps/app-status-badge.tsx';
 import {
   Table,
   TableBody,
@@ -18,7 +18,7 @@ export function AppsTable({ apps }: { apps: readonly AppSummary[] }) {
       <TableHeader>
         <TableRow>
           <TableHead>Slug</TableHead>
-          <TableHead>State</TableHead>
+          <TableHead>Status</TableHead>
           <TableHead>Last change</TableHead>
         </TableRow>
       </TableHeader>
@@ -35,7 +35,7 @@ export function AppsTable({ apps }: { apps: readonly AppSummary[] }) {
               </Link>
             </TableCell>
             <TableCell>
-              <AppStateBadge state={app.state} />
+              <AppStatusBadge app={app} />
             </TableCell>
             <TableCell className="text-muted-foreground tabular-nums">
               {dayAndMinute(app.updatedAt)}


### PR DESCRIPTION
An app row is `active` from the moment it is created, so the apps list said nothing about whether anything was serving — an app whose binary was still uploading read as `active`.

The badge now comes from the app's newest deployment, fetched per row off the existing `useDeployments` hook. The app's own state still wins when it is not `active`, since `live_apps` lists suspended and deleting apps too.