### PR TITLE
ci: main gets built and checked too, not just the way in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,10 @@
 name: checks
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   types:


### PR DESCRIPTION
`build` and `checks` only ran on pull requests, so nothing verified main itself once a merge landed. They now run on pushes to main as well.