### PR TITLE
fix(dashboard): a deploy dialog keeps its width, so a digest wraps instead of escaping

### DIFF
--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -13,7 +13,7 @@ export function DeployForm({ appId }: { appId: string | undefined }) {
 
   return (
     <form
-      className="flex flex-col gap-5"
+      className="flex min-w-0 flex-col gap-5"
       onSubmit={(event) => {
         event.preventDefault();
         void api.handleSubmit();
@@ -82,7 +82,7 @@ export function DeployForm({ appId }: { appId: string | undefined }) {
       </api.Field>
 
       {replacing !== undefined && (
-        <p className="rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
+        <p className="wrap-anywhere rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
           This replaces the binary <span className="font-medium font-mono">{replacing.slug}</span>{' '}
           is running. Its hostnames and everything on its volume stay as they are.
         </p>
@@ -91,7 +91,7 @@ export function DeployForm({ appId }: { appId: string | undefined }) {
       <api.Subscribe selector={(state) => state.canSubmit}>
         {(canSubmit) => (
           <Button type="submit" size="lg" disabled={!canSubmit || !targetResolved}>
-            {submitLabel({ replacing: replacing?.slug, locked })}
+            <span className="truncate">{submitLabel({ replacing: replacing?.slug, locked })}</span>
           </Button>
         )}
       </api.Subscribe>

--- a/apps/dashboard/src/components/apps/deploy-progress.tsx
+++ b/apps/dashboard/src/components/apps/deploy-progress.tsx
@@ -12,12 +12,12 @@ export function DeployProgress() {
   const waiting = waitingOn(run.phase);
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex min-w-0 flex-col gap-5">
       <ol className="flex flex-col gap-2 text-sm">
         {run.steps.map((step) => (
-          <li key={step.kind} className="flex items-center gap-2">
-            <CheckIcon className="size-4 shrink-0 text-muted-foreground" />
-            <span className="truncate font-mono">{describeStep(step)}</span>
+          <li key={step.kind} className="flex items-start gap-2">
+            <CheckIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <span className="wrap-anywhere font-mono">{describeStep(step)}</span>
           </li>
         ))}
         {waiting !== undefined && (
@@ -40,7 +40,7 @@ export function DeployProgress() {
             href={run.deployed.url}
             target="_blank"
             rel="noreferrer"
-            className="truncate font-medium font-mono underline underline-offset-4"
+            className="wrap-anywhere font-medium font-mono underline underline-offset-4"
           >
             {run.deployed.url}
           </a>
@@ -50,7 +50,7 @@ export function DeployProgress() {
       {run.reason !== undefined && (
         <p className="flex items-start gap-2 rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
           <TriangleAlertIcon className="mt-0.5 size-4 shrink-0" />
-          <span>{run.reason}</span>
+          <span className="wrap-anywhere">{run.reason}</span>
         </p>
       )}
 


### PR DESCRIPTION
The dialog popup lays its children out with `grid`, whose items default to `min-width: auto` — so the sha256 digest and the served URL forced the item wider than the popup and spilled over the page. The long values now wrap instead of being clipped, and neither view can push the popup out.