### PR TITLE
perf(filesystem): a host waits at the control plane for a read rather than on a timer

### DIFF
--- a/apps/agent/src/lib/agent/filesystem.ts
+++ b/apps/agent/src/lib/agent/filesystem.ts
@@ -1,5 +1,5 @@
 import type { FilesystemQuery, FilesystemQueryResult } from '@repo/protocol';
-import { type Duration, Effect } from 'effect';
+import { Duration, Effect } from 'effect';
 import { CONTROL_PLANE_BACKOFF } from '#lib/agent/backoff.ts';
 import { supervised } from '#lib/agent/loop.ts';
 import { reportedMessage } from '#lib/failure.ts';
@@ -9,14 +9,20 @@ import { FilesystemReader } from '#services/filesystem-reader.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 
 /**
- * Slept only when there was nothing to read, so this is how long an idle host waits rather than
- * how long a browsing caller does: every query has somebody holding a request open for it, and
- * pausing between two of them would charge that person for a host that had nothing else to do.
+ * A floor under one poll rather than a pause between two, and on the path that matters nothing is
+ * left to wait out: the control plane holds an idle request open until a read arrives, so a poll
+ * that came back with nothing has already spent longer than this and asks again at once. Every
+ * query has somebody holding a request open for it, and pausing before collecting one would charge
+ * that person for a host that had nothing else to do.
  *
- * Reading back to back cannot run away, because a query exists only while its caller waits —
- * demand is what bounds the rate, and demand stops when people stop asking.
+ * What it is for is an api that answers `none` the instant it is asked, which is what one deployed
+ * before the hold does — and one of those stands in front of this agent for the length of every
+ * rollout. Without a floor the two would spin against each other as fast as the link allows.
+ *
+ * Reading back to back still cannot run away: a query exists only while its caller waits, so
+ * demand bounds the rate and demand stops when people stop asking.
  */
