### PR TITLE
feat(dashboard): the dashboard is drawn in the sketchpad theme

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource-variable/geist-mono": "^5.3.0",
     "@repo/api-client": "workspace:*",
     "@repo/app-operations": "workspace:*",
     "@repo/protocol": "workspace:*",

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/inter";
+@import "@fontsource-variable/geist-mono";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -21,7 +21,7 @@ body {
 
 @theme inline {
   --font-heading: var(--font-sans);
-  --font-sans: Chakra Petch, ui-sans-serif, sans-serif, system-ui;
+  --font-sans: Geist Mono Variable, ui-monospace, monospace;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -60,7 +60,7 @@ body {
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
-  --font-mono: IBM Plex Mono, ui-monospace, monospace;
+  --font-mono: Geist Mono Variable, ui-monospace, monospace;
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --radius: 0rem;
   --tracking-tighter: calc(var(--tracking-normal) - 0.05em);
@@ -89,122 +89,124 @@ body {
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.2178 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.2178 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.2178 0 0);
-  --primary: oklch(0.2264 0 0);
+  --background: oklch(0.9721 0.0158 110.5501);
+  --foreground: oklch(0.5066 0.2501 271.8903);
+  --card: oklch(0.9721 0.0158 110.5501);
+  --card-foreground: oklch(0.5066 0.2501 271.8903);
+  --popover: oklch(0.9721 0.0158 110.5501);
+  --popover-foreground: oklch(0.5066 0.2501 271.8903);
+  --primary: oklch(0.5066 0.2501 271.8903);
   --primary-foreground: oklch(1 0 0);
   --secondary: oklch(1 0 0);
-  --secondary-foreground: oklch(0.2264 0 0);
-  --muted: oklch(1 0 0);
-  --muted-foreground: oklch(0.6334 0 0);
-  --accent: oklch(1 0 0);
-  --accent-foreground: oklch(0.2264 0 0);
-  --destructive: oklch(0.5954 0.2344 23.9586);
-  --border: oklch(1 0 0);
-  --input: oklch(1 0 0);
-  --ring: oklch(0.8109 0 0);
-  --chart-1: oklch(0.9667 0.0148 251.1556);
-  --chart-2: oklch(0.7422 0.1166 260.2);
-  --chart-3: oklch(0.6588 0.1585 264.3926);
-  --chart-4: oklch(0.5814 0.1857 265.2966);
-  --chart-5: oklch(0.4861 0.2073 266.0672);
+  --secondary-foreground: oklch(0.5066 0.2501 271.8903);
+  --muted: oklch(0.9189 0.0147 106.6853);
+  --muted-foreground: oklch(0.5066 0.2501 271.8903);
+  --accent: oklch(0.9168 0.0214 109.7161);
+  --accent-foreground: oklch(0.4486 0.2266 271.5512);
+  --destructive: oklch(0.63 0.19 23.03);
+  --border: oklch(0.5066 0.2501 271.8903);
+  --input: oklch(0.5066 0.2501 271.8903);
+  --ring: oklch(0.468 0.2721 279.6007);
+  --chart-1: oklch(0.5066 0.2501 271.8903);
+  --chart-2: oklch(0.7 0.19 48);
+  --chart-3: oklch(0.77 0.2 131);
+  --chart-4: oklch(0.68 0.15 237);
+  --chart-5: oklch(0.66 0.21 354);
   --radius: 0rem;
-  --sidebar: oklch(1 0 0);
-  --sidebar-foreground: oklch(0.2178 0 0);
-  --sidebar-primary: oklch(0.2264 0 0);
+  --sidebar: oklch(0.9721 0.0158 110.5501);
+  --sidebar-foreground: oklch(0.5066 0.2501 271.8903);
+  --sidebar-primary: oklch(0.5066 0.2501 271.8903);
   --sidebar-primary-foreground: oklch(1 0 0);
-  --sidebar-accent: oklch(1 0 0);
-  --sidebar-accent-foreground: oklch(0.2264 0 0);
-  --sidebar-border: oklch(1 0 0);
-  --sidebar-ring: oklch(0.8109 0 0);
+  --sidebar-accent: oklch(0.9168 0.0214 109.7161);
+  --sidebar-accent-foreground: oklch(0.4486 0.2266 271.5512);
+  --sidebar-border: oklch(0.4486 0.2266 271.5512);
+  --sidebar-ring: oklch(0.4486 0.2266 271.5512);
   --destructive-foreground: oklch(1 0 0);
-  --font-sans: Chakra Petch, ui-sans-serif, sans-serif, system-ui;
+  --font-sans: Geist Mono Variable, ui-monospace, monospace;
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
-  --font-mono: IBM Plex Mono, ui-monospace, monospace;
-  --shadow-color: oklch(0 0 0);
-  --shadow-opacity: 0.1;
-  --shadow-blur: 3px;
+  --font-mono: Geist Mono Variable, ui-monospace, monospace;
+  --shadow-color: hsl(238.3146 85.5769% 59.2157%);
+  --shadow-opacity: 0.15;
+  --shadow-blur: 0px;
   --shadow-spread: 0px;
-  --shadow-offset-x: 0;
-  --shadow-offset-y: 1px;
+  --shadow-offset-x: 4px;
+  --shadow-offset-y: 4px;
   --letter-spacing: 0em;
   --spacing: 0.25rem;
-  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
+  --shadow-2xs: 4px 4px 0px 0px hsl(238.3146 85.5769% 59.2157% / 0.07);
+  --shadow-xs: 4px 4px 0px 0px hsl(238.3146 85.5769% 59.2157% / 0.07);
   --shadow-sm:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+    4px 4px 0px 0px hsl(238.3146 85.5769% 59.2157% / 0.15),
+    4px 1px 2px -1px hsl(238.3146 85.5769% 59.2157% / 0.15);
+  --shadow:
+    4px 4px 0px 0px hsl(238.3146 85.5769% 59.2157% / 0.15),
+    4px 1px 2px -1px hsl(238.3146 85.5769% 59.2157% / 0.15);
   --shadow-md:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
+    4px 4px 0px 0px hsl(238.3146 85.5769% 59.2157% / 0.15),
+    4px 2px 4px -1px hsl(238.3146 85.5769% 59.2157% / 0.15);
   --shadow-lg:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+    4px 4px 0px 0px hsl(238.3146 85.5769% 59.2157% / 0.15),
+    4px 4px 6px -1px hsl(238.3146 85.5769% 59.2157% / 0.15);
   --shadow-xl:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
-  --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+    4px 4px 0px 0px hsl(238.3146 85.5769% 59.2157% / 0.15),
+    4px 8px 10px -1px hsl(238.3146 85.5769% 59.2157% / 0.15);
+  --shadow-2xl: 4px 4px 0px 0px hsl(238.3146 85.5769% 59.2157% / 0.38);
   --tracking-normal: 0em;
 }
 
 .dark {
-  --background: oklch(0 0 0);
-  --foreground: oklch(1 0 0);
-  --card: oklch(0 0 0);
-  --card-foreground: oklch(1 0 0);
-  --popover: oklch(0 0 0);
-  --popover-foreground: oklch(1 0 0);
-  --primary: oklch(0.6152 0.1657 26.98);
-  --primary-foreground: oklch(0 0 0);
-  --secondary: oklch(0.6152 0.1657 26.98);
-  --secondary-foreground: oklch(0 0 0);
-  --muted: oklch(0.2246 0.0094 107.1335);
-  --muted-foreground: oklch(1 0 0);
-  --accent: oklch(0.6152 0.1657 26.98);
-  --accent-foreground: oklch(0 0 0);
-  --destructive: oklch(0.6152 0.1657 26.98);
-  --border: oklch(0.252 0 0);
-  --input: oklch(0 0 0);
-  --ring: oklch(0.6152 0.1657 26.98);
-  --chart-1: oklch(0.7152 0.1485 58.8324);
-  --chart-2: oklch(0.8299 0.1718 107.4066);
-  --chart-3: oklch(0.5798 0.1829 259.5141);
-  --chart-4: oklch(0.4962 0.2332 288.0574);
-  --chart-5: oklch(0.6152 0.1657 26.98);
-  --sidebar: oklch(0 0 0);
-  --sidebar-foreground: oklch(1 0 0);
-  --sidebar-primary: oklch(0.6152 0.1657 26.98);
+  --background: oklch(0.256 0.151 268.343);
+  --foreground: oklch(0.972 0.016 110.55);
+  --card: oklch(0.256 0.151 268.343);
+  --card-foreground: oklch(0.972 0.016 110.55);
+  --popover: oklch(0.507 0.25 271.89);
+  --popover-foreground: oklch(0.972 0.016 110.55);
+  --primary: oklch(0.972 0.016 110.55);
+  --primary-foreground: oklch(0.253 0.094 275.725);
+  --secondary: oklch(1 0 0 / 0.2);
+  --secondary-foreground: oklch(1 0 0);
+  --muted: oklch(0.228 0.127 269.556);
+  --muted-foreground: oklch(0.972 0.016 110.55);
+  --accent: oklch(0.228 0.127 269.556);
+  --accent-foreground: oklch(0.972 0.016 110.55);
+  --destructive: oklch(0.711 0.166 22.216);
+  --border: oklch(0.427 0.149 277.089);
+  --input: oklch(0.427 0.149 277.089);
+  --ring: oklch(1 0 0);
+  --chart-1: oklch(0.972 0.016 110.55);
+  --chart-2: oklch(0.7 0.19 48);
+  --chart-3: oklch(0.77 0.2 131);
+  --chart-4: oklch(0.68 0.15 237);
+  --chart-5: oklch(0.66 0.21 354);
+  --sidebar: oklch(0.256 0.151 268.343);
+  --sidebar-foreground: oklch(0.972 0.016 110.55);
+  --sidebar-primary: oklch(0.507 0.25 271.89);
   --sidebar-primary-foreground: oklch(1 0 0);
-  --sidebar-accent: oklch(0.6152 0.1657 26.98);
-  --sidebar-accent-foreground: oklch(0 0 0);
-  --sidebar-border: oklch(0 0 0);
-  --sidebar-ring: oklch(0.6152 0.1657 26.98);
+  --sidebar-accent: oklch(0.416 0.203 272.082);
+  --sidebar-accent-foreground: oklch(0.972 0.016 110.55);
+  --sidebar-border: oklch(0.972 0.016 110.55);
+  --sidebar-ring: oklch(0.972 0.016 110.55);
   --destructive-foreground: oklch(0 0 0);
   --radius: 0rem;
-  --font-sans: Chakra Petch, ui-sans-serif, sans-serif, system-ui;
+  --font-sans: Geist Mono Variable, ui-monospace, monospace;
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
-  --font-mono: IBM Plex Mono, ui-monospace, monospace;
-  --shadow-color: oklch(0 0 0);
-  --shadow-opacity: 0.1;
-  --shadow-blur: 3px;
+  --font-mono: Geist Mono Variable, ui-monospace, monospace;
+  --shadow-color: oklch(0.427 0.149 277.089);
+  --shadow-opacity: 0.5;
+  --shadow-blur: 0px;
   --shadow-spread: 0px;
-  --shadow-offset-x: 0;
-  --shadow-offset-y: 1px;
+  --shadow-offset-x: 4px;
+  --shadow-offset-y: 4px;
   --letter-spacing: 0em;
   --spacing: 0.25rem;
-  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-sm:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow-md:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
-  --shadow-lg:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
-  --shadow-xl:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
-  --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+  --shadow-2xs: 4px 4px 0px 0px oklch(0.427 0.149 277.089 / 0.5);
+  --shadow-xs: 4px 4px 0px 0px oklch(0.427 0.149 277.089 / 0.5);
+  --shadow-sm: 4px 4px 0px 0px oklch(0.427 0.149 277.089 / 0.5);
+  --shadow: 4px 4px 0px 0px oklch(0.427 0.149 277.089 / 0.5);
+  --shadow-md: 4px 4px 0px 0px oklch(0.427 0.149 277.089 / 0.5);
+  --shadow-lg: 4px 4px 0px 0px oklch(0.427 0.149 277.089 / 0.5);
+  --shadow-xl: 4px 4px 0px 0px oklch(0.427 0.149 277.089 / 0.5);
+  --shadow-2xl: 4px 4px 0px 0px oklch(0.427 0.149 277.089 / 0.5);
 }
 
 @layer base {

--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
       "name": "@repo/dashboard",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
-        "@fontsource-variable/inter": "^5.3.0",
+        "@fontsource-variable/geist-mono": "^5.3.0",
         "@repo/api-client": "workspace:*",
         "@repo/app-operations": "workspace:*",
         "@repo/protocol": "workspace:*",
@@ -397,7 +397,7 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
 
-    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.3.0", "", {}, "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA=="],
+    "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.3.0", "", {}, "sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw=="],
 
     "@hono/node-server": ["@hono/node-server@2.0.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg=="],
 
@@ -1313,9 +1313,9 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
-    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+    "seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
 
-    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
+    "seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -1493,10 +1493,6 @@
 
     "@tanstack/router-cli/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
-    "@tanstack/router-core/seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
-
-    "@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
-
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "conf/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
@@ -1536,6 +1532,10 @@
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "solid-js/seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "solid-js/seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/packages/cli/src/lib/apps.test.ts
+++ b/packages/cli/src/lib/apps.test.ts
@@ -10,11 +10,14 @@ type Asked = {
 const asked: Asked[] = [];
 let chosen: unknown = null;
 
+const clack = await import('@clack/prompts');
+
 // Replaced wholesale rather than reached through a port, as `plan.test.ts` does it: what is being
-// pinned down is which question an owner is asked and what it offers them. `mock.module` is
-// global, so this answers for clack for the rest of the run — only for what `#lib/apps.ts` asks of
-// it, which is why a file prompting for anything else stubs it itself.
+// pinned down is which question an owner is asked and what it offers them. `mock.module` is global
+// and outlives this file, so the rest of clack is spread back in: a stub carrying only what
+// `#lib/apps.ts` asks for leaves whichever file runs next unable to import the rest.
 mock.module('@clack/prompts', () => ({
+  ...clack,
   isCancel: (value: unknown) => typeof value === 'symbol',
   select(opts: Asked) {
     asked.push(opts);

--- a/packages/cli/src/lib/plan.test.ts
+++ b/packages/cli/src/lib/plan.test.ts
@@ -6,10 +6,13 @@ const notes: string[] = [];
 let chosenApp: unknown = null;
 let confirmed: boolean = true;
 
+const clack = await import('@clack/prompts');
+
 // Stubbed at the module rather than behind an injected port: what is being pinned down is which
 // questions get asked and in what order, and a port would only let this file answer that about
-// itself.
+// itself. The rest of clack is spread back in because `mock.module` outlives this file.
 mock.module('@clack/prompts', () => ({
+  ...clack,
   isCancel: (value: unknown) => typeof value === 'symbol',
   select(opts: { message: string; options: Array<{ label: string }> }) {
     asked.push(`select:${opts.message} [${opts.options.map((option) => option.label).join('|')}]`);


### PR DESCRIPTION
Colors, shadows and typeface from `@shadcndesign/theme-sketchpad`, merged into our `styles.css` by hand — the registry item is a `registry:theme` and `shadcn add` would have replaced the whole `cssVars` block, taking `--font-heading`, the tracking scale and the larger radii with it.

Two things the diff doesn't say:

- **The theme names a font and ships none**, which surfaced that we were doing the same. Inter was installed and imported but named in no stack; Chakra Petch and IBM Plex Mono were named everywhere and installed nowhere. The dashboard has been rendering in system fallbacks. It now loads the one font it names.
- **`font-mono` no longer contrasts with body text**, since sans and mono are both Geist Mono. The IDs, paths, log lines and device code that used to be set off by it read the same as everything else now.

---

The second commit is unrelated and only here because it was failing CI on this branch. Both files stubbing `@clack/prompts` were replacing the module with just the prompts each one used, and `mock.module` outlives the file that calls it — so whichever file ran next could not import the rest. It turns on file order, which held locally and did not on CI. Happy to split it out if you'd rather it landed on its own.