### PR TITLE
feat(cli,dashboard): an owner adds a domain and is handed the records to place

### DIFF
--- a/apps/dashboard/src/components/apps/add-domain-form.tsx
+++ b/apps/dashboard/src/components/apps/add-domain-form.tsx
@@ -1,0 +1,68 @@
+import { HostnameSchema, Value } from '@repo/protocol';
+import { Button } from '@repo/ui/components/button';
+import { Field, FieldError, FieldLabel } from '@repo/ui/components/field';
+import { Input } from '@repo/ui/components/input';
+import { Spinner } from '@repo/ui/components/spinner';
+import { revalidateLogic, useForm } from '@tanstack/react-form';
+import { useAddDomain } from '#lib/hooks/use-app-domains.ts';
+import { useAppId } from '#lib/hooks/use-app-id.ts';
+
+export function AddDomainForm() {
+  const addition = useAddDomain(useAppId());
+
+  // Nearly every prefix of a domain is malformed, so validating as it is typed would refuse the
+  // owner from the first keystroke. Checked on submit instead, and from then on as they type.
+  const api = useForm({
+    defaultValues: { hostname: '' },
+    validationLogic: revalidateLogic(),
+    onSubmit: ({ value, formApi }) => {
+      addition.mutate(value.hostname.trim(), { onSuccess: () => formApi.reset() });
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void api.handleSubmit();
+      }}
+    >
+      <api.Field name="hostname" validators={{ onDynamic: validateHostname }}>
+        {(field) => {
+          // The api's refusal reads as a field error too: it is about this hostname, and there is
+          // nowhere else on the form for it to go.
+          const refused = field.state.meta.errors[0] ?? addition.error?.message;
+          return (
+            <Field data-invalid={refused !== undefined || undefined}>
+              <FieldLabel htmlFor="hostname">Add a domain</FieldLabel>
+              <div className="flex gap-2">
+                <Input
+                  id="hostname"
+                  value={field.state.value}
+                  placeholder="app.example.com"
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="font-mono"
+                  onChange={(event) => field.handleChange(event.target.value)}
+                />
+                <Button
+                  type="submit"
+                  disabled={field.state.value.trim() === '' || addition.isPending}
+                >
+                  {addition.isPending ? <Spinner /> : 'Add'}
+                </Button>
+              </div>
+              {refused === undefined ? null : <FieldError>{refused}</FieldError>}
+            </Field>
+          );
+        }}
+      </api.Field>
+    </form>
+  );
+}
+
+function validateHostname({ value }: { value: string }): string | undefined {
+  return Value.Check(HostnameSchema, value.trim())
+    ? undefined
+    : 'A domain looks like app.example.com.';
+}

--- a/apps/dashboard/src/components/apps/app-overview-card.tsx
+++ b/apps/dashboard/src/components/apps/app-overview-card.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@repo/ui/components/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
 import { ExternalLinkIcon } from 'lucide-react';
 import { AppStateBadge } from '#components/apps/app-state-badge.tsx';
+import { HostnameStateBadge } from '#components/apps/hostname-state-badge.tsx';
 import { dayAndMinute } from '#lib/format-timestamp.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
@@ -34,7 +35,14 @@ export function AppOverviewCard({ app }: { app: AppSummary }) {
                   <span className="truncate">{hostname.hostname}</span>
                   <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
                 </a>
-                {hostname.kind === 'custom' ? <Badge variant="outline">Custom</Badge> : null}
+                <span className="flex shrink-0 items-center gap-2">
+                  {hostname.kind === 'custom' ? <Badge variant="outline">Custom</Badge> : null}
+                  {/* Only where it says something: a platform hostname is active from the moment
+                      it is minted, so a badge on one is a word that never changes. */}
+                  {hostname.state === 'active' ? null : (
+                    <HostnameStateBadge state={hostname.state} />
+                  )}
+                </span>
               </li>
             ))}
           </ul>

