### PR TITLE
feat(cli): an installer that puts nib on a machine

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,56 @@
+name: install-smoke
+
+on:
+  pull_request:
+    paths:
+      - packages/cli/install.sh
+      - .github/workflows/install-smoke.yml
+  push:
+    branches: [main]
+    paths:
+      - packages/cli/install.sh
+      - .github/workflows/install-smoke.yml
+  workflow_dispatch:
+  workflow_run:
+    workflows: [release-cli]
+    types: [completed]
+
+jobs:
+  install:
+    name: install (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: darwin-arm64
+            runner: macos-latest
+          - platform: linux-x64
+            runner: ubuntu-latest
+          - platform: linux-arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install nib
+        # `pipefail` is off by default, and without it the status read is tee's rather than sh's.
+        run: |
+          set -eo pipefail
+          cat packages/cli/install.sh | sh 2>&1 | tee install.log
+
+      - name: It fetched the asset for this machine
+        run: grep -q "(${{ matrix.platform }})" install.log
+
+      - name: Put the default install dir on PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: nib runs and says which version it is
+        run: |
+          nib --version
+          nib --help > /dev/null
+
+      - name: Installing again leaves it alone
+        run: |
+          set -eo pipefail
+          cat packages/cli/install.sh | sh 2>&1 | tee second-run.log
+          grep -q "already installed" second-run.log

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+# Installs `nib`, the nibrun CLI. Served from https://nibrun.com/install.sh, so the usual
+#
+#   curl -fsSL https://nibrun.com/install.sh | sh
+#
+# reaches it. POSIX sh rather than the bash the repo's own build scripts use: this one runs on
+# whatever machine an owner happens to have, and `sh` is the shell that is always there.
+#
+# Nothing here is nibrun-aware. It resolves a platform to one of the assets `release-cli.yml`
+# publishes, fetches it, and asks the result which version it is. Running it again is how an
+# owner upgrades, so it is written to be run any number of times.
+set -eu
+
+REPO="ilbertt/nibrun"
+# The CLI is tagged apart from anything else this repo may come to release, so the newest release
+# is not necessarily the newest *CLI* release.
+TAG_PREFIX="cli-v"
+DEFAULT_INSTALL_DIR="$HOME/.local/bin"
+
+main() {
+  target=$(resolve_target)
+
+  # The one thing worth asking without installing: it is what the tests assert on.
+  if [ "${1:-}" = "--print-target" ]; then
+    echo "$target"
+    return 0
+  fi
+
+  version=${NIB_VERSION:-$(latest_version)}
+  install_dir=${NIB_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}
+  binary="$install_dir/nib"
+  installed=$(installed_version "$binary")
+  # The tag carries the prefix and `nib --version` does not, so one is stripped to the other
+  # before they are compared — the whole point of this check is that they can be equal.
+  wanted=${version#"$TAG_PREFIX"}
+
+  if [ "$installed" = "$wanted" ]; then
+    say "nib $wanted is already installed at $binary"
+    report_path "$install_dir"
+    return 0
+  fi
+
+  mkdir -p "$install_dir"
+  # Staged inside the install dir rather than in /tmp, so the move below is a rename on one
+  # filesystem — a half-written download is never something called nib, and replacing a binary
+  # that is currently running is a rename rather than a write.
+  staged=$(mktemp "$install_dir/.nib.XXXXXX")
+  trap 'rm -f "$staged"' EXIT
+
+  url="https://github.com/$REPO/releases/download/$version/nib-$target"
+  say "Downloading nib $version ($target)"
+  curl --fail --silent --show-error --location "$url" --output "$staged" ||
+    die "Could not download $url"
+
+  # Explicit rather than +x: mktemp creates it 600, so +x would leave a binary nobody but its
+  # owner can read — surprising in a shared install dir.
+  chmod 755 "$staged"
+  mv "$staged" "$binary"
+
+  if [ -n "$installed" ]; then
+    say "Updated nib $installed -> $(nib_version "$binary")"
+  else
+    say "Installed nib $(nib_version "$binary") to $binary"
+  fi
+  report_path "$install_dir"
+}
+
+# One of the assets a release carries. Anything else is a platform the CLI is not built for, and
+# saying so is better than a download that 404s.
+resolve_target() {
+  os=$(uname -s)
+  arch=$(uname -m)
+
+  case "$os" in
+    Darwin) os=darwin ;;
+    Linux) os=linux ;;
+    *) die "Unsupported operating system: $os" ;;
+  esac
+
+  case "$arch" in
+    arm64 | aarch64) arch=arm64 ;;
+    x86_64 | amd64) arch=x64 ;;
+    *) die "Unsupported architecture: $arch" ;;
+  esac
+
+  case "$os-$arch" in
+    darwin-arm64 | linux-x64 | linux-arm64) echo "$os-$arch" ;;
+    *) die "There is no nib build for $os-$arch" ;;
+  esac
+}
+
+latest_version() {
+  found=$(newest_from_feed)
+  if [ -z "$found" ]; then
+    found=$(newest_from_api)
+  fi
+
+  [ -n "$found" ] ||
+    die "No ${TAG_PREFIX}* release found — GitHub may be unreachable or rate-limiting this address. Set NIB_VERSION to install a specific one."
+  echo "$found"
+}
+
+# github.com rather than api.github.com, because the API allows sixty unauthenticated requests an
+# hour per address — and an address shared by an office or a CI runner can have spent them before
+# an owner runs this at all.
+newest_from_feed() {
+  body=$(curl --fail --silent --location "https://github.com/$REPO/releases.atom") || return 0
+  printf "%s\n" "$body" | grep -o "releases/tag/${TAG_PREFIX}[^\"]*" | head -n 1 | sed "s|.*/||"
+}
+
+# The feed carries only the ten newest releases of anything, so this is what still answers once the
+# repo's other release trains have pushed the CLI's off the end of it.
+newest_from_api() {
+  body=$(curl --fail --silent --location "https://api.github.com/repos/$REPO/releases?per_page=100") ||
+    return 0
+  printf "%s\n" "$body" |
+    grep -o "\"tag_name\": *\"${TAG_PREFIX}[^\"]*\"" |
+    head -n 1 |
+    sed "s/.*\"\(${TAG_PREFIX}[^\"]*\)\"/\1/"
+}
+
+# Empty when nothing is installed there yet, which is what tells an install from an upgrade.
+installed_version() {
+  if [ -x "$1" ]; then
+    nib_version "$1"
+  fi
+}
+
+nib_version() {
+  "$1" --version 2>/dev/null || echo unknown
+}
+
+report_path() {
+  case ":$PATH:" in
+    *":$1:"*)
+      # On PATH is not the same as reached: an older nib earlier in it still wins.
+      reached=$(command -v nib || true)
+      if [ -n "$reached" ] && [ "$reached" != "$1/nib" ]; then
+        say "Note: $reached comes first on your PATH and will be used instead."
+      fi
+      ;;
+    *)
+      say "Note: $1 is not on your PATH. Add it with:"
+      say "  export PATH=\"$1:\$PATH\""
+      ;;
+  esac
+}
+
+say() { echo "$*" >&2; }
+die() { echo "install.sh: $*" >&2; exit 1; }
+
+main "$@"

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -1,15 +1,12 @@
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { PROGRAM_NAME } from '#config.ts';
+import { RELEASE_PLATFORMS } from './release-platforms.ts';
 
 const CLI_DIR = join(import.meta.dir, '..');
 const DIST_DIR = join(CLI_DIR, 'dist');
 const BUN_VERSION_FILE = join(CLI_DIR, '../../.bun-version');
 const ENTRYPOINT = 'src/main.ts';
