### PR TITLE
feat(api): a brought domain is registered at the edge and proved by its own DNS

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -23,3 +23,9 @@ S3_REGION=us-east-1
 # Domain tenant apps are served under, as <slug>.<APP_HOST_DOMAIN>. Must be a different
 # registrable domain from BASE_URL, or an app could read the dashboard's cookies.
 APP_HOST_DOMAIN=apps.localhost
+
+# Custom domains, through Cloudflare for SaaS on the APP_HOST_DOMAIN zone. Left blank here:
+# there is no local edge to register a hostname with, and the api refuses those routes rather
+# than pretending. Token scope is Zone -> SSL and Certificates -> Edit, on that zone alone.
+CLOUDFLARE_API_TOKEN=
+CLOUDFLARE_ZONE_ID=

--- a/apps/api/src/db/migrations/0021_custom_hostnames_reach_the_edge.sql
+++ b/apps/api/src/db/migrations/0021_custom_hostnames_reach_the_edge.sql
@@ -1,0 +1,16 @@
+-- 0020 gave a hostname a state to wait in. This is what the waiting is on: a brought domain has
+-- to exist at the edge before anything can serve it, and the owner has to be told which record
+-- to place before the edge will issue a certificate for it.
+--
+-- Both are absent on a platform hostname. The wildcard record and the wildcard certificate
+-- already cover those, so there is nothing at the edge naming one and nothing to ask its owner.
+
+ALTER TABLE nibrun.app_hostnames
+  ADD COLUMN cloudflare_id text,
+  ADD COLUMN dcv_target    text;
+
+COMMENT ON COLUMN nibrun.app_hostnames.cloudflare_id IS 'The custom hostname this row is projected onto at the edge. Absent for a platform hostname, which the wildcard already covers.';
+COMMENT ON COLUMN nibrun.app_hostnames.dcv_target IS 'What the owner points _acme-challenge at, so the edge can renew the certificate without asking them again. Absent for a platform hostname.';
+
+-- Read once per pass over the rows still waiting, and partial because those are always the few.
+CREATE INDEX app_hostnames_pending_idx ON nibrun.app_hostnames (id) WHERE state = 'pending';

--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -71,6 +71,63 @@ export interface ISelectDesiredExportsResult {
     original_file_name: import("@repo/protocol").Filename;
 }
 