--- a/apps/dashboard/src/components/apps/app-tabs.tsx
+++ b/apps/dashboard/src/components/apps/app-tabs.tsx
@@ -3,6 +3,7 @@ import { Tabs, TabsList, TabsTrigger } from '@repo/ui/components/tabs';
 import { Link } from '@tanstack/react-router';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
 import { useAppTab } from '#lib/hooks/use-app-tab.ts';
+import { Route as DomainsRoute } from '#routes/(dashboard)/apps/$appId/domains.tsx';
 import { Route as FilesRoute } from '#routes/(dashboard)/apps/$appId/files.tsx';
 import { Route as AppRoute } from '#routes/(dashboard)/apps/$appId/index.tsx';
 import { Route as LogsRoute } from '#routes/(dashboard)/apps/$appId/logs.tsx';
@@ -34,6 +35,9 @@ export function AppTabs() {
           render={<Link to={FilesRoute.to} params={{ appId }} search={{ path: GUEST_PATH_ROOT }} />}
         >
           Files
+        </TabsTrigger>
+        <TabsTrigger value="domains" render={<Link to={DomainsRoute.to} params={{ appId }} />}>
+          Domains
         </TabsTrigger>
       </TabsList>
     </Tabs>

--- a/apps/dashboard/src/components/apps/domain-records.tsx
+++ b/apps/dashboard/src/components/apps/domain-records.tsx
@@ -1,0 +1,35 @@
+import { useApp } from '#lib/hooks/use-app.ts';
+import { useAppId } from '#lib/hooks/use-app-id.ts';
+import { usePlatformSuffix } from '#lib/hooks/use-platform-suffix.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+type Hostname = AppSummary['hostnames'][number];
+
+/**
+ * The two records a pending domain is waiting on, laid out the way a DNS provider asks for them.
+ *
+ * Selectable text rather than a copy button per field: these are pasted into somebody else's
+ * form, usually more than once, and often not by the person reading this page.
+ */
+export function DomainRecords({ hostname }: { hostname: Hostname }) {
+  const app = useApp(useAppId());
+  const suffix = usePlatformSuffix();
+
+  return (
+    <dl className="flex flex-col gap-2 rounded-xl bg-muted px-3 py-2 font-mono text-xs">
+      <DomainRecord name={hostname.hostname} value={`${app.data?.slug}.${suffix}`} />
+      {hostname.dcvTarget ? (
+        <DomainRecord name={`_acme-challenge.${hostname.hostname}`} value={hostname.dcvTarget} />
+      ) : null}
+    </dl>
+  );
+}
+
+function DomainRecord({ name, value }: { name: string; value: string }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <dt className="truncate text-muted-foreground">{name}</dt>
+      <dd className="select-all truncate">CNAME {value}</dd>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/apps/domain-row.tsx
+++ b/apps/dashboard/src/components/apps/domain-row.tsx
@@ -1,0 +1,50 @@
+import { Badge } from '@repo/ui/components/badge';
+import { Button } from '@repo/ui/components/button';
+import { Spinner } from '@repo/ui/components/spinner';
+import { ExternalLinkIcon, Trash2Icon } from 'lucide-react';
+import { DomainRecords } from '#components/apps/domain-records.tsx';
+import { HostnameStateBadge } from '#components/apps/hostname-state-badge.tsx';
+import { useRemoveDomain } from '#lib/hooks/use-app-domains.ts';
+import { useAppId } from '#lib/hooks/use-app-id.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+type Hostname = AppSummary['hostnames'][number];
+
+export function DomainRow({ hostname }: { hostname: Hostname }) {
+  const removal = useRemoveDomain(useAppId());
+  // The platform hostname has no remove: it is how the app is addressed once every brought
+  // domain has gone, and nothing would put it back.
+  const isPlatform = hostname.kind === 'platform';
+
+  return (
+    <li className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-4">
+        <a
+          href={`https://${hostname.hostname}`}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex min-w-0 items-center gap-1.5 font-mono hover:underline"
+        >
+          <span className="truncate">{hostname.hostname}</span>
+          <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
+        </a>
+        <div className="flex shrink-0 items-center gap-2">
+          {isPlatform ? <Badge variant="outline">Issued</Badge> : null}
+          <HostnameStateBadge state={hostname.state} />
+          {isPlatform ? null : (
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={`Remove ${hostname.hostname}`}
+              disabled={removal.isPending}
+              onClick={() => removal.mutate(hostname.hostname)}
+            >
+              {removal.isPending ? <Spinner /> : <Trash2Icon />}
+            </Button>
+          )}
+        </div>
+      </div>
+      {hostname.state === 'pending' ? <DomainRecords hostname={hostname} /> : null}
+    </li>
+  );
+}

--- a/apps/dashboard/src/components/apps/domains-card.tsx
+++ b/apps/dashboard/src/components/apps/domains-card.tsx
@@ -1,0 +1,25 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
+import { AddDomainForm } from '#components/apps/add-domain-form.tsx';
+import { DomainRow } from '#components/apps/domain-row.tsx';
+import { useApp } from '#lib/hooks/use-app.ts';
+import { useAppId } from '#lib/hooks/use-app-id.ts';
+
+export function DomainsCard() {
+  const app = useApp(useAppId());
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Domains</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6 text-sm">
+        <ul className="flex flex-col gap-4">
+          {app.data?.hostnames.map((hostname) => (
+            <DomainRow key={hostname.hostname} hostname={hostname} />
+          ))}
+        </ul>
+        <AddDomainForm />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/apps/hostname-state-badge.tsx
+++ b/apps/dashboard/src/components/apps/hostname-state-badge.tsx
@@ -1,0 +1,15 @@
+import type { AppHostnameState } from '@repo/protocol';
+import { Badge } from '@repo/ui/components/badge';
+import type { ComponentProps } from 'react';
+
+type BadgeVariant = ComponentProps<typeof Badge>['variant'];
+
+const VARIANT: Record<AppHostnameState, BadgeVariant> = {
+  pending: 'secondary',
+  active: 'default',
+  failed: 'destructive',
+};
+
+export function HostnameStateBadge({ state }: { state: AppHostnameState }) {
+  return <Badge variant={VARIANT[state]}>{state}</Badge>;
+}

--- a/apps/dashboard/src/lib/hooks/use-app-domains.ts
+++ b/apps/dashboard/src/lib/hooks/use-app-domains.ts
@@ -1,0 +1,28 @@
+import { addDomain, removeDomain } from '@repo/app-operations';
+import { type UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '#lib/api.ts';
+
+export type AddedDomain = Awaited<ReturnType<typeof addDomain>>;
+
+/**
+ * Both invalidate the app rather than writing the new hostname into the cache: a domain arrives
+ * `pending` and turns active on a clock neither this page nor the api controls, so the list is
+ * refetched rather than reasoned about.
+ */
+export function useAddDomain(appId: string): UseMutationResult<AddedDomain, Error, string> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (hostname: string) => addDomain({ api, appId, hostname }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['apps'] }),
+  });
+}
+
+export function useRemoveDomain(appId: string): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (hostname: string) => removeDomain({ api, appId, hostname }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['apps'] }),
+  });
+}

