### PR TITLE
feat(dashboard): a directory listing leads with the name, so an icon says what a row is

### DIFF
--- a/apps/dashboard/src/components/files/directory-table.tsx
+++ b/apps/dashboard/src/components/files/directory-table.tsx
@@ -1,5 +1,5 @@
 import type { FilesystemEntry } from '@repo/protocol';
-import { Link } from '@tanstack/react-router';
+import { EntryName } from '#components/files/entry-name.tsx';
 import {
   Table,
   TableBody,
@@ -10,50 +10,32 @@ import {
 } from '#components/ui/table.tsx';
 import { formatBytes } from '#lib/format-bytes.ts';
 import { dayAndMinute } from '#lib/format-timestamp.ts';
-import { useAppId } from '#lib/hooks/use-app-id.ts';
-import { useDirectoryPath } from '#lib/hooks/use-directory-path.ts';
-import { Route as FilesRoute } from '#routes/(dashboard)/apps/$appId/files.tsx';
 
 export function DirectoryTable({ entries }: { entries: readonly FilesystemEntry[] }) {
-  const appId = useAppId();
-  const path = useDirectoryPath();
-
   return (
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead>Kind</TableHead>
+          <TableHead>Name</TableHead>
           <TableHead className="text-right">Size</TableHead>
           <TableHead>Modified</TableHead>
-          <TableHead>Name</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {byName(entries).map((entry) => (
+        {inBrowsingOrder(entries).map((entry) => (
           <TableRow key={entry.name}>
-            <TableCell className="text-muted-foreground">{entry.kind}</TableCell>
-            <TableCell
-              className="text-right font-mono tabular-nums"
-              title={`${entry.sizeBytes} bytes`}
-            >
-              {formatBytes(entry.sizeBytes)}
+            <TableCell className="w-full max-w-0 font-mono">
+              <EntryName entry={entry} />
+            </TableCell>
+            <TableCell className="text-right font-mono tabular-nums">
+              {entry.kind === 'directory' ? (
+                <span className="text-muted-foreground">—</span>
+              ) : (
+                <span title={`${entry.sizeBytes} bytes`}>{formatBytes(entry.sizeBytes)}</span>
+              )}
             </TableCell>
             <TableCell className="text-muted-foreground tabular-nums">
               {dayAndMinute(entry.modifiedAt)}
-            </TableCell>
-            <TableCell className="font-mono">
-              {entry.kind === 'directory' ? (
-                <Link
-                  to={FilesRoute.to}
-                  params={{ appId }}
-                  search={{ path: childPath({ path, name: entry.name }) }}
-                  className="hover:underline"
-                >
-                  {entry.name}
-                </Link>
-              ) : (
-                entry.name
-              )}
             </TableCell>
           </TableRow>
         ))}
@@ -62,11 +44,17 @@ export function DirectoryTable({ entries }: { entries: readonly FilesystemEntry[
   );
 }
 
-function childPath({ path, name }: { path: string; name: string }): string {
-  return path.endsWith('/') ? `${path}${name}` : `${path}/${name}`;
+function inBrowsingOrder(entries: readonly FilesystemEntry[]): FilesystemEntry[] {
+  const found = new Map(entries.map((entry) => [entry.name, entry]));
+  return [...found.values()].sort(byDirectoryThenName);
 }
 
-function byName(entries: readonly FilesystemEntry[]): FilesystemEntry[] {
-  const found = new Map(entries.map((entry) => [entry.name, entry]));
-  return [...found.keys()].toSorted().map((name) => found.get(name)!);
+// biome-ignore lint/complexity/useMaxParams: a comparator compares two entries
+function byDirectoryThenName(left: FilesystemEntry, right: FilesystemEntry): number {
+  const leftIsDirectory = left.kind === 'directory';
+  const rightIsDirectory = right.kind === 'directory';
+  if (leftIsDirectory !== rightIsDirectory) {
+    return leftIsDirectory ? -1 : 1;
+  }
+  return left.name < right.name ? -1 : 1;
 }

--- a/apps/dashboard/src/components/files/entry-name.tsx
+++ b/apps/dashboard/src/components/files/entry-name.tsx
@@ -1,0 +1,45 @@
+import type { FilesystemEntry, FilesystemEntryKind } from '@repo/protocol';
+import { Link } from '@tanstack/react-router';
+import { FileIcon, FileQuestionMarkIcon, FolderIcon, type LucideIcon } from 'lucide-react';
+import { useAppId } from '#lib/hooks/use-app-id.ts';
+import { useDirectoryPath } from '#lib/hooks/use-directory-path.ts';
+import { Route as FilesRoute } from '#routes/(dashboard)/apps/$appId/files.tsx';
+
+const KIND_ICONS: Record<FilesystemEntryKind, LucideIcon> = {
+  directory: FolderIcon,
+  file: FileIcon,
+  other: FileQuestionMarkIcon,
+};
+
+export function EntryName({ entry }: { entry: FilesystemEntry }) {
+  const appId = useAppId();
+  const path = useDirectoryPath();
+  const Icon = KIND_ICONS[entry.kind];
+  const name = (
+    <>
+      <Icon className="size-4 shrink-0 text-muted-foreground" />
+      <span className="truncate" title={entry.name}>
+        {entry.name}
+      </span>
+    </>
+  );
+
+  if (entry.kind !== 'directory') {
+    return <span className="flex items-center gap-2">{name}</span>;
+  }
+
+  return (
+    <Link
+      to={FilesRoute.to}
+      params={{ appId }}
+      search={{ path: childPath({ path, name: entry.name }) }}
+      className="flex items-center gap-2 hover:underline"
+    >
+      {name}
+    </Link>
+  );
+}
+
+function childPath({ path, name }: { path: string; name: string }): string {
+  return path.endsWith('/') ? `${path}${name}` : `${path}/${name}`;
+}


### PR DESCRIPTION
The Files table read backwards: the name — the one thing a reader scans for — sat last, behind a column spelling out "directory" or "file". It now reads like a file browser: name first with a kind icon beside it, metadata after, directories sorted first.