### PR TITLE
feat(www): a headline and three plain facts, so the landing page says what it is

### DIFF
--- a/apps/www/src/components/binary-drop.tsx
+++ b/apps/www/src/components/binary-drop.tsx
@@ -9,7 +9,12 @@ export function BinaryDrop() {
   const picker = useBinaryPicker({ onPick: handoff.offer });
 
   return (
-    <div className="flex w-full flex-col gap-3">
+    <div className="relative isolate flex w-full flex-col gap-3">
+      <div
+        aria-hidden="true"
+        data-dragging={picker.dragging || undefined}
+        className="pointer-events-none absolute -inset-6 -z-10 rounded-full bg-primary/30 opacity-70 blur-3xl transition-opacity duration-300 data-[dragging=true]:opacity-100"
+      />
       <div
         data-dragging={picker.dragging || undefined}
         data-invalid={handoff.failure !== undefined || undefined}
@@ -26,13 +31,11 @@ export function BinaryDrop() {
         />
         <label
           htmlFor={BINARY_INPUT_ID}
-          className="flex cursor-pointer flex-col items-center gap-4 px-6 py-16 text-center sm:py-24"
+          className="flex cursor-pointer flex-col items-center gap-4 px-6 py-16 text-center sm:py-20"
         >
           <Glyph handoff={handoff} />
           <span className="flex flex-col gap-1.5">
-            <span className="font-medium text-lg sm:text-xl">
-              Drop your binary here, get a server
-            </span>
+            <span className="font-medium text-lg sm:text-xl">Drop it here</span>
             <span className="text-muted-foreground text-sm">{caption(handoff)}</span>
           </span>
         </label>
@@ -64,7 +67,7 @@ function caption(handoff: BinaryHandoff): string {
     return `Sending ${handoff.binary?.name}…`;
   }
   if (handoff.binary === undefined) {
-    return 'or click to browse for it';
+    return 'or click to browse';
   }
   return handoff.binary.name;
 }

--- a/apps/www/src/components/binary-drop.tsx
+++ b/apps/www/src/components/binary-drop.tsx
@@ -9,16 +9,11 @@ export function BinaryDrop() {
   const picker = useBinaryPicker({ onPick: handoff.offer });
 
   return (
-    <div className="relative isolate flex w-full flex-col gap-3">
-      <div
-        aria-hidden="true"
-        data-dragging={picker.dragging || undefined}
-        className="pointer-events-none absolute -inset-6 -z-10 rounded-full bg-primary/30 opacity-70 blur-3xl transition-opacity duration-300 data-[dragging=true]:opacity-100"
-      />
+    <div className="flex w-full flex-col gap-3">
       <div
         data-dragging={picker.dragging || undefined}
         data-invalid={handoff.failure !== undefined || undefined}
-        className="relative rounded-3xl border-2 border-muted-foreground/25 border-dashed bg-input/40 transition-[color,background-color,border-color] duration-200 hover:border-muted-foreground/40 hover:bg-input/70 has-[input:focus-visible]:border-ring has-[input:focus-visible]:ring-3 has-[input:focus-visible]:ring-ring/30 data-[dragging=true]:border-ring data-[invalid=true]:border-destructive/60 data-[dragging=true]:border-solid data-[dragging=true]:bg-primary/10"
+        className="relative rounded-3xl border-2 border-muted-foreground/25 border-dashed bg-input/40 transition-[color,background-color,border-color] duration-200 hover:border-muted-foreground/40 hover:bg-input/70 has-[input:focus-visible]:border-ring has-[input:focus-visible]:ring-3 has-[input:focus-visible]:ring-ring/30 data-[dragging=true]:border-ring data-[invalid=true]:border-destructive/60 data-[dragging=true]:border-solid data-[dragging=true]:bg-primary/10 data-[dragging=true]:ring-4 data-[dragging=true]:ring-primary/20"
         {...picker.dropHandlers}
       >
         <input

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -5,7 +5,8 @@ export function Hero() {
         Drop a binary. Get a server.
       </h1>
       <p className="text-balance text-lg text-muted-foreground">
-        No Dockerfile. No YAML. No cluster. Just your binary, a microVM, and a disk that remembers.
+        No Dockerfile. No YAML. No cluster. Just your binary, a microVM, and a persistent
+        filesystem.
       </p>
     </div>
   );

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -5,9 +5,8 @@ export function Hero() {
         Drop a binary. Get a server.
       </h1>
       <p className="text-balance text-lg text-muted-foreground">
-        It boots in a microVM of its own, with a{' '}
-        <code className="font-mono text-foreground">data/</code> that outlives every redeploy. No
-        Dockerfile. No YAML.
+        No Dockerfile. No YAML. No cluster. A microVM and a filesystem is all most software ever
+        needed.
       </p>
     </div>
   );

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -5,7 +5,7 @@ export function Hero() {
         Drop a binary. Get a server.
       </h1>
       <p className="text-balance text-lg text-muted-foreground">
-        No Dockerfile. No YAML. No cluster. Just the binary you already built.
+        No Dockerfile. No YAML. No cluster. Just your binary, a microVM, and a disk that remembers.
       </p>
     </div>
   );

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -1,0 +1,14 @@
+export function Hero() {
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <h1 className="text-balance font-semibold text-4xl tracking-tight sm:text-5xl">
+        Drop a binary. Get a server.
+      </h1>
+      <p className="text-balance text-lg text-muted-foreground">
+        It boots in a microVM of its own, with a{' '}
+        <code className="font-mono text-foreground">data/</code> that outlives every redeploy. No
+        Dockerfile. No YAML.
+      </p>
+    </div>
+  );
+}

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -5,8 +5,7 @@ export function Hero() {
         Drop a binary. Get a server.
       </h1>
       <p className="text-balance text-lg text-muted-foreground">
-        No Dockerfile. No YAML. No cluster. A microVM and a filesystem is all most software ever
-        needed.
+        No Dockerfile. No YAML. No cluster. Just the binary you already built.
       </p>
     </div>
   );

--- a/apps/www/src/components/page-backdrop.tsx
+++ b/apps/www/src/components/page-backdrop.tsx
@@ -1,0 +1,11 @@
+// Fixed rather than in flow: the mask is what keeps the grid from reaching the text, so it has
+// to stay under the viewport — scrolling it with the page would drift the faded part away from
+// whatever is being read.
+export function PageBackdrop() {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(currentColor_1px,transparent_1px)] text-muted-foreground/30 [background-size:22px_22px] [mask-image:radial-gradient(ellipse_65%_55%_at_50%_30%,black,transparent)]"
+    />
+  );
+}

--- a/apps/www/src/components/terminal-hint.tsx
+++ b/apps/www/src/components/terminal-hint.tsx
@@ -1,8 +1,8 @@
 export function TerminalHint() {
   return (
-    <p className="text-center text-muted-foreground text-sm">
-      Rather stay in the terminal?{' '}
-      <code className="rounded-md border bg-muted px-1.5 py-0.5 font-mono text-foreground text-xs">
+    <p className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1.5 text-muted-foreground text-sm">
+      <span>Rather stay in the terminal?</span>
+      <code className="whitespace-nowrap rounded-md border bg-muted px-1.5 py-0.5 font-mono text-foreground text-xs">
         nib run ./server
       </code>
     </p>

--- a/apps/www/src/components/terminal-hint.tsx
+++ b/apps/www/src/components/terminal-hint.tsx
@@ -1,0 +1,10 @@
+export function TerminalHint() {
+  return (
+    <p className="text-center text-muted-foreground text-sm">
+      Rather stay in the terminal?{' '}
+      <code className="rounded-md border bg-muted px-1.5 py-0.5 font-mono text-foreground text-xs">
+        nib run ./server
+      </code>
+    </p>
+  );
+}

--- a/apps/www/src/components/what-you-get.tsx
+++ b/apps/www/src/components/what-you-get.tsx
@@ -3,23 +3,23 @@ import { CpuIcon, DatabaseIcon, GlobeIcon, PackageIcon } from 'lucide-react';
 const WHAT_YOU_GET = [
   {
     icon: CpuIcon,
-    title: 'One guest, one volume',
-    body: 'No orchestrator, no sidecars, no service mesh. Your binary is the only thing that ever executes in there.',
+    title: 'A machine to itself',
+    body: 'One microVM per app. Your binary is the only thing running inside it, so nothing else can crash it or read its disk.',
   },
   {
     icon: DatabaseIcon,
-    title: 'SQLite is just a file',
-    body: 'And so are your uploads. A real ext4 volume at data/ — nothing to provision, no connection string to keep.',
+    title: 'Just write to the disk',
+    body: 'SQLite for your data, data/ for your uploads. No database to provision, no bucket to configure, and it survives every redeploy.',
   },
   {
     icon: PackageIcon,
-    title: 'Take it and go',
-    body: 'One .tar.gz with the binary and everything on its volume, from a button. It runs anywhere Linux does.',
+    title: 'Take it all with you',
+    body: 'One click, one .tar.gz: the binary and every byte of its disk, read while the filesystem is frozen so the SQLite inside is intact. Runs on any Linux box.',
   },
   {
     icon: GlobeIcon,
-    title: 'An HTTPS endpoint',
-    body: 'Issued and served the moment it boots. No certificate to renew, no load balancer to stand up.',
+    title: 'A URL right away',
+    body: 'An HTTPS subdomain, issued and served the moment it boots. Point a domain of your own at it when you are ready.',
   },
 ];
 
@@ -28,8 +28,10 @@ export function WhatYouGet() {
     <section className="grid w-full gap-10 border-border/60 border-t py-16 sm:grid-cols-2 sm:gap-8 sm:py-20 lg:grid-cols-4">
       {WHAT_YOU_GET.map(({ icon: Icon, title, body }) => (
         <div key={title} className="flex flex-col items-start gap-3">
-          <Icon className="size-5 text-primary" />
-          <h2 className="font-medium">{title}</h2>
+          <span className="flex size-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <Icon className="size-5" />
+          </span>
+          <h2 className="text-balance font-medium">{title}</h2>
           <p className="text-pretty text-muted-foreground text-sm leading-relaxed">{body}</p>
         </div>
       ))}

--- a/apps/www/src/components/what-you-get.tsx
+++ b/apps/www/src/components/what-you-get.tsx
@@ -9,7 +9,7 @@ const WHAT_YOU_GET = [
   {
     icon: DatabaseIcon,
     title: 'Just write to the disk',
-    body: 'SQLite for data, data/ for uploads. It survives every redeploy.',
+    body: 'data/ is yours: a SQLite file, uploads, both. It survives every redeploy.',
   },
   {
     icon: PackageIcon,

--- a/apps/www/src/components/what-you-get.tsx
+++ b/apps/www/src/components/what-you-get.tsx
@@ -1,0 +1,33 @@
+import { CpuIcon, GlobeIcon, HardDriveIcon } from 'lucide-react';
+
+const WHAT_YOU_GET = [
+  {
+    icon: CpuIcon,
+    title: 'A machine of its own',
+    body: 'One microVM per app. Its PID 1 measures 1.3 MiB of memory and 69 KiB on disk, and your binary is the only other thing that ever runs in there.',
+  },
+  {
+    icon: HardDriveIcon,
+    title: 'A volume that outlives deploys',
+    body: 'Mounted at data/, kept across restarts and redeploys. Export the whole filesystem whenever you want it somewhere else.',
+  },
+  {
+    icon: GlobeIcon,
+    title: 'A hostname as soon as it boots',
+    body: 'nibrun issues a subdomain and serves it over HTTPS. Point a domain of your own at it whenever you are ready.',
+  },
+];
+
+export function WhatYouGet() {
+  return (
+    <section className="grid w-full gap-10 border-border/60 border-t py-16 sm:grid-cols-3 sm:gap-8 sm:py-20">
+      {WHAT_YOU_GET.map(({ icon: Icon, title, body }) => (
+        <div key={title} className="flex flex-col items-start gap-3">
+          <Icon className="size-5 text-primary" />
+          <h2 className="font-medium">{title}</h2>
+          <p className="text-pretty text-muted-foreground text-sm leading-relaxed">{body}</p>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/apps/www/src/components/what-you-get.tsx
+++ b/apps/www/src/components/what-you-get.tsx
@@ -1,26 +1,31 @@
-import { CpuIcon, GlobeIcon, HardDriveIcon } from 'lucide-react';
+import { CpuIcon, DatabaseIcon, GlobeIcon, PackageIcon } from 'lucide-react';
 
 const WHAT_YOU_GET = [
   {
     icon: CpuIcon,
-    title: 'A machine of its own',
-    body: 'One microVM per app. Its PID 1 measures 1.3 MiB of memory and 69 KiB on disk, and your binary is the only other thing that ever runs in there.',
+    title: 'One guest, one volume',
+    body: 'No orchestrator, no sidecars, no service mesh. Your binary is the only thing that ever executes in there.',
   },
   {
-    icon: HardDriveIcon,
-    title: 'A volume that outlives deploys',
-    body: 'Mounted at data/, kept across restarts and redeploys. Export the whole filesystem whenever you want it somewhere else.',
+    icon: DatabaseIcon,
+    title: 'SQLite is just a file',
+    body: 'And so are your uploads. A real ext4 volume at data/ — nothing to provision, no connection string to keep.',
+  },
+  {
+    icon: PackageIcon,
+    title: 'Take it and go',
+    body: 'One .tar.gz with the binary and everything on its volume, from a button. It runs anywhere Linux does.',
   },
   {
     icon: GlobeIcon,
-    title: 'A hostname as soon as it boots',
-    body: 'nibrun issues a subdomain and serves it over HTTPS. Point a domain of your own at it whenever you are ready.',
+    title: 'An HTTPS endpoint',
+    body: 'Issued and served the moment it boots. No certificate to renew, no load balancer to stand up.',
   },
 ];
 
 export function WhatYouGet() {
   return (
-    <section className="grid w-full gap-10 border-border/60 border-t py-16 sm:grid-cols-3 sm:gap-8 sm:py-20">
+    <section className="grid w-full gap-10 border-border/60 border-t py-16 sm:grid-cols-2 sm:gap-8 sm:py-20 lg:grid-cols-4">
       {WHAT_YOU_GET.map(({ icon: Icon, title, body }) => (
         <div key={title} className="flex flex-col items-start gap-3">
           <Icon className="size-5 text-primary" />

--- a/apps/www/src/components/what-you-get.tsx
+++ b/apps/www/src/components/what-you-get.tsx
@@ -4,35 +4,37 @@ const WHAT_YOU_GET = [
   {
     icon: CpuIcon,
     title: 'A machine to itself',
-    body: 'One microVM per app. Your binary is the only thing running inside it, so nothing else can crash it or read its disk.',
+    body: 'One microVM per app. Nothing else runs in it.',
   },
   {
     icon: DatabaseIcon,
     title: 'Just write to the disk',
-    body: 'SQLite for your data, data/ for your uploads. No database to provision, no bucket to configure, and it survives every redeploy.',
+    body: 'SQLite for data, data/ for uploads. It survives every redeploy.',
   },
   {
     icon: PackageIcon,
     title: 'Take it all with you',
-    body: 'One click, one .tar.gz: the binary and every byte of its disk, read while the filesystem is frozen so the SQLite inside is intact. Runs on any Linux box.',
+    body: 'One click: the binary and its whole disk, as one .tar.gz.',
   },
   {
     icon: GlobeIcon,
     title: 'A URL right away',
-    body: 'An HTTPS subdomain, issued and served the moment it boots. Point a domain of your own at it when you are ready.',
+    body: 'An HTTPS subdomain, the moment it boots.',
   },
 ];
 
 export function WhatYouGet() {
   return (
-    <section className="grid w-full gap-10 border-border/60 border-t py-16 sm:grid-cols-2 sm:gap-8 sm:py-20 lg:grid-cols-4">
+    <section className="grid w-full gap-8 border-border/60 border-t py-16 sm:grid-cols-2 sm:gap-x-16 sm:gap-y-12 sm:py-20">
       {WHAT_YOU_GET.map(({ icon: Icon, title, body }) => (
-        <div key={title} className="flex flex-col items-start gap-3">
-          <span className="flex size-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+        <div key={title} className="flex items-start gap-4">
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
             <Icon className="size-5" />
           </span>
-          <h2 className="text-balance font-medium">{title}</h2>
-          <p className="text-pretty text-muted-foreground text-sm leading-relaxed">{body}</p>
+          <div className="flex flex-col gap-1">
+            <h2 className="font-medium text-lg">{title}</h2>
+            <p className="text-pretty text-muted-foreground">{body}</p>
+          </div>
         </div>
       ))}
     </section>

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import { themeScript } from '#lib/theme-script.ts';
 const SITE_URL = 'https://nibrun.com';
 const TITLE = 'nibrun — drop your binary, get a server';
 const DESCRIPTION =
-  'Drop a compiled binary and get a server. No Dockerfile, no YAML, no cluster — a microVM and a filesystem is all most software ever needed.';
+  'Drop a compiled binary and get a server: a microVM of its own, a disk that survives redeploys, and an HTTPS URL. No Dockerfile, no YAML, no cluster.';
 const OG_IMAGE = `${SITE_URL}/og.png`;
 
 export const Route = createRootRoute({

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import { themeScript } from '#lib/theme-script.ts';
 const SITE_URL = 'https://nibrun.com';
 const TITLE = 'nibrun — drop your binary, get a server';
 const DESCRIPTION =
-  'Drop a compiled binary and get a server: a microVM of its own, a disk that survives redeploys, and an HTTPS URL. No Dockerfile, no YAML, no cluster.';
+  'Drop a compiled binary and get a server: a microVM of its own, a persistent filesystem, and an HTTPS URL. No Dockerfile, no YAML, no cluster.';
 const OG_IMAGE = `${SITE_URL}/og.png`;
 
 export const Route = createRootRoute({

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import { themeScript } from '#lib/theme-script.ts';
 const SITE_URL = 'https://nibrun.com';
 const TITLE = 'nibrun — drop your binary, get a server';
 const DESCRIPTION =
-  'Drop a compiled binary and get it running on a server, in an isolated guest with a persistent volume. No Dockerfile, no YAML.';
+  'Drop a compiled binary and get a server. No Dockerfile, no YAML, no cluster — a microVM and a filesystem is all most software ever needed.';
 const OG_IMAGE = `${SITE_URL}/og.png`;
 
 export const Route = createRootRoute({

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -1,16 +1,31 @@
 import { BrandMark } from '@repo/ui/custom/brand-mark';
 import { createFileRoute } from '@tanstack/react-router';
 import { BinaryDrop } from '#components/binary-drop.tsx';
+import { Hero } from '#components/hero.tsx';
+import { PageBackdrop } from '#components/page-backdrop.tsx';
+import { TerminalHint } from '#components/terminal-hint.tsx';
+import { WhatYouGet } from '#components/what-you-get.tsx';
 
 export const Route = createFileRoute('/')({ component: RouteComponent });
 
 function RouteComponent() {
   return (
-    <main className="flex min-h-svh flex-col items-center justify-center gap-10 p-6">
-      <BrandMark />
-      <div className="w-full max-w-xl">
-        <BinaryDrop />
-      </div>
-    </main>
+    <>
+      <PageBackdrop />
+      <main className="mx-auto flex w-full max-w-5xl flex-col items-center px-6">
+        {/* Short of the viewport on purpose: the section below has to peek, or nobody scrolls. */}
+        <section className="flex min-h-[85svh] w-full max-w-xl flex-col items-center justify-center gap-12 py-16">
+          <div className="flex flex-col items-center gap-6">
+            <BrandMark />
+            <Hero />
+          </div>
+          <div className="flex w-full flex-col items-center gap-4">
+            <BinaryDrop />
+            <TerminalHint />
+          </div>
+        </section>
+        <WhatYouGet />
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
The page rendered a logo, a dashed box, and nothing else — no heading element anywhere, so the prerender we chose Start for shipped a title tag with no outline under it.

Adds an `h1`, a subline, three short facts below the drop zone, and the `nib run ./server` alternative for people who would rather not drag. Everything stated is checkable in this repo: the microVM figures come from `apps/runtime`, `data/` from the volume mount, and platform subdomains from `AppHostnameSchema`.