### PR TITLE
feat(cli): one binary per platform a release ships to

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -76,3 +76,6 @@ the layout under `src/commands/` is the command tree.
 - Run it with `bun run --filter @repo/cli nib …`. A package script runs from the
   package directory, so relative paths resolve against `packages/cli` rather than
   the caller's shell — pass absolute ones until the CLI ships as a real `bin`.
+- `bun run build` compiles one binary per released platform into `dist/`, named
+  `nib-<os>-<arch>`. That name is what a release asset is downloaded as, so
+  renaming it breaks whatever already points at the old one.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,7 @@
     "#*": "./src/*"
   },
   "scripts": {
+    "build": "bun run scripts/build.ts",
     "nib": "bun run src/main.ts",
     "test": "bun test",
     "generate": "parsh-codegen generate --commands src/commands --out src/command-tree.gen.ts",

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -1,0 +1,46 @@
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { PROGRAM_NAME } from '#config.ts';
+
+const CLI_DIR = join(import.meta.dir, '..');
+const DIST_DIR = join(CLI_DIR, 'dist');
+const BUN_VERSION_FILE = join(CLI_DIR, '../../.bun-version');
+const ENTRYPOINT = 'src/main.ts';
+
+// Every platform a release carries an asset for. An owner downloads one of these by name, so a
+// suffix here is the asset's identity rather than an implementation detail of the compile target.
+const RELEASE_PLATFORMS = ['darwin-arm64', 'linux-x64', 'linux-arm64'] as const;
+
+const FAILURE_EXIT_CODE = 1;
+
+// The target pins the released Bun `.bun-version` names rather than resolving to whichever one
+// runs the build. Left unversioned, Bun embeds its own version and downloads it for every platform
+// that is not the host — and CI upgrades to a canary after installing, which publishes no such
+// download, so two of these three would fail there. The versioned form is undocumented, and the
+// type does not describe it.
+const bunVersion = (await Bun.file(BUN_VERSION_FILE).text()).trim();
+
+console.log('🧹 Cleaning dist dir...');
+await rm(DIST_DIR, { recursive: true, force: true });
+
+for (const platform of RELEASE_PLATFORMS) {
+  const binaryName = `${PROGRAM_NAME}-${platform}`;
+
+  console.log(`🔨 Compiling ${binaryName}...`);
+  const buildResult = await Bun.build({
+    entrypoints: [ENTRYPOINT],
+    compile: {
+      outfile: join(DIST_DIR, binaryName),
+      target: `bun-v${bunVersion}-${platform}` as unknown as Bun.Build.CompileTarget,
+    },
+    minify: { whitespace: true, syntax: true },
+    target: 'bun',
+  });
+
+  if (!buildResult.success) {
+    console.error(`❌ Build failed for ${platform}:`, JSON.stringify(buildResult, null, 2));
+    process.exit(FAILURE_EXIT_CODE);
+  }
+}
+
+console.log('✅ Done');

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["src"],
-  "exclude": ["node_modules"]
+  "include": ["src", "scripts"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
`bun run build` compiles `nib` for darwin-arm64 and for linux on both x64 and
arm64, so a release has an asset to carry for each.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>