--- a/apps/dashboard/src/lib/hooks/use-app-tab.ts
+++ b/apps/dashboard/src/lib/hooks/use-app-tab.ts
@@ -1,8 +1,9 @@
 import { useRouterState } from '@tanstack/react-router';
+import { Route as DomainsRoute } from '#routes/(dashboard)/apps/$appId/domains.tsx';
 import { Route as FilesRoute } from '#routes/(dashboard)/apps/$appId/files.tsx';
 import { Route as LogsRoute } from '#routes/(dashboard)/apps/$appId/logs.tsx';
 
-export type AppTab = 'overview' | 'logs' | 'files';
+export type AppTab = 'overview' | 'logs' | 'files' | 'domains';
 
 export function useAppTab(): AppTab {
   const routeId = useRouterState({ select: (state) => state.matches.at(-1)?.routeId });
@@ -12,6 +13,9 @@ export function useAppTab(): AppTab {
   }
   if (routeId === FilesRoute.id) {
     return 'files';
+  }
+  if (routeId === DomainsRoute.id) {
+    return 'domains';
   }
   return 'overview';
 }

--- a/apps/dashboard/src/lib/hooks/use-platform-suffix.ts
+++ b/apps/dashboard/src/lib/hooks/use-platform-suffix.ts
@@ -1,0 +1,16 @@
+import { useApp } from '#lib/hooks/use-app.ts';
+import { useAppId } from '#lib/hooks/use-app-id.ts';
+
+/**
+ * What a brought domain is pointed at: the domain the app's own hostname sits under, which
+ * already resolves to the fleet.
+ *
+ * Read off the app rather than configured here, so the dashboard holds no copy of a domain the
+ * deployment owns and a deployment served under a different one needs no build of its own.
+ */
+export function usePlatformSuffix(): string {
+  const app = useApp(useAppId());
+  const platform = app.data?.hostnames.find((each) => each.kind === 'platform');
+
+  return platform?.hostname.split('.').slice(1).join('.') ?? '';
+}

--- a/apps/dashboard/src/routeTree.gen.ts
+++ b/apps/dashboard/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as dashboardIndexRouteImport } from './routes/(dashboard)/index'
 import { Route as dashboardAppsIndexRouteImport } from './routes/(dashboard)/apps/index'
 import { Route as dashboardAppsAppIdRouteRouteImport } from './routes/(dashboard)/apps/$appId/route'
 import { Route as dashboardAppsAppIdIndexRouteImport } from './routes/(dashboard)/apps/$appId/index'
+import { Route as dashboardAppsAppIdDomainsRouteImport } from './routes/(dashboard)/apps/$appId/domains'
 import { Route as dashboardAppsAppIdFilesRouteImport } from './routes/(dashboard)/apps/$appId/files'
 import { Route as dashboardAppsAppIdLogsRouteImport } from './routes/(dashboard)/apps/$appId/logs'
 
@@ -64,6 +65,12 @@ const dashboardAppsAppIdIndexRoute = dashboardAppsAppIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => dashboardAppsAppIdRouteRoute,
 } as any)
+const dashboardAppsAppIdDomainsRoute =
+  dashboardAppsAppIdDomainsRouteImport.update({
+    id: '/domains',
+    path: '/domains',
+    getParentRoute: () => dashboardAppsAppIdRouteRoute,
+  } as any)
 const dashboardAppsAppIdFilesRoute = dashboardAppsAppIdFilesRouteImport.update({
   id: '/files',
   path: '/files',
@@ -82,6 +89,7 @@ export interface FileRoutesByFullPath {
   '/': typeof dashboardIndexRoute
   '/apps/$appId': typeof dashboardAppsAppIdRouteRouteWithChildren
   '/apps/': typeof dashboardAppsIndexRoute
+  '/apps/$appId/domains': typeof dashboardAppsAppIdDomainsRoute
   '/apps/$appId/files': typeof dashboardAppsAppIdFilesRoute
   '/apps/$appId/logs': typeof dashboardAppsAppIdLogsRoute
   '/apps/$appId/': typeof dashboardAppsAppIdIndexRoute
@@ -92,6 +100,7 @@ export interface FileRoutesByTo {
   '/login': typeof authLoginRoute
   '/': typeof dashboardIndexRoute
   '/apps': typeof dashboardAppsIndexRoute
+  '/apps/$appId/domains': typeof dashboardAppsAppIdDomainsRoute
   '/apps/$appId/files': typeof dashboardAppsAppIdFilesRoute
   '/apps/$appId/logs': typeof dashboardAppsAppIdLogsRoute
   '/apps/$appId': typeof dashboardAppsAppIdIndexRoute
@@ -106,6 +115,7 @@ export interface FileRoutesById {
   '/(dashboard)/': typeof dashboardIndexRoute
   '/(dashboard)/apps/$appId': typeof dashboardAppsAppIdRouteRouteWithChildren
   '/(dashboard)/apps/': typeof dashboardAppsIndexRoute
+  '/(dashboard)/apps/$appId/domains': typeof dashboardAppsAppIdDomainsRoute
   '/(dashboard)/apps/$appId/files': typeof dashboardAppsAppIdFilesRoute
   '/(dashboard)/apps/$appId/logs': typeof dashboardAppsAppIdLogsRoute
   '/(dashboard)/apps/$appId/': typeof dashboardAppsAppIdIndexRoute
@@ -119,6 +129,7 @@ export interface FileRouteTypes {
     | '/'
     | '/apps/$appId'
     | '/apps/'
+    | '/apps/$appId/domains'
     | '/apps/$appId/files'
     | '/apps/$appId/logs'
     | '/apps/$appId/'
@@ -129,6 +140,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/'
     | '/apps'
+    | '/apps/$appId/domains'
     | '/apps/$appId/files'
     | '/apps/$appId/logs'
     | '/apps/$appId'
@@ -142,6 +154,7 @@ export interface FileRouteTypes {
     | '/(dashboard)/'
     | '/(dashboard)/apps/$appId'
     | '/(dashboard)/apps/'
+    | '/(dashboard)/apps/$appId/domains'
     | '/(dashboard)/apps/$appId/files'
     | '/(dashboard)/apps/$appId/logs'
     | '/(dashboard)/apps/$appId/'
@@ -218,6 +231,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dashboardAppsAppIdIndexRouteImport
       parentRoute: typeof dashboardAppsAppIdRouteRoute
     }
+    '/(dashboard)/apps/$appId/domains': {
+      id: '/(dashboard)/apps/$appId/domains'
+      path: '/domains'
+      fullPath: '/apps/$appId/domains'
+      preLoaderRoute: typeof dashboardAppsAppIdDomainsRouteImport
+      parentRoute: typeof dashboardAppsAppIdRouteRoute
+    }
     '/(dashboard)/apps/$appId/files': {
       id: '/(dashboard)/apps/$appId/files'
       path: '/files'
@@ -250,6 +270,7 @@ const authRouteRouteWithChildren = authRouteRoute._addFileChildren(
 )
 
 interface dashboardAppsAppIdRouteRouteChildren {
+  dashboardAppsAppIdDomainsRoute: typeof dashboardAppsAppIdDomainsRoute
   dashboardAppsAppIdFilesRoute: typeof dashboardAppsAppIdFilesRoute
   dashboardAppsAppIdLogsRoute: typeof dashboardAppsAppIdLogsRoute
   dashboardAppsAppIdIndexRoute: typeof dashboardAppsAppIdIndexRoute
@@ -257,6 +278,7 @@ interface dashboardAppsAppIdRouteRouteChildren {
 
 const dashboardAppsAppIdRouteRouteChildren: dashboardAppsAppIdRouteRouteChildren =
   {
+    dashboardAppsAppIdDomainsRoute: dashboardAppsAppIdDomainsRoute,
     dashboardAppsAppIdFilesRoute: dashboardAppsAppIdFilesRoute,
     dashboardAppsAppIdLogsRoute: dashboardAppsAppIdLogsRoute,
     dashboardAppsAppIdIndexRoute: dashboardAppsAppIdIndexRoute,

--- a/apps/dashboard/src/routes/(dashboard)/apps/$appId/domains.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/apps/$appId/domains.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { DomainsCard } from '#components/apps/domains-card.tsx';
+
+export const Route = createFileRoute('/(dashboard)/apps/$appId/domains')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <DomainsCard />;
+}

--- a/packages/app-operations/src/domains.ts
+++ b/packages/app-operations/src/domains.ts
@@ -1,0 +1,35 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
+import { HostnameSchema, Value } from '@repo/protocol';
+
+export type AddDomainInput = { api: PublicApiClient; appId: string; hostname: string };
+export type RemoveDomainInput = AddDomainInput;
+
+/**
+ * Register a domain the owner brought.
+ *
+ * What comes back is not a working domain — nothing here can point their DNS at us — but the two
+ * records that make it one. Nothing proves ownership beforehand: placing those records is the
+ * proof, because a certificate cannot be issued for a name that has not.
+ *
+ * Parsed here rather than passed through, so a typed domain is refused by the caller that took it
+ * rather than by a round trip that comes back a validation error.
+ */
+export async function addDomain({ api, appId, hostname }: AddDomainInput) {
+  return unwrap(
+    await api.api.apps({ appId }).hostnames.post({
+      hostname: Value.Parse(HostnameSchema, hostname),
+    }),
+  );
+}
+
+export async function removeDomain({ api, appId, hostname }: RemoveDomainInput): Promise<void> {
+  unwrap(
+    await api.api.apps({ appId }).hostnames.delete(
+      {},
+      {
+        query: { hostname: Value.Parse(HostnameSchema, hostname) },
+      },
+    ),
+  );
+}

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -11,6 +11,7 @@ export {
   type UploadableBinary,
   type UploadWait,
 } from '#deploy.ts';
+export { type AddDomainInput, addDomain, type RemoveDomainInput, removeDomain } from '#domains.ts';
 export { parseEnvironment } from '#environment.ts';
 export { InvalidEnvironmentError, InvalidPathError } from '#errors.ts';
 export { awaitExportBundle, type ExportBundle, requestExport } from '#exports.ts';

--- a/packages/cli/src/command-tree.gen.ts
+++ b/packages/cli/src/command-tree.gen.ts
@@ -3,6 +3,9 @@
 import type { InferForwardedOptions, InferParams, RuntimeNode } from '@parshjs/core';
 import type { command as appsCmd } from './commands/apps.ts';
 import type { command as appsDeleteCmd } from './commands/apps/delete.ts';
+import type { command as appsDomainsAddHostnameCmd } from './commands/apps/domains/add/[hostname].ts';
+import type { command as appsDomainsCmd } from './commands/apps/domains.ts';
+import type { command as appsDomainsRemoveHostnameCmd } from './commands/apps/domains/remove/[hostname].ts';
 import type { command as appsExportDestinationCmd } from './commands/apps/export/[destination].ts';
 import type { command as appsFilesLsCmd } from './commands/apps/files/ls.ts';
 import type { command as appsFilesLsPathCmd } from './commands/apps/files/ls/[path].ts';
@@ -20,6 +23,26 @@ declare module '@parshjs/core' {
     'apps delete': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+      };
+      rootOptions: {};
+    };
+    'apps domains': {
+      parents: {
+        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+      };
+      rootOptions: {};
+    };
+    'apps domains add [hostname]': {
+      parents: {
+        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+        'apps domains': { options: InferForwardedOptions<typeof appsDomainsCmd.options>; params: InferParams<typeof appsDomainsCmd.params> };
+      };
+      rootOptions: {};
+    };
+    'apps domains remove [hostname]': {
+      parents: {
+        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+        'apps domains': { options: InferForwardedOptions<typeof appsDomainsCmd.options>; params: InferParams<typeof appsDomainsCmd.params> };
       };
       rootOptions: {};
     };
@@ -77,6 +100,35 @@ export const commandTree: RuntimeNode = {
           segment: { kind: 'literal', value: 'delete' },
           command: { path: 'apps delete', load: () => import('./commands/apps/delete.ts').then((m) => m.command) },
           literalChildren: {},
+          paramChild: null,
+        },
+        'domains': {
+          segment: { kind: 'literal', value: 'domains' },
+          command: { path: 'apps domains', load: () => import('./commands/apps/domains.ts').then((m) => m.command) },
+          literalChildren: {
+            'add': {
+              segment: { kind: 'literal', value: 'add' },
+              command: null,
+              literalChildren: {},
+              paramChild: {
+                segment: { kind: 'param', name: 'hostname' },
+                command: { path: 'apps domains add [hostname]', load: () => import('./commands/apps/domains/add/[hostname].ts').then((m) => m.command) },
+                literalChildren: {},
+                paramChild: null,
+              },
+            },
+            'remove': {
+              segment: { kind: 'literal', value: 'remove' },
+              command: null,
+              literalChildren: {},
+              paramChild: {
+                segment: { kind: 'param', name: 'hostname' },
+                command: { path: 'apps domains remove [hostname]', load: () => import('./commands/apps/domains/remove/[hostname].ts').then((m) => m.command) },
+                literalChildren: {},
+                paramChild: null,
+              },
+            },
+          },
           paramChild: null,
         },
         'export': {

--- a/packages/cli/src/commands/apps/domains.ts
+++ b/packages/cli/src/commands/apps/domains.ts
@@ -1,0 +1,22 @@
+import { defineCommand } from '@parshjs/core';
+import { selectApp } from '#lib/apps.ts';
+import { requireSignedIn } from '#lib/credentials.ts';
+import { listDomains } from '#lib/domains.ts';
+import { isInteractive } from '#lib/ui.ts';
+
+export const command = defineCommand('apps domains', {
+  description:
+    "List the hostnames an app answers on: the one nibrun issued it, and any domain you brought. A brought domain is 'pending' until your DNS points at us.",
+  options: {},
+  beforeHandler: ({ context }) => requireSignedIn(context),
+  handler: async ({ parents, context, print }) => {
+    const { api } = context;
+    const slug = await selectApp({
+      api,
+      slug: parents.apps.options.app,
+      interactive: isInteractive(),
+    });
+
+    await listDomains({ api, slug, print });
+  },
+});

--- a/packages/cli/src/commands/apps/domains/add/[hostname].ts
+++ b/packages/cli/src/commands/apps/domains/add/[hostname].ts
@@ -1,0 +1,28 @@
+import { defineCommand } from '@parshjs/core';
+import { z } from 'zod';
+import { selectApp } from '#lib/apps.ts';
+import { requireSignedIn } from '#lib/credentials.ts';
+import { addAppDomain } from '#lib/domains.ts';
+import { createUi, isInteractive } from '#lib/ui.ts';
+
+export const command = defineCommand('apps domains add [hostname]', {
+  description:
+    'Point a domain you own at this app. Prints the two DNS records to add; the app answers on it once they resolve.',
+  options: {},
+  params: {
+    hostname: {
+      schema: z.string().min(1),
+    },
+  },
+  beforeHandler: ({ context }) => requireSignedIn(context),
+  handler: async ({ params, parents, context, print }) => {
+    const { api } = context;
+    const interactive = isInteractive();
+    const ui = createUi({ print, interactive });
+
+    ui.open('nib apps domains add');
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
+
+    await addAppDomain({ api, slug, hostname: params.hostname, ui });
+  },
+});

--- a/packages/cli/src/commands/apps/domains/remove/[hostname].ts
+++ b/packages/cli/src/commands/apps/domains/remove/[hostname].ts
@@ -1,0 +1,29 @@
+import { defineCommand } from '@parshjs/core';
+import { z } from 'zod';
+import { selectApp } from '#lib/apps.ts';
+import { requireSignedIn } from '#lib/credentials.ts';
+import { removeAppDomain } from '#lib/domains.ts';
+import { createUi, isInteractive } from '#lib/ui.ts';
+
+// Unasked, unlike `apps delete`: the app keeps running on every other hostname, and re-adding
+// this one costs the same two records it cost the first time.
+export const command = defineCommand('apps domains remove [hostname]', {
+  description: 'Stop serving this app on a domain you brought. The app keeps its other hostnames.',
+  options: {},
+  params: {
+    hostname: {
+      schema: z.string().min(1),
+    },
+  },
+  beforeHandler: ({ context }) => requireSignedIn(context),
+  handler: async ({ params, parents, context, print }) => {
+    const { api } = context;
+    const interactive = isInteractive();
+    const ui = createUi({ print, interactive });
+
+    ui.open('nib apps domains remove');
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
+
+    await removeAppDomain({ api, slug, hostname: params.hostname, ui });
+  },
+});

--- a/packages/cli/src/lib/domains.ts
+++ b/packages/cli/src/lib/domains.ts
@@ -1,0 +1,127 @@
+import type { Print } from '@parshjs/core';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { addDomain, appBySlug, removeDomain } from '@repo/app-operations';
+import type { Ui } from '#lib/ui.ts';
+
+const COLUMN_GAP = '  ';
+
+const HEADINGS = { hostname: 'HOSTNAME', kind: 'KIND', state: 'STATE' };
+
+type DomainRow = { hostname: string; kind: string; state: string };
+
+/** Print every hostname the app answers on, or is waiting to. */
+export async function listDomains({
+  api,
+  slug,
+  print,
+}: {
+  api: PublicApiClient;
+  slug: string;
+  print: Print;
+}): Promise<void> {
+  const app = await appBySlug({ api, slug });
+  for (const line of render(app.hostnames)) {
+    print.info(line);
+  }
+
+  // Under the table rather than in it: a pending domain is waiting on the reader's own DNS, and
+  // a column wide enough to say which records would not be a column.
+  for (const pending of app.hostnames.filter((each) => each.state === 'pending')) {
+    print.dim('');
+    print.dim(`${pending.hostname} is waiting on:`);
+    for (const record of pendingRecords({
+      hostname: pending.hostname,
+      dcvTarget: pending.dcvTarget,
+      app,
+    })) {
+      print.dim(`  ${record}`);
+    }
+  }
+}
+
+export async function addAppDomain({
+  api,
+  slug,
+  hostname,
+  ui,
+}: {
+  api: PublicApiClient;
+  slug: string;
+  hostname: string;
+  ui: Ui;
+}): Promise<void> {
+  const app = await appBySlug({ api, slug });
+  const added = await addDomain({ api, appId: app.id, hostname });
+
+  for (const record of pendingRecords({
+    hostname: added.hostname,
+    dcvTarget: added.dcvTarget,
+    app,
+  })) {
+    ui.step(record);
+  }
+  ui.done(`${added.hostname} answers once those resolve. Nothing here has to be run again.`);
+}
+
+/**
+ * The two records, in the order they matter: the first is what routes the domain and what proves
+ * the owner controls it, the second is what lets the edge renew the certificate afterwards
+ * without ever coming back to them.
+ */
+function pendingRecords({
+  hostname,
+  dcvTarget,
+  app,
+}: {
+  hostname: string;
+  dcvTarget: string | null;
+  app: { slug: string; hostnames: readonly { hostname: string; kind: string }[] };
+}): string[] {
+  const records = [`${hostname}  CNAME  ${app.slug}.${platformSuffix(app.hostnames)}`];
+  if (dcvTarget) {
+    records.push(`_acme-challenge.${hostname}  CNAME  ${dcvTarget}`);
+  }
+  return records;
+}
+
+/**
+ * The domain goes without being confirmed. Unlike deleting an app there is nothing underneath it
+ * to lose — the app keeps running on every other hostname — and re-adding it costs the same two
+ * records it cost the first time.
+ */
+export async function removeAppDomain({
+  api,
+  slug,
+  hostname,
+  ui,
+}: {
+  api: PublicApiClient;
+  slug: string;
+  hostname: string;
+  ui: Ui;
+}): Promise<void> {
+  const app = await appBySlug({ api, slug });
+  await removeDomain({ api, appId: app.id, hostname });
+
+  ui.done(`${hostname} no longer points at ${app.slug}.`);
+}
+
+/**
+ * What a brought domain is pointed at: the app's own platform hostname, which resolves to the
+ * fleet already. Read off the app rather than configured here, so the CLI holds no copy of a
+ * domain the deployment owns.
+ */
+function platformSuffix(hostnames: readonly { hostname: string; kind: string }[]): string {
+  const platform = hostnames.find((each) => each.kind === 'platform');
+  return platform?.hostname.split('.').slice(1).join('.') ?? '';
+}
+
+export function render(hostnames: readonly DomainRow[]): string[] {
+  const rows = [HEADINGS, ...hostnames];
+  const hostnameWidth = Math.max(...rows.map((row) => row.hostname.length));
+  const kindWidth = Math.max(...rows.map((row) => row.kind.length));
+
+  return rows.map((row) =>
+    [row.hostname.padEnd(hostnameWidth), row.kind.padEnd(kindWidth), row.state].join(COLUMN_GAP),
+  );
+}


### PR DESCRIPTION
Both surfaces show the two CNAMEs and what the hostname is waiting on, because
the work left after adding one belongs to whoever runs the owner's DNS — often
not the person who added it.

The platform hostname has no remove: it is how an app is addressed once every
brought domain has gone.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>