### PR TITLE
feat(dashboard): a listing is re-read on demand, current deployment included

### DIFF
--- a/apps/dashboard/src/components/files/directory-browser.tsx
+++ b/apps/dashboard/src/components/files/directory-browser.tsx
@@ -2,6 +2,7 @@ import { DIRECTORY_ENTRY_LIMIT } from '@repo/protocol';
 import { FolderOpenIcon } from 'lucide-react';
 import { DeploymentLine } from '#components/apps/deployment-line.tsx';
 import { FailureEmpty } from '#components/failure-empty.tsx';
+import { DirectoryRefreshButton } from '#components/files/directory-refresh-button.tsx';
 import { DirectoryTable } from '#components/files/directory-table.tsx';
 import { PathBreadcrumb } from '#components/files/path-breadcrumb.tsx';
 import { Card } from '#components/ui/card.tsx';
@@ -19,7 +20,10 @@ export function DirectoryBrowser() {
   return (
     <div className="flex flex-col gap-4">
       {view.deploymentId !== undefined && <DeploymentLine deploymentId={view.deploymentId} />}
-      <PathBreadcrumb />
+      <div className="flex items-center justify-between gap-4">
+        <PathBreadcrumb />
+        <DirectoryRefreshButton />
+      </div>
       {view.status === 'failed' && (
         <FailureEmpty title="Could not read that directory" reason={view.reason ?? ''} />
       )}

--- a/apps/dashboard/src/components/files/directory-refresh-button.tsx
+++ b/apps/dashboard/src/components/files/directory-refresh-button.tsx
@@ -1,0 +1,19 @@
+import { RefreshCwIcon } from 'lucide-react';
+import { Button } from '#components/ui/button.tsx';
+import { useDirectoryRefresh } from '#lib/hooks/use-directory-refresh.ts';
+
+export function DirectoryRefreshButton() {
+  const { isRefreshing, refresh } = useDirectoryRefresh();
+
+  return (
+    <Button
+      aria-label="Refresh this directory"
+      disabled={isRefreshing}
+      onClick={refresh}
+      size="icon-sm"
+      variant="outline"
+    >
+      <RefreshCwIcon className={isRefreshing ? 'animate-spin' : undefined} />
+    </Button>
+  );
+}

--- a/apps/dashboard/src/lib/hooks/use-directory-refresh.ts
+++ b/apps/dashboard/src/lib/hooks/use-directory-refresh.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAppId } from '#lib/hooks/use-app-id.ts';
+import { latestDeploymentQueryOptions } from '#queries/deployments.ts';
+import { filesystemQueryKey } from '#queries/filesystem.ts';
+
+export type DirectoryRefresh = {
+  isRefreshing: boolean;
+  refresh: () => void;
+};
+
+export function useDirectoryRefresh(): DirectoryRefresh {
+  const appId = useAppId();
+  const queryClient = useQueryClient();
+
+  // Which deployment is current is half of what a listing means, so a refresh asks that again
+  // first: entries read from a superseded deployment are stale in a way re-reading the same
+  // deployment cannot fix.
+  const refreshing = useMutation({
+    mutationFn: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: latestDeploymentQueryOptions(appId).queryKey,
+      });
+      await queryClient.invalidateQueries({ queryKey: filesystemQueryKey(appId) });
+    },
+  });
+
+  return {
+    isRefreshing: refreshing.isPending,
+    refresh: () => refreshing.mutate(),
+  };
+}

--- a/apps/dashboard/src/queries/filesystem.ts
+++ b/apps/dashboard/src/queries/filesystem.ts
@@ -9,9 +9,13 @@ export type DirectoryTarget = {
   path: GuestPath | undefined;
 };
 
+export function filesystemQueryKey(appId: string) {
+  return ['filesystem', appId] as const;
+}
+
 export function directoryQueryOptions({ appId, deploymentId, path }: DirectoryTarget) {
   return queryOptions({
-    queryKey: ['filesystem', appId, deploymentId, path],
+    queryKey: [...filesystemQueryKey(appId), deploymentId, path],
     queryFn:
       deploymentId === undefined || path === undefined
         ? skipToken


### PR DESCRIPTION
The Files view had no way to ask for a fresh listing. A refresh button beside the breadcrumb re-reads which deployment is current and then the directory it is showing, spinning while it does.