+/** Result of query `SelectAppHostnamesByOwner`. */
+export interface ISelectAppHostnamesByOwnerResult {
+    app_id: import("@repo/protocol").AppId;
+    hostname: import("@repo/protocol").Hostname;
+    kind: import("@repo/protocol").AppHostnameKind;
+    state: import("@repo/protocol").AppHostnameState;
+    /** What the owner points _acme-challenge at, so the edge can renew the certificate without asking them again. Absent for a platform hostname. */
+    dcv_target: string | null;
+}
+
+/** Result of query `SelectAppHostnamesByApp`. */
+export interface ISelectAppHostnamesByAppResult {
+    hostname: import("@repo/protocol").Hostname;
+    kind: import("@repo/protocol").AppHostnameKind;
+    state: import("@repo/protocol").AppHostnameState;
+    /** What the owner points _acme-challenge at, so the edge can renew the certificate without asking them again. Absent for a platform hostname. */
+    dcv_target: string | null;
+}
+
+/** Result of query `InsertCustomAppHostname`. */
+export interface IInsertCustomAppHostnameResult {
+    hostname: import("@repo/protocol").Hostname;
+    kind: import("@repo/protocol").AppHostnameKind;
+    state: import("@repo/protocol").AppHostnameState;
+    /** What the owner points _acme-challenge at, so the edge can renew the certificate without asking them again. Absent for a platform hostname. */
+    dcv_target: string | null;
+}
+
+/** Result of query `UpdateCustomAppHostnameEdge`. */
+export interface IUpdateCustomAppHostnameEdgeResult {
+    hostname: import("@repo/protocol").Hostname;
+    kind: import("@repo/protocol").AppHostnameKind;
+    state: import("@repo/protocol").AppHostnameState;
+    /** What the owner points _acme-challenge at, so the edge can renew the certificate without asking them again. Absent for a platform hostname. */
+    dcv_target: string | null;
+}
+
+/** Result of query `UpdateCustomAppHostnameState`. */
+export interface IUpdateCustomAppHostnameStateResult {
+    hostname: import("@repo/protocol").Hostname;
+}
+
+/** Result of query `DeleteCustomAppHostname`. */
+export interface IDeleteCustomAppHostnameResult {
+    /** The custom hostname this row is projected onto at the edge. Absent for a platform hostname, which the wildcard already covers. */
+    cloudflare_id: string | null;
+}
+
+/** Result of query `SelectPendingCustomHostnames`. */
+export interface ISelectPendingCustomHostnamesResult {
+    hostname: import("@repo/protocol").Hostname;
+    /** The custom hostname this row is projected onto at the edge. Absent for a platform hostname, which the wildcard already covers. */
+    cloudflare_id: string | null;
+    /** Derived from the uuidv7 id; the moment the row was created. */
+    created_at: Date;
+}
+
 /** Result of query `SelectAppOwnership`. */
 export interface ISelectAppOwnershipResult {
     id: import("@repo/protocol").AppId;
@@ -91,6 +148,8 @@ export interface IInsertAppHostnameResult {
     hostname: import("@repo/protocol").Hostname;
     kind: import("@repo/protocol").AppHostnameKind;
     state: import("@repo/protocol").AppHostnameState;
+    /** What the owner points _acme-challenge at, so the edge can renew the certificate without asking them again. Absent for a platform hostname. */
+    dcv_target: string | null;
 }
 
 /** Result of query `SelectCreatedApp`. */
@@ -145,14 +204,6 @@ export interface ISelectAppsByOwnerResult {
     environment_names: string[];
 }
 
-/** Result of query `SelectAppHostnamesByOwner`. */
-export interface ISelectAppHostnamesByOwnerResult {
-    app_id: import("@repo/protocol").AppId;
-    hostname: import("@repo/protocol").Hostname;
-    kind: import("@repo/protocol").AppHostnameKind;
-    state: import("@repo/protocol").AppHostnameState;
-}
-
 /** Result of query `SelectAppById`. */
 export interface ISelectAppByIdResult {
     id: import("@repo/protocol").AppId;
@@ -177,13 +228,6 @@ export interface ISelectAppByIdResult {
     restart_backoff_factor: number;
     restart_reset_after_ms: number;
     environment_names: string[];
-}
-
-/** Result of query `SelectAppHostnamesByApp`. */
-export interface ISelectAppHostnamesByAppResult {
-    hostname: import("@repo/protocol").Hostname;
-    kind: import("@repo/protocol").AppHostnameKind;
-    state: import("@repo/protocol").AppHostnameState;
 }
 
 /** Result of query `SelectAppForConfigUpdate`. */
@@ -608,15 +652,20 @@ export interface Queries {
     SelectDesiredHostnames: ISelectDesiredHostnamesResult;
     SelectDesiredEnvironment: ISelectDesiredEnvironmentResult;
     SelectDesiredExports: ISelectDesiredExportsResult;
+    SelectAppHostnamesByOwner: ISelectAppHostnamesByOwnerResult;
+    SelectAppHostnamesByApp: ISelectAppHostnamesByAppResult;
+    InsertCustomAppHostname: IInsertCustomAppHostnameResult;
+    UpdateCustomAppHostnameEdge: IUpdateCustomAppHostnameEdgeResult;
+    UpdateCustomAppHostnameState: IUpdateCustomAppHostnameStateResult;
+    DeleteCustomAppHostname: IDeleteCustomAppHostnameResult;
+    SelectPendingCustomHostnames: ISelectPendingCustomHostnamesResult;
     SelectAppOwnership: ISelectAppOwnershipResult;
     InsertApp: IInsertAppResult;
     InsertAppConfig: IInsertAppConfigResult;
     InsertAppHostname: IInsertAppHostnameResult;
     SelectCreatedApp: ISelectCreatedAppResult;
     SelectAppsByOwner: ISelectAppsByOwnerResult;
-    SelectAppHostnamesByOwner: ISelectAppHostnamesByOwnerResult;
     SelectAppById: ISelectAppByIdResult;
-    SelectAppHostnamesByApp: ISelectAppHostnamesByAppResult;
     SelectAppForConfigUpdate: ISelectAppForConfigUpdateResult;
     SelectCurrentAppConfig: ISelectCurrentAppConfigResult;
     InsertPatchedAppConfig: IInsertPatchedAppConfigResult;

--- a/apps/api/src/lib/app-hostname.ts
+++ b/apps/api/src/lib/app-hostname.ts
@@ -26,19 +26,42 @@ export function platformHostname({
 // than silently reading undefined.
 export type AppHostnameColumns = Pick<
   Queries['SelectAppHostnamesByApp'],
-  'hostname' | 'kind' | 'state'
+  'hostname' | 'kind' | 'state' | 'dcv_target'
 >;
 
 /**
- * What an owner is told about one of their hostnames. More than a host is told: a host is sent
- * only the hostnames it should answer for, so `state` would always read `active` there.
+ * Whether a hostname is one this platform hands out rather than one an owner may bring.
+ *
+ * The unique index on `hostname` already stops a brought domain taking a name another app holds,
+ * but only once that app exists. Without this, an owner could claim a slug nothing has been
+ * minted under yet and be handed it by the platform later — so the reservation is what is being
+ * enforced here, not the collision.
  */
-export type PublicAppHostname = AppHostname & { state: AppHostnameState };
+export function isPlatformHostname({
+  hostname,
+  appHostDomain,
+}: {
+  hostname: Hostname;
+  appHostDomain: string;
+}): boolean {
+  return hostname === appHostDomain || hostname.endsWith(`.${appHostDomain}`);
+}
+
+/**
+ * What an owner is told about one of their hostnames. More than a host is told: a host is sent
+ * only the hostnames it should answer for, so `state` would always read `active` there and the
+ * record to place is the owner's business rather than the fleet's.
+ */
+export type PublicAppHostname = AppHostname & {
+  state: AppHostnameState;
+  dcvTarget: string | null;
+};
 
 export function toAppHostname(row: AppHostnameColumns): PublicAppHostname {
   return {
     hostname: row.hostname,
     kind: row.kind,
     state: row.state,
+    dcvTarget: row.dcv_target,
   };
 }

--- a/apps/api/src/lib/cloudflare/client.ts
+++ b/apps/api/src/lib/cloudflare/client.ts
@@ -1,0 +1,133 @@
+const API_BASE = 'https://api.cloudflare.com/client/v4/';
+
+const MAX_ERROR_BODY = 256;
+
+/**
+ * Where Cloudflare answers the challenge on the owner's behalf. They point `_acme-challenge` at
+ * this once and the edge renews against it forever, which is the whole reason to prefer it over
+ * handing them a TXT value that changes on every issuance.
+ */
+const DCV_DELEGATION_SUFFIX = 'dcv.cloudflare.com';
+
+export class CloudflareError extends Error {
+  constructor({ status, body }: { status: number; body: string }) {
+    super(`cloudflare answered ${status}: ${body}`);
+    this.name = 'CloudflareError';
+  }
+}
+
+type CloudflareEnvelope<Result> = {
+  success: boolean;
+  result: Result;
+  errors: ReadonlyArray<{ code: number; message: string }>;
+};
+
+export type CustomHostnameSsl = {
+  status: string;
+  validation_errors?: ReadonlyArray<{ message: string }>;
+};
+
+export type CustomHostname = {
+  id: string;
+  hostname: string;
+  status: string;
+  ssl: CustomHostnameSsl;
+  verification_errors?: ReadonlyArray<string>;
+};
+
+/**
+ * The zone's custom hostnames, which is the whole of what this end asks Cloudflare for. The
+ * certificate is the edge's to issue, renew and serve; nothing here holds key material or is
+ * told when a renewal happened.
+ *
+ * Status is read back rather than pushed: Cloudflare has no callback to register, and a hostname
+ * becomes serveable when the owner's DNS says so, which is a moment neither end is told about.
+ */
+export class CloudflareClient {
+  readonly #apiToken: string;
+  readonly #zoneId: string;
+  // Per zone rather than per hostname, so it is fetched once and every target derived from it.
+  #dcvDelegationUuid: string | undefined;
+
+  constructor({ apiToken, zoneId }: { apiToken: string; zoneId: string }) {
+    this.#apiToken = apiToken;
+    this.#zoneId = zoneId;
+  }
+
+  createCustomHostname({ hostname }: { hostname: string }): Promise<CustomHostname> {
+    return this.#request<CustomHostname>({
+      method: 'POST',
+      path: 'custom_hostnames',
+      // `txt` is what delegated DCV answers with: the records go to the delegation target the
+      // owner already pointed at us, so no value here ever has to reach them.
+      body: {
+        hostname,
+        ssl: { method: 'txt', type: 'dv', settings: { min_tls_version: '1.2' } },
+      },
+    });
+  }
+
+  getCustomHostname({ id }: { id: string }): Promise<CustomHostname> {
+    return this.#request<CustomHostname>({ method: 'GET', path: `custom_hostnames/${id}` });
+  }
+
+  async deleteCustomHostname({ id }: { id: string }): Promise<void> {
+    await this.#request({ method: 'DELETE', path: `custom_hostnames/${id}` });
+  }
+
+  /**
+   * What the owner points `_acme-challenge.<hostname>` at. Derived rather than read back per
+   * hostname, because the uuid is the zone's and the hostname is already known here.
+   */
+  async dcvDelegationTarget({ hostname }: { hostname: string }): Promise<string> {
+    this.#dcvDelegationUuid ??= (
+      await this.#request<{ uuid: string }>({ method: 'GET', path: 'dcv_delegation/uuid' })
+    ).uuid;
+    return `${hostname}.${this.#dcvDelegationUuid}.${DCV_DELEGATION_SUFFIX}`;
+  }
+
+  /**
+   * A refused call is an error however it is refused: Cloudflare answers some failures with a
+   * non-2xx and others with 200 and `success: false`, so reading only the status code would let
+   * the second kind through as a result.
+   */
+  async #request<Result>({
+    method,
+    path,
+    body,
+  }: {
+    method: string;
+    path: string;
+    body?: unknown;
+  }): Promise<Result> {
+    const response = await fetch(new URL(`zones/${this.#zoneId}/${path}`, API_BASE), {
+      method,
+      headers: {
+        authorization: `Bearer ${this.#apiToken}`,
+        ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+
+    const text = await response.text();
+    const envelope = parseEnvelope<Result>(text);
+    if (!response.ok || envelope?.success !== true) {
+      throw new CloudflareError({
+        status: response.status,
+        body: (envelope?.errors.map((error) => error.message).join('; ') || text).slice(
+          0,
+          MAX_ERROR_BODY,
+        ),
+      });
+    }
+    return envelope.result;
+  }
+}
+
+function parseEnvelope<Result>(text: string): CloudflareEnvelope<Result> | undefined {
+  try {
+    return JSON.parse(text) as CloudflareEnvelope<Result>;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/api/src/lib/duration.ts
+++ b/apps/api/src/lib/duration.ts
@@ -3,6 +3,9 @@ import { LOG_TIMERANGE_PATTERN } from '@repo/protocol';
 const MS_PER_SECOND = 1_000;
 const SECONDS_PER_MINUTE = 60;
 const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+
+export const MS_PER_DAY = MS_PER_SECOND * SECONDS_PER_MINUTE * MINUTES_PER_HOUR * HOURS_PER_DAY;
 
 const UNIT_MS = {
   s: MS_PER_SECOND,

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -16,6 +16,8 @@ interface CustomProcessEnv {
   readonly S3_SECRET_ACCESS_KEY: string;
   readonly S3_REGION: string;
   readonly APP_HOST_DOMAIN: string;
+  readonly CLOUDFLARE_API_TOKEN?: string;
+  readonly CLOUDFLARE_ZONE_ID?: string;
 }
 
 const DEFAULT_PORT = '3000';
@@ -61,6 +63,8 @@ type Env = {
   S3_SECRET_ACCESS_KEY: string;
   S3_REGION: string;
   APP_HOST_DOMAIN: string;
+  CLOUDFLARE_API_TOKEN: string;
+  CLOUDFLARE_ZONE_ID: string;
 };
 
 function loadEnv(): Env {
@@ -83,6 +87,8 @@ function loadEnv(): Env {
     S3_SECRET_ACCESS_KEY: required('S3_SECRET_ACCESS_KEY'),
     S3_REGION: required('S3_REGION'),
     APP_HOST_DOMAIN: required('APP_HOST_DOMAIN'),
+    CLOUDFLARE_API_TOKEN: optional({ name: 'CLOUDFLARE_API_TOKEN', defaultValue: '' }),
+    CLOUDFLARE_ZONE_ID: optional({ name: 'CLOUDFLARE_ZONE_ID', defaultValue: '' }),
   };
 }
 

--- a/apps/api/src/repositories/app-hostnames.repository.ts
+++ b/apps/api/src/repositories/app-hostnames.repository.ts
@@ -1,0 +1,147 @@
+import type { AppHostnameKind, AppHostnameState, AppId, Hostname, OwnerId } from '@repo/protocol';
+import type { Queries } from '#db/queries.gen.d.ts';
+import { Repository } from '#repositories/repository.ts';
+
+export type AppHostnameRow = Queries['SelectAppHostnamesByApp'];
+export type OwnedAppHostnameRow = Queries['SelectAppHostnamesByOwner'];
+export type PendingHostnameRow = Queries['SelectPendingCustomHostnames'];
+
+type OwnedApp = { appId: AppId; ownerId: OwnerId };
+
+export const CUSTOM_KIND: AppHostnameKind = 'custom';
+
+/**
+ * The names an app answers on.
+ *
+ * Its own concern rather than part of the app: an app is created once and read back, while a
+ * brought domain has a life of its own — claimed, proved at the edge, and given up — against a
+ * table nothing else writes. Minting the one nibrun issues stays with creating the app, because
+ * that happens in the same transaction and an app without a hostname is not an app.
+ */
+export abstract class AppHostnamesRepositoryContract {
+  abstract listByOwner(input: { ownerId: OwnerId }): Promise<OwnedAppHostnameRow[]>;
+  abstract listByApp(input: OwnedApp): Promise<AppHostnameRow[]>;
+  abstract addCustom(input: OwnedApp & { hostname: Hostname }): Promise<AppHostnameRow | null>;
+  abstract attachCustom(input: {
+    hostname: Hostname;
+    cloudflareId: string;
+    dcvTarget: string | null;
+  }): Promise<AppHostnameRow | null>;
+  abstract setCustomState(input: { hostname: Hostname; state: AppHostnameState }): Promise<boolean>;
+  abstract removeCustom(input: OwnedApp & { hostname: Hostname }): Promise<string | null>;
+  abstract listPendingCustom(input: { limit: number }): Promise<PendingHostnameRow[]>;
+}
+
+export class AppHostnamesRepository extends Repository implements AppHostnamesRepositoryContract {
+  listByOwner({ ownerId }: { ownerId: OwnerId }): Promise<OwnedAppHostnameRow[]> {
+    return this.sql.SelectAppHostnamesByOwner`
+      SELECT h.app_id, h.hostname, h.kind, h.state, h.dcv_target
+      FROM nibrun.app_hostnames h
+      JOIN nibrun.live_apps a ON a.id = h.app_id
+      WHERE a.owner_id = ${ownerId}
+      ORDER BY h.app_id, h.hostname
+    `;
+  }
+
+  listByApp({ appId, ownerId }: OwnedApp): Promise<AppHostnameRow[]> {
+    return this.sql.SelectAppHostnamesByApp`
+      SELECT h.hostname, h.kind, h.state, h.dcv_target
+      FROM nibrun.app_hostnames h
+      JOIN nibrun.live_apps a ON a.id = h.app_id
+      WHERE h.app_id = ${appId} AND a.owner_id = ${ownerId}
+      ORDER BY h.hostname
+    `;
+  }
+
+  /**
+   * Written before the edge is asked for anything, so a row exists to find the custom hostname by
+   * if this process dies before the edge answers. The reverse order would leave a hostname at the
+   * edge that nothing here names, and nothing to notice it.
+   */
+  async addCustom({
+    appId,
+    ownerId,
+    hostname,
+  }: OwnedApp & { hostname: Hostname }): Promise<AppHostnameRow | null> {
+    const [row] = await this.sql.InsertCustomAppHostname`
+      INSERT INTO nibrun.app_hostnames (app_id, hostname, kind)
+      SELECT a.id, ${hostname}, ${CUSTOM_KIND}
+      FROM nibrun.live_apps a
+      WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
+      RETURNING hostname, kind, state, dcv_target
+    `;
+    return row ?? null;
+  }
+
+  async attachCustom({
+    hostname,
+    cloudflareId,
+    dcvTarget,
+  }: {
+    hostname: Hostname;
+    cloudflareId: string;
+    dcvTarget: string | null;
+  }): Promise<AppHostnameRow | null> {
+    const [row] = await this.sql.UpdateCustomAppHostnameEdge`
+      UPDATE nibrun.app_hostnames
+      SET cloudflare_id = ${cloudflareId}, dcv_target = ${dcvTarget}
+      WHERE hostname = ${hostname} AND kind = ${CUSTOM_KIND}
+      RETURNING hostname, kind, state, dcv_target
+    `;
+    return row ?? null;
+  }
+
+  async setCustomState({
+    hostname,
+    state,
+  }: {
+    hostname: Hostname;
+    state: AppHostnameState;
+  }): Promise<boolean> {
+    const [row] = await this.sql.UpdateCustomAppHostnameState`
+      UPDATE nibrun.app_hostnames
+      SET state = ${state}
+      WHERE hostname = ${hostname} AND kind = ${CUSTOM_KIND} AND state <> ${state}
+      RETURNING hostname
+    `;
+    return row !== undefined;
+  }
+
+  /**
+   * By hostname rather than by id: the caller has the name the owner typed, and the name is
+   * unique across every app. Guarded on ownership and on kind, so neither another owner's domain
+   * nor an app's own platform hostname can be removed through this.
+   */
+  async removeCustom({
+    appId,
+    ownerId,
+    hostname,
+  }: OwnedApp & { hostname: Hostname }): Promise<string | null> {
+    const [row] = await this.sql.DeleteCustomAppHostname`
+      DELETE FROM nibrun.app_hostnames h
+      USING nibrun.live_apps a
+      WHERE h.app_id = a.id
+        AND h.app_id = ${appId} AND a.owner_id = ${ownerId}
+        AND h.hostname = ${hostname} AND h.kind = ${CUSTOM_KIND}
+      RETURNING h.cloudflare_id
+    `;
+    if (!row) {
+      return null;
+    }
+    return row.cloudflare_id ?? null;
+  }
+
+  /**
+   * Every custom hostname still waiting, whatever app it belongs to and whoever owns it: this
+   * feeds the pass that asks the edge what became of them, which answers to nobody's request.
+   */
+  listPendingCustom({ limit }: { limit: number }): Promise<PendingHostnameRow[]> {
+    return this.sql.SelectPendingCustomHostnames`
+      SELECT h.hostname, h.cloudflare_id, h.created_at
+      FROM nibrun.app_hostnames h
+      WHERE h.state = 'pending' AND h.kind = ${CUSTOM_KIND}
+      ORDER BY h.id
+      LIMIT ${limit}
+    `;
+  }
+}

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -13,6 +13,7 @@ import type { ArrayType } from 'bun';
 import type { Queries } from '#db/queries.gen.d.ts';
 import { type SealedConfigPatch, type StoredAppConfig, toAppConfig } from '#lib/app-config.ts';
 import type { SealedEnvironment } from '#lib/tenant-secrets.ts';
+import type { AppHostnameRow } from '#repositories/app-hostnames.repository.ts';
 import { Repository } from '#repositories/repository.ts';
 
 /**
@@ -23,8 +24,6 @@ import { Repository } from '#repositories/repository.ts';
 const TEXT_ARRAY: ArrayType = 'TEXT';
 
 export type AppRow = Queries['SelectAppById'];
-export type AppHostnameRow = Queries['SelectAppHostnamesByApp'];
-export type OwnedAppHostnameRow = Queries['SelectAppHostnamesByOwner'];
 
 export type CreatedApp = { app: AppRow; hostnames: AppHostnameRow[] };
 
@@ -49,9 +48,7 @@ export abstract class AppsRepositoryContract {
     config: StoredAppConfig;
   }): Promise<CreatedApp>;
   abstract listByOwner(input: { ownerId: OwnerId }): Promise<AppRow[]>;
-  abstract listHostnamesByOwner(input: { ownerId: OwnerId }): Promise<OwnedAppHostnameRow[]>;
   abstract findById(input: OwnedApp): Promise<AppRow | null>;
-  abstract listHostnamesByApp(input: OwnedApp): Promise<AppHostnameRow[]>;
   abstract updateConfig(input: OwnedApp & { patch: SealedConfigPatch }): Promise<AppRow | null>;
   abstract updateState(input: OwnedApp & { state: AppState }): Promise<AppRow | null>;
   abstract finishDeleting(input: { appId: AppId }): Promise<boolean>;
@@ -134,7 +131,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
       const [hostnameRow] = await tx.InsertAppHostname`
         INSERT INTO nibrun.app_hostnames (app_id, hostname, kind, state)
         VALUES (${inserted.id}, ${hostname}, ${PLATFORM_KIND}, ${ACTIVE_STATE})
-        RETURNING hostname, kind, state
+        RETURNING hostname, kind, state, dcv_target
       `;
       if (!hostnameRow) {
         throw new Error('Inserting into nibrun.app_hostnames returned no row.');
@@ -186,16 +183,6 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
     `;
   }
 
-  listHostnamesByOwner({ ownerId }: { ownerId: OwnerId }): Promise<OwnedAppHostnameRow[]> {
-    return this.sql.SelectAppHostnamesByOwner`
-      SELECT h.app_id, h.hostname, h.kind, h.state
-      FROM nibrun.app_hostnames h
-      JOIN nibrun.live_apps a ON a.id = h.app_id
-      WHERE a.owner_id = ${ownerId}
-      ORDER BY h.app_id, h.hostname
-    `;
-  }
-
   async findById({ appId, ownerId }: OwnedApp): Promise<AppRow | null> {
     const [app] = await this.sql.SelectAppById`
       /* @notNull environment_names */
@@ -215,16 +202,6 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
       WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
     `;
     return app ?? null;
-  }
-
-  listHostnamesByApp({ appId, ownerId }: OwnedApp): Promise<AppHostnameRow[]> {
-    return this.sql.SelectAppHostnamesByApp`
-      SELECT h.hostname, h.kind, h.state
-      FROM nibrun.app_hostnames h
-      JOIN nibrun.live_apps a ON a.id = h.app_id
-      WHERE h.app_id = ${appId} AND a.owner_id = ${ownerId}
-      ORDER BY h.hostname
-    `;
   }
 
   // A patch appends a version rather than editing one, and the newest version is the live one,

--- a/apps/api/src/repositories/custom-hostnames.repository.ts
+++ b/apps/api/src/repositories/custom-hostnames.repository.ts
@@ -1,0 +1,113 @@
+import type { AppHostnameState, Hostname } from '@repo/protocol';
+import type { CloudflareClient, CustomHostname } from '#lib/cloudflare/client.ts';
+
+/**
+ * Cloudflare answers a hostname's activation and its certificate separately, and traffic needs
+ * both. Anything that is neither serving nor finished stays `pending`, because the edge retries
+ * on its own and calling it failed would strand a hostname that was about to work.
+ */
+const ACTIVE_HOSTNAME_STATUS = 'active';
+const ACTIVE_SSL_STATUS = 'active';
+
+/**
+ * The states the edge will not leave without being asked again. A timeout is terminal here even
+ * though it reads transient: it means the owner never placed the records, and the row is what
+ * tells them so.
+ */
+const TERMINAL_HOSTNAME_STATUSES = new Set(['blocked', 'moved', 'deleted']);
+const TERMINAL_SSL_STATUSES = new Set([
+  'initializing_timed_out',
+  'validation_timed_out',
+  'issuance_timed_out',
+  'deployment_timed_out',
+  'deletion_timed_out',
+  'expired',
+]);
+
+export type EdgeHostname = {
+  cloudflareId: string;
+  state: AppHostnameState;
+};
+
+/**
+ * No client, because the deployment configured no Cloudflare account. Thrown rather than answered
+ * with a value, so a caller that forgot to ask `available` first cannot mistake "not configured"
+ * for "the edge said no".
+ */
+export class CustomHostnamesUnavailableError extends Error {
+  constructor() {
+    super('No Cloudflare account is configured for this deployment.');
+    this.name = 'CustomHostnamesUnavailableError';
+  }
+}
+
+export abstract class CustomHostnamesRepositoryContract {
+  /** Whether this deployment can register a hostname at the edge at all. */
+  abstract readonly available: boolean;
+  abstract add(input: { hostname: Hostname }): Promise<EdgeHostname>;
+  abstract dcvTarget(input: { hostname: Hostname }): Promise<string>;
+  abstract state(input: { cloudflareId: string }): Promise<AppHostnameState>;
+  abstract remove(input: { cloudflareId: string }): Promise<void>;
+}
+
+/**
+ * The edge's view of a hostname, in this codebase's vocabulary. Cloudflare's two status fields
+ * and its several dozen values are collapsed here rather than in a service, so nothing above has
+ * to know which of them mean the hostname is serving.
+ */
+export class CustomHostnamesRepository implements CustomHostnamesRepositoryContract {
+  private readonly client: CloudflareClient | undefined;
+
+  /**
+   * Absent on every deployment that configured no Cloudflare account, which is every local stack.
+   * Held here rather than left to the caller: whether the edge can be reached is a fact about the
+   * system this fronts, and a service that had to be constructed differently without one would be
+   * carrying that fact for it.
+   */
+  constructor(client: CloudflareClient | undefined) {
+    this.client = client;
+  }
+
+  get available(): boolean {
+    return this.client !== undefined;
+  }
+
+  async add({ hostname }: { hostname: Hostname }): Promise<EdgeHostname> {
+    const created = await this.reachable().createCustomHostname({ hostname });
+    return { cloudflareId: created.id, state: toState(created) };
+  }
+
+  // `async` like its siblings: a method returning a promise has to reject rather than throw where
+  // the caller is reaching for `.catch`.
+  async dcvTarget({ hostname }: { hostname: Hostname }): Promise<string> {
+    return await this.reachable().dcvDelegationTarget({ hostname });
+  }
+
+  async state({ cloudflareId }: { cloudflareId: string }): Promise<AppHostnameState> {
+    return toState(await this.reachable().getCustomHostname({ id: cloudflareId }));
+  }
+
+  async remove({ cloudflareId }: { cloudflareId: string }): Promise<void> {
+    await this.reachable().deleteCustomHostname({ id: cloudflareId });
+  }
+
+  private reachable(): CloudflareClient {
+    if (!this.client) {
+      throw new CustomHostnamesUnavailableError();
+    }
+    return this.client;
+  }
+}
+
+export function toState(hostname: CustomHostname): AppHostnameState {
+  if (hostname.status === ACTIVE_HOSTNAME_STATUS && hostname.ssl.status === ACTIVE_SSL_STATUS) {
+    return 'active';
+  }
+  if (
+    TERMINAL_HOSTNAME_STATUSES.has(hostname.status) ||
+    TERMINAL_SSL_STATUSES.has(hostname.ssl.status)
+  ) {
+    return 'failed';
+  }
+  return 'pending';
+}

--- a/apps/api/src/routes/api/apps/[appId]/hostnames/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/hostnames/controller.ts
@@ -1,0 +1,50 @@
+import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
+import { Elysia, StatusMap, t } from 'elysia';
+import { authPlugin } from '#lib/auth/plugin.ts';
+import {
+  AddHostnameRequestSchema,
+  RemoveHostnameQuerySchema,
+} from '#routes/api/apps/[appId]/hostnames/model.ts';
+import { AppHostnameResponseSchema } from '#routes/api/apps/model.ts';
+import { HostnamesServicePlugin, loggerPlugin } from '#services/plugins.ts';
+
+export const AppsAppIdHostnamesController = new Elysia()
+  .use(loggerPlugin('appsAppIdHostnamesController'))
+  .use(authPlugin)
+  .use(HostnamesServicePlugin)
+  .guard({ auth: true })
+  /**
+   * Created rather than accepted: the row exists and the edge knows the hostname. What is still
+   * outstanding is the owner's own DNS, which is theirs to do — the response carries the record
+   * to place, so there is nothing here for them to poll before acting.
+   */
+  .post(
+    '/apps/:appId/hostnames',
+    async ({ hostnamesService, params, body, user, status }) => {
+      const hostname = await hostnamesService.add({
+        appId: Value.Parse(AppIdSchema, params.appId),
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
+        hostname: body.hostname,
+      });
+      return status(StatusMap.Created, hostname);
+    },
+    {
+      body: AddHostnameRequestSchema,
+      response: { [StatusMap.Created]: AppHostnameResponseSchema },
+    },
+  )
+  .delete(
+    '/apps/:appId/hostnames',
+    async ({ hostnamesService, params, query, user, status }) => {
+      await hostnamesService.remove({
+        appId: Value.Parse(AppIdSchema, params.appId),
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
+        hostname: query.hostname,
+      });
+      return status(StatusMap['No Content'], undefined);
+    },
+    {
+      query: RemoveHostnameQuerySchema,
+      response: { [StatusMap['No Content']]: t.Void() },
+    },
+  );

--- a/apps/api/src/routes/api/apps/[appId]/hostnames/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/hostnames/model.ts
@@ -1,0 +1,17 @@
+import { HostnameSchema } from '@repo/protocol';
+import { t } from 'elysia';
+
+// A hostname, not a URL: a scheme or a path here would be a request about something this cannot
+// route, and the schema is what says so rather than a parser that quietly drops them.
+export const AddHostnameRequestSchema = t.Object(
+  { hostname: HostnameSchema },
+  { additionalProperties: false },
+);
+
+// The hostname to stop serving, in the URL rather than a body: DELETE content has no defined
+// semantics and some intermediaries drop it, and a removal that named its target only in the body
+// would read the same as every other one in an access log.
+export const RemoveHostnameQuerySchema = t.Object(
+  { hostname: HostnameSchema },
+  { additionalProperties: false },
+);

--- a/apps/api/src/routes/api/apps/model.ts
+++ b/apps/api/src/routes/api/apps/model.ts
@@ -41,11 +41,21 @@ export const AppConfigPatchSchema = t.Partial(
   { additionalProperties: false },
 );
 
-// What a host is told about a hostname, plus the one thing only its owner needs: whether the
-// edge can serve it yet.
+/**
+ * What a host is told about a hostname, plus the two things only its owner needs: whether the
+ * edge can serve it yet, and the record to place so that it can.
+ *
+ * Here rather than under `hostnames/` because the app response below carries it too, and a
+ * schema shared by sibling routes belongs to the folder above them.
+ */
 export const AppHostnameResponseSchema = t.Composite([
   AppHostnameSchema,
-  t.Object({ state: AppHostnameStateSchema }),
+  t.Object({
+    state: AppHostnameStateSchema,
+    // Absent on a platform hostname, which the wildcard certificate already covers, and until
+    // the edge has answered with a target for a custom one.
+    dcvTarget: t.Nullable(t.String()),
+  }),
 ]);
 
 // `hostnames` is widened the same way `config` is: what an owner is shown carries the state,

--- a/apps/api/src/routes/api/controller.ts
+++ b/apps/api/src/routes/api/controller.ts
@@ -9,6 +9,7 @@ import { AppsAppIdDeploymentsDeploymentIdLogsController } from '#routes/api/apps
 import { AppsAppIdDeploymentsController } from '#routes/api/apps/[appId]/deployments/controller.ts';
 import { AppsAppIdExportsExportIdController } from '#routes/api/apps/[appId]/exports/[exportId]/controller.ts';
 import { AppsAppIdExportsController } from '#routes/api/apps/[appId]/exports/controller.ts';
+import { AppsAppIdHostnamesController } from '#routes/api/apps/[appId]/hostnames/controller.ts';
 import { AppsController } from '#routes/api/apps/controller.ts';
 import { AuthController } from '#routes/api/auth/controller.ts';
 import { HealthController } from '#routes/api/health/controller.ts';
@@ -25,4 +26,5 @@ export const ApiController = new Elysia({ prefix: RoutePrefix.Api })
   .use(AppsAppIdDeploymentsDeploymentIdFilesystemController)
   .use(AppsAppIdDeploymentsDeploymentIdLogsController)
   .use(AppsAppIdExportsController)
-  .use(AppsAppIdExportsExportIdController);
+  .use(AppsAppIdExportsExportIdController)
+  .use(AppsAppIdHostnamesController);

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -16,6 +16,7 @@ import type { AppsService } from '#services/apps.service.ts';
 import type { ArtifactsService } from '#services/artifacts.service.ts';
 import type { DeploymentsService } from '#services/deployments.service.ts';
 import type { ExportsService } from '#services/exports.service.ts';
+import type { HostnamesService } from '#services/hostnames.service.ts';
 import { Service } from '#services/service.ts';
 
 const MS_PER_SECOND = 1000;
@@ -25,12 +26,16 @@ const SESSION_LIFETIME_MS = SECONDS_PER_HOUR * MS_PER_SECOND;
 /** What a report is borrowed for, and nothing else artifacts can do. */
 export type UploadSweep = Pick<ArtifactsService, 'sweepAbandoned'>;
 
+/** Likewise for hostnames: a report is the clock, not permission to add or remove one. */
+export type HostnameReconcile = Pick<HostnamesService, 'reconcile'>;
+
 export class AgentService extends Service {
   private readonly agentRepo: AgentRepositoryContract;
   private readonly deploymentsService: DeploymentsService;
   private readonly appsService: AppsService;
   private readonly exportsService: ExportsService;
   private readonly artifactsService: UploadSweep;
+  private readonly hostnamesService: HostnameReconcile;
 
   constructor({
     agentRepo,
@@ -38,12 +43,14 @@ export class AgentService extends Service {
     appsService,
     exportsService,
     artifactsService,
+    hostnamesService,
   }: {
     agentRepo: AgentRepositoryContract;
     deploymentsService: DeploymentsService;
     appsService: AppsService;
     exportsService: ExportsService;
     artifactsService: UploadSweep;
+    hostnamesService: HostnameReconcile;
   }) {
     super();
     this.agentRepo = agentRepo;
@@ -51,6 +58,7 @@ export class AgentService extends Service {
     this.appsService = appsService;
     this.exportsService = exportsService;
     this.artifactsService = artifactsService;
+    this.hostnamesService = hostnamesService;
   }
 
   /**
@@ -126,5 +134,8 @@ export class AgentService extends Service {
     // Nothing to do with this report. A report is simply the clock this process has, and an
     // upload nobody ever came back about is work that needs one.
     await this.artifactsService.sweepAbandoned();
+    // The same clock, for the same reason: whether a custom hostname has been pointed at us is
+    // decided in somebody else's DNS, so there is no moment to act on but a passing one.
+    await this.hostnamesService.reconcile();
   }
 }

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -14,9 +14,9 @@ import { sealEnvironment, type TenantSecretsKey } from '#lib/tenant-secrets.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
 import type {
   AppHostnameRow,
-  AppRow,
-  AppsRepositoryContract,
-} from '#repositories/apps.repository.ts';
+  AppHostnamesRepositoryContract,
+} from '#repositories/app-hostnames.repository.ts';
+import type { AppRow, AppsRepositoryContract } from '#repositories/apps.repository.ts';
 import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
 import type { ExportsRepositoryContract } from '#repositories/exports.repository.ts';
 import { Service } from '#services/service.ts';
@@ -37,6 +37,9 @@ const SLUG_CONSTRAINTS = ['apps_slug_key', 'app_hostnames_hostname_key'];
 // Six characters of base32 make a collision vanishingly rare, so exhausting this many rolls is
 // a signal that something other than luck is wrong.
 const MAX_SLUG_ATTEMPTS = 5;
+
+/** Reading them back is all an app needs of its hostnames; the rest is the hostnames' own. */
+export type AppHostnameReads = Pick<AppHostnamesRepositoryContract, 'listByOwner' | 'listByApp'>;
 
 /** What deleting an app needs from the exports it leaves behind, and nothing else. */
 export type ExportCancellation = Pick<ExportsRepositoryContract, 'failInFlight'>;
@@ -65,6 +68,7 @@ const FINISH_BATCH = 8;
 
 export class AppsService extends Service {
   private readonly appsRepo: AppsRepositoryContract;
+  private readonly hostnamesRepo: AppHostnameReads;
   private readonly exportsRepo: ExportCancellation;
   private readonly artifactStorageRepo: ObjectRemoval;
   private readonly exportStorageRepo: ObjectRemoval;
@@ -73,6 +77,7 @@ export class AppsService extends Service {
 
   constructor({
     appsRepo,
+    hostnamesRepo,
     exportsRepo,
     artifactStorageRepo,
     exportStorageRepo,
@@ -80,6 +85,7 @@ export class AppsService extends Service {
     secretsKey,
   }: {
     appsRepo: AppsRepositoryContract;
+    hostnamesRepo: AppHostnameReads;
     exportsRepo: ExportCancellation;
     artifactStorageRepo: ObjectRemoval;
     exportStorageRepo: ObjectRemoval;
@@ -88,6 +94,7 @@ export class AppsService extends Service {
   }) {
     super();
     this.appsRepo = appsRepo;
+    this.hostnamesRepo = hostnamesRepo;
     this.exportsRepo = exportsRepo;
     this.artifactStorageRepo = artifactStorageRepo;
     this.exportStorageRepo = exportStorageRepo;
@@ -151,7 +158,7 @@ export class AppsService extends Service {
   async list({ ownerId }: { ownerId: OwnerId }): Promise<PublicApp[]> {
     const [apps, hostnames] = await Promise.all([
       this.appsRepo.listByOwner({ ownerId }),
-      this.appsRepo.listHostnamesByOwner({ ownerId }),
+      this.hostnamesRepo.listByOwner({ ownerId }),
     ]);
     const byApp = Map.groupBy(hostnames, (row) => row.app_id);
 
@@ -161,7 +168,7 @@ export class AppsService extends Service {
   async get({ appId, ownerId }: OwnedApp): Promise<PublicApp> {
     const [app, hostnames] = await Promise.all([
       this.appsRepo.findById({ appId, ownerId }),
-      this.appsRepo.listHostnamesByApp({ appId, ownerId }),
+      this.hostnamesRepo.listByApp({ appId, ownerId }),
     ]);
 
     return toPublicApp({ app: requireApp(app), hostnames });
@@ -175,7 +182,7 @@ export class AppsService extends Service {
     const app = requireApp(
       await this.appsRepo.updateConfig({ appId, ownerId, patch: this.sealed(patch) }),
     );
-    const hostnames = await this.appsRepo.listHostnamesByApp({ appId, ownerId });
+    const hostnames = await this.hostnamesRepo.listByApp({ appId, ownerId });
 
     return toPublicApp({ app, hostnames });
   }
@@ -260,7 +267,7 @@ export class AppsService extends Service {
     await this.exportsRepo.failInFlight({ appId, message: APP_DELETED });
     const [torndown, hostnames] = await Promise.all([
       this.finishIfNothingToTearDown({ appId }),
-      this.appsRepo.listHostnamesByApp({ appId, ownerId }),
+      this.hostnamesRepo.listByApp({ appId, ownerId }),
     ]);
 
     return toPublicApp({ app: torndown ? { ...app, state: 'deleted' } : app, hostnames });

--- a/apps/api/src/services/hostnames.service.ts
+++ b/apps/api/src/services/hostnames.service.ts
@@ -1,0 +1,217 @@
+import type { AppId, Hostname, OwnerId } from '@repo/protocol';
+import { isPlatformHostname, type PublicAppHostname, toAppHostname } from '#lib/app-hostname.ts';
+import { MS_PER_DAY } from '#lib/duration.ts';
+import { BadGatewayError, BadRequestError, ConflictError, NotFoundError } from '#lib/errors.ts';
+import { isUniqueViolation } from '#lib/pg-errors.ts';
+import type {
+  AppHostnameRow,
+  AppHostnamesRepositoryContract,
+} from '#repositories/app-hostnames.repository.ts';
+import type { CustomHostnamesRepositoryContract } from '#repositories/custom-hostnames.repository.ts';
+import { Service } from '#services/service.ts';
+
+type OwnedApp = { appId: AppId; ownerId: OwnerId };
+
+const HOSTNAME_TAKEN = 'app_hostnames_hostname_key';
+
+/**
+ * How many waiting hostnames one host report asks the edge about. Each is its own round trip to
+ * Cloudflare on the way through a request a host is blocked on, and a hostname the owner has not
+ * pointed at us yet is in no hurry — the next report takes the next batch.
+ */
+const POLL_BATCH = 8;
+
+/**
+ * How long a hostname may sit unproved before the claim on it lapses. Uniqueness is
+ * platform-wide, so an unexpired claim is one owner holding a name every other owner is refused
+ * — and the owner who actually controls the domain is the one who would be refused.
+ *
+ * Long enough to cross a weekend, because pointing DNS at us is usually somebody else's ticket.
+ */
+const PENDING_TTL_DAYS = 7;
+const PENDING_TTL_MS = PENDING_TTL_DAYS * MS_PER_DAY;
+
+/**
+ * Custom domains, which live either side of a boundary this process does not control: a row here
+ * saying what an owner asked for, a hostname at the edge that can serve it, and the owner's own
+ * DNS deciding whether it ever does.
+ *
+ * Nothing here proves ownership itself. Pointing DNS at us *is* the proof — the edge cannot issue
+ * a certificate until the records are in place — so this service's job is to keep the row and the
+ * edge agreeing about what happened, not to adjudicate who owns what.
+ */
+export class HostnamesService extends Service {
+  private readonly hostnamesRepo: AppHostnamesRepositoryContract;
+  private readonly customHostnamesRepo: CustomHostnamesRepositoryContract;
+  private readonly appHostDomain: string;
+
+  constructor({
+    hostnamesRepo,
+    customHostnamesRepo,
+    appHostDomain,
+  }: {
+    hostnamesRepo: AppHostnamesRepositoryContract;
+    customHostnamesRepo: CustomHostnamesRepositoryContract;
+    appHostDomain: string;
+  }) {
+    super();
+    this.hostnamesRepo = hostnamesRepo;
+    this.customHostnamesRepo = customHostnamesRepo;
+    this.appHostDomain = appHostDomain;
+  }
+
+  /**
+   * The row first, then the edge: a row with no hostname behind it is found by the pass below and
+   * finished, while a hostname at the edge with no row naming it is invisible to everything here.
+   *
+   * The edge call is made while the owner waits rather than deferred, because what comes back is
+   * the record they have to go and place — deferring it would mean answering the request with
+   * nothing to act on.
+   */
+  async add({
+    appId,
+    ownerId,
+    hostname,
+  }: OwnedApp & { hostname: Hostname }): Promise<PublicAppHostname> {
+    this.refuseWithoutEdge();
+    if (isPlatformHostname({ hostname, appHostDomain: this.appHostDomain })) {
+      throw new BadRequestError(
+        `${this.appHostDomain} hostnames are issued by nibrun and cannot be added as custom domains.`,
+      );
+    }
+
+    const row = await this.insert({ appId, ownerId, hostname });
+    const { cloudflareId, state } = await this.customHostnamesRepo.add({ hostname });
+    const dcvTarget = await this.customHostnamesRepo.dcvTarget({ hostname });
+    const attached = await this.hostnamesRepo.attachCustom({
+      hostname,
+      cloudflareId,
+      dcvTarget,
+    });
+
+    this.logger.info('custom hostname added', { appId, hostname, state });
+
+    return toAppHostname(attached ?? { ...row, state, dcv_target: dcvTarget });
+  }
+
+  private async insert({
+    appId,
+    ownerId,
+    hostname,
+  }: OwnedApp & { hostname: Hostname }): Promise<AppHostnameRow> {
+    try {
+      const row = await this.hostnamesRepo.addCustom({ appId, ownerId, hostname });
+      if (!row) {
+        throw new NotFoundError('App not found.');
+      }
+      return row;
+    } catch (error) {
+      if (isUniqueViolation({ error, constraint: HOSTNAME_TAKEN })) {
+        throw new ConflictError('That hostname is already in use.');
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * The row goes whatever the edge says. A hostname left at the edge is picked up as an orphan by
+   * the pass below; a row left behind is a name nobody can re-add and an owner told the removal
+   * failed for a reason they cannot act on.
+   */
+  async remove({ appId, ownerId, hostname }: OwnedApp & { hostname: Hostname }): Promise<void> {
+    const cloudflareId = await this.hostnamesRepo.removeCustom({ appId, ownerId, hostname });
+    if (cloudflareId === null) {
+      throw new NotFoundError('Custom hostname not found.');
+    }
+    try {
+      await this.customHostnamesRepo.remove({ cloudflareId });
+    } catch (error) {
+      this.logger.error('removing a custom hostname from the edge failed', {
+        appId,
+        hostname,
+        error,
+      });
+    }
+
+    this.logger.info('custom hostname removed', { appId, hostname });
+  }
+
+  /**
+   * Asks the edge what became of the hostnames still waiting, and lets go of the ones nobody ever
+   * pointed at us.
+   *
+   * Driven off the rows still pending rather than off a queue of work owed, so a pass that fails
+   * part way is retried by the next report finding the same rows — and one hostname the edge
+   * cannot answer for does not stop the rest.
+   */
+  async reconcile(): Promise<void> {
+    const pending = await this.hostnamesRepo.listPendingCustom({ limit: POLL_BATCH });
+    for (const row of pending) {
+      await this.advance(row);
+    }
+  }
+
+  private async advance(row: {
+    hostname: Hostname;
+    cloudflare_id: string | null;
+    created_at: Date;
+  }): Promise<void> {
+    if (Date.now() - row.created_at.getTime() > PENDING_TTL_MS) {
+      await this.expire(row);
+      return;
+    }
+    try {
+      // Written before the edge was asked, and the ask never arrived — the edge was away, or this
+      // process died between the two. Finished here rather than left to lapse: the owner cannot
+      // add it again while their own half-finished row holds the name.
+      const cloudflareId = row.cloudflare_id ?? (await this.attachAtEdge(row));
+      const state = await this.customHostnamesRepo.state({ cloudflareId });
+      if (state && state !== 'pending') {
+        await this.hostnamesRepo.setCustomState({ hostname: row.hostname, state });
+        this.logger.info('custom hostname settled', { hostname: row.hostname, state });
+      }
+    } catch (error) {
+      this.logger.error('reading a custom hostname from the edge failed', {
+        hostname: row.hostname,
+        error,
+      });
+    }
+  }
+
+  private async attachAtEdge(row: { hostname: Hostname }): Promise<string> {
+    const { cloudflareId } = await this.customHostnamesRepo.add({ hostname: row.hostname });
+    const dcvTarget = await this.customHostnamesRepo.dcvTarget({ hostname: row.hostname });
+    await this.hostnamesRepo.attachCustom({ hostname: row.hostname, cloudflareId, dcvTarget });
+
+    this.logger.info('custom hostname reached the edge on a later pass', {
+      hostname: row.hostname,
+    });
+    return cloudflareId;
+  }
+
+  private async expire(row: { hostname: Hostname; cloudflare_id: string | null }): Promise<void> {
+    if (row.cloudflare_id) {
+      try {
+        await this.customHostnamesRepo.remove({ cloudflareId: row.cloudflare_id });
+      } catch (error) {
+        this.logger.error('removing an expired custom hostname from the edge failed', {
+          hostname: row.hostname,
+          error,
+        });
+        return;
+      }
+    }
+    await this.hostnamesRepo.setCustomState({ hostname: row.hostname, state: 'failed' });
+    this.logger.info('custom hostname claim expired', { hostname: row.hostname });
+  }
+
+  /**
+   * Refused before the row is written rather than after: a claim left behind by a deployment that
+   * can never prove it is a name every other owner is then refused.
+   */
+  private refuseWithoutEdge(): void {
+    if (!this.customHostnamesRepo.available) {
+      throw new BadGatewayError('Custom domains are not configured on this deployment.');
+    }
+  }
+}

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -1,15 +1,18 @@
 import { Elysia } from 'elysia';
 import { sql } from '#db/client.ts';
+import { CloudflareClient } from '#lib/cloudflare/client.ts';
 import { env } from '#lib/env.ts';
 import { createLogger } from '#lib/logger.ts';
 import { artifactsS3, artifactsSigner, exportsS3 } from '#lib/s3/client.ts';
 import { readSecretsKey } from '#lib/tenant-secrets.ts';
 import { VictoriaLogsClient } from '#lib/victorialogs/client.ts';
 import { AgentRepository } from '#repositories/agent.repository.ts';
+import { AppHostnamesRepository } from '#repositories/app-hostnames.repository.ts';
 import { AppsRepository } from '#repositories/apps.repository.ts';
 import { ArtifactStorageRepository } from '#repositories/artifact-storage.repository.ts';
 import { ArtifactsRepository } from '#repositories/artifacts.repository.ts';
 import { AssetsRepository } from '#repositories/assets.repository.ts';
+import { CustomHostnamesRepository } from '#repositories/custom-hostnames.repository.ts';
 import { DeploymentsRepository } from '#repositories/deployments.repository.ts';
 import { ExportStorageRepository } from '#repositories/export-storage.repository.ts';
 import { ExportsRepository } from '#repositories/exports.repository.ts';
@@ -23,16 +26,26 @@ import { DeploymentsService } from '#services/deployments.service.ts';
 import { ExportsService } from '#services/exports.service.ts';
 import { FilesystemService } from '#services/filesystem.service.ts';
 import { HealthService } from '#services/health.service.ts';
+import { HostnamesService } from '#services/hostnames.service.ts';
 import { LogsService } from '#services/logs.service.ts';
 
 // Read once, where every other piece of the environment is read: a key of the wrong length is a
 // deployment that fails to start rather than one that fails on the first secret written.
 const secretsKey = readSecretsKey(env.TENANT_SECRETS_KEY);
 
+const cloudflareClient =
+  env.CLOUDFLARE_API_TOKEN && env.CLOUDFLARE_ZONE_ID
+    ? new CloudflareClient({
+        apiToken: env.CLOUDFLARE_API_TOKEN,
+        zoneId: env.CLOUDFLARE_ZONE_ID,
+      })
+    : undefined;
+
 const agentRepository = new AgentRepository({ sql, secretsKey });
 const assetsRepository = new AssetsRepository(sql);
 const healthRepository = new HealthRepository(sql);
 const appsRepository = new AppsRepository(sql);
+const appHostnamesRepository = new AppHostnamesRepository(sql);
 const artifactsRepository = new ArtifactsRepository(sql);
 const deploymentsRepository = new DeploymentsRepository(sql);
 const artifactStorageRepository = new ArtifactStorageRepository({
@@ -42,16 +55,23 @@ const artifactStorageRepository = new ArtifactStorageRepository({
 });
 const exportsRepository = new ExportsRepository(sql);
 const exportStorageRepository = new ExportStorageRepository(exportsS3);
+const customHostnamesRepository = new CustomHostnamesRepository(cloudflareClient);
 const logsRepository = new LogsRepository(new VictoriaLogsClient(env.VICTORIALOGS_ENDPOINT));
 
 const deploymentsService = new DeploymentsService({ deploymentsRepo: deploymentsRepository });
 const appsService = new AppsService({
   appsRepo: appsRepository,
+  hostnamesRepo: appHostnamesRepository,
   exportsRepo: exportsRepository,
   artifactStorageRepo: artifactStorageRepository,
   exportStorageRepo: exportStorageRepository,
   appHostDomain: env.APP_HOST_DOMAIN,
   secretsKey,
+});
+const hostnamesService = new HostnamesService({
+  hostnamesRepo: appHostnamesRepository,
+  customHostnamesRepo: customHostnamesRepository,
+  appHostDomain: env.APP_HOST_DOMAIN,
 });
 const exportsService = new ExportsService({
   exportsRepo: exportsRepository,
@@ -74,6 +94,7 @@ const agentService = new AgentService({
   appsService,
   exportsService,
   artifactsService,
+  hostnamesService,
 });
 const logsService = new LogsService({
   logsRepo: logsRepository,
@@ -123,6 +144,11 @@ export const DeploymentsServicePlugin = new Elysia({ name: 'service.deployments'
 export const LogsServicePlugin = new Elysia({ name: 'service.logs' }).decorate(
   'logsService',
   logsService,
+);
+
+export const HostnamesServicePlugin = new Elysia({ name: 'service.hostnames' }).decorate(
+  'hostnamesService',
+  hostnamesService,
 );
 
 export const ExportsServicePlugin = new Elysia({ name: 'service.exports' }).decorate(

--- a/apps/api/tests/lib/app-hostname.test.ts
+++ b/apps/api/tests/lib/app-hostname.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { HostnameSchema, isValidMessage } from '@repo/protocol';
-import { platformHostname } from '#lib/app-hostname.ts';
+import { type Hostname, HostnameSchema, isValidMessage } from '@repo/protocol';
+import { isPlatformHostname, platformHostname } from '#lib/app-hostname.ts';
 import { deriveAppSlug } from '#lib/app-slug.ts';
 
 const APP_HOST_DOMAIN = 'apps.example.com';
@@ -27,5 +27,34 @@ describe('an app is reachable at its slug under the app domain', () => {
         expect(isValidMessage({ schema: HostnameSchema, value: hostname })).toBe(true);
       }
     }
+  });
+});
+
+describe('a hostname the platform hands out is not one an owner may bring', () => {
+  function brought(hostname: string): boolean {
+    return !isPlatformHostname({
+      hostname: hostname as Hostname,
+      appHostDomain: APP_HOST_DOMAIN,
+    });
+  }
+
+  // The unique index stops a brought domain taking a name another app already holds. It cannot
+  // stop one taking a name no app holds yet — and the platform would hand that name out later.
+  test('a slug nothing has been minted under yet is still refused', () => {
+    expect(brought('not-created-yet.apps.example.com')).toBe(false);
+  });
+
+  test('and so is the app domain itself', () => {
+    expect(brought(APP_HOST_DOMAIN)).toBe(false);
+  });
+
+  // `notapps.example.com` ends with the domain as a *string* and is a different registrable
+  // domain entirely, so refusing it would refuse a domain somebody legitimately owns.
+  test("a domain that merely ends in the same letters is somebody else's to bring", () => {
+    expect(brought(`not${APP_HOST_DOMAIN}`)).toBe(true);
+  });
+
+  test('an ordinary brought domain is allowed', () => {
+    expect(brought('app.example.dev')).toBe(true);
   });
 });

--- a/apps/api/tests/lib/cloudflare.test.ts
+++ b/apps/api/tests/lib/cloudflare.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { CloudflareClient, CloudflareError } from '#lib/cloudflare/client.ts';
+
+const ZONE_ID = 'zone-1';
+const API_TOKEN = 'token-1';
+const HOSTNAME = 'app.example.dev';
+const HTTP_OK = 200;
+const HTTP_BAD_GATEWAY = 502;
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+type Answer = { status?: number; body: unknown };
+
+/** Records what was asked and answers with what the test wants back. */
+function answering(answers: Answer[]): { calls: Request[] } {
+  const calls: Request[] = [];
+  let index = 0;
+
+  globalThis.fetch = ((...args: Parameters<typeof fetch>) => {
+    const [input, init] = args;
+    calls.push(new Request(input as string, init));
+    const answer = answers[index++] ?? answers.at(-1);
+    return Promise.resolve(
+      new Response(JSON.stringify(answer?.body), { status: answer?.status ?? HTTP_OK }),
+    );
+  }) as typeof fetch;
+
+  return { calls };
+}
+
+function client(): CloudflareClient {
+  return new CloudflareClient({ apiToken: API_TOKEN, zoneId: ZONE_ID });
+}
+
+function ok(result: unknown): Answer {
+  return { body: { success: true, result, errors: [] } };
+}
+
+describe('a call to the edge carries this zone and this token', () => {
+  test('the hostname is created under the configured zone', async () => {
+    const { calls } = answering([ok({ id: 'ch-1' })]);
+
+    await client().createCustomHostname({ hostname: HOSTNAME });
+
+    expect(calls[0]?.url).toBe(
+      `https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/custom_hostnames`,
+    );
+    expect(calls[0]?.headers.get('authorization')).toBe(`Bearer ${API_TOKEN}`);
+  });
+
+  // Delegated DCV is what keeps renewal from ever coming back to the owner, and it answers the
+  // `txt` method. `http` would need their server rather than their DNS, which is a different
+  // promise to the one the dashboard prints them.
+  test('and asks for the validation the owner answers once and never again', async () => {
+    const { calls } = answering([ok({ id: 'ch-1' })]);
+
+    await client().createCustomHostname({ hostname: HOSTNAME });
+
+    expect(await calls[0]?.json()).toMatchObject({
+      hostname: HOSTNAME,
+      ssl: { method: 'txt', type: 'dv' },
+    });
+  });
+});
+
+describe('a refusal is an error however the edge phrases it', () => {
+  test('a non-2xx is an error', async () => {
+    answering([{ status: 403, body: { success: false, result: null, errors: [] } }]);
+
+    await expect(client().createCustomHostname({ hostname: HOSTNAME })).rejects.toBeInstanceOf(
+      CloudflareError,
+    );
+  });
+
+  // Cloudflare answers some failures 200 with `success: false`. Reading only the status code
+  // would let those through as a result, and the caller would store an id that is `undefined`.
+  test('so is a 200 that says it did not succeed', async () => {
+    answering([
+      {
+        body: { success: false, result: null, errors: [{ code: 1406, message: 'already exists' }] },
+      },
+    ]);
+
+    await expect(client().createCustomHostname({ hostname: HOSTNAME })).rejects.toThrow(
+      /already exists/,
+    );
+  });
+
+  // An edge that answered with a proxy's error page rather than its own envelope is still a
+  // refusal, and reading `.result` off a body that never parsed would be a 500 out of this end.
+  test('and so is a body that is not the envelope at all', async () => {
+    answering([{ status: HTTP_BAD_GATEWAY, body: undefined }]);
+
+    await expect(client().createCustomHostname({ hostname: HOSTNAME })).rejects.toBeInstanceOf(
+      CloudflareError,
+    );
+  });
+});
+
+describe('the record the owner places is derived, not fetched per hostname', () => {
+  test('the target names the hostname and the zone delegation uuid', async () => {
+    answering([ok({ uuid: 'abc123' })]);
+
+    expect(await client().dcvDelegationTarget({ hostname: HOSTNAME })).toBe(
+      `${HOSTNAME}.abc123.dcv.cloudflare.com`,
+    );
+  });
+
+  // The uuid belongs to the zone rather than to a hostname, so asking again per hostname would be
+  // a round trip for an answer that cannot have changed.
+  test('and the uuid is asked for once however many hostnames need it', async () => {
+    const { calls } = answering([ok({ uuid: 'abc123' })]);
+    const cloudflare = client();
+
+    await cloudflare.dcvDelegationTarget({ hostname: HOSTNAME });
+    await cloudflare.dcvDelegationTarget({ hostname: 'other.example.dev' });
+
+    expect(calls.length).toBe(1);
+  });
+});

--- a/apps/api/tests/repositories/custom-hostnames.test.ts
+++ b/apps/api/tests/repositories/custom-hostnames.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import type { CustomHostname } from '#lib/cloudflare/client.ts';
+import {
+  CustomHostnamesRepository,
+  CustomHostnamesUnavailableError,
+  toState,
+} from '#repositories/custom-hostnames.repository.ts';
+
+function edge({ status, ssl }: { status: string; ssl: string }): CustomHostname {
+  return {
+    id: 'ch-1',
+    hostname: 'app.example.dev',
+    status,
+    ssl: { status: ssl },
+  };
+}
+
+describe('a hostname serves only when both halves of it do', () => {
+  test('an active hostname with an active certificate is routable', () => {
+    expect(toState(edge({ status: 'active', ssl: 'active' }))).toBe('active');
+  });
+
+  // The hostname is live but there is no certificate to serve it with, so routing it would be a
+  // handshake failure rather than a working domain.
+  test('an active hostname whose certificate is still coming is not', () => {
+    expect(toState(edge({ status: 'active', ssl: 'pending_validation' }))).toBe('pending');
+  });
+
+  test('nor is a certificate that is ready for a hostname that is not', () => {
+    expect(toState(edge({ status: 'pending', ssl: 'active' }))).toBe('pending');
+  });
+});
+
+describe('waiting is the default, because the edge retries on its own', () => {
+  // Calling one of these failed would strand a hostname that was about to work, and the owner
+  // would be told to fix something that is already fixing itself.
+  test('a status nothing here has an opinion about is still waiting', () => {
+    expect(toState(edge({ status: 'pending_deployment', ssl: 'pending_issuance' }))).toBe(
+      'pending',
+    );
+  });
+
+  test('a blocked hostname is finished', () => {
+    expect(toState(edge({ status: 'blocked', ssl: 'pending_validation' }))).toBe('failed');
+  });
+
+  // A timeout reads transient but is not: it means the owner never placed the records, and
+  // nothing at the edge will ask again without being told to.
+  test('and so is a validation nobody ever answered', () => {
+    expect(toState(edge({ status: 'pending', ssl: 'validation_timed_out' }))).toBe('failed');
+  });
+});
+
+describe('a deployment with no Cloudflare account says so where the edge would be reached', () => {
+  const unconfigured = new CustomHostnamesRepository(undefined);
+
+  // The one question a caller may ask without a client, so it can refuse before writing a row.
+  test('it answers that it is unavailable rather than throwing', () => {
+    expect(unconfigured.available).toBe(false);
+  });
+
+  // Defence for the caller that did not ask: better a named error than a read of `undefined`.
+  test('and every call that needs the edge refuses', async () => {
+    const hostname = 'app.example.dev' as Parameters<typeof unconfigured.add>[0]['hostname'];
+
+    await expect(unconfigured.add({ hostname })).rejects.toBeInstanceOf(
+      CustomHostnamesUnavailableError,
+    );
+    await expect(unconfigured.dcvTarget({ hostname })).rejects.toBeInstanceOf(
+      CustomHostnamesUnavailableError,
+    );
+    await expect(unconfigured.state({ cloudflareId: 'ch-1' })).rejects.toBeInstanceOf(
+      CustomHostnamesUnavailableError,
+    );
+    await expect(unconfigured.remove({ cloudflareId: 'ch-1' })).rejects.toBeInstanceOf(
+      CustomHostnamesUnavailableError,
+    );
+  });
+});

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@repo/protocol';
 import { UnauthorizedError } from '#lib/errors.ts';
 import type { AgentRepositoryContract } from '#repositories/agent.repository.ts';
-import { AgentService, type UploadSweep } from '#services/agent.service.ts';
+import { AgentService, type HostnameReconcile, type UploadSweep } from '#services/agent.service.ts';
 import type { AppsService } from '#services/apps.service.ts';
 import type { DeploymentsService } from '#services/deployments.service.ts';
 import type { ExportsService } from '#services/exports.service.ts';
@@ -99,22 +99,35 @@ class FakeUploadSweep implements UploadSweep {
   }
 }
 
+/** The same clock, borrowed for the hostnames whose fate is decided in somebody else's DNS. */
+class FakeHostnameReconcile implements HostnameReconcile {
+  reconciled = 0;
+
+  reconcile(): Promise<void> {
+    this.reconciled += 1;
+    return Promise.resolve();
+  }
+}
+
 function build() {
   const deployments = new FakeDeploymentsService();
   const apps = new FakeAppsService();
   const exports = new FakeExportsService();
   const artifacts = new FakeUploadSweep();
+  const hostnames = new FakeHostnameReconcile();
   return {
     apps,
     deployments,
     exports,
     artifacts,
+    hostnames,
     service: new AgentService({
       agentRepo: new FakeAgentRepository(),
       deploymentsService: deployments as unknown as DeploymentsService,
       appsService: apps as unknown as AppsService,
       exportsService: exports as unknown as ExportsService,
       artifactsService: artifacts,
+      hostnamesService: hostnames,
     }),
   };
 }
@@ -190,5 +203,22 @@ describe('a report is read by whatever owns what it talks about', () => {
     await service.acceptReport({ reported });
 
     expect(apps.trace).toEqual(['completeDeletions', 'finishDeletions', 'purgeDeleted']);
+  });
+
+  // Nothing in the report says anything about hostnames. It is borrowed as a clock, because
+  // whether an owner has pointed their domain at us happens in DNS with nobody to announce it.
+  test('and the clock it lends is what advances a custom hostname nobody announced', async () => {
+    const { artifacts, hostnames, service } = build();
+    const reported = {
+      hostId: Value.Parse(HostIdSchema, 'host-1'),
+      instances: [],
+      volumes: [],
+      exports: [],
+    } as unknown as HostReportedState;
+
+    await service.acceptReport({ reported });
+
+    expect(artifacts.swept).toBe(1);
+    expect(hostnames.reconciled).toBe(1);
   });
 });

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -23,13 +23,16 @@ import { ConflictError, NotFoundError } from '#lib/errors.ts';
 import { openSecret, sealedFromStore } from '#lib/tenant-secrets.ts';
 import type {
   AppHostnameRow,
+  OwnedAppHostnameRow,
+} from '#repositories/app-hostnames.repository.ts';
+import type {
   AppRow,
   AppsRepositoryContract,
   CreatedApp,
   Leftovers,
-  OwnedAppHostnameRow,
 } from '#repositories/apps.repository.ts';
 import {
+  type AppHostnameReads,
   AppsService,
   type ExportCancellation,
   type ObjectRemoval,
@@ -143,7 +146,7 @@ class StubAppsRepository implements AppsRepositoryContract {
     }
     return Promise.resolve({
       app: { ...appRow(slug), ...configColumns(config) },
-      hostnames: [{ hostname, kind: 'platform', state: 'active' }],
+      hostnames: [{ hostname, kind: 'platform', state: 'active', dcv_target: null }],
     });
   }
 
@@ -155,16 +158,8 @@ class StubAppsRepository implements AppsRepositoryContract {
     return Promise.resolve([]);
   }
 
-  listHostnamesByOwner(): Promise<OwnedAppHostnameRow[]> {
-    return Promise.resolve([]);
-  }
-
   findById(): Promise<AppRow | null> {
     return Promise.resolve(null);
-  }
-
-  listHostnamesByApp(): Promise<AppHostnameRow[]> {
-    return Promise.resolve([]);
   }
 
   updateConfig({
@@ -218,6 +213,17 @@ class StubAppsRepository implements AppsRepositoryContract {
  * deleted after the row naming it: a bucket refusing a delete has to leave work a later pass can
  * still find.
  */
+/** Every read answers empty, which is what an app belonging to somebody else looks like. */
+class StubHostnameReads implements AppHostnameReads {
+  listByOwner(): Promise<OwnedAppHostnameRow[]> {
+    return Promise.resolve([]);
+  }
+
+  listByApp(): Promise<AppHostnameRow[]> {
+    return Promise.resolve([]);
+  }
+}
+
 class StubObjectStorage {
   readonly removed: ObjectKey[] = [];
   readonly #trace: string[];
@@ -270,6 +276,7 @@ function serviceWith({
 }) {
   return new AppsService({
     appsRepo,
+    hostnamesRepo: new StubHostnameReads(),
     exportsRepo,
     artifactStorageRepo,
     exportStorageRepo,
@@ -322,6 +329,7 @@ describe('a taken hostname is a re-roll, not something the owner sees', () => {
         hostname: Value.Parse(HostnameSchema, `${app.slug}.${APP_HOST_DOMAIN}`),
         kind: 'platform',
         state: 'active',
+        dcvTarget: null,
       },
     ]);
   });

--- a/apps/api/tests/services/hostnames.test.ts
+++ b/apps/api/tests/services/hostnames.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type AppHostnameState,
+  type AppId,
+  AppIdSchema,
+  type Hostname,
+  HostnameSchema,
+  type OwnerId,
+  OwnerIdSchema,
+  Value,
+} from '@repo/protocol';
+import { MS_PER_DAY } from '#lib/duration.ts';
+import { BadGatewayError, BadRequestError, ConflictError, NotFoundError } from '#lib/errors.ts';
+import type {
+  AppHostnameRow,
+  AppHostnamesRepositoryContract,
+} from '#repositories/app-hostnames.repository.ts';
+import type {
+  CustomHostnamesRepositoryContract,
+  EdgeHostname,
+} from '#repositories/custom-hostnames.repository.ts';
+import { HostnamesService } from '#services/hostnames.service.ts';
+import { uniqueViolation } from '#tests/support/postgres.ts';
+
+const APP_HOST_DOMAIN = 'apps.example.com';
+const APP_ID = Value.Parse(AppIdSchema, 'app-1');
+const OWNER_ID = Value.Parse(OwnerIdSchema, 'owner-1');
+const BROUGHT = Value.Parse(HostnameSchema, 'app.example.dev');
+const CLOUDFLARE_ID = 'ch-1';
+const PENDING_TTL_DAYS = 7;
+
+type PendingRow = { hostname: Hostname; cloudflare_id: string | null; created_at: Date };
+
+function hostnameRow(overrides: Partial<AppHostnameRow> = {}): AppHostnameRow {
+  return {
+    hostname: BROUGHT,
+    kind: 'custom',
+    state: 'pending',
+    dcv_target: null,
+    ...overrides,
+  };
+}
+
+class StubHostnamesRepository implements AppHostnamesRepositoryContract {
+  readonly trace: string[] = [];
+  readonly states: AppHostnameState[] = [];
+  pending: PendingRow[] = [];
+  owns = true;
+  insertFailure: unknown;
+  removed: string | null = CLOUDFLARE_ID;
+
+  addCustom(): Promise<AppHostnameRow | null> {
+    this.trace.push('insert');
+    if (this.insertFailure) {
+      return Promise.reject(this.insertFailure);
+    }
+    return Promise.resolve(this.owns ? hostnameRow() : null);
+  }
+
+  attachCustom({ dcvTarget }: { dcvTarget: string | null }): Promise<AppHostnameRow | null> {
+    this.trace.push('attach');
+    return Promise.resolve(hostnameRow({ dcv_target: dcvTarget }));
+  }
+
+  setCustomState({ state }: { state: AppHostnameState }): Promise<boolean> {
+    this.trace.push(`state:${state}`);
+    this.states.push(state);
+    return Promise.resolve(true);
+  }
+
+  removeCustom(): Promise<string | null> {
+    this.trace.push('remove');
+    return Promise.resolve(this.removed);
+  }
+
+  listPendingCustom(): Promise<PendingRow[]> {
+    return Promise.resolve(this.pending);
+  }
+
+  // Reads an app makes of its own hostnames; nothing here asks for them.
+  listByOwner = notAsked;
+  listByApp = notAsked;
+}
+
+function notAsked(): never {
+  throw new Error('Not part of what a hostname needs.');
+}
+
+class StubEdge implements CustomHostnamesRepositoryContract {
+  readonly trace: string[] = [];
+  available = true;
+  state_: AppHostnameState = 'pending';
+  addFailure: unknown;
+  removeFailure: unknown;
+
+  add(): Promise<EdgeHostname> {
+    this.trace.push('add');
+    if (this.addFailure) {
+      return Promise.reject(this.addFailure);
+    }
+    return Promise.resolve({ cloudflareId: CLOUDFLARE_ID, state: 'pending' });
+  }
+
+  dcvTarget({ hostname }: { hostname: Hostname }): Promise<string> {
+    return Promise.resolve(`${hostname}.uuid.dcv.cloudflare.com`);
+  }
+
+  state(): Promise<AppHostnameState> {
+    this.trace.push('state');
+    return Promise.resolve(this.state_);
+  }
+
+  remove(): Promise<void> {
+    this.trace.push('remove');
+    if (this.removeFailure) {
+      return Promise.reject(this.removeFailure);
+    }
+    return Promise.resolve();
+  }
+}
+
+function build({ withEdge = true }: { withEdge?: boolean } = {}) {
+  const hostnamesRepo = new StubHostnamesRepository();
+  const customHostnamesRepo = new StubEdge();
+  customHostnamesRepo.available = withEdge;
+  return {
+    appsRepo: hostnamesRepo,
+    customHostnamesRepo,
+    service: new HostnamesService({
+      hostnamesRepo,
+      customHostnamesRepo,
+      appHostDomain: APP_HOST_DOMAIN,
+    }),
+  };
+}
+
+function owned(hostname: Hostname = BROUGHT): {
+  appId: AppId;
+  ownerId: OwnerId;
+  hostname: Hostname;
+} {
+  return { appId: APP_ID, ownerId: OWNER_ID, hostname };
+}
+
+describe('a domain the platform issues is not one an owner may claim', () => {
+  test('a name under the app domain is refused before anything is written', async () => {
+    const { service, appsRepo } = build();
+
+    await expect(
+      service.add(owned(Value.Parse(HostnameSchema, `taken.${APP_HOST_DOMAIN}`))),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(appsRepo.trace).toEqual([]);
+  });
+
+  // Uniqueness spans platform and custom together, so this is also what a brought domain hits
+  // when it names a hostname nibrun issued to somebody else.
+  test('a hostname another app already holds is a conflict the owner can read', async () => {
+    const { service, appsRepo } = build();
+    appsRepo.insertFailure = uniqueViolation('app_hostnames_hostname_key');
+
+    await expect(service.add(owned())).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  // Every other violation means the request itself is wrong in a way retrying cannot fix, and
+  // dressing one up as a conflict would tell the owner to try a different hostname.
+  test('and any other violation is not rewritten into one', async () => {
+    const { service, appsRepo } = build();
+    appsRepo.insertFailure = uniqueViolation('some_other_key');
+
+    await expect(service.add(owned())).rejects.not.toBeInstanceOf(ConflictError);
+  });
+
+  test('an app the caller does not own is indistinguishable from one that is not there', async () => {
+    const { service, appsRepo } = build();
+    appsRepo.owns = false;
+
+    await expect(service.add(owned())).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe('the row is written before the edge is told', () => {
+  // The reverse order leaves a hostname at the edge that nothing here names — invisible to the
+  // pass that would otherwise clean it up, and billed for.
+  test('so a crash between the two leaves something findable rather than something orphaned', async () => {
+    const { service, appsRepo, customHostnamesRepo } = build();
+
+    await service.add(owned());
+
+    expect(appsRepo.trace[0]).toBe('insert');
+    expect(customHostnamesRepo.trace).toContain('add');
+  });
+
+  test('and the owner is handed the record to place rather than told to come back', async () => {
+    const { service } = build();
+
+    const added = await service.add(owned());
+
+    expect(added.state).toBe('pending');
+    expect(added.dcvTarget).toBe(`${BROUGHT}.uuid.dcv.cloudflare.com`);
+  });
+});
+
+describe('removing a domain lets the row go whatever the edge says', () => {
+  test("a hostname this app never had is not somebody else's to remove", async () => {
+    const { service, appsRepo } = build();
+    appsRepo.removed = null;
+
+    await expect(service.remove(owned())).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  // A row left behind is a name nobody can ever re-add, and an owner told the removal failed for
+  // a reason they cannot act on. The stranded hostname is the pass below's problem.
+  test('an edge that refuses does not keep the row alive', async () => {
+    const { service, customHostnamesRepo } = build();
+    customHostnamesRepo.removeFailure = new Error('cloudflare is away');
+
+    await expect(service.remove(owned())).resolves.toBeUndefined();
+  });
+});
+
+describe('a waiting hostname is settled by the clock a host report lends', () => {
+  function pendingSince(days: number): PendingRow {
+    return {
+      hostname: BROUGHT,
+      cloudflare_id: CLOUDFLARE_ID,
+      created_at: new Date(Date.now() - days * MS_PER_DAY),
+    };
+  }
+
+  test('one the edge is now serving becomes routable', async () => {
+    const { service, appsRepo, customHostnamesRepo } = build();
+    appsRepo.pending = [pendingSince(1)];
+    customHostnamesRepo.state_ = 'active';
+
+    await service.reconcile();
+
+    expect(appsRepo.states).toEqual(['active']);
+  });
+
+  // Writing `pending` over `pending` would touch `updated_at` on every report forever.
+  test('one still waiting is left exactly as it was', async () => {
+    const { service, appsRepo } = build();
+    appsRepo.pending = [pendingSince(1)];
+
+    await service.reconcile();
+
+    expect(appsRepo.states).toEqual([]);
+  });
+
+  // Uniqueness is platform-wide, so a claim nobody ever proved is a name every other owner is
+  // refused — including the one who actually controls the domain.
+  test('a claim nobody ever proved lapses, and the edge stops holding it', async () => {
+    const { service, appsRepo, customHostnamesRepo } = build();
+    appsRepo.pending = [pendingSince(PENDING_TTL_DAYS + 1)];
+
+    await service.reconcile();
+
+    expect(customHostnamesRepo.trace).toContain('remove');
+    expect(appsRepo.states).toEqual(['failed']);
+  });
+
+  test('and it is not expired while the edge still refuses to let go of it', async () => {
+    const { service, appsRepo, customHostnamesRepo } = build();
+    appsRepo.pending = [pendingSince(PENDING_TTL_DAYS + 1)];
+    customHostnamesRepo.removeFailure = new Error('cloudflare is away');
+
+    await service.reconcile();
+
+    expect(appsRepo.states).toEqual([]);
+  });
+
+  // The edge was away when the owner added it, or this process died between the two writes.
+  // Leaving it would mean the owner cannot add the domain again — their own half-finished row
+  // holds the name — until the claim lapses a week later.
+  test('one that never reached the edge is finished rather than left to lapse', async () => {
+    const { service, appsRepo, customHostnamesRepo } = build();
+    appsRepo.pending = [{ hostname: BROUGHT, cloudflare_id: null, created_at: new Date() }];
+    customHostnamesRepo.state_ = 'active';
+
+    await service.reconcile();
+
+    expect(customHostnamesRepo.trace).toEqual(['add', 'state']);
+    expect(appsRepo.trace).toContain('attach');
+    expect(appsRepo.states).toEqual(['active']);
+  });
+
+  // One hostname the edge cannot answer for is not a reason to stop reading the others.
+  test('and one the edge still cannot answer for does not stop the rest', async () => {
+    const { service, appsRepo, customHostnamesRepo } = build();
+    appsRepo.pending = [
+      { hostname: BROUGHT, cloudflare_id: null, created_at: new Date() },
+      pendingSince(1),
+    ];
+    customHostnamesRepo.addFailure = new Error('cloudflare is away');
+    customHostnamesRepo.state_ = 'active';
+
+    await service.reconcile();
+
+    expect(appsRepo.states).toEqual(['active']);
+  });
+});
+
+describe('a deployment without an edge says so rather than half-working', () => {
+  test('adding a domain is refused outright', async () => {
+    const { service } = build({ withEdge: false });
+
+    await expect(service.add(owned())).rejects.toBeInstanceOf(BadGatewayError);
+  });
+
+  test('and the pass that settles them does nothing at all', async () => {
+    const { service, appsRepo } = build({ withEdge: false });
+    appsRepo.pending = [
+      { hostname: BROUGHT, cloudflare_id: CLOUDFLARE_ID, created_at: new Date() },
+    ];
+
+    await service.reconcile();
+
+    expect(appsRepo.states).toEqual([]);
+  });
+});


### PR DESCRIPTION
Cloudflare for SaaS terminates TLS for a name outside our zone. On the fallback
origin it names the custom hostname in both the handshake and the request, so the
site blocks a host already renders match it and the agent is untouched.

Nothing here adjudicates ownership. Pointing DNS at us is the proof — no
certificate is issued until the records are in place — so this only keeps the row
and the edge agreeing about what happened, on the clock a host report already
lends this process.

A deployment with no Cloudflare account configured serves platform hostnames and
refuses these routes, which is what every local stack is.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>