### PR TITLE
chore(infra): adopt the guest image the current runtime builds

### DIFF
--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -16,5 +16,5 @@
     "url": "https://github.com/caddyserver/caddy/releases/download/v2.11.4/caddy_2.11.4_linux_amd64.tar.gz",
     "sha256": "527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9"
   },
-  "guestImage": "6.1.180-858fce9d6123"
+  "guestImage": "6.1.180-88272af88c5a"
 }


### PR DESCRIPTION
`deploy-app-hosts` fails on the current pin: the host fetches an empty prefix and dies on a missing `SHA256SUMS`.

The pin has been stale since 7 August. #175 and #176 both changed `apps/runtime`, moving the digest `version.sh` takes over the compiled `/init`, and CI published a new image for each — publishing is not adopting, so nothing picked them up. It stayed invisible while the old account's bucket still held `6.1.180-858fce9d6123`; a new account's bucket holds only what has been built into it.

`6.1.180-88272af88c5a` is what this commit's inputs produce, published by the `build-guest-image` job on `64caa69d`:

```
Guest image version: 6.1.180-88272af88c5a
Published s3://nibrun-guest-images-…/6.1.180-88272af88c5a/
```

Adopting it means the fleet boots the runtime carrying #175 and #176.