### PR TITLE
feat(dashboard): a breadcrumb separates with a slash, so a guest path reads as one

### DIFF
--- a/apps/dashboard/src/components/apps/app-breadcrumb.tsx
+++ b/apps/dashboard/src/components/apps/app-breadcrumb.tsx
@@ -21,7 +21,7 @@ export function AppBreadcrumb() {
         <BreadcrumbItem>
           <BreadcrumbLink render={<Link to={AppsRoute.to} />}>Apps</BreadcrumbLink>
         </BreadcrumbItem>
-        <BreadcrumbSeparator />
+        <BreadcrumbSeparator>/</BreadcrumbSeparator>
         <BreadcrumbItem>
           <BreadcrumbPage className="font-mono">{app.data?.slug ?? appId}</BreadcrumbPage>
         </BreadcrumbItem>

--- a/apps/dashboard/src/components/files/path-breadcrumb.tsx
+++ b/apps/dashboard/src/components/files/path-breadcrumb.tsx
@@ -41,7 +41,7 @@ export function PathBreadcrumb() {
         </BreadcrumbItem>
         {steps.map((step) => (
           <Fragment key={step.path}>
-            <BreadcrumbSeparator />
+            <BreadcrumbSeparator>/</BreadcrumbSeparator>
             <BreadcrumbItem>
               {step.path === path ? (
                 <BreadcrumbPage>{step.name}</BreadcrumbPage>


### PR DESCRIPTION
The chevron said "deeper"; a slash says which path you are looking at. Applied to both the app and the guest-path breadcrumb.