### PR TITLE
fix(agent): an instance nobody has started yet is pending, not failed

### DIFF
--- a/apps/agent/src/lib/health/state.ts
+++ b/apps/agent/src/lib/health/state.ts
@@ -126,7 +126,11 @@ export function evaluateInstanceState({
     if (stopRequested || !desiredRunning) {
       return 'stopped';
     }
-    return unit.loaded || startedAtMs !== undefined ? 'failed' : 'pending';
+    // Being loaded is not having been started: systemd keeps a template instance loaded after
+    // it stops, so the unit a replace has just torn down is still loaded while the next one is
+    // being staged. Only a start this agent saw through records a time, which is what separates
+    // a boot still in flight from one that died.
+    return startedAtMs !== undefined ? 'failed' : 'pending';
   }
   if (stopRequested) {
     return 'stopping';

--- a/apps/agent/tests/lib/health/state.test.ts
+++ b/apps/agent/tests/lib/health/state.test.ts
@@ -244,6 +244,19 @@ describe('what the VM itself is doing', () => {
     ).toBe('stopping');
   });
 
+  test('a start still being staged is pending, though the replaced unit is still loaded', () => {
+    expect(
+      evaluateInstanceState({
+        unit: exited,
+        tracker: initialTracker(),
+        healthCheck: check(),
+        desiredRunning: true,
+        stopRequested: false,
+        nowMs: STARTED_AT_MS,
+      }),
+    ).toBe('pending');
+  });
+
   test('an instance that was never started is pending', () => {
     expect(
       evaluateInstanceState({


### PR DESCRIPTION
A healthy microVM was stopped 185 ms after it was observed serving. `evaluateInstanceState` treated `unit.loaded` as evidence that a start had been attempted, but systemd keeps a template instance loaded after it stops — so during a replace the torn-down unit is still loaded while the next one is being staged, and a status tick landing in that window reports `failed` for a VM nobody has asked systemd to start.

That verdict is terminal: the api marks the deployment failed, `applyReport` then refuses every later update, and `desired_deployments` drops the app — so the reconciler stops the instance as `not-desired`.

Observed on a real deploy, with a 1.7 s gap between the record being written and `systemctl start`:

```
07:55:10.495  instance state changed  pending -> failed
07:55:10.531  instance started
07:55:11.526  (guest) listening on http://0.0.0.0:3000
07:55:11.784  instance state changed  starting -> running
07:55:11.969  instance stopped  reason: not-desired
```

`startedAt` is set only on a boot this agent saw through and is persisted across restarts, so it already covers every case `unit.loaded` was standing in for. The new test fails on the old expression and passes on this one.