### PR TITLE
feat(api): a hostname is routed once it has earned it, not once it is asked for

### DIFF
--- a/apps/api/src/db/migrations/0020_hostnames_earn_their_routing.sql
+++ b/apps/api/src/db/migrations/0020_hostnames_earn_their_routing.sql
@@ -1,0 +1,34 @@
+-- A hostname is now routable only once the edge can serve it, which 0007 had no way to say.
+--
+-- A platform hostname could be routed the moment it was minted: the wildcard record and the
+-- wildcard certificate already cover it. A brought domain covers neither, and nothing in DNS
+-- points at us until its owner makes it — so it has to wait, and something has to hold the
+-- answer to whether it still is.
+--
+-- The CHECK repeats APP_HOSTNAME_STATES from @repo/protocol and nothing compares the two, so
+-- adding a state there is also a migration here.
+--
+-- The default is `pending` rather than `active` because the two failures are not the same size:
+-- a hostname that is not served yet is a customer waiting, and one served before it was proved
+-- is somebody else's domain answering from our fleet.
+
+-- Added with `active` as the default and re-defaulted to `pending` immediately, which is what
+-- backfills the rows already here without this migration writing a row. Everything that predates
+-- it is a platform hostname the fleet is already answering for; everything after it is a claim.
+ALTER TABLE nibrun.app_hostnames
+  ADD COLUMN state text NOT NULL DEFAULT 'active',
+  ADD CONSTRAINT app_hostnames_state_check CHECK (state IN ('pending', 'active', 'failed'));
+
+ALTER TABLE nibrun.app_hostnames ALTER COLUMN state SET DEFAULT 'pending';
+
+COMMENT ON COLUMN nibrun.app_hostnames.state IS $c$@type import('@repo/protocol').AppHostnameState$c$;
+
+-- The rendered proxy config is built from this, so the filter below is the whole of what stops a
+-- hostname nobody has proved they own from being answered for by the fleet. One condition over
+-- both kinds rather than a rule per kind: a platform row is `active` from birth, so there is no
+-- second sentence for a mistake to hide in.
+CREATE OR REPLACE VIEW nibrun.desired_hostnames AS
+  SELECT h.app_id, h.hostname, h.kind
+  FROM nibrun.app_hostnames h
+  JOIN nibrun.desired_deployments d ON d.app_id = h.app_id
+  WHERE h.state = 'active';

