### PR TITLE
ci(cli): a release is also the packages the binary bundles

### DIFF
--- a/packages/internal-scripts/src/cli-release-notes.ts
+++ b/packages/internal-scripts/src/cli-release-notes.ts
@@ -1,17 +1,12 @@
 import * as core from '@actions/core';
-import { runGitCliff } from 'git-cliff';
-import { CLI_TAG_PREFIX, cliCliffOptions, readCliVersion } from '#shared/cli-release.ts';
+import { CLI_TAG_PREFIX, cliVersion, readCliCliff } from '#shared/cli-release.ts';
 import { optionalEnv } from '#shared/env.ts';
-import { repoRoot } from '#shared/paths.ts';
 
-await assertTagMatchesVersion();
+assertTagMatchesVersion();
 
-const { stdout } = await runGitCliff(
-  { ...cliCliffOptions, latest: true, strip: 'header' },
-  { cwd: repoRoot, stdio: ['ignore', 'pipe', 'inherit'] },
-);
+const changes = await readCliCliff({ latest: true, strip: 'header' });
 
-const notes = `${String(stdout).trimEnd()}\n${installSection()}${attestationFooter()}`;
+const notes = `${changes.trimEnd()}\n${installSection()}${attestationFooter()}`;
 
 // Written where the workflow points rather than printed, because `bun run --filter` labels every
 // line of stdout with the package it came from. Without the variable this is a local preview.
