### PR TITLE
feat(cli): nib says which version of itself it is

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,7 +1,10 @@
 import type { CommandOption } from '@parshjs/core';
 import { z } from 'zod';
+import packageJson from '../package.json' with { type: 'json' };
 
 export const PROGRAM_NAME = 'nib';
+
+export const PROGRAM_VERSION = packageJson.version;
 
 export const DEFAULT_API_URL = 'https://app.nibrun.com';
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env bun
 import { createCli } from '@parshjs/core';
 import { commandTree } from '#command-tree.gen.ts';
-import { PROGRAM_NAME } from '#config.ts';
+import { PROGRAM_NAME, PROGRAM_VERSION } from '#config.ts';
 import { createCliContext } from '#context.ts';
 import { CancelledError } from '#lib/errors.ts';
 
 const cli = createCli({
   programName: PROGRAM_NAME,
   programDescription: 'Run a binary on nibrun.',
+  version: PROGRAM_VERSION,
   tree: commandTree,
   context: createCliContext,
   errors: { CANCELLED: CancelledError },


### PR DESCRIPTION
`bun run build` defines `VERSION` from `packages/cli/package.json`, and parsh prints it for `--version`/`-V`. A run from source answers `dev`, since no build replaced the identifier.

Pairs with the release train: the version a release tags is the version its binaries report.