### PR TITLE
feat(dashboard): the logs header says whether the stream is still live

### DIFF
--- a/apps/dashboard/src/components/logs/deployment-logs.tsx
+++ b/apps/dashboard/src/components/logs/deployment-logs.tsx
@@ -1,6 +1,7 @@
 import { DeploymentLine } from '#components/apps/deployment-line.tsx';
 import { FailureEmpty } from '#components/failure-empty.tsx';
 import { LogStream } from '#components/logs/log-stream.tsx';
+import { LogStreamStatus } from '#components/logs/log-stream-status.tsx';
 import { LogTimerangeMenu } from '#components/logs/log-timerange-menu.tsx';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
 import { useDeploymentLogs } from '#lib/hooks/use-deployment-logs.ts';
@@ -24,7 +25,10 @@ export function DeploymentLogs() {
         ) : (
           <DeploymentLine deploymentId={logs.deploymentId} />
         )}
-        <LogTimerangeMenu />
+        <div className="flex items-center gap-3">
+          <LogStreamStatus status={logs.status} />
+          <LogTimerangeMenu />
+        </div>
       </div>
       <LogStream records={logs.records} />
     </div>

--- a/apps/dashboard/src/components/logs/log-stream-status.tsx
+++ b/apps/dashboard/src/components/logs/log-stream-status.tsx
@@ -1,0 +1,37 @@
+import type { DeploymentLogsView } from '#lib/hooks/use-deployment-logs.ts';
+import { cn } from '#lib/utils.ts';
+
+const PRESENTATION: Record<
+  DeploymentLogsView['status'],
+  { label: string; dotClassName: string; haloClassName: string }
+> = {
+  connecting: {
+    label: 'Connecting',
+    dotClassName: 'bg-muted-foreground motion-safe:animate-pulse',
+    haloClassName: 'hidden',
+  },
+  following: {
+    label: 'Live',
+    dotClassName: 'bg-emerald-500',
+    haloClassName: 'bg-emerald-500 motion-safe:animate-live-halo',
+  },
+  failed: {
+    label: 'Stream disconnected',
+    dotClassName: 'bg-destructive',
+    haloClassName: 'hidden',
+  },
+};
+
+export function LogStreamStatus({ status }: { status: DeploymentLogsView['status'] }) {
+  const { label, dotClassName, haloClassName } = PRESENTATION[status];
+
+  return (
+    <p className="flex items-center gap-2 text-muted-foreground text-xs" role="status">
+      <span className="relative inline-flex size-1.5">
+        <span className={cn('absolute inset-0 rounded-full', haloClassName)} />
+        <span className={cn('relative inline-flex size-1.5 rounded-full', dotClassName)} />
+      </span>
+      {label}
+    </p>
+  );
+}

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -88,6 +88,22 @@ body {
   --color-destructive-foreground: var(--destructive-foreground);
 }
 
+@theme {
+  --animate-live-halo: live-halo 2.4s cubic-bezier(0, 0, 0.2, 1) infinite;
+
+  @keyframes live-halo {
+    0% {
+      transform: scale(1);
+      opacity: 0.5;
+    }
+    70%,
+    100% {
+      transform: scale(2.6);
+      opacity: 0;
+    }
+  }
+}
+
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.25 0.051 149.2);


### PR DESCRIPTION
The logs view tails a stream, but nothing on screen said so. A small status dot in the header row now reflects the three states `useDeploymentLogs` already reports — connecting, live, disconnected — with a slow halo pulsing out of it while it is following.