### PR TITLE
ci(cli): a release train of its own, cut from cli-v tags

### DIFF
--- a/.github/workflows/prepare-cli-release.yml
+++ b/.github/workflows/prepare-cli-release.yml
@@ -1,0 +1,59 @@
+name: prepare-cli-release
+
+on: workflow_dispatch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-cli-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          # git-cliff reads the version off the tags and the changelog off the commits between
+          # them, so a shallow clone would compute both from nothing.
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare
+
+      - name: Prepare the release
+        id: release
+        run: bun run --filter @repo/internal-scripts prepare-cli-release
+
+      - name: Configure git user
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Commit and push to the release branch
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_BRANCH: release/${{ steps.release.outputs.tag }}
+        run: |
+          git switch -c "$RELEASE_BRANCH"
+          git add packages/cli/package.json packages/cli/CHANGELOG.md
+          git commit -m "chore(release): ${TAG}"
+          git push --set-upstream origin "$RELEASE_BRANCH"
+
+      - name: Create the release PR
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat > "${RUNNER_TEMP}/pr-body.md" <<EOF
+          Bumps \`@repo/cli\` to **${VERSION}** and regenerates its changelog.
+
+          Merging this releases nothing. Tagging the commit it lands as is what does:
+
+          \`\`\`sh
+          git switch main && git pull
+          git tag ${TAG}
+          git push origin ${TAG}
+          \`\`\`
+          EOF
+          gh pr create --title "chore(release): ${TAG}" --body-file "${RUNNER_TEMP}/pr-body.md"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,48 @@
+name: release-cli
+
+on:
+  push:
+    tags:
+      # Its own prefix, so a train cut for anything else in this monorepo never lands here.
+      - "cli-v*"
+
+permissions:
+  contents: write # create the GitHub Release
+  id-token: write # OIDC token for the build provenance attestation
+  attestations: write # write the attestation
+
+jobs:
+  release-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The release notes are the commits since the previous tag, which a shallow clone has
+          # neither of.
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare
+
+      # Every asset cross-compiles from here, so one runner cuts the whole release.
+      - name: Build the binaries
+        run: bun run --filter @repo/cli build
+
+      - name: Attest build provenance
+        id: attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: packages/cli/dist/nib-*
+
+      - name: Create the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+          RELEASE_NOTES_FILE: ${{ runner.temp }}/cli-release-notes.md
+          ATTESTATION_URL: ${{ steps.attest.outputs.attestation-url }}
+        run: |
+          bun run --filter @repo/internal-scripts cli-release-notes
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --notes-file "$RELEASE_NOTES_FILE" \
+            packages/cli/dist/nib-*

--- a/bun.lock
+++ b/bun.lock
@@ -164,6 +164,7 @@
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
+        "git-cliff": "^2.13.1",
         "typescript": "catalog:",
       },
     },
@@ -1249,6 +1250,20 @@
 
     "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
+    "git-cliff": ["git-cliff@2.13.1", "", { "dependencies": { "execa": "^9.6.0" }, "optionalDependencies": { "git-cliff-darwin-arm64": "2.13.1", "git-cliff-darwin-x64": "2.13.1", "git-cliff-linux-arm64": "2.13.1", "git-cliff-linux-x64": "2.13.1", "git-cliff-windows-arm64": "2.13.1", "git-cliff-windows-x64": "2.13.1" }, "bin": "lib/cli/cli.js" }, "sha512-2BzXwrom+SMHeNA5Ut+MtzqXejg0wbVwmzj3k7e9w62UQoyCDrM9UIcvtl6hnT3jocEQ1zLRQBaXXx97Gmnk7A=="],
+
+    "git-cliff-darwin-arm64": ["git-cliff-darwin-arm64@2.13.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3ebPUnUlLmrSZDHknSZQmyZV7DEJVtKse8I25Am0cENET5Py9u9Hg9k8IRXdiDtHtPDs6MYZx7BOi11WtcfqSg=="],
+
+    "git-cliff-darwin-x64": ["git-cliff-darwin-x64@2.13.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-KZfggGAiw1EvZH3BOUclEU4eGCP2+Z+lH/N2Ni3FH9L2M1U7FYJqqaMhqgO8azTj67betvDshH8WBUkIkSsVxA=="],
+
+    "git-cliff-linux-arm64": ["git-cliff-linux-arm64@2.13.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-clNRcNzdvk4GKyTt3ZhhWqcrjVRghcUcGNSV/Y87YJf3Mc/zl9ajUAhnXPOBSX/KWBr2od5SmkCt0qGYagY07g=="],
+
+    "git-cliff-linux-x64": ["git-cliff-linux-x64@2.13.1", "", { "os": "linux", "cpu": "x64" }, "sha512-gZcIQhIQ1lDUMD8UieUSEZAYoyZN7nPd8O3VQoj1Ddhqll4UAS1Zxms1SU3U8pb0UTdc2m3ia/wtOnyhvbjdjQ=="],
+
+    "git-cliff-windows-arm64": ["git-cliff-windows-arm64@2.13.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-+XubuQv68DuDwF0u6Af5d889MEf/RD48VBQS7ZmPi4sUSCXAZqRm1/ApCsStLqxMDCf1+7s05B/kNbm9wjV80A=="],
+
+    "git-cliff-windows-x64": ["git-cliff-windows-x64@2.13.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Bi8ehp1VMkomY7M/356PgovKQ8CBRiuOOkq+aWC2evQuMFfXWjG0GBlPED9QkZoUJ4iQ5ygB5DYdK3BjhaOyPw=="],
+
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "global-directory": ["global-directory@5.0.0", "", { "dependencies": { "ini": "6.0.0" } }, "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w=="],
@@ -1553,9 +1568,9 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
-    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+    "seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
 
-    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
+    "seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -1773,10 +1788,6 @@
 
     "@tanstack/router-core/@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
 
-    "@tanstack/router-core/seroval": ["seroval@1.6.0", "", {}, "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug=="],
-
-    "@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.6.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ=="],
-
     "@tanstack/start-client-core/@tanstack/router-core": ["@tanstack/router-core@1.171.24", "", { "dependencies": { "@tanstack/history": "1.162.1", "cookie-es": "^3.0.0", "seroval": "^1.6.2", "seroval-plugins": "^1.6.2" } }, "sha512-+j+8NmV4QOS+ILNLdXFlLTdKPPbBQIy6mXDZ0QWEKYZ0xQOdlnOCXVHPflyGanD2SWSxjqGkw8CsW0CXXP7fLg=="],
 
     "@tanstack/start-client-core/seroval": ["seroval@1.6.2", "", {}, "sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ=="],
@@ -1846,6 +1857,10 @@
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "solid-js/seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "solid-js/seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -79,3 +79,8 @@ the layout under `src/commands/` is the command tree.
 - `bun run build` compiles one binary per released platform into `dist/`, named
   `nib-<os>-<arch>`. That name is what a release asset is downloaded as, so
   renaming it breaks whatever already points at the old one.
+- **Releasing is its own train, tagged `cli-v*`.** The `prepare-cli-release`
+  workflow opens a PR bumping `version` and regenerating `CHANGELOG.md`; pushing
+  the tag that PR names is what builds the binaries and cuts the release.
+  `cliff.toml` scopes both to commits touching this package, which is why the
+  release commit has to touch it — a tag outside that filter is not a release.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+All notable changes to `nib` are documented in this file.
+

--- a/packages/cli/cliff.toml
+++ b/packages/cli/cliff.toml
@@ -1,0 +1,74 @@
+# git-cliff configuration ~ https://git-cliff.org/docs/configuration
+#
+# The CLI's own release train. It lives here rather than at the repo root because the tag pattern,
+# the first version and the changelog heading are all about `nib` alone — a second train gets a
+# second file beside its own package, not another branch in this one.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to `nib` are documented in this file.
+
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="cli-v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+render_always = true
+postprocessors = []
+
+[bump]
+features_always_bump_minor = true
+breaking_always_bump_major = true
+# What the first release is called. Without it git-cliff proposes a bare `0.1.0` and then rejects
+# it against `tag_pattern`, because a bumped version only carries a prefix it read off an existing
+# tag and there is none to read yet.
+initial_tag = "cli-v0.1.0"
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+require_conventional = false
+split_commits = false
+commit_preprocessors = []
+protect_breaking_commits = false
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^build", group = "<!-- 7 -->📦 Build & Dependencies" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 8 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 9 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 10 -->◀️ Revert" },
+    { message = ".*", group = "<!-- 11 -->💼 Other" },
+]
+filter_commits = false
+fail_on_unmatched_commit = false
+link_parsers = []
+use_branch_tags = false
+topo_order = false
+topo_order_commits = true
+sort_commits = "newest"
+recurse_submodules = false
+# Only this train's tags rank as releases, so a tag cut for anything else neither ends a section
+# nor lends its version to the next bump.
+tag_pattern = "cli-v[0-9]*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@repo/cli",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "imports": {

--- a/packages/internal-scripts/package.json
+++ b/packages/internal-scripts/package.json
@@ -7,6 +7,8 @@
   },
   "scripts": {
     "build-and-push-image": "bun run src/build-and-push-image.ts",
+    "cli-release-notes": "bun run src/cli-release-notes.ts",
+    "prepare-cli-release": "bun run src/prepare-cli-release.ts",
     "publish-agent-binary": "bun run src/publish-agent-binary.ts",
     "publish-app-host-bundle": "bun run src/publish-app-host-bundle.ts",
     "publish-guest-image": "bun run src/publish-guest-image.ts",
@@ -21,6 +23,7 @@
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
+    "git-cliff": "^2.13.1",
     "typescript": "catalog:"
   },
   "dependencies": {

--- a/packages/internal-scripts/src/cli-release-notes.ts
+++ b/packages/internal-scripts/src/cli-release-notes.ts
@@ -1,0 +1,75 @@
+import * as core from '@actions/core';
+import { runGitCliff } from 'git-cliff';
+import { CLI_TAG_PREFIX, cliCliffOptions, readCliVersion } from '#shared/cli-release.ts';
+import { optionalEnv } from '#shared/env.ts';
+import { repoRoot } from '#shared/paths.ts';
+
+await assertTagMatchesVersion();
+
+const { stdout } = await runGitCliff(
+  { ...cliCliffOptions, latest: true, strip: 'header' },
+  { cwd: repoRoot, stdio: ['ignore', 'pipe', 'inherit'] },
+);
+
+const notes = `${String(stdout).trimEnd()}\n${installSection()}${attestationFooter()}`;
+
+// Written where the workflow points rather than printed, because `bun run --filter` labels every
+// line of stdout with the package it came from. Without the variable this is a local preview.
+const outFile = optionalEnv('RELEASE_NOTES_FILE');
+if (outFile) {
+  await Bun.write(outFile, notes);
+} else {
+  console.log(notes);
+}
+
+/**
+ * A tag is pushed by hand, so it can name a version the package was never bumped to. Nothing
+ * downstream would notice — the assets would ship under a number that matches no source — and this
+ * is the last step before the release exists, so it is where the two are made to agree.
+ */
+async function assertTagMatchesVersion() {
+  const tag = optionalEnv('GITHUB_REF_NAME');
+  if (!tag) {
+    return;
+  }
+
+  const expected = `${CLI_TAG_PREFIX}${await readCliVersion()}`;
+  if (tag !== expected) {
+    core.setFailed(
+      `Tag ${tag} does not match the CLI version on this commit (expected ${expected}).`,
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * macOS quarantines anything a browser downloaded, and these binaries are cross-compiled on Linux,
+ * so none of them carries a signature Gatekeeper accepts. Saying so here is cheaper than an owner
+ * meeting "cannot be opened" with nothing to go on.
+ */
+function installSection() {
+  return `
+## Install
+
+Download the asset for your platform, then:
+
+\`\`\`sh
+chmod +x nib-<platform>
+xattr -d com.apple.quarantine nib-<platform>  # macOS only
+mv nib-<platform> /usr/local/bin/nib
+\`\`\`
+`;
+}
+
+function attestationFooter() {
+  const attestationUrl = optionalEnv('ATTESTATION_URL');
+  if (!attestationUrl) {
+    return '';
+  }
+
+  return `
+---
+
+🔒 Every asset here was built and signed on GitHub Actions. Verify the build provenance [here](${attestationUrl}).
+`;
+}

