### PR TITLE
feat(dashboard): the tab carries the mark and the product's name

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>dashboard</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+    <title>nibrun</title>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/dashboard/public/favicon.svg
+++ b/apps/dashboard/public/favicon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <title>nibrun</title>
+  <defs>
+    <linearGradient id="mark" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#16a34a" />
+      <stop offset="100%" stop-color="#83fd9e" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#mark)" />
+  <g
+    transform="translate(256, 256) scale(23.75) translate(-8, -8)"
+    fill="none"
+    stroke="#0a0a0a"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="1.5"
+  >
+    <rect width="3" height="4.5" x="3.25" y="1.75" />
+    <path d="m9.75 6.25h3m-3-4.5h1.5v4" />
+    <rect width="3" height="4.5" x="9.75" y="9.75" />
+    <path d="m3.25 14.25h3m-3-4.5h1.5v4" />
+  </g>
+</svg>


### PR DESCRIPTION
The dashboard had no favicon at all — no `public/` directory — and its tab read `dashboard`.

The mark itself was already in the UI: `BrandMark` renders in the site header, the auth layout and the handoff page. This is only the browser-chrome half.

`favicon.svg` is a copy of the one in `apps/'www'/public`, since Vite serves each app's `public/` on its own. That is now a third rendering of the same artwork alongside `NibrunMark` — worth collapsing if it ever drifts.