-const IDLE_POLL_INTERVAL: Duration.DurationInput = '5 seconds';
+const IDLE_POLL_FLOOR: Duration.DurationInput = '5 seconds';
 
 /**
  * A read this host can serve is one it has a device for, which is what the slot table records.
@@ -56,18 +62,21 @@ export const answer = (query: FilesystemQuery) =>
     );
   });
 
-const once = Effect.gen(function* () {
+/** One poll: ask for a read, and either answer it or wait out what is left of the floor. */
+export const pollForRead = Effect.gen(function* () {
   const control = yield* ControlPlane;
   const sessions = yield* AgentSessionHolder;
   const session = yield* sessions.current;
 
-  const response = yield* control.fetchFilesystemQuery({
-    sessionToken: session.sessionToken,
-    request: { servedAppIds: yield* servedAppIds },
-  });
+  const [held, response] = yield* Effect.timed(
+    control.fetchFilesystemQuery({
+      sessionToken: session.sessionToken,
+      request: { servedAppIds: yield* servedAppIds },
+    }),
+  );
 
   if (response.result === 'none') {
-    return yield* Effect.sleep(IDLE_POLL_INTERVAL);
+    return yield* Effect.sleep(Duration.subtract(IDLE_POLL_FLOOR, held));
   }
 
   yield* control.sendFilesystemQueryResult({
@@ -79,13 +88,14 @@ const once = Effect.gen(function* () {
 /**
  * The fifth loop, and deliberately not part of the reconcile: a read observes the host without
  * changing it, so a slow device delays the person waiting on it and nothing else. A backlog of
- * reads must never be able to hold up a stop.
+ * reads must never be able to hold up a stop — nor may the request this loop spends most of its
+ * life parked on, which interruption abandons rather than waits out.
  */
 export const filesystemLoop = Effect.gen(function* () {
   const sessions = yield* AgentSessionHolder;
   // An idle tick is not a failure, so a host nobody is browsing never backs off.
   yield* supervised({
-    once: Effect.tapErrorTag(once, 'ControlPlaneError', sessions.onExpired),
+    once: Effect.tapErrorTag(pollForRead, 'ControlPlaneError', sessions.onExpired),
     onFailure: (cause) => Effect.logWarning('filesystem query loop failed', cause),
     schedule: CONTROL_PLANE_BACKOFF,
   });

--- a/apps/agent/src/lib/control/client.ts
+++ b/apps/agent/src/lib/control/client.ts
@@ -18,6 +18,15 @@ import { Data, Effect } from 'effect';
 import { decode } from '#lib/protocol.ts';
 
 const REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * The one route the api answers slowly on purpose: a poll for a read is held there until a read
+ * arrives or its own 25s hold expires, so the ordinary ceiling would abandon every idle poll a
+ * few seconds before the reply it was waiting for. Above the hold with room for the round trip,
+ * and never below it — a client that gives up first turns an idle fleet into a retry loop and
+ * loses every read handed to a host on the way out.
+ */
+const FILESYSTEM_QUERY_TIMEOUT_MS = 45_000;
 const HTTP_UNAUTHORIZED = 401;
 const NOT_DELIVERED = 0;
 const MAX_BODY = 256;
@@ -91,9 +100,15 @@ export const makeControlPlaneClient = ({ baseUrl }: { baseUrl: string }) => {
       Effect.withSpan('controlPlane', { attributes: { route } }),
     );
 
-  const options = (sessionToken?: SecretString) => ({
+  const options = ({
+    sessionToken,
+    timeoutMs = REQUEST_TIMEOUT_MS,
+  }: {
+    sessionToken?: SecretString;
+    timeoutMs?: number;
+  } = {}) => ({
     headers: protocolHeaders({ sessionToken }),
-    fetch: { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+    fetch: { signal: AbortSignal.timeout(timeoutMs) },
   });
 
   return {
@@ -116,7 +131,7 @@ export const makeControlPlaneClient = ({ baseUrl }: { baseUrl: string }) => {
     }) =>
       call({
         route: AGENT_ROUTES.desiredState,
-        send: () => api.internal.agent['desired-state'].post(request, options(sessionToken)),
+        send: () => api.internal.agent['desired-state'].post(request, options({ sessionToken })),
       }).pipe(
         Effect.flatMap((value) =>
           decode(() => parseMessage({ schema: DesiredStateResponseSchema, value })),
@@ -133,7 +148,7 @@ export const makeControlPlaneClient = ({ baseUrl }: { baseUrl: string }) => {
       Effect.asVoid(
         call({
           route: AGENT_ROUTES.reportedState,
-          send: () => api.internal.agent['reported-state'].post(report, options(sessionToken)),
+          send: () => api.internal.agent['reported-state'].post(report, options({ sessionToken })),
         }),
       ),
 
@@ -146,7 +161,11 @@ export const makeControlPlaneClient = ({ baseUrl }: { baseUrl: string }) => {
     }) =>
       call({
         route: AGENT_ROUTES.filesystemQuery,
-        send: () => api.internal.agent['filesystem-query'].post(request, options(sessionToken)),
+        send: () =>
+          api.internal.agent['filesystem-query'].post(
+            request,
+            options({ sessionToken, timeoutMs: FILESYSTEM_QUERY_TIMEOUT_MS }),
+          ),
       }).pipe(
         Effect.flatMap((value) =>
           decode(() => parseMessage({ schema: FilesystemQueryResponseSchema, value })),
@@ -164,7 +183,7 @@ export const makeControlPlaneClient = ({ baseUrl }: { baseUrl: string }) => {
         call({
           route: AGENT_ROUTES.filesystemQueryResult,
           send: () =>
-            api.internal.agent['filesystem-query-result'].post(result, options(sessionToken)),
+            api.internal.agent['filesystem-query-result'].post(result, options({ sessionToken })),
         }),
       ),
   };

--- a/apps/agent/tests/lib/agent/filesystem.test.ts
+++ b/apps/agent/tests/lib/agent/filesystem.test.ts
@@ -1,18 +1,28 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  type AgentSession,
   AppIdSchema,
+  DEFAULT_AGENT_POLL_SETTINGS,
   type DirectoryListing,
   type FilesystemQuery,
   FilesystemQueryIdSchema,
+  type FilesystemQueryRequest,
+  type FilesystemQueryResult,
   GuestPathSchema,
+  type HostVersions,
   TimestampSchema,
   Value,
 } from '@repo/protocol';
-import { Effect, Layer } from 'effect';
-import { answer } from '#lib/agent/filesystem.ts';
+import { type Duration, Effect, Fiber, Layer, TestClock, TestContext } from 'effect';
+import { answer, filesystemLoop } from '#lib/agent/filesystem.ts';
 import { UnreadableDirectory } from '#lib/filesystem/debugfs.ts';
+import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
+import { ControlPlane } from '#services/control-plane.service.ts';
 import { FilesystemReader, NoDeviceForApp } from '#services/filesystem-reader.service.ts';
+import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { recordingCommands } from '#tests/support/commands.ts';
+import { agentConfig } from '#tests/support/config.ts';
+import { platform } from '#tests/support/run.ts';
 
 const APP = Value.Parse(AppIdSchema, 'app-pocketbase');
 const QUERY: FilesystemQuery = {
@@ -81,5 +91,127 @@ describe('a query is answered whatever the read did', () => {
     }
     expect(result.outcome.message).toContain('/dev/nbd7');
     expect(result.outcome.message).not.toContain('UnreadableDirectory');
+  });
+});
+
+// Virtual time, so a test that spans three polls of a five-second floor still runs in an instant.
+const NO_TIME_AT_ALL: Duration.DurationInput = '0 millis';
+const TWO_FLOORS_AND_A_MOMENT: Duration.DurationInput = '12 seconds';
+const POLLS_ACROSS_TWO_FLOORS = 3;
+
+const SESSION = {
+  hostId: 'host-1',
+  sessionToken: 'session-token',
+  expiresAt: '2026-08-03T11:00:00Z',
+  poll: DEFAULT_AGENT_POLL_SETTINGS,
+} as AgentSession;
+
+function unreached() {
+  return Effect.dieMessage('the filesystem loop speaks on its own two routes and no others');
+}
+
+/**
+ * An api that answers a poll the instant it arrives rather than holding it open — which is what an
+ * api deployed before the hold does, and what stands in front of a new agent for the length of
+ * every rollout. Whatever is queued comes back first; every poll after that finds nothing.
+ */
+function immediateApi(queued: FilesystemQuery[]) {
+  const polls: FilesystemQueryRequest[] = [];
+  const answers: FilesystemQueryResult[] = [];
+  const layer = Layer.succeed(
+    ControlPlane,
+    ControlPlane.make({
+      openSession: unreached,
+      fetchDesiredState: unreached,
+      sendReportedState: unreached,
+      fetchFilesystemQuery: ({ request }: { request: FilesystemQueryRequest }) =>
+        Effect.sync(() => {
+          polls.push(request);
+          const query = queued.shift();
+          return query ? { result: 'query' as const, query } : { result: 'none' as const };
+        }),
+      sendFilesystemQueryResult: ({ result }: { result: FilesystemQueryResult }) =>
+        Effect.sync(() => {
+          answers.push(result);
+        }),
+    }),
+  );
+  return { polls, answers, layer };
+}
+
+const sessionHolder = Layer.succeed(
+  AgentSessionHolder,
+  AgentSessionHolder.make({
+    versions: {} as HostVersions,
+    current: Effect.succeed(SESSION),
+    pollSettings: Effect.succeed(SESSION.poll),
+    onExpired: () => Effect.void,
+  }),
+);
+
+// What a read would reach for on a host, none of which is reached here: the stub above keeps the
+// reader's signature, and a signature that shells out is one the layer has to satisfy.
+const host = Layer.mergeAll(agentConfig(), platform, recordingCommands().layer);
+
+// The real allocator over a slots file nothing wrote: a host holding no volume serves no app,
+// which is what an idle poll carries.
+const slots = Layer.provide(SlotAllocator.DefaultWithoutDependencies, host);
+
+const reader = Layer.succeed(
+  FilesystemReader,
+  FilesystemReader.make({ list: () => Effect.succeed(LISTING) }),
+);
+
+/**
+ * The loop over virtual time, so what is asserted is the cadence rather than the clock. Everything
+ * the api answers is instant here, which leaves the floor as the only thing that can space two
+ * polls apart.
+ */
+async function polling({
+  queued = [],
+  over,
+}: {
+  queued?: FilesystemQuery[];
+  over: Duration.DurationInput;
+}) {
+  const api = immediateApi(queued);
+  await Effect.runPromise(
+    Effect.provide(
+      Effect.gen(function* () {
+        const loop = yield* Effect.fork(filesystemLoop);
+        yield* TestClock.adjust(over);
+        yield* Fiber.interrupt(loop);
+      }),
+      Layer.mergeAll(api.layer, sessionHolder, slots, reader, host, TestContext.TestContext),
+    ),
+  );
+  return api;
+}
+
+/**
+ * The api holds an idle poll open, so the floor below is spent only against one that does not —
+ * and an agent is in front of exactly that api for the length of every rollout. Without it the two
+ * would spin against each other as fast as the network allows.
+ */
+describe('a poll that comes straight back is not repeated straight away', () => {
+  test('an idle host polls once and waits out the floor', async () => {
+    expect((await polling({ over: NO_TIME_AT_ALL })).polls).toHaveLength(1);
+  });
+
+  test('and asks again once, and only once, per interval it has waited', async () => {
+    expect((await polling({ over: TWO_FLOORS_AND_A_MOMENT })).polls).toHaveLength(
+      POLLS_ACROSS_TWO_FLOORS,
+    );
+  });
+
+  // The floor is under an idle poll and nothing else: a host that was given a read answers it and
+  // asks for the next one at once, because somebody is waiting on both.
+  test('a read that came back is answered and the next poll opens immediately', async () => {
+    const { polls, answers } = await polling({ queued: [QUERY], over: NO_TIME_AT_ALL });
+
+    expect(answers).toEqual([
+      { queryId: QUERY.queryId, outcome: { status: 'listed', listing: LISTING } },
+    ]);
+    expect(polls).toHaveLength(2);
   });
 });

--- a/apps/agent/tests/lib/control/client.test.ts
+++ b/apps/agent/tests/lib/control/client.test.ts
@@ -9,7 +9,7 @@ import {
   SecretStringSchema,
   Value,
 } from '@repo/protocol';
-import { Effect } from 'effect';
+import { type Duration, Effect, Exit, Fiber } from 'effect';
 import { ControlPlaneError, makeControlPlaneClient } from '#lib/control/client.ts';
 import { runScoped } from '#tests/support/run.ts';
 import {
@@ -17,9 +17,15 @@ import {
   HTTP_UNAUTHORIZED,
   HTTP_UNAVAILABLE,
   recordingServer,
+  serving,
 } from '#tests/support/server.ts';
 
 const SESSION_TOKEN = Value.Parse(SecretStringSchema, 'session-token');
+
+/** An api holding a poll open, which is what it does with every poll nothing has arrived for. */
+const NEVER_ANSWERED = new Promise<Response>(() => {});
+
+const IN_FLIGHT: Duration.DurationInput = '20 millis';
 
 const VALID_DESIRED_STATE = {
   hostId: 'host-1',
@@ -156,6 +162,29 @@ describe('a filesystem read travels on its own routes', () => {
 
     expect(result).toBeUndefined();
     expect(call?.url).toBe(`${baseUrl}${AGENT_API_PREFIX}${AGENT_ROUTES.filesystemQueryResult}`);
+  });
+
+  /**
+   * The api holds this poll open until it has a read to send down it, so it is the request the
+   * agent spends almost all of its life inside. A stop has to leave it where it stands: waiting
+   * for a reply that only arrives when somebody opens a folder would hold the whole binary open.
+   */
+  test('a poll the api is holding open is abandoned when the fiber is interrupted', async () => {
+    const exit = await runScoped(
+      Effect.gen(function* () {
+        const { baseUrl } = yield* serving(() => NEVER_ANSWERED);
+        const poll = yield* Effect.fork(
+          makeControlPlaneClient({ baseUrl }).fetchFilesystemQuery({
+            sessionToken: SESSION_TOKEN,
+            request: { servedAppIds: [] },
+          }),
+        );
+        yield* Effect.sleep(IN_FLIGHT);
+        return yield* Fiber.interrupt(poll);
+      }),
+    );
+
+    expect(Exit.isInterrupted(exit)).toBe(true);
   });
 
   test('a malformed query is rejected rather than read as a directory', async () => {

--- a/apps/api/src/lib/filesystem/pending-queries.ts
+++ b/apps/api/src/lib/filesystem/pending-queries.ts
@@ -18,13 +18,20 @@ type Read = {
   claimed: boolean;
 };
 
+/** A host holding a poll open with nothing in it yet, and the apps it said it can read. */
+type ParkedHost = {
+  readonly servedAppIds: readonly AppId[];
+  readonly hand: (query: FilesystemQuery) => void;
+};
+
 export type PendingRead = {
   readonly queryId: FilesystemQueryId;
   readonly answered: Promise<Outcome>;
 };
 
 /**
- * The reads somebody is currently waiting on, held in the process holding their requests open.
+ * The reads somebody is currently waiting on and the hosts currently waiting to be given one, held
+ * in the process holding both their requests open.
  *
  * Deliberately not a table. A query is worth exactly as long as its caller stays connected, so it
  * is born and retired inside one request — writing it down would outlive the only thing that gives
@@ -34,6 +41,7 @@ export type PendingRead = {
  */
 export class PendingFilesystemQueries {
   readonly #reads = new Map<FilesystemQueryId, Read>();
+  readonly #parked = new Set<ParkedHost>();
 
   /**
    * Callers asking for the same directory at the same time wait on one read rather than one each.
@@ -74,6 +82,8 @@ export class PendingFilesystemQueries {
     signal.addEventListener('abort', giveUp, { once: true });
     if (signal.aborted) {
       giveUp();
+    } else {
+      this.#offer(read);
     }
 
     return { queryId: read.query.queryId, answered: promise };
@@ -81,19 +91,47 @@ export class PendingFilesystemQueries {
 
   /**
    * The read that has waited longest among those this host says it can serve — insertion order,
-   * so a slow directory delays the people who asked for it rather than the queue behind them.
+   * so a slow directory delays the people who asked for it rather than the queue behind them — or,
+   * when there is none, the first one to open while this host waits here for it.
+   *
+   * Waiting is the point. A host answered with nothing comes back on a timer of its own, so a read
+   * opening a moment after one poll was looked at only on the next; held here it goes down a
+   * request the host already has open, and what a person browsing waits for is one round trip.
+   * `signal` is that request: it ends the wait when the host goes away or its hold expires, and a
+   * host arriving with it already fired takes what is standing rather than waiting for more.
    *
    * Handed out once. A second host taking the same query would read a filesystem for a request
    * another host is already finishing, and only one answer per id can arrive.
    */
-  claim({ servedAppIds }: { servedAppIds: readonly AppId[] }): FilesystemQuery | undefined {
-    for (const read of this.#reads.values()) {
-      if (!read.claimed && servedAppIds.includes(read.query.appId)) {
-        read.claimed = true;
-        return read.query;
-      }
+  claim({
+    servedAppIds,
+    signal,
+  }: {
+    servedAppIds: readonly AppId[];
+    signal: AbortSignal;
+  }): Promise<FilesystemQuery | undefined> {
+    const standing = this.#standingFor(servedAppIds);
+    if (standing) {
+      standing.claimed = true;
+      return Promise.resolve(standing.query);
     }
-    return undefined;
+
+    const { promise, resolve } = Promise.withResolvers<FilesystemQuery | undefined>();
+    const host: ParkedHost = { servedAppIds, hand: resolve };
+    const parked = this.#parked;
+
+    function leave() {
+      parked.delete(host);
+      resolve(undefined);
+    }
+
+    parked.add(host);
+    signal.addEventListener('abort', leave, { once: true });
+    if (signal.aborted) {
+      leave();
+    }
+
+    return promise;
   }
 
   /** Whether anyone was still waiting — a host that answered after they left is not an error. */
@@ -107,6 +145,37 @@ export class PendingFilesystemQueries {
       settle(outcome);
     }
     return true;
+  }
+
+  /**
+   * A host parked on this app is holding a poll open with nothing in it, so the read goes down
+   * that poll now rather than waiting to be asked for again.
+   *
+   * Woken by the read that concerns it and by nothing else: a host is handed a query for an app it
+   * said it serves, so a busy tenant cannot wake the fleet. A read a host is already reading is
+   * past this, which is what keeps a claim a claim.
+   */
+  #offer(read: Read): void {
+    if (read.claimed) {
+      return;
+    }
+    for (const host of this.#parked) {
+      if (host.servedAppIds.includes(read.query.appId)) {
+        this.#parked.delete(host);
+        read.claimed = true;
+        host.hand(read.query);
+        return;
+      }
+    }
+  }
+
+  #standingFor(servedAppIds: readonly AppId[]): Read | undefined {
+    for (const read of this.#reads.values()) {
+      if (!read.claimed && servedAppIds.includes(read.query.appId)) {
+        return read;
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/apps/api/src/routes/internal/agent/filesystem-query/controller.ts
+++ b/apps/api/src/routes/internal/agent/filesystem-query/controller.ts
@@ -11,6 +11,24 @@ import { ProtocolHeadersSchema } from '#routes/internal/agent/model.ts';
 import { AgentServicePlugin, FilesystemServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 /**
+ * How long a host with nothing to read is left holding this request open.
+ *
+ * The direction of dialling is unchanged and cannot change — the host calls the control plane and
+ * nothing here ever connects to a host — so a read reaches a host either on a request the host is
+ * already holding open or one poll interval later. Holding it is what makes the first the usual
+ * case: what a person browsing waits for becomes a round trip rather than the rest of somebody
+ * else's timer.
+ *
+ * It has to expire below every ceiling that can close this request from outside, because a poll
+ * that ends as an error is one the host backs off from rather than reopens. Two sit above it: Bun
+ * drops a connection nothing has travelled on for 30s — Elysia's default `idleTimeout` — and the
+ * agent gives this one route 45s before it stops waiting for a reply.
+ */
+const HOLD_SECONDS = 25;
+const MS_PER_SECOND = 1000;
+const HOLD_MS = HOLD_SECONDS * MS_PER_SECOND;
+
+/**
  * What a host should read, if anything.
  *
  * It carries no generation, and that is what keeps this off the desired-state channel: a read is
@@ -23,13 +41,17 @@ export const AgentFilesystemQueryController = new Elysia()
   .use(FilesystemServicePlugin)
   .post(
     agentRoutePath(AGENT_ROUTES.filesystemQuery),
-    async ({ agentService, filesystemService, body, headers }) => {
+    async ({ agentService, filesystemService, body, headers, request }) => {
       assertProtocolVersion(headers);
       // Resolved and discarded: nothing below needs the host id, but an expired session must not
-      // be able to collect another tenant's query.
+      // be able to collect another tenant's query. Decided before the wait, so a session that
+      // expires while a host is parked is caught on the poll after this one and not this one.
       await agentService.hostForSession({ sessionToken: sessionTokenFrom(headers) });
 
-      const query = filesystemService.pendingQuery({ servedAppIds: body.servedAppIds });
+      const query = await filesystemService.pendingQuery({
+        servedAppIds: body.servedAppIds,
+        signal: AbortSignal.any([request.signal, AbortSignal.timeout(HOLD_MS)]),
+      });
       return query ? { result: 'query' as const, query } : { result: 'none' as const };
     },
     {

--- a/apps/api/src/services/filesystem.service.ts
+++ b/apps/api/src/services/filesystem.service.ts
@@ -45,8 +45,8 @@ export class FilesystemService extends Service {
 
   /**
    * Asks the fleet for one directory and waits for the answer, because there is nowhere to read it
-   * from: no host is ever connected to, so a read only happens when the host that holds the volume
-   * next asks whether there is anything to do. The request stays open across that round trip.
+   * from: no host is ever connected to, so a read happens on a request the host that holds the
+   * volume is holding open in the hope of one. This request stays open across that round trip.
    *
    * The deployment decides who may read, not what is read — the filesystem belongs to the app and
    * outlives every release of it. It is looked up rather than the app because a deployment under
@@ -85,9 +85,18 @@ export class FilesystemService extends Service {
    * Offered only to a host that says it serves the app. The claim is the host's, restated on each
    * poll: it is the only party that knows what it has attached, and a control plane deciding this
    * from its own records would keep sending reads to a host that no longer holds the volume.
+   *
+   * Answered when there is something to answer with rather than at once — `signal` is the host's
+   * own request, and holding it is what takes the poll interval out of what a reader waits.
    */
-  pendingQuery({ servedAppIds }: { servedAppIds: readonly AppId[] }): FilesystemQuery | undefined {
-    return this.pending.claim({ servedAppIds });
+  pendingQuery({
+    servedAppIds,
+    signal,
+  }: {
+    servedAppIds: readonly AppId[];
+    signal: AbortSignal;
+  }): Promise<FilesystemQuery | undefined> {
+    return this.pending.claim({ servedAppIds, signal });
   }
 
   acceptResult(result: FilesystemQueryResult): void {

--- a/apps/api/tests/controllers/agent.test.ts
+++ b/apps/api/tests/controllers/agent.test.ts
@@ -21,6 +21,8 @@ const A_SERVED_APP_ID = Value.Parse(AppIdSchema, 'app-pocketbase');
 
 const PROTOCOL_VERSION_SKEW = 1;
 
+const A_BRIEF_HOLD_MS = 30;
+
 const versions: HostVersions = {
   agent: 'abc123',
   guestImage: '6.1.180-436861c7d163',
@@ -35,11 +37,13 @@ function post({
   body,
   sessionToken,
   protocolVersion = PROTOCOL_VERSION,
+  signal,
 }: {
   route: string;
   body: unknown;
   sessionToken?: string;
   protocolVersion?: number;
+  signal?: AbortSignal;
 }) {
   return sendJson({
     method: 'POST',
@@ -49,6 +53,7 @@ function post({
       ...(sessionToken && { authorization: `Bearer ${sessionToken}` }),
     },
     body,
+    signal,
   });
 }
 
@@ -74,14 +79,25 @@ async function startSession() {
   return readSession(await openSession());
 }
 
+/**
+ * A poll with a hold of the test's own. The route holds an idle one open for 25s, so a test that
+ * did not end it itself would be waiting on that rather than on anything it wrote.
+ */
 function pollFilesystem({
   sessionToken,
   servedAppIds = [],
+  signal = AbortSignal.timeout(A_BRIEF_HOLD_MS),
 }: {
   sessionToken?: string;
   servedAppIds?: readonly AppId[];
+  signal?: AbortSignal;
 }) {
-  return post({ route: AGENT_ROUTES.filesystemQuery, body: { servedAppIds }, sessionToken });
+  return post({
+    route: AGENT_ROUTES.filesystemQuery,
+    body: { servedAppIds },
+    sessionToken,
+    signal,
+  });
 }
 
 function answerFilesystem({ sessionToken, queryId }: { sessionToken?: string; queryId: string }) {
@@ -118,6 +134,18 @@ describe('a host polls for filesystem reads on a channel of its own', () => {
     );
 
     expect(body).toEqual({ result: 'none' });
+  });
+
+  // The poll is where a host waits, so nothing comes back until there is something to say or the
+  // hold ends — here, the host's own request going away. Answering an idle poll on the spot is
+  // what used to leave a person browsing waiting on the host's next one.
+  test('and told so only once its request has ended', async () => {
+    const session = await startSession();
+    const startedAt = Date.now();
+
+    await pollFilesystem({ sessionToken: session.sessionToken });
+
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(A_BRIEF_HOLD_MS);
   });
 
   // A read exists only while somebody is waiting on it, so serving an app is not by itself a

--- a/apps/api/tests/controllers/support/api.ts
+++ b/apps/api/tests/controllers/support/api.ts
@@ -25,18 +25,22 @@ const api = createApp();
 // A bare path is not a URL, so every request here carries an origin. Nothing routes on it.
 export const ORIGIN = 'http://localhost';
 
+// `signal` is the caller going away, exactly as it is for a request off a socket: a route that
+// holds one open has nothing else to end it inside a test.
 export function send({
   method = 'GET',
   url,
   body,
   headers,
+  signal,
 }: {
   method?: string;
   url: string;
   body?: RequestInit['body'];
   headers?: Record<string, string>;
+  signal?: AbortSignal;
 }): Promise<Response> {
-  return api.handle(new Request(url, { method, headers, body }));
+  return api.handle(new Request(url, { method, headers, body, signal }));
 }
 
 export function sendJson({
@@ -44,16 +48,19 @@ export function sendJson({
   url,
   body,
   headers,
+  signal,
 }: {
   method?: string;
   url: string;
   body?: unknown;
   headers?: Record<string, string>;
+  signal?: AbortSignal;
 }): Promise<Response> {
   return send({
     method,
     url,
     headers: { 'content-type': 'application/json', ...headers },
     body: body === undefined ? undefined : JSON.stringify(body),
+    signal,
   });
 }

--- a/apps/api/tests/services/filesystem.test.ts
+++ b/apps/api/tests/services/filesystem.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  type AppId,
   AppIdSchema,
   type DirectoryListing,
   type FilesystemQuery,
@@ -23,6 +24,9 @@ import {
 
 const OTHER_APP = Value.Parse(AppIdSchema, 'app-somebody-else');
 const DATA = Value.Parse(GuestPathSchema, '/pb_data');
+
+// Long enough to be a hold and short enough that a test waits it out rather than the clock.
+const A_BRIEF_HOLD_MS = 20;
 
 const UNREADABLE_DEVICE = 'no directory could be read from /dev/nbd7';
 
@@ -70,12 +74,40 @@ function read({
 }
 
 /**
- * What a host polling now would be handed. The ownership lookup is awaited first, because a read
- * is only offered once it is one somebody is actually waiting on.
+ * What a host polling now would be handed without waiting for more. An already-aborted signal is a
+ * host that is no longer holding its poll open, which is the only way to ask what is standing
+ * without becoming the one it would be handed to.
  */
+function handedTo({
+  filesystemService,
+  servedAppIds = [APP_ID],
+}: {
+  filesystemService: FilesystemService;
+  servedAppIds?: readonly AppId[];
+}) {
+  return filesystemService.pendingQuery({ servedAppIds, signal: AbortSignal.abort() });
+}
+
+/**
+ * A host holding its poll open, as a request the api has not answered yet is. Nothing fires the
+ * signal unless a test does, so a host no test sends away waits the way a real one would.
+ */
+function polling({
+  filesystemService,
+  servedAppIds = [APP_ID],
+  signal = new AbortController().signal,
+}: {
+  filesystemService: FilesystemService;
+  servedAppIds?: readonly AppId[];
+  signal?: AbortSignal;
+}) {
+  return filesystemService.pendingQuery({ servedAppIds, signal });
+}
+
+/** The ownership lookup is awaited first, because a read is only offered once somebody waits on it. */
 async function offered(filesystemService: FilesystemService) {
   await Bun.sleep(0);
-  return filesystemService.pendingQuery({ servedAppIds: [APP_ID] });
+  return handedTo({ filesystemService });
 }
 
 async function claimed(filesystemService: FilesystemService): Promise<FilesystemQuery> {
@@ -131,8 +163,8 @@ describe('a read waits for the host that holds the volume', () => {
     void read({ filesystemService });
     await Bun.sleep(0);
 
-    expect(filesystemService.pendingQuery({ servedAppIds: [OTHER_APP] })).toBeUndefined();
-    expect(filesystemService.pendingQuery({ servedAppIds: [] })).toBeUndefined();
+    expect(await handedTo({ filesystemService, servedAppIds: [OTHER_APP] })).toBeUndefined();
+    expect(await handedTo({ filesystemService, servedAppIds: [] })).toBeUndefined();
   });
 
   // A second host taking it would read a filesystem for a request another host is already
@@ -142,7 +174,7 @@ describe('a read waits for the host that holds the volume', () => {
     void read({ filesystemService });
     await claimed(filesystemService);
 
-    expect(filesystemService.pendingQuery({ servedAppIds: [APP_ID] })).toBeUndefined();
+    expect(await handedTo({ filesystemService })).toBeUndefined();
   });
 });
 
@@ -153,7 +185,7 @@ describe('people looking at the same directory wait on one read', () => {
     void read({ filesystemService, path: DATA });
     await claimed(filesystemService);
 
-    expect(filesystemService.pendingQuery({ servedAppIds: [APP_ID] })).toBeUndefined();
+    expect(await handedTo({ filesystemService })).toBeUndefined();
   });
 
   test('and both are answered by the one listing that comes back', async () => {
@@ -230,7 +262,72 @@ describe('people looking at the same directory wait on one read', () => {
     giveUp.abort();
     await expect(abandoned).rejects.toThrow(GatewayTimeoutError);
 
-    expect(filesystemService.pendingQuery({ servedAppIds: [APP_ID] })).toBeUndefined();
+    expect(await handedTo({ filesystemService })).toBeUndefined();
+  });
+});
+
+/**
+ * Where the wait went. A host used to be told there was nothing and come back on a timer of its
+ * own, so a directory opened a moment after one poll was not read until the next — half an idle
+ * interval, on average, spent by somebody staring at a spinner while the host that could answer
+ * had nothing to do.
+ */
+describe('a host with nothing to read waits here rather than on a timer of its own', () => {
+  test('a read opening is what answers the host waiting for one', async () => {
+    const { filesystemService } = service();
+    const host = polling({ filesystemService });
+
+    void read({ filesystemService, path: DATA });
+
+    expect(await host).toMatchObject({ appId: APP_ID, path: DATA });
+  });
+
+  // A host is woken by the reads it could serve and by nothing else, or a fleet would be roused
+  // by every directory anybody opened.
+  test('a read for an app it does not serve leaves it waiting', async () => {
+    const { filesystemService } = service();
+    const host = polling({ filesystemService, servedAppIds: [OTHER_APP] });
+
+    void read({ filesystemService, path: DATA });
+    await Bun.sleep(0);
+
+    expect(Bun.peek.status(host)).toBe('pending');
+  });
+
+  // The hold expiring is an ordinary answer rather than a failure: the host reopens the poll, and
+  // a request nothing has travelled on is one every hop in between is entitled to close.
+  test('a hold that expires with nothing standing answers with nothing', async () => {
+    const { filesystemService } = service();
+
+    const query = await polling({
+      filesystemService,
+      signal: AbortSignal.timeout(A_BRIEF_HOLD_MS),
+    });
+
+    expect(query).toBeUndefined();
+  });
+
+  // A host that has gone must take nothing with it: a read handed to a waiter nobody is listening
+  // to is a read that is never performed and never offered again.
+  test('a host that goes away leaves no waiter behind it', async () => {
+    const { filesystemService } = service();
+    const gone = new AbortController();
+    const host = polling({ filesystemService, signal: gone.signal });
+
+    gone.abort();
+    expect(await host).toBeUndefined();
+    void read({ filesystemService, path: DATA });
+
+    expect(await offered(filesystemService)).toMatchObject({ path: DATA });
+  });
+
+  test('and a read handed to one that stayed is not offered to the next', async () => {
+    const { filesystemService } = service();
+    const host = polling({ filesystemService });
+    void read({ filesystemService, path: DATA });
+    await host;
+
+    expect(await offered(filesystemService)).toBeUndefined();
   });
 });
 
@@ -284,7 +381,7 @@ describe('a read that gets no usable answer says so rather than hanging', () => 
     giveUp.abort();
     await expect(listing).rejects.toThrow(GatewayTimeoutError);
 
-    expect(filesystemService.pendingQuery({ servedAppIds: [APP_ID] })).toBeUndefined();
+    expect(await handedTo({ filesystemService })).toBeUndefined();
   });
 
   // A host answering a request that has already ended is late, not broken.


### PR DESCRIPTION
The host's filesystem poll becomes a long poll: it parks at the control plane until a read for an app it serves arrives, instead of asking every 5 seconds. A directory listing stops costing a ~2.5s expected wait before any I/O happens.

The wire shape is unchanged, so `PROTOCOL_VERSION` does not move.

One number to be careful with: the ordering is 25s api hold < 30s Elysia `idleTimeout` (the Bun adapter default, not overridden) < 45s agent client ceiling. Raising the hold past ~28s needs `idleTimeout` set on the listen call.