--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -90,6 +90,7 @@ export interface IInsertAppConfigResult {
 export interface IInsertAppHostnameResult {
     hostname: import("@repo/protocol").Hostname;
     kind: import("@repo/protocol").AppHostnameKind;
+    state: import("@repo/protocol").AppHostnameState;
 }
 
 /** Result of query `SelectCreatedApp`. */
@@ -149,6 +150,7 @@ export interface ISelectAppHostnamesByOwnerResult {
     app_id: import("@repo/protocol").AppId;
     hostname: import("@repo/protocol").Hostname;
     kind: import("@repo/protocol").AppHostnameKind;
+    state: import("@repo/protocol").AppHostnameState;
 }
 
 /** Result of query `SelectAppById`. */
@@ -181,6 +183,7 @@ export interface ISelectAppByIdResult {
 export interface ISelectAppHostnamesByAppResult {
     hostname: import("@repo/protocol").Hostname;
     kind: import("@repo/protocol").AppHostnameKind;
+    state: import("@repo/protocol").AppHostnameState;
 }
 
 /** Result of query `SelectAppForConfigUpdate`. */

--- a/apps/api/src/lib/app-hostname.ts
+++ b/apps/api/src/lib/app-hostname.ts
@@ -1,4 +1,12 @@
-import { type DnsLabel, type Hostname, HostnameSchema, Value } from '@repo/protocol';
+import {
+  type AppHostname,
+  type AppHostnameState,
+  type DnsLabel,
+  type Hostname,
+  HostnameSchema,
+  Value,
+} from '@repo/protocol';
+import type { Queries } from '#db/queries.gen.d.ts';
 
 /**
  * The app domain is a different registrable domain from the one the dashboard is served on, so
@@ -12,4 +20,25 @@ export function platformHostname({
   appHostDomain: string;
 }): Hostname {
   return Value.Parse(HostnameSchema, `${slug}.${appHostDomain}`);
+}
+
+// Keys named once here, types taken from the query, so renaming a column fails to compile rather
+// than silently reading undefined.
+export type AppHostnameColumns = Pick<
+  Queries['SelectAppHostnamesByApp'],
+  'hostname' | 'kind' | 'state'
+>;
+
+/**
+ * What an owner is told about one of their hostnames. More than a host is told: a host is sent
+ * only the hostnames it should answer for, so `state` would always read `active` there.
+ */
+export type PublicAppHostname = AppHostname & { state: AppHostnameState };
+
+export function toAppHostname(row: AppHostnameColumns): PublicAppHostname {
+  return {
+    hostname: row.hostname,
+    kind: row.kind,
+    state: row.state,
+  };
 }

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -1,6 +1,7 @@
 import type { TypedSQL } from '@ilbertt/bun-sqlgen';
 import type {
   AppHostnameKind,
+  AppHostnameState,
   AppId,
   AppState,
   DnsLabel,
@@ -64,6 +65,8 @@ export abstract class AppsRepositoryContract {
 
 export const PLATFORM_KIND: AppHostnameKind = 'platform';
 
+const ACTIVE_STATE: AppHostnameState = 'active';
+
 export class AppsRepository extends Repository implements AppsRepositoryContract {
   async isOwnedBy({ appId, ownerId }: OwnedApp): Promise<boolean> {
     const [row] = await this.sql.SelectAppOwnership`
@@ -126,10 +129,12 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
         environment: config.environment,
       });
 
+      // Active on insert: the wildcard record and the wildcard certificate already cover this
+      // name, so there is nothing for it to wait for. Only a brought domain has to be proved.
       const [hostnameRow] = await tx.InsertAppHostname`
-        INSERT INTO nibrun.app_hostnames (app_id, hostname, kind)
-        VALUES (${inserted.id}, ${hostname}, ${PLATFORM_KIND})
-        RETURNING hostname, kind
+        INSERT INTO nibrun.app_hostnames (app_id, hostname, kind, state)
+        VALUES (${inserted.id}, ${hostname}, ${PLATFORM_KIND}, ${ACTIVE_STATE})
+        RETURNING hostname, kind, state
       `;
       if (!hostnameRow) {
         throw new Error('Inserting into nibrun.app_hostnames returned no row.');
@@ -183,7 +188,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
 
   listHostnamesByOwner({ ownerId }: { ownerId: OwnerId }): Promise<OwnedAppHostnameRow[]> {
     return this.sql.SelectAppHostnamesByOwner`
-      SELECT h.app_id, h.hostname, h.kind
+      SELECT h.app_id, h.hostname, h.kind, h.state
       FROM nibrun.app_hostnames h
       JOIN nibrun.live_apps a ON a.id = h.app_id
       WHERE a.owner_id = ${ownerId}
@@ -214,7 +219,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
 
   listHostnamesByApp({ appId, ownerId }: OwnedApp): Promise<AppHostnameRow[]> {
     return this.sql.SelectAppHostnamesByApp`
-      SELECT h.hostname, h.kind
+      SELECT h.hostname, h.kind, h.state
       FROM nibrun.app_hostnames h
       JOIN nibrun.live_apps a ON a.id = h.app_id
       WHERE h.app_id = ${appId} AND a.owner_id = ${ownerId}

--- a/apps/api/src/routes/api/apps/model.ts
+++ b/apps/api/src/routes/api/apps/model.ts
@@ -1,7 +1,10 @@
 import {
   AppConfigSchema,
+  AppHostnameSchema,
+  AppHostnameStateSchema,
   AppSchema,
   ByteSizeSchema,
+  MIN_HOSTNAMES,
   REDACTED,
   TenantEnvironmentSchema,
 } from '@repo/protocol';
@@ -38,9 +41,22 @@ export const AppConfigPatchSchema = t.Partial(
   { additionalProperties: false },
 );
 
+// What a host is told about a hostname, plus the one thing only its owner needs: whether the
+// edge can serve it yet.
+export const AppHostnameResponseSchema = t.Composite([
+  AppHostnameSchema,
+  t.Object({ state: AppHostnameStateSchema }),
+]);
+
+// `hostnames` is widened the same way `config` is: what an owner is shown carries the state,
+// which a host is never sent. `minItems` is restated from the schema it replaces rather than
+// left off — an app always has the hostname nibrun issued it.
 export const AppResponseSchema = t.Composite([
-  t.Omit(AppSchema, ['config']),
-  t.Object({ config: PublicAppConfigSchema }),
+  t.Omit(AppSchema, ['config', 'hostnames']),
+  t.Object({
+    config: PublicAppConfigSchema,
+    hostnames: t.Array(AppHostnameResponseSchema, { minItems: MIN_HOSTNAMES }),
+  }),
 ]);
 
 export const ListAppsResponseSchema = t.Object({ apps: t.Array(AppResponseSchema) });

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -1,4 +1,4 @@
-import type { App, AppHostname, AppId, OwnerId, ReportedVolume } from '@repo/protocol';
+import type { App, AppId, OwnerId, ReportedVolume } from '@repo/protocol';
 import {
   type AppConfigPatch,
   configWithDefaults,
@@ -6,7 +6,7 @@ import {
   type SealedConfigPatch,
   toAppConfig,
 } from '#lib/app-config.ts';
-import { platformHostname } from '#lib/app-hostname.ts';
+import { type PublicAppHostname, platformHostname, toAppHostname } from '#lib/app-hostname.ts';
 import { deriveAppSlug } from '#lib/app-slug.ts';
 import { ConflictError, NotFoundError } from '#lib/errors.ts';
 import { isUniqueViolation } from '#lib/pg-errors.ts';
@@ -21,7 +21,10 @@ import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-s
 import type { ExportsRepositoryContract } from '#repositories/exports.repository.ts';
 import { Service } from '#services/service.ts';
 
-export type PublicApp = Omit<App, 'config'> & { config: PublicAppConfig };
+export type PublicApp = Omit<App, 'config' | 'hostnames'> & {
+  config: PublicAppConfig;
+  hostnames: PublicAppHostname[];
+};
 
 type AppWithHostnames = { app: AppRow; hostnames: readonly AppHostnameRow[] };
 
@@ -307,10 +310,6 @@ function requireApp(app: AppRow | null): AppRow {
     throw new NotFoundError('App not found.');
   }
   return app;
-}
-
-function toAppHostname(row: AppHostnameRow): AppHostname {
-  return { hostname: row.hostname, kind: row.kind };
 }
 
 function toPublicApp({ app, hostnames }: AppWithHostnames): PublicApp {

--- a/apps/api/tests/repositories/desired-hostnames.test.ts
+++ b/apps/api/tests/repositories/desired-hostnames.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { SQL } from 'bun';
+import { startTestDatabase, stopTestDatabase } from '#tests/support/database.ts';
+
+const DATABASE_START_TIMEOUT_MS = 180_000;
+
+const APP_SLUG = 'routing';
+const PLATFORM = 'routing.apps.example.com';
+const BROUGHT = 'brought.example.dev';
+
+/**
+ * `nibrun.desired_hostnames` is the whole of what a host renders its proxy config from, and its
+ * `state` filter is the only thing standing between a hostname nobody has proved they own and the
+ * fleet answering for it. That filter is SQL, so no test over a fake repository can reach it —
+ * this is the one place it is exercised.
+ */
+describe('a hostname is routed once it has earned it', () => {
+  let sql: SQL;
+
+  // Long enough to pull the image, which the first run on a fresh machine does inside this hook.
+  // Bun's default is five seconds, and a pull is not something a timeout should be racing.
+  beforeAll(async () => {
+    sql = await startTestDatabase();
+    await seedDeployedApp(sql);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await stopTestDatabase(sql);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  async function routedHostnames(): Promise<string[]> {
+    const rows = (await sql.unsafe(
+      'SELECT hostname FROM nibrun.desired_hostnames ORDER BY hostname',
+    )) as Array<{ hostname: string }>;
+    return rows.map((row) => row.hostname);
+  }
+
+  // Nothing waits for a name the wildcard record and the wildcard certificate already cover.
+  test('the hostname nibrun issued is routable the moment the app exists', async () => {
+    expect(await routedHostnames()).toEqual([PLATFORM]);
+  });
+
+  test('a brought domain is not, until its owner has pointed DNS at us', async () => {
+    await sql.unsafe(
+      `INSERT INTO nibrun.app_hostnames (app_id, hostname, kind)
+       SELECT id, $1, 'custom' FROM nibrun.apps WHERE slug = $2`,
+      [BROUGHT, APP_SLUG],
+    );
+
+    expect(await routedHostnames()).toEqual([PLATFORM]);
+  });
+
+  test('and is routable once it is', async () => {
+    await sql.unsafe('UPDATE nibrun.app_hostnames SET state = $1 WHERE hostname = $2', [
+      'active',
+      BROUGHT,
+    ]);
+
+    expect(await routedHostnames()).toEqual([BROUGHT, PLATFORM]);
+  });
+
+  // A claim that lapsed is a name the fleet has to stop answering for, not one it keeps serving
+  // because it once did.
+  test('and stops being routable if the claim is given up', async () => {
+    await sql.unsafe('UPDATE nibrun.app_hostnames SET state = $1 WHERE hostname = $2', [
+      'failed',
+      BROUGHT,
+    ]);
+
+    expect(await routedHostnames()).toEqual([PLATFORM]);
+  });
+});
+
+/** An app a host would be told to run: one live deployment, one platform hostname. */
+async function seedDeployedApp(sql: SQL): Promise<void> {
+  await sql.unsafe(
+    `INSERT INTO auth."user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+     VALUES ('owner', 'owner', 'owner@example.com', true, now(), now())`,
+  );
+  await sql.unsafe(`INSERT INTO nibrun.apps (owner_id, slug) VALUES ('owner', $1)`, [APP_SLUG]);
+  await sql.unsafe(
+    `INSERT INTO nibrun.app_hostnames (app_id, hostname, kind, state)
+     SELECT id, $1, 'platform', 'active' FROM nibrun.apps WHERE slug = $2`,
+    [PLATFORM, APP_SLUG],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.artifacts (app_id, digest, size_bytes, object_key, original_file_name)
+     SELECT id, 'sha256:a', 1, 'artifacts/a', 'app' FROM nibrun.apps WHERE slug = $1`,
+    [APP_SLUG],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.app_configs (
+       app_id, guest_port, args, vcpu_count, memory_mib,
+       health_check_interval_ms, health_check_timeout_ms, health_check_grace_period_ms,
+       health_check_healthy_threshold, health_check_unhealthy_threshold,
+       restart_max_restarts, restart_initial_backoff_ms, restart_max_backoff_ms,
+       restart_backoff_factor, restart_reset_after_ms)
+     SELECT id, 8080, '{}'::text[], 1, 512, 1000, 1000, 1000, 1, 3, 5, 500, 5000, 2, 60000
+     FROM nibrun.apps WHERE slug = $1`,
+    [APP_SLUG],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.deployments (app_id, artifact_id, config_id, state)
+     SELECT a.id, ar.id, c.id, 'active'
+     FROM nibrun.apps a
+     JOIN nibrun.artifacts ar ON ar.app_id = a.id
+     JOIN nibrun.app_configs c ON c.app_id = a.id
+     WHERE a.slug = $1`,
+    [APP_SLUG],
+  );
+}

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -143,7 +143,7 @@ class StubAppsRepository implements AppsRepositoryContract {
     }
     return Promise.resolve({
       app: { ...appRow(slug), ...configColumns(config) },
-      hostnames: [{ hostname, kind: 'platform' }],
+      hostnames: [{ hostname, kind: 'platform', state: 'active' }],
     });
   }
 
@@ -318,7 +318,11 @@ describe('a taken hostname is a re-roll, not something the owner sees', () => {
     expect(appsRepo.offeredSlugs).toHaveLength(COLLISIONS_BEFORE_SUCCESS + 1);
     expect(distinct(appsRepo.offeredSlugs)).toBe(appsRepo.offeredSlugs.length);
     expect(app.hostnames).toEqual([
-      { hostname: Value.Parse(HostnameSchema, `${app.slug}.${APP_HOST_DOMAIN}`), kind: 'platform' },
+      {
+        hostname: Value.Parse(HostnameSchema, `${app.slug}.${APP_HOST_DOMAIN}`),
+        kind: 'platform',
+        state: 'active',
+      },
     ]);
   });
 });

--- a/apps/api/tests/support/database.ts
+++ b/apps/api/tests/support/database.ts
@@ -1,0 +1,54 @@
+import { resolve } from 'node:path';
+import { SQL } from 'bun';
+import { getMigrations } from '#lib/assets.ts';
+
+const COMPOSE_FILE = resolve(import.meta.dir, '..', '..', '..', '..', 'docker-compose.test.yml');
+
+// Fixed rather than discovered, because the compose file publishes it: a test that asked Docker
+// which port it got would be reading back what it already said.
+const DATABASE_URL = 'postgres://nibrun:nibrun@127.0.0.1:55432/nibrun_test';
+
+// The two the migrations own. Dropped before applying so a run finds the same empty database as
+// the one before it, including after a run that was killed before it could tear anything down.
+const OWNED_SCHEMAS = ['nibrun', 'auth'];
+
+/**
+ * The database this suite checks its SQL against, brought up and migrated.
+ *
+ * Started here rather than by whatever invoked the tests, so `bun test` means the same thing on a
+ * developer's machine as it does in CI. Nothing is configured and nothing is skipped: a rule that
+ * only holds where somebody remembered to provide a database is a rule that stops being checked.
+ */
+export async function startTestDatabase(): Promise<SQL> {
+  await compose(['up', '-d', '--wait']);
+
+  const sql = new SQL(DATABASE_URL);
+  for (const schema of OWNED_SCHEMAS) {
+    await sql.unsafe(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
+  }
+  // Read through the same accessor the server migrates from, so a test cannot drift onto a copy
+  // of the schema: what it queries is what a deploy would have built.
+  for (const [, file] of getMigrations()) {
+    await sql.unsafe(await file.text());
+  }
+  return sql;
+}
+
+export async function stopTestDatabase(sql: SQL | undefined): Promise<void> {
+  await sql?.end();
+  await compose(['down']);
+}
+
+async function compose(args: string[]): Promise<void> {
+  const run = Bun.spawn(['docker', 'compose', '-f', COMPOSE_FILE, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if ((await run.exited) === 0) {
+    return;
+  }
+  throw new Error(
+    `\`docker compose ${args.join(' ')}\` failed. This suite runs its own database and Docker ` +
+      `has to be running for it.\n${await new Response(run.stderr).text()}`,
+  );
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,23 @@
+# The database the test suite brings up for itself. Its own file rather than a profile on the
+# dev stack: what starts it is `bun test`, not a developer, and nothing here should be reachable
+# by a `docker compose up` meant to run nibrun locally.
+#
+# Same image as the dev database, so CI and a developer's machine agree on the server the SQL is
+# checked against. No volume and its own port: what it holds is rebuilt from the migrations on
+# every run, and it must never be mistaken for the one holding a developer's apps.
+
+services:
+  postgres-test:
+    image: postgres:18-alpine
+    container_name: nibrun-postgres-test
+    environment:
+      POSTGRES_USER: nibrun
+      POSTGRES_PASSWORD: nibrun
+      POSTGRES_DB: nibrun_test
+    ports:
+      - "127.0.0.1:55432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U nibrun -d nibrun_test"]
+      interval: 1s
+      timeout: 3s
+      retries: 30

--- a/packages/protocol/src/domain/app.ts
+++ b/packages/protocol/src/domain/app.ts
@@ -10,7 +10,11 @@ import { stringEnum } from '#lib/string-enum.ts';
 import { DnsLabelSchema, GuestPortSchema, HostnameSchema, TimestampSchema } from '#lib/wire.ts';
 
 const ENVIRONMENT_NAME_PATTERN = '^[A-Za-z_][A-Za-z0-9_]*$';
-const MIN_HOSTNAMES = 1;
+
+// An app is always reachable at the hostname nibrun issued it, so every list of them has one.
+// Exported because the api narrows this array for its own response and would otherwise restate
+// the bound — or, as it did, quietly drop it.
+export const MIN_HOSTNAMES = 1;
 
 // Mirrored by CONFIG_MAX_ARGUMENTS in apps/runtime, which refuses a file exceeding it.
 const MAX_ARGUMENTS = 64;
@@ -25,6 +29,17 @@ export const AppHostnameKindSchema = stringEnum(APP_HOSTNAME_KINDS);
 
 export type AppHostnameKind = typeof AppHostnameKindSchema.static;
 
+// Whether the edge can serve the hostname yet. A platform hostname is born `active` — the
+// wildcard record and the wildcard certificate already cover it — while a custom one waits for
+// the owner to point DNS at us, which is the only proof of ownership there is.
+export const APP_HOSTNAME_STATES = ['pending', 'active', 'failed'] as const;
+
+export const AppHostnameStateSchema = stringEnum(APP_HOSTNAME_STATES);
+
+export type AppHostnameState = typeof AppHostnameStateSchema.static;
+
+// No state: a host is sent the hostnames it should be answering for, and one it should not
+// answer for yet is left out rather than sent with a flag saying so.
 export const AppHostnameSchema = Type.Object({
   hostname: HostnameSchema,
   kind: AppHostnameKindSchema,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -66,6 +66,7 @@ export {
 } from '#control/transport.ts';
 export {
   APP_HOSTNAME_KINDS,
+  APP_HOSTNAME_STATES,
   APP_STATES,
   type App,
   type AppConfig,
@@ -74,9 +75,12 @@ export {
   type AppHostnameKind,
   AppHostnameKindSchema,
   AppHostnameSchema,
+  type AppHostnameState,
+  AppHostnameStateSchema,
   AppSchema,
   type AppState,
   AppStateSchema,
+  MIN_HOSTNAMES,
   type TenantArguments,
   TenantArgumentsSchema,
   type TenantEnvironment,


### PR DESCRIPTION
An app's hostnames were all equally routable, which was true while nibrun issued
every one of them. A brought domain is not: nothing in DNS points at us until its
owner makes it, and the certificate that would serve it cannot be issued before
that. So a hostname now carries the state it is in, and `desired_hostnames` — the
one relation a host renders its proxy config from — carries only the active ones.

A platform hostname is born active: the wildcard record and the wildcard
certificate already cover it. Nothing yet creates a hostname that is not.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>