### PR TITLE
feat(www): a preview build and upload, so a change is seen before it serves traffic

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -8,9 +8,11 @@
   "scripts": {
     "dev": "vite dev --port 3002",
     "build": "vite build",
+    "build:preview": "CLOUDFLARE_ENV=preview vite build",
     "preview": "vite preview",
     "cf:typegen": "wrangler types",
     "cf:deploy": "bun run build && wrangler deploy",
+    "cf:deploy:preview": "bun run build:preview && wrangler versions upload",
     "check:types": "bun run cf:typegen && bun run --bun tsc"
   },
   "dependencies": {

--- a/apps/www/wrangler.jsonc
+++ b/apps/www/wrangler.jsonc
@@ -10,5 +10,14 @@
   },
   "assets": {
     "binding": "ASSETS"
+  },
+  "env": {
+    // Wrangler derives `nibrun-www-preview` from the environment name and would deploy a
+    // second worker under it. Naming it back to the base keeps preview a version of the one
+    // worker — which is what `wrangler versions upload` ships, a version that serves no
+    // traffic until it is promoted. Anything a preview should do differently goes here.
+    "preview": {
+      "name": "nibrun-www"
+    }
   }
 }


### PR DESCRIPTION
Stacked on #193.

Follows `ilbertt/kordeon`'s `apps/website`, minus the D1 migration steps this app has no use for:

```
"build:preview":     "CLOUDFLARE_ENV=preview vite build"
"cf:deploy:preview": "bun run build:preview && wrangler versions upload"
```

`wrangler versions upload` ships a version that serves no traffic until it is promoted, which is the point of a preview.

`wrangler.jsonc` needed an `env.preview` block to go with it — without one the build warns four times that no such environment exists, and `CLOUDFLARE_ENV=preview` silently produces a build identical to production, which is worse than not having the script. The block names the worker back to the base, since wrangler would otherwise derive `nibrun-www-preview` and deploy a *second* worker rather than a version of the one.

Verified the emitted `dist/server/wrangler.json` names the worker `nibrun-www`, identical to a production build. Nothing differs between the two environments yet — the block is where anything that should will go.

One residual: the build still warns once, against its own generated `dist/server/wrangler.json`, because the plugin re-reads that already-resolved config while `CLOUDFLARE_ENV` is still set. It does not affect the output, and it does not appear at deploy time — the variable is scoped to the `build:preview` command, so `wrangler versions upload` runs without it.