### PR TITLE
feat(dashboard): a binary is dropped where it was only ever picked, and the one chosen is named back

### DIFF
--- a/apps/dashboard/src/components/apps/binary-drop-zone.tsx
+++ b/apps/dashboard/src/components/apps/binary-drop-zone.tsx
@@ -1,0 +1,67 @@
+import { FileTerminalIcon, UploadIcon, XIcon } from 'lucide-react';
+import { Button } from '#components/ui/button.tsx';
+import { useBinaryPicker } from '#lib/hooks/use-binary-picker.ts';
+
+export const BINARY_INPUT_ID = 'deploy-binary';
+
+export function BinaryDropZone({
+  binary,
+  invalid,
+  onPick,
+}: {
+  binary: File | undefined;
+  invalid: boolean;
+  onPick: (binary: File | undefined) => void;
+}) {
+  const picker = useBinaryPicker({ onPick });
+
+  return (
+    <div
+      data-dragging={picker.dragging || undefined}
+      data-invalid={invalid || undefined}
+      className="relative flex w-full items-center gap-2 rounded-2xl border border-muted-foreground/30 border-dashed bg-input/50 px-3 py-4 text-sm transition-[color,background-color,box-shadow] duration-200 hover:bg-input has-[input:focus-visible]:border-ring has-[input:focus-visible]:ring-3 has-[input:focus-visible]:ring-ring/30 data-[dragging=true]:border-ring data-[invalid=true]:border-destructive/50 data-[dragging=true]:border-solid data-[dragging=true]:bg-primary/10"
+      {...picker.dropHandlers}
+    >
+      <input
+        ref={picker.inputRef}
+        id={BINARY_INPUT_ID}
+        type="file"
+        className="sr-only"
+        aria-invalid={invalid}
+        onChange={(event) => onPick(event.target.files?.[0])}
+      />
+      <label
+        htmlFor={BINARY_INPUT_ID}
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 font-normal"
+      >
+        {binary === undefined ? (
+          <>
+            <UploadIcon className="size-4 shrink-0 text-muted-foreground" />
+            <span>Drop the binary here, or browse for it.</span>
+          </>
+        ) : (
+          <>
+            <FileTerminalIcon className="size-4 shrink-0 text-muted-foreground" />
+            <span className="flex min-w-0 flex-col">
+              <span className="truncate font-mono" title={binary.name}>
+                {binary.name}
+              </span>
+              <span className="text-muted-foreground text-xs">Drop another to replace it.</span>
+            </span>
+          </>
+        )}
+      </label>
+      {binary !== undefined && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Clear the binary"
+          onClick={picker.clear}
+        >
+          <XIcon />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/apps/deploy-binary-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-binary-field.tsx
@@ -1,0 +1,35 @@
+import { BINARY_INPUT_ID, BinaryDropZone } from '#components/apps/binary-drop-zone.tsx';
+import { Field, FieldDescription, FieldError, FieldLabel } from '#components/ui/field.tsx';
+import { formatBytes } from '#lib/format-bytes.ts';
+import { type DeployFormApi, validateBinary } from '#lib/hooks/use-deploy-form.ts';
+
+export function DeployBinaryField({ api }: { api: DeployFormApi }) {
+  return (
+    <api.Field name="binary" validators={{ onMount: validateBinary, onChange: validateBinary }}>
+      {(field) => {
+        const rejected = field.state.value !== undefined && field.state.meta.errors.length > 0;
+        return (
+          <Field data-invalid={rejected || undefined}>
+            <FieldLabel htmlFor={BINARY_INPUT_ID}>Binary</FieldLabel>
+            <BinaryDropZone
+              binary={field.state.value}
+              invalid={rejected}
+              onPick={field.handleChange}
+            />
+            {rejected ? (
+              <FieldError>{field.state.meta.errors[0]}</FieldError>
+            ) : (
+              <FieldDescription>{describeBinary(field.state.value)}</FieldDescription>
+            )}
+          </Field>
+        );
+      }}
+    </api.Field>
+  );
+}
+
+function describeBinary(binary: File | undefined): string {
+  return binary === undefined
+    ? 'The compiled binary to run in the guest.'
+    : `${formatBytes(binary.size)}, uploaded straight to the store.`;
+}

--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -1,10 +1,10 @@
+import { DeployBinaryField } from '#components/apps/deploy-binary-field.tsx';
 import { DeployNameField } from '#components/apps/deploy-name-field.tsx';
 import { Button } from '#components/ui/button.tsx';
 import { Field, FieldDescription, FieldError, FieldLabel } from '#components/ui/field.tsx';
 import { Input } from '#components/ui/input.tsx';
 import { Textarea } from '#components/ui/textarea.tsx';
-import { formatBytes } from '#lib/format-bytes.ts';
-import { useDeployForm, validateBinary, validatePort } from '#lib/hooks/use-deploy-form.ts';
+import { useDeployForm, validatePort } from '#lib/hooks/use-deploy-form.ts';
 
 export function DeployForm({ appId }: { appId: string | undefined }) {
   const { api, locked, replacing, targetResolved, defaultPort, defaultArgs } = useDeployForm({
@@ -19,26 +19,7 @@ export function DeployForm({ appId }: { appId: string | undefined }) {
         void api.handleSubmit();
       }}
     >
-      <api.Field name="binary" validators={{ onMount: validateBinary, onChange: validateBinary }}>
-        {(field) => {
-          const rejected = field.state.value !== undefined && field.state.meta.errors.length > 0;
-          return (
-            <Field data-invalid={rejected || undefined}>
-              <FieldLabel htmlFor="deploy-binary">Binary</FieldLabel>
-              <Input
-                id="deploy-binary"
-                type="file"
-                onChange={(event) => field.handleChange(event.target.files?.[0])}
-              />
-              {rejected ? (
-                <FieldError>{field.state.meta.errors[0]}</FieldError>
-              ) : (
-                <FieldDescription>{describeBinary(field.state.value)}</FieldDescription>
-              )}
-            </Field>
-          );
-        }}
-      </api.Field>
+      <DeployBinaryField api={api} />
 
       {!locked && <DeployNameField api={api} />}
 
@@ -97,12 +78,6 @@ export function DeployForm({ appId }: { appId: string | undefined }) {
       </api.Subscribe>
     </form>
   );
-}
-
-function describeBinary(binary: File | undefined): string {
-  return binary === undefined
-    ? 'The compiled binary to run in the guest.'
-    : `${formatBytes(binary.size)}, uploaded straight to the store.`;
 }
 
 function submitLabel({

--- a/apps/dashboard/src/lib/hooks/use-binary-picker.ts
+++ b/apps/dashboard/src/lib/hooks/use-binary-picker.ts
@@ -1,0 +1,82 @@
+import { type DragEvent, type RefObject, useRef, useState } from 'react';
+
+type DropHandlers = {
+  onDragEnter: (event: DragEvent<HTMLElement>) => void;
+  onDragOver: (event: DragEvent<HTMLElement>) => void;
+  onDragLeave: (event: DragEvent<HTMLElement>) => void;
+  onDrop: (event: DragEvent<HTMLElement>) => void;
+};
+
+export type BinaryPicker = {
+  inputRef: RefObject<HTMLInputElement | null>;
+  dragging: boolean;
+  clear: () => void;
+  dropHandlers: DropHandlers;
+};
+
+export function useBinaryPicker({
+  onPick,
+}: {
+  onPick: (binary: File | undefined) => void;
+}): BinaryPicker {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  function clear(): void {
+    forgetPicked(inputRef.current);
+    onPick(undefined);
+    inputRef.current?.focus();
+  }
+
+  function armDrop(event: DragEvent<HTMLElement>): void {
+    if (!carriesFiles(event)) {
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setDragging(true);
+  }
+
+  function disarmDrop(event: DragEvent<HTMLElement>): void {
+    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      setDragging(false);
+    }
+  }
+
+  function takeDrop(event: DragEvent<HTMLElement>): void {
+    if (!carriesFiles(event)) {
+      return;
+    }
+    event.preventDefault();
+    setDragging(false);
+    const dropped = event.dataTransfer.files[0];
+    if (dropped !== undefined) {
+      // A file input reports no change for the file it already holds, so emptying it
+      // keeps a dropped binary from shadowing the same one picked afterwards.
+      forgetPicked(inputRef.current);
+      onPick(dropped);
+    }
+  }
+
+  return {
+    inputRef,
+    dragging,
+    clear,
+    dropHandlers: {
+      onDragEnter: armDrop,
+      onDragOver: armDrop,
+      onDragLeave: disarmDrop,
+      onDrop: takeDrop,
+    },
+  };
+}
+
+function carriesFiles(event: DragEvent<HTMLElement>): boolean {
+  return event.dataTransfer.types.includes('Files');
+}
+
+function forgetPicked(input: HTMLInputElement | null): void {
+  if (input !== null) {
+    input.value = '';
+  }
+}


### PR DESCRIPTION
The Binary field was a bare `<input type="file">`: its two halves rendered flush and in one colour, and the field never said which binary was picked.

It is now a drop target that is also the picker. The real input stays in the DOM, clipped but focusable, so the label resolves to it and the keyboard still opens the dialog; a dropped file goes through `field.handleChange` and so through `validateBinary` exactly as a picked one does.