@@ -27,13 +22,13 @@ if (outFile) {
  * downstream would notice — the assets would ship under a number that matches no source — and this
  * is the last step before the release exists, so it is where the two are made to agree.
  */
-async function assertTagMatchesVersion() {
+function assertTagMatchesVersion() {
   const tag = optionalEnv('GITHUB_REF_NAME');
   if (!tag) {
     return;
   }
 
-  const expected = `${CLI_TAG_PREFIX}${await readCliVersion()}`;
+  const expected = `${CLI_TAG_PREFIX}${cliVersion}`;
   if (tag !== expected) {
     core.setFailed(
       `Tag ${tag} does not match the CLI version on this commit (expected ${expected}).`,

--- a/packages/internal-scripts/src/prepare-cli-release.ts
+++ b/packages/internal-scripts/src/prepare-cli-release.ts
@@ -1,23 +1,21 @@
 import * as core from '@actions/core';
-import { runGitCliff } from 'git-cliff';
 import {
   CLI_TAG_PREFIX,
   cliChangelog,
-  cliCliffOptions,
-  cliPackageJson,
-  readCliVersion,
+  cliVersion,
+  readCliCliff,
+  runCliCliff,
+  writeCliVersion,
 } from '#shared/cli-release.ts';
-import { repoRoot } from '#shared/paths.ts';
 
-const currentVersion = await readCliVersion();
-const nextTag = await bumpedTag();
+const nextTag = (await readCliCliff({ bumpedVersion: true })).trim();
 const nextVersion = nextTag.slice(CLI_TAG_PREFIX.length);
 
 // git-cliff answers with the last tag rather than an error when nothing it counts has landed, so
 // this is what tells a release cut too early from one with something in it.
-if (nextVersion === currentVersion) {
+if (nextVersion === cliVersion) {
   core.setFailed(
-    `Nothing to release: no commit under the CLI since ${CLI_TAG_PREFIX}${currentVersion}.`,
+    `Nothing to release: no commit under the CLI since ${CLI_TAG_PREFIX}${cliVersion}.`,
   );
   process.exit(1);
 }
@@ -26,22 +24,8 @@ await writeCliVersion(nextVersion);
 
 // Regenerated in full from history and tags on every release rather than prepended to, so the file
 // is a function of the repo and a re-cut cannot leave a half-written section behind.
-await runGitCliff({ ...cliCliffOptions, tag: nextTag, output: cliChangelog }, { cwd: repoRoot });
+await runCliCliff({ tag: nextTag, output: cliChangelog });
 
 core.setOutput('version', nextVersion);
 core.setOutput('tag', nextTag);
-core.info(`${currentVersion} → ${nextVersion}`);
-
-async function bumpedTag() {
-  const { stdout } = await runGitCliff(
-    { ...cliCliffOptions, bumpedVersion: true },
-    { cwd: repoRoot, stdio: ['ignore', 'pipe', 'inherit'] },
-  );
-  return String(stdout).trim();
-}
-
-async function writeCliVersion(version: string) {
-  const pkg = await Bun.file(cliPackageJson).json();
-  pkg.version = version;
-  await Bun.write(cliPackageJson, `${JSON.stringify(pkg, null, 2)}\n`);
-}
+core.info(`${cliVersion} → ${nextVersion}`);

--- a/packages/internal-scripts/src/shared/cli-release.ts
+++ b/packages/internal-scripts/src/shared/cli-release.ts
@@ -1,32 +1,70 @@
 import { join } from 'node:path';
-import type { Options } from 'git-cliff';
+import { type Options, runGitCliff } from 'git-cliff';
+import { packageJson, WORKSPACE_DEPENDENCY, workspacePackageDirs } from '#shared/package-json.ts';
 import { repoRoot } from '#shared/paths.ts';
 
 const CLI_PACKAGE_PATH = 'packages/cli';
 
 export const CLI_TAG_PREFIX = 'cli-v';
 
-export const cliPackageJson = join(repoRoot, CLI_PACKAGE_PATH, 'package.json');
 export const cliChangelog = join(repoRoot, CLI_PACKAGE_PATH, 'CHANGELOG.md');
+export const cliVersion = packageJson.cli.version;
+
+const cliPackageJsonPath = join(repoRoot, CLI_PACKAGE_PATH, 'package.json');
+const cliffConfig = join(repoRoot, CLI_PACKAGE_PATH, 'cliff.toml');
+
+/** Everything a caller may ask for. The scope is not theirs to set — it is what makes it a release. */
+type CliCliffOptions = Omit<Options, 'config' | 'includePath'>;
+
+export async function runCliCliff(options: CliCliffOptions) {
+  await runGitCliff(await scoped(options), { cwd: repoRoot });
+}
+
+export async function readCliCliff(options: CliCliffOptions): Promise<string> {
+  const { stdout } = await runGitCliff(await scoped(options), {
+    cwd: repoRoot,
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  return String(stdout);
+}
+
+export async function writeCliVersion(version: string) {
+  const updated = { ...packageJson.cli, version };
+  await Bun.write(cliPackageJsonPath, `${JSON.stringify(updated, null, 2)}\n`);
+}
+
+async function scoped(options: CliCliffOptions): Promise<Options> {
+  return {
+    ...options,
+    config: cliffConfig,
+    // git-cliff repeats `--include-path` once per entry of an array, which is the only spelling
+    // that takes more than one path — a brace glob is left unexpanded and silently matches nothing.
+    // The published type describes only the single-path form.
+    includePath: (await cliReleasePaths()) as unknown as string,
+  };
+}
 
 /**
- * What every git-cliff invocation for this train shares.
+ * Which commits a release of the CLI is about: the ones touching the CLI, and the ones touching a
+ * workspace package it bundles. Read off its dependencies rather than listed, because a package
+ * left out of this is not an error anywhere — it is a change that ships inside the binary with no
+ * changelog entry and no version bump, which is the one failure this scoping exists to avoid.
  *
- * `includePath` is what keeps the CLI's history its own: most of this monorepo is not `nib`, so
- * without it every dashboard and infra commit would land in the changelog and move the version.
- * The cost is that a release commit has to touch `packages/cli/` for its tag to survive the
- * filter — bumping the version there is what guarantees it does.
- *
- * `satisfies` rather than a bare object, because git-cliff takes an all-optional bag: a misspelled
- * key is not a type error at any call site, it is an option silently dropped — and dropping this
- * one releases the whole monorepo under the CLI's name.
+ * A path is a proxy for a subject, so the noise is accepted in the other direction: a commit that
+ * touched one of these while meaning to change something else is still counted.
  */
-export const cliCliffOptions = {
-  config: join(repoRoot, CLI_PACKAGE_PATH, 'cliff.toml'),
-  includePath: `${CLI_PACKAGE_PATH}/**`,
-} satisfies Options;
+async function cliReleasePaths(): Promise<string[]> {
+  const workspaceDirs = await workspacePackageDirs();
 
-export async function readCliVersion(): Promise<string> {
-  const { version } = (await Bun.file(cliPackageJson).json()) as { version: string };
-  return version;
+  const bundled = Object.entries(packageJson.cli.dependencies)
+    .filter(([, specifier]) => specifier === WORKSPACE_DEPENDENCY)
+    .map(([name]) => {
+      const dir = workspaceDirs.get(name);
+      if (!dir) {
+        throw new Error(`${name} is a dependency of the CLI but not a workspace package.`);
+      }
+      return dir;
+    });
+
+  return [CLI_PACKAGE_PATH, ...bundled].map((dir) => `${dir}/**`);
 }

--- a/packages/internal-scripts/src/shared/package-json.ts
+++ b/packages/internal-scripts/src/shared/package-json.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from 'node:path';
+import { repoRoot } from '#shared/paths.ts';
+import rootPackageJson from '../../../../package.json' with { type: 'json' };
+import cliPackageJson from '../../../cli/package.json' with { type: 'json' };
+
+/**
+ * The package.json files scripts read, imported rather than opened so each is handed the real
+ * shape of its file instead of `any`. One a script comes to need is one more entry here, not
+ * another relative path spelled at the point of use.
+ */
+export const packageJson = {
+  root: rootPackageJson,
+  cli: cliPackageJson,
+};
+
+export const WORKSPACE_DEPENDENCY = 'workspace:*';
+
+/**
+ * Every workspace package by name, mapped to its directory relative to the repo root. Built from
+ * the packages the root declares rather than assuming a directory is named after what is inside
+ * it — the two agree today, and nothing would say so if they stopped.
+ */
+export async function workspacePackageDirs(): Promise<Map<string, string>> {
+  const dirs = new Map<string, string>();
+
+  for (const pattern of packageJson.root.workspaces.packages) {
+    for await (const path of new Bun.Glob(`${pattern}/package.json`).scan({ cwd: repoRoot })) {
+      const { name }: { name: string } = await Bun.file(join(repoRoot, path)).json();
+      dirs.set(name, dirname(path));
+    }
+  }
+  return dirs;
+}


### PR DESCRIPTION
The CLI's release train was scoped to `packages/cli/**`, which is a proxy for "CLI commits" that misses the packages the binary bundles — a `@repo/protocol` or `@repo/api-client` fix shipped with no changelog entry and no version bump.

The scope is now read off the CLI's own workspace dependencies, so adding one later cannot silently reopen the gap. Some noise comes in the other direction, which is the accepted trade.