--- a/packages/internal-scripts/src/prepare-cli-release.ts
+++ b/packages/internal-scripts/src/prepare-cli-release.ts
@@ -1,0 +1,47 @@
+import * as core from '@actions/core';
+import { runGitCliff } from 'git-cliff';
+import {
+  CLI_TAG_PREFIX,
+  cliChangelog,
+  cliCliffOptions,
+  cliPackageJson,
+  readCliVersion,
+} from '#shared/cli-release.ts';
+import { repoRoot } from '#shared/paths.ts';
+
+const currentVersion = await readCliVersion();
+const nextTag = await bumpedTag();
+const nextVersion = nextTag.slice(CLI_TAG_PREFIX.length);
+
+// git-cliff answers with the last tag rather than an error when nothing it counts has landed, so
+// this is what tells a release cut too early from one with something in it.
+if (nextVersion === currentVersion) {
+  core.setFailed(
+    `Nothing to release: no commit under the CLI since ${CLI_TAG_PREFIX}${currentVersion}.`,
+  );
+  process.exit(1);
+}
+
+await writeCliVersion(nextVersion);
+
+// Regenerated in full from history and tags on every release rather than prepended to, so the file
+// is a function of the repo and a re-cut cannot leave a half-written section behind.
+await runGitCliff({ ...cliCliffOptions, tag: nextTag, output: cliChangelog }, { cwd: repoRoot });
+
+core.setOutput('version', nextVersion);
+core.setOutput('tag', nextTag);
+core.info(`${currentVersion} → ${nextVersion}`);
+
+async function bumpedTag() {
+  const { stdout } = await runGitCliff(
+    { ...cliCliffOptions, bumpedVersion: true },
+    { cwd: repoRoot, stdio: ['ignore', 'pipe', 'inherit'] },
+  );
+  return String(stdout).trim();
+}
+
+async function writeCliVersion(version: string) {
+  const pkg = await Bun.file(cliPackageJson).json();
+  pkg.version = version;
+  await Bun.write(cliPackageJson, `${JSON.stringify(pkg, null, 2)}\n`);
+}