-
-// Every platform a release carries an asset for. An owner downloads one of these by name, so a
-// suffix here is the asset's identity rather than an implementation detail of the compile target.
-const RELEASE_PLATFORMS = ['darwin-arm64', 'linux-x64', 'linux-arm64'] as const;
 
 const FAILURE_EXIT_CODE = 1;
 

--- a/packages/cli/scripts/release-platforms.ts
+++ b/packages/cli/scripts/release-platforms.ts
@@ -1,0 +1,8 @@
+/**
+ * Every platform a release carries an asset for. Shared rather than spelled twice: the build emits
+ * one binary per entry and `install.sh` resolves a machine to one of them, so a platform added to
+ * one side and not the other is either an asset nobody can install or an install that 404s.
+ */
+export const RELEASE_PLATFORMS = ['darwin-arm64', 'linux-x64', 'linux-arm64'] as const;
+
+export type ReleasePlatform = (typeof RELEASE_PLATFORMS)[number];

--- a/packages/cli/tests/install.test.ts
+++ b/packages/cli/tests/install.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { chmod, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RELEASE_PLATFORMS } from '../scripts/release-platforms.ts';
+
+const INSTALL_SH = join(import.meta.dir, '..', 'install.sh');
+
+const EXECUTABLE = 0o755;
+
+// What `uname` answers on machines the CLI is built for. The values are the real ones rather than
+// tidy names, because it is exactly their untidiness the script has to absorb.
+const MACHINES = [
+  { uname: { os: 'Darwin', arch: 'arm64' }, platform: 'darwin-arm64' },
+  { uname: { os: 'Linux', arch: 'x86_64' }, platform: 'linux-x64' },
+  { uname: { os: 'Linux', arch: 'amd64' }, platform: 'linux-x64' },
+  { uname: { os: 'Linux', arch: 'aarch64' }, platform: 'linux-arm64' },
+  { uname: { os: 'Linux', arch: 'arm64' }, platform: 'linux-arm64' },
+];
+
+const UNSUPPORTED = [
+  { uname: { os: 'Darwin', arch: 'x86_64' }, because: 'no darwin-x64 asset is published' },
+  { uname: { os: 'Linux', arch: 'riscv64' }, because: 'the architecture is not one we build' },
+  { uname: { os: 'FreeBSD', arch: 'x86_64' }, because: 'the operating system is not one we build' },
+  { uname: { os: 'MINGW64_NT-10.0', arch: 'x86_64' }, because: 'Windows is not one we build' },
+];
+
+const stubDirs: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(stubDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('a machine is resolved to the asset built for it', () => {
+  for (const { uname, platform } of MACHINES) {
+    test(`${uname.os}/${uname.arch} is ${platform}`, async () => {
+      const resolved = await resolveTarget(uname);
+      expect(resolved.exitCode).toBe(0);
+      expect(resolved.stdout).toBe(platform);
+    });
+  }
+
+  // The two lists are the same fact, so this is what fails when only one of them is added to.
+  test('every platform a release carries is reachable from some machine', () => {
+    expect(new Set(MACHINES.map(({ platform }) => platform))).toEqual(new Set(RELEASE_PLATFORMS));
+  });
+});
+
+describe('a machine with no asset is told so rather than sent to a 404', () => {
+  for (const { uname, because } of UNSUPPORTED) {
+    test(`${uname.os}/${uname.arch}: ${because}`, async () => {
+      const resolved = await resolveTarget(uname);
+      expect(resolved.exitCode).not.toBe(0);
+      expect(resolved.stdout).toBe('');
+      expect(resolved.stderr).toContain('install.sh:');
+    });
+  }
+});
+
+/**
+ * Runs the real script against a `uname` that answers for the machine being described. Stubbing the
+ * command rather than the script is what keeps this a test of the thing an owner actually runs.
+ */
+async function resolveTarget({ os, arch }: { os: string; arch: string }) {
+  const dir = await mkdtemp(join(tmpdir(), 'nib-uname-'));
+  stubDirs.push(dir);
+
+  const stub = join(dir, 'uname');
+  await Bun.write(stub, `#!/bin/sh\ncase "$1" in\n-s) echo ${os} ;;\n-m) echo ${arch} ;;\nesac\n`);
+  await chmod(stub, EXECUTABLE);
+
+  const proc = Bun.spawn(['sh', INSTALL_SH, '--print-target'], {
+    env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["src", "scripts"],
+  "include": ["src", "scripts", "tests"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
`install.sh` resolves a machine to one of the assets a release publishes, fetches
it, and asks the result which version it is. Running it again is how an owner
upgrades — it leaves an install alone when there is nothing newer.

The platform list is shared with the build, so an asset nobody can install and an
install that 404s are both a failing test.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>