### PR TITLE
feat(www): the install command, where someone looking for it would look

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,17 @@
 git clone https://github.com/ilbertt/nibrun.git
 cd nibrun
 bun install
+bun run build
 ```
+
+## Tooling
+
+- [Bun](https://bun.sh) — runtime, package manager, bundler
+- [Docker](https://docs.docker.com/get-started/get-docker/) — runs the stack
+- [Turborepo](https://turborepo.dev/) — task orchestration with caching
+- [Biome](https://biomejs.dev/) — linter and formatter
+- [commitlint](https://commitlint.js.org/) — conventional commit enforcement
+- [TypeScript](https://www.typescriptlang.org/) — shared config via `@repo/typescript-config`
 
 ## Commit messages
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
-# nibrun
+<div align="center">
+  <img src="apps/www/public/favicon.svg" alt="nibrun logo" width="128" />
+  <h1>nibrun</h1>
+  <p><em>Drop a binary. Get a server.</em></p>
+</div>
 
-A monorepo powered by [Bun](https://bun.sh) and [Turborepo](https://turborepo.dev/).
+Each binary gets a microVM of its own, a persistent filesystem, and an HTTPS URL. No Dockerfile,
+no YAML, no cluster.
 
-## Requirements
+## Get started
 
-- [Bun](https://bun.sh)
-- [Docker](https://docs.docker.com/get-started/get-docker/) — to run the stack
+Create an HTTP app (use the [bun-full-stack-starter](https://github.com/ilbertt/bun-full-stack-starter)
+template) and compile it to a single binary. Then deploy it:
 
-## Getting started
+### Use the dashboard
+
+Drag the binary onto [app.nibrun.com](https://app.nibrun.com).
+
+### Use the CLI
 
 ```sh
-bun install
-bun run build
+curl -fsSL https://nibrun.com/install.sh | sh
 ```
 
-## Tooling
-
-- [Bun](https://bun.sh) — runtime, package manager, bundler
-- [Turborepo](https://turborepo.dev/) — task orchestration with caching
-- [Biome](https://biomejs.dev/) — linter and formatter
-- [commitlint](https://commitlint.js.org/) — conventional commit enforcement
-- [TypeScript](https://www.typescriptlang.org/) — shared config via `@repo/typescript-config`
+```sh
+nib run ./my-server
+```

--- a/apps/www/public/install.sh
+++ b/apps/www/public/install.sh
@@ -1,0 +1,1 @@
+../../../packages/cli/install.sh

--- a/apps/www/src/components/terminal-hint.tsx
+++ b/apps/www/src/components/terminal-hint.tsx
@@ -1,9 +1,13 @@
+import { SITE_URL } from '#lib/site-url.ts';
+
+const INSTALL_COMMAND = `curl -fsSL ${SITE_URL}/install.sh | sh`;
+
 export function TerminalHint() {
   return (
-    <p className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1.5 text-muted-foreground text-sm">
+    <p className="flex max-w-full flex-wrap items-center justify-center gap-x-2 gap-y-1.5 text-muted-foreground text-sm">
       <span>Rather stay in the terminal?</span>
-      <code className="whitespace-nowrap rounded-md border bg-muted px-1.5 py-0.5 font-mono text-foreground text-xs">
-        nib run ./server
+      <code className="max-w-full rounded-md border bg-muted px-1.5 py-0.5 font-mono text-foreground text-xs">
+        {INSTALL_COMMAND}
       </code>
     </p>
   );

--- a/apps/www/src/lib/site-url.ts
+++ b/apps/www/src/lib/site-url.ts
@@ -1,0 +1,1 @@
+export const SITE_URL = 'https://nibrun.com';

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -1,9 +1,9 @@
 import appCss from '@repo/ui/globals.css?url';
 import { createRootRoute, HeadContent, Scripts } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
+import { SITE_URL } from '#lib/site-url.ts';
 import { themeScript } from '#lib/theme-script.ts';
 
-const SITE_URL = 'https://nibrun.com';
 const TITLE = 'nibrun — drop your binary, get a server';
 const DESCRIPTION =
   'Drop a compiled binary and get a server: a microVM of its own, a persistent filesystem, and an HTTPS URL. No Dockerfile, no YAML, no cluster.';


### PR DESCRIPTION
The landing page prints the command under the question it answers, and
`/install.sh` is the CLI's own script — symlinked into the site's public dir
rather than copied, so the page can only ever serve the one that is tested.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>