--- a/packages/internal-scripts/src/shared/cli-release.ts
+++ b/packages/internal-scripts/src/shared/cli-release.ts
@@ -1,0 +1,32 @@
+import { join } from 'node:path';
+import type { Options } from 'git-cliff';
+import { repoRoot } from '#shared/paths.ts';
+
+const CLI_PACKAGE_PATH = 'packages/cli';
+
+export const CLI_TAG_PREFIX = 'cli-v';
+
+export const cliPackageJson = join(repoRoot, CLI_PACKAGE_PATH, 'package.json');
+export const cliChangelog = join(repoRoot, CLI_PACKAGE_PATH, 'CHANGELOG.md');
+
+/**
+ * What every git-cliff invocation for this train shares.
+ *
+ * `includePath` is what keeps the CLI's history its own: most of this monorepo is not `nib`, so
+ * without it every dashboard and infra commit would land in the changelog and move the version.
+ * The cost is that a release commit has to touch `packages/cli/` for its tag to survive the
+ * filter — bumping the version there is what guarantees it does.
+ *
+ * `satisfies` rather than a bare object, because git-cliff takes an all-optional bag: a misspelled
+ * key is not a type error at any call site, it is an option silently dropped — and dropping this
+ * one releases the whole monorepo under the CLI's name.
+ */
+export const cliCliffOptions = {
+  config: join(repoRoot, CLI_PACKAGE_PATH, 'cliff.toml'),
+  includePath: `${CLI_PACKAGE_PATH}/**`,
+} satisfies Options;
+
+export async function readCliVersion(): Promise<string> {
+  const { version } = (await Bun.file(cliPackageJson).json()) as { version: string };
+  return version;
+}


### PR DESCRIPTION
`prepare-cli-release` opens a PR with the bumped version and the regenerated
changelog; pushing the `cli-v*` tag it names builds the binaries, attests them
and cuts the GitHub release. git-cliff is scoped to commits touching the CLI, so
neither the version nor the notes move for anything else in the monorepo.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>