### PR TITLE
feat(dashboard): a binary dropped on the landing page is received at /deploy

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@repo/api-client": "workspace:*",
     "@repo/app-operations": "workspace:*",
+    "@repo/binary-handoff": "workspace:*",
     "@repo/protocol": "workspace:*",
     "@repo/ui": "workspace:*",
     "@tanstack/react-devtools": "^0.10.9",

--- a/apps/dashboard/src/components/handoff/handed-off-binary.tsx
+++ b/apps/dashboard/src/components/handoff/handed-off-binary.tsx
@@ -1,0 +1,67 @@
+import { Button } from '@repo/ui/components/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@repo/ui/components/empty';
+import { Spinner } from '@repo/ui/components/spinner';
+import { BrandMark } from '@repo/ui/custom/brand-mark';
+import { Link } from '@tanstack/react-router';
+import { FileTerminalIcon, UploadIcon } from 'lucide-react';
+import { formatBytes } from '#lib/format-bytes.ts';
+import { useHandedOffBinary } from '#lib/hooks/use-handed-off-binary.ts';
+import { useSession } from '#lib/hooks/use-session.ts';
+import { Route as LoginRoute } from '#routes/(auth)/login.tsx';
+import { Route as DeployRoute } from '#routes/deploy.tsx';
+
+export function HandedOffBinary() {
+  const { binary, loading } = useHandedOffBinary();
+  const session = useSession();
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
+      <BrandMark />
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        {loading ? <Spinner /> : <Waiting binary={binary} signedIn={session !== null} />}
+      </div>
+    </div>
+  );
+}
+
+function Waiting({ binary, signedIn }: { binary: File | undefined; signedIn: boolean }) {
+  if (binary === undefined) {
+    return (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <UploadIcon />
+          </EmptyMedia>
+          <EmptyTitle>No binary waiting</EmptyTitle>
+          <EmptyDescription>Drop one on nibrun.com to bring it here.</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <FileTerminalIcon />
+        </EmptyMedia>
+        <EmptyTitle className="break-all font-mono">{binary.name}</EmptyTitle>
+        <EmptyDescription>{formatBytes(binary.size)}, waiting to be deployed.</EmptyDescription>
+      </EmptyHeader>
+      {!signedIn && (
+        <EmptyContent>
+          <Button render={<Link to={LoginRoute.to} search={{ redirect: DeployRoute.to }} />}>
+            Sign in to deploy it
+          </Button>
+        </EmptyContent>
+      )}
+    </Empty>
+  );
+}

--- a/apps/dashboard/src/lib/handoff-store.ts
+++ b/apps/dashboard/src/lib/handoff-store.ts
@@ -1,0 +1,39 @@
+// Where a binary dropped on the landing page waits. IndexedDB rather than localStorage
+// because it holds a `File` as it is — localStorage stores strings, so a binary would have to
+// be base64'd into a quota measured in single megabytes.
+
+const DB_NAME = 'nibrun-handoff';
+const DB_VERSION = 1;
+const STORE_NAME = 'binaries';
+const BINARY_KEY = 'dropped';
+
+function request<T>(source: IDBRequest<T>): Promise<T> {
+  const { promise, resolve, reject } = Promise.withResolvers<T>();
+
+  source.onsuccess = () => resolve(source.result);
+  source.onerror = () => reject(source.error ?? new Error('The browser refused the read.'));
+
+  return promise;
+}
+
+function openStore(mode: IDBTransactionMode): Promise<IDBObjectStore> {
+  const { promise, resolve, reject } = Promise.withResolvers<IDBObjectStore>();
+  const open = indexedDB.open(DB_NAME, DB_VERSION);
+
+  open.onupgradeneeded = () => open.result.createObjectStore(STORE_NAME);
+  open.onerror = () => reject(open.error ?? new Error('The browser refused to open storage.'));
+  open.onsuccess = () => resolve(open.result.transaction(STORE_NAME, mode).objectStore(STORE_NAME));
+
+  return promise;
+}
+
+export async function storeHandedOffBinary(binary: File): Promise<void> {
+  const store = await openStore('readwrite');
+  await request(store.put(binary, BINARY_KEY));
+}
+
+export async function readHandedOffBinary(): Promise<File | undefined> {
+  const store = await openStore('readonly');
+  const stored = await request<unknown>(store.get(BINARY_KEY));
+  return stored instanceof File ? stored : undefined;
+}

--- a/apps/dashboard/src/lib/hooks/use-handed-off-binary.ts
+++ b/apps/dashboard/src/lib/hooks/use-handed-off-binary.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { readHandedOffBinary } from '#lib/handoff-store.ts';
+
+export type HandedOffBinary = {
+  binary: File | undefined;
+  loading: boolean;
+};
+
+export function useHandedOffBinary(): HandedOffBinary {
+  const [binary, setBinary] = useState<File>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let live = true;
+
+    readHandedOffBinary()
+      .then(function keep(stored) {
+        if (live) {
+          setBinary(stored);
+          setLoading(false);
+        }
+      })
+      .catch(function giveUp() {
+        if (live) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  return { binary, loading };
+}

--- a/apps/dashboard/src/lib/hooks/use-handoff-receiver.ts
+++ b/apps/dashboard/src/lib/hooks/use-handoff-receiver.ts
@@ -1,0 +1,51 @@
+import { HANDOFF_READY, HANDOFF_STORED, isHandoffOffer } from '@repo/binary-handoff';
+import { useEffect, useState } from 'react';
+import { storeHandedOffBinary } from '#lib/handoff-store.ts';
+
+const LANDING_ORIGIN = import.meta.env.DEV ? 'http://localhost:3002' : 'https://nibrun.com';
+
+function framedByLandingPage(): boolean {
+  return window.parent !== window;
+}
+
+/**
+ * The landing page cannot reach this origin's storage, so it frames this route and posts the
+ * binary in. Returns whether the page is that frame — when it is, there is nobody to render
+ * for, since the frame is hidden inside the page the visitor is actually looking at.
+ */
+export function useHandoffReceiver(): boolean {
+  const [framed] = useState(framedByLandingPage);
+
+  useEffect(() => {
+    if (!framed) {
+      return;
+    }
+    const { parent } = window;
+
+    function onMessage(event: MessageEvent): void {
+      // Anything else on the landing origin could post here too, so the parent being the
+      // sender is as much a part of trusting this as the origin is.
+      if (event.origin !== LANDING_ORIGIN || event.source !== parent) {
+        return;
+      }
+      if (!isHandoffOffer(event.data)) {
+        return;
+      }
+      storeHandedOffBinary(event.data.binary)
+        .then(function acknowledge() {
+          parent.postMessage({ kind: HANDOFF_STORED }, LANDING_ORIGIN);
+        })
+        .catch(function staySilent() {
+          // No ack: the landing page times out and says so, which is the only thing it could
+          // usefully tell someone whose browser refused the write.
+        });
+    }
+
+    window.addEventListener('message', onMessage);
+    parent.postMessage({ kind: HANDOFF_READY }, LANDING_ORIGIN);
+
+    return () => window.removeEventListener('message', onMessage);
+  }, [framed]);
+
+  return framed;
+}

--- a/apps/dashboard/src/routeTree.gen.ts
+++ b/apps/dashboard/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as authRouteRouteImport } from './routes/(auth)/route'
 import { Route as dashboardRouteRouteImport } from './routes/(dashboard)/route'
+import { Route as DeployRouteImport } from './routes/deploy'
 import { Route as authDeviceRouteImport } from './routes/(auth)/device'
 import { Route as authLoginRouteImport } from './routes/(auth)/login'
 import { Route as dashboardIndexRouteImport } from './routes/(dashboard)/index'
@@ -26,6 +27,11 @@ const authRouteRoute = authRouteRouteImport.update({
 } as any)
 const dashboardRouteRoute = dashboardRouteRouteImport.update({
   id: '/(dashboard)',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DeployRoute = DeployRouteImport.update({
+  id: '/deploy',
+  path: '/deploy',
   getParentRoute: () => rootRouteImport,
 } as any)
 const authDeviceRoute = authDeviceRouteImport.update({
@@ -70,6 +76,7 @@ const dashboardAppsAppIdLogsRoute = dashboardAppsAppIdLogsRouteImport.update({
 } as any)
 
 export interface FileRoutesByFullPath {
+  '/deploy': typeof DeployRoute
   '/device': typeof authDeviceRoute
   '/login': typeof authLoginRoute
   '/': typeof dashboardIndexRoute
@@ -80,6 +87,7 @@ export interface FileRoutesByFullPath {
   '/apps/$appId/': typeof dashboardAppsAppIdIndexRoute
 }
 export interface FileRoutesByTo {
+  '/deploy': typeof DeployRoute
   '/device': typeof authDeviceRoute
   '/login': typeof authLoginRoute
   '/': typeof dashboardIndexRoute
@@ -92,6 +100,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/(auth)': typeof authRouteRouteWithChildren
   '/(dashboard)': typeof dashboardRouteRouteWithChildren
+  '/deploy': typeof DeployRoute
   '/(auth)/device': typeof authDeviceRoute
   '/(auth)/login': typeof authLoginRoute
   '/(dashboard)/': typeof dashboardIndexRoute
@@ -104,6 +113,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/deploy'
     | '/device'
     | '/login'
     | '/'
@@ -114,6 +124,7 @@ export interface FileRouteTypes {
     | '/apps/$appId/'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/deploy'
     | '/device'
     | '/login'
     | '/'
@@ -125,6 +136,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/(auth)'
     | '/(dashboard)'
+    | '/deploy'
     | '/(auth)/device'
     | '/(auth)/login'
     | '/(dashboard)/'
@@ -138,6 +150,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   authRouteRoute: typeof authRouteRouteWithChildren
   dashboardRouteRoute: typeof dashboardRouteRouteWithChildren
+  DeployRoute: typeof DeployRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -154,6 +167,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: ''
       preLoaderRoute: typeof dashboardRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/deploy': {
+      id: '/deploy'
+      path: '/deploy'
+      fullPath: '/deploy'
+      preLoaderRoute: typeof DeployRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(auth)/device': {
@@ -266,6 +286,7 @@ const dashboardRouteRouteWithChildren = dashboardRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   authRouteRoute: authRouteRouteWithChildren,
   dashboardRouteRoute: dashboardRouteRouteWithChildren,
+  DeployRoute: DeployRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -4,17 +4,28 @@ import { AppDevtools } from '#components/app-devtools.tsx';
 import { sessionQueryOptions } from '#queries/session.ts';
 import { Route as LoginRoute } from '#routes/(auth)/login.tsx';
 import { Route as IndexRoute } from '#routes/(dashboard)/index.tsx';
+import { Route as DeployRoute } from '#routes/deploy.tsx';
 
 import '../styles.css';
 
+// Enumerated rather than opted into, so the guard below stays the thing that decides who is
+// public: signing in cannot itself require a session, and the landing page frames /deploy to
+// post a binary here before anyone has signed in.
+//
+// A function, not a module-level set: these routes import this module back, so at evaluation
+// time their `to` is still undefined and every path — including /login — would read as private.
+function isPublic(pathname: string): boolean {
+  return pathname === LoginRoute.to || pathname === DeployRoute.to;
+}
+
 // Guarding at the root, rather than under a pathless layout, is what makes it
 // impossible to add a route that forgets to ask for a session: every route is
-// already behind this, and signing in is the one path that cannot be.
+// already behind this, and the paths above are the only ones that cannot be.
 export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()({
   beforeLoad: async ({ context, location }) => {
     const session = await context.queryClient.ensureQueryData(sessionQueryOptions);
 
-    if (!session && location.pathname !== LoginRoute.to) {
+    if (!session && !isPublic(location.pathname)) {
       // Home is where signing in lands you with no destination, so saying so
       // would only put a `?redirect=%2F` in front of the user.
       const isHome = location.href === IndexRoute.to;

--- a/apps/dashboard/src/routes/deploy.tsx
+++ b/apps/dashboard/src/routes/deploy.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { HandedOffBinary } from '#components/handoff/handed-off-binary.tsx';
+import { useHandoffReceiver } from '#lib/hooks/use-handoff-receiver.ts';
+
+// Outside `(auth)` and `(dashboard)` on purpose: the landing page frames this route, and a
+// hidden frame should render neither the signed-in chrome nor the auth card.
+export const Route = createFileRoute('/deploy')({ component: RouteComponent });
+
+function RouteComponent() {
+  const framed = useHandoffReceiver();
+
+  return framed ? null : <HandedOffBinary />;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
       "dependencies": {
         "@repo/api-client": "workspace:*",
         "@repo/app-operations": "workspace:*",
+        "@repo/binary-handoff": "workspace:*",
         "@repo/protocol": "workspace:*",
         "@repo/ui": "workspace:*",
         "@tanstack/react-devtools": "^0.10.9",
@@ -98,6 +99,13 @@
         "@repo/api-client": "workspace:*",
         "@repo/protocol": "workspace:*",
       },
+      "devDependencies": {
+        "@repo/typescript-config": "workspace:*",
+        "typescript": "catalog:",
+      },
+    },
+    "packages/binary-handoff": {
+      "name": "@repo/binary-handoff",
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
         "typescript": "catalog:",
@@ -546,6 +554,8 @@
     "@repo/api-client": ["@repo/api-client@workspace:packages/api-client"],
 
     "@repo/app-operations": ["@repo/app-operations@workspace:packages/app-operations"],
+
+    "@repo/binary-handoff": ["@repo/binary-handoff@workspace:packages/binary-handoff"],
 
     "@repo/cli": ["@repo/cli@workspace:packages/cli"],
 
@@ -1335,9 +1345,9 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
-    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+    "seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
 
-    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
+    "seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -1515,10 +1525,6 @@
 
     "@tanstack/router-cli/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
-    "@tanstack/router-core/seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
-
-    "@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
-
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "conf/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
@@ -1558,6 +1564,10 @@
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "solid-js/seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "solid-js/seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/packages/binary-handoff/package.json
+++ b/packages/binary-handoff/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@repo/binary-handoff",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "imports": {
+    "#*": "./src/*"
+  },
+  "scripts": {
+    "test": "bun test",
+    "check:types": "bun run --bun tsc"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/binary-handoff/src/index.ts
+++ b/packages/binary-handoff/src/index.ts
@@ -1,0 +1,14 @@
+/** biome-ignore-all lint/performance/noBarrelFile: index is the only allowed file where we can export other files */
+
+export {
+  HANDOFF_FRAME_PATH,
+  HANDOFF_OFFER,
+  HANDOFF_READY,
+  HANDOFF_STORED,
+  type HandoffOffer,
+  type HandoffReady,
+  type HandoffStored,
+  isHandoffOffer,
+  isHandoffReady,
+  isHandoffStored,
+} from '#messages.ts';

--- a/packages/binary-handoff/src/messages.test.ts
+++ b/packages/binary-handoff/src/messages.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  HANDOFF_OFFER,
+  HANDOFF_READY,
+  HANDOFF_STORED,
+  isHandoffOffer,
+  isHandoffReady,
+  isHandoffStored,
+} from '#messages.ts';
+
+// These guards stand between an arbitrary page and the app's storage, so what they reject
+// matters more than what they accept.
+describe('a message is only trusted for what it actually carries', () => {
+  test('an offer needs a real File, not something shaped like one', () => {
+    const binary = new File(['#!/bin/sh'], 'server');
+
+    expect(isHandoffOffer({ kind: HANDOFF_OFFER, binary })).toBe(true);
+    expect(isHandoffOffer({ kind: HANDOFF_OFFER, binary: { name: 'server', size: 9 } })).toBe(
+      false,
+    );
+    expect(isHandoffOffer({ kind: HANDOFF_OFFER })).toBe(false);
+    expect(isHandoffOffer({ kind: HANDOFF_OFFER, binary: new Blob(['#!/bin/sh']) })).toBe(false);
+  });
+
+  test('a kind is not enough on its own', () => {
+    expect(isHandoffOffer({ kind: HANDOFF_READY, binary: new File([], 'server') })).toBe(false);
+    expect(isHandoffReady({ kind: HANDOFF_STORED })).toBe(false);
+    expect(isHandoffStored({ kind: HANDOFF_READY })).toBe(false);
+  });
+
+  test('anything that is not a message is refused rather than thrown at', () => {
+    // A window accepts a post of any shape, so the guards have to survive all of them.
+    const notMessages: unknown[] = [
+      null,
+      undefined,
+      'handoff-offer',
+      Number.NaN,
+      [],
+      new File([], 'server'),
+    ];
+
+    for (const value of notMessages) {
+      expect(isHandoffOffer(value)).toBe(false);
+      expect(isHandoffReady(value)).toBe(false);
+      expect(isHandoffStored(value)).toBe(false);
+    }
+  });
+
+  test('the signals carry nothing beyond their kind', () => {
+    expect(isHandoffReady({ kind: HANDOFF_READY })).toBe(true);
+    expect(isHandoffStored({ kind: HANDOFF_STORED })).toBe(true);
+  });
+});

--- a/packages/binary-handoff/src/messages.ts
+++ b/packages/binary-handoff/src/messages.ts
@@ -1,0 +1,42 @@
+/**
+ * The landing page and the app are different origins, so a binary dropped on the former
+ * reaches the latter only by being posted into a frame the app itself serves. These are the
+ * messages that crossing is made of.
+ *
+ * Plain types and guards rather than schemas: the offer carries a `File`, which survives a
+ * structured clone but has no JSON form for a schema to describe. The guards are what makes a
+ * message trustworthy, and the sender's origin is what makes it worth reading at all; both
+ * sides check both, and neither ever posts to `*`.
+ */
+
+// Where the app serves the receiving frame. Shared so the two sides cannot disagree about it.
+export const HANDOFF_FRAME_PATH = '/deploy';
+
+export const HANDOFF_READY = 'handoff-ready';
+export const HANDOFF_OFFER = 'handoff-offer';
+export const HANDOFF_STORED = 'handoff-stored';
+
+/** The frame has mounted and is listening. Sent to the parent. */
+export type HandoffReady = { kind: typeof HANDOFF_READY };
+
+/** The binary itself. Sent to the frame. */
+export type HandoffOffer = { kind: typeof HANDOFF_OFFER; binary: File };
+
+/** The binary is in the app's own storage and the parent may navigate. Sent to the parent. */
+export type HandoffStored = { kind: typeof HANDOFF_STORED };
+
+function hasKind({ value, kind }: { value: unknown; kind: string }): boolean {
+  return typeof value === 'object' && value !== null && (value as { kind?: unknown }).kind === kind;
+}
+
+export function isHandoffReady(value: unknown): value is HandoffReady {
+  return hasKind({ value, kind: HANDOFF_READY });
+}
+
+export function isHandoffStored(value: unknown): value is HandoffStored {
+  return hasKind({ value, kind: HANDOFF_STORED });
+}
+
+export function isHandoffOffer(value: unknown): value is HandoffOffer {
+  return hasKind({ value, kind: HANDOFF_OFFER }) && (value as HandoffOffer).binary instanceof File;
+}

--- a/packages/binary-handoff/tsconfig.json
+++ b/packages/binary-handoff/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
`nibrun.com` and `app.nibrun.com` are different origins, so a binary dropped on the landing page cannot be read here — localStorage and IndexedDB are both per origin, and localStorage is strings-only with a ~5MB quota besides. The landing page frames this route and posts the `File` into it; the receiver writes it to IndexedDB under *this* origin, which is the only place the deploy flow could later find it.

**The contract lives in a new `@repo/binary-handoff`.** It first went into `@repo/protocol`, which was wrong: that package is the wire format and domain model the api and the agent share, and this is two frontends agreeing how a file crosses an origin boundary. Named for what happens rather than how — `postMessage` is today's transport, and an anonymous upload would make a name like `postmessage-*` a lie.

- Plain types and guards rather than TypeBox: the offer carries a `File`, which survives structured clone but has no JSON form for a schema to describe.
- The guards are unit-tested, since they stand between an arbitrary page and this origin's storage. Notably a `Blob` is rejected where a `File` is required, and an object merely *shaped* like a file is too.
- Both sides check `event.origin` **and** that the sender is the expected window, and neither posts to `*`.
- `/deploy` joins `/login` as reachable without a session — the frame renders before anyone has signed in. The check is a function rather than a module-level `Set`: these route modules import `__root` back, so at evaluation time their `to` is still undefined and every path, `/login` included, would read as private and redirect-loop.
- It sits outside both route groups because a hidden frame should render neither the signed-in chrome nor the auth card.

Standalone, `/deploy` shows the waiting binary and prompts sign-in. Turning it into a deployment is the follow-up.