### PR TITLE
feat(www): a way to the dashboard for people who already have apps

### DIFF
--- a/apps/www/src/components/dashboard-link.tsx
+++ b/apps/www/src/components/dashboard-link.tsx
@@ -1,0 +1,12 @@
+import { Button } from '@repo/ui/components/button';
+import { APP_ORIGIN } from '#lib/app-origin.ts';
+
+// Same tab, no target: the drop below navigates this window to the app, and a header that
+// opened a second one would leave the two halves of the same journey behaving differently.
+export function DashboardLink() {
+  return (
+    <Button variant="ghost" size="sm" render={<a href={APP_ORIGIN} />}>
+      Sign in
+    </Button>
+  );
+}

--- a/apps/www/src/lib/app-origin.ts
+++ b/apps/www/src/lib/app-origin.ts
@@ -1,0 +1,3 @@
+// The landing page both links to the dashboard and posts a binary into a frame the dashboard
+// serves, so where it lives is named once here rather than once per use.
+export const APP_ORIGIN = import.meta.env.DEV ? 'http://localhost:3001' : 'https://app.nibrun.com';

--- a/apps/www/src/lib/handoff.ts
+++ b/apps/www/src/lib/handoff.ts
@@ -4,12 +4,7 @@ import {
   isHandoffReady,
   isHandoffStored,
 } from '@repo/binary-handoff';
-
-// The app is a different origin, so its storage is only reachable from a document it serves
-// itself. A hidden frame is that document: the binary is posted into it and written on the
-// far side, which is why dropping here is something the app can still find after the
-// navigation below.
-const APP_ORIGIN = import.meta.env.DEV ? 'http://localhost:3001' : 'https://app.nibrun.com';
+import { APP_ORIGIN } from '#lib/app-origin.ts';
 
 // A frame that never answers would otherwise leave the page spinning for good.
 const REPLY_TIMEOUT_MS = 15_000;
@@ -18,6 +13,9 @@ export function appDestination(): string {
   return `${APP_ORIGIN}${HANDOFF_FRAME_PATH}`;
 }
 
+// The app is a different origin, so its storage is only reachable from a document it serves
+// itself. A hidden frame is that document: the binary is posted into it and written on the far
+// side, which is why dropping here is something the app can still find after the navigation.
 export function handOffBinary(binary: File): Promise<void> {
   const { promise, resolve, reject } = Promise.withResolvers<void>();
 

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { BrandMark } from '@repo/ui/custom/brand-mark';
 import { createFileRoute } from '@tanstack/react-router';
 import { BinaryDrop } from '#components/binary-drop.tsx';
+import { DashboardLink } from '#components/dashboard-link.tsx';
 import { Hero } from '#components/hero.tsx';
 import { PageBackdrop } from '#components/page-backdrop.tsx';
 import { TerminalHint } from '#components/terminal-hint.tsx';
@@ -13,8 +14,11 @@ function RouteComponent() {
     <>
       <PageBackdrop />
       <main className="mx-auto flex w-full max-w-5xl flex-col items-center px-6">
+        <header className="flex w-full justify-end py-5">
+          <DashboardLink />
+        </header>
         {/* Short of the viewport on purpose: the section below has to peek, or nobody scrolls. */}
-        <section className="flex min-h-[85svh] w-full max-w-xl flex-col items-center justify-center gap-12 py-16">
+        <section className="flex min-h-[78svh] w-full max-w-xl flex-col items-center justify-center gap-12 pb-16">
           <div className="flex flex-col items-center gap-6">
             <BrandMark />
             <Hero />


### PR DESCRIPTION
The landing page had no path to app.nibrun.com except dropping a binary, so anyone who already has apps had nowhere to click.

Same tab, no `target`: the drop already navigates this window to the app, and a header that opened a second one would leave the two halves of the same journey behaving differently. `APP_ORIGIN` moves out of `handoff.ts` so the link and the frame cannot disagree about where the app is.