### PR TITLE
fix(agent): a failed instance says what failed about it

### DIFF
--- a/apps/agent/src/lib/health/state.ts
+++ b/apps/agent/src/lib/health/state.ts
@@ -1,4 +1,4 @@
-import type { HealthCheck, InstanceState, Timestamp } from '@repo/protocol';
+import type { GuestPort, HealthCheck, InstanceState, Timestamp } from '@repo/protocol';
 import type { UnitStatus } from '#lib/vm/unit-status.ts';
 
 const NO_PROBES = 0;
@@ -91,6 +91,32 @@ export function nextProbeDelayMs(inputs: ProbeInputs): number {
   return isOnStartupGrid(inputs)
     ? Math.min(STARTUP_PROBE_INTERVAL_MS, inputs.healthCheck.intervalMs)
     : inputs.healthCheck.intervalMs;
+}
+
+/**
+ * Why a `failed` verdict was reached, for the owner who only ever sees the verdict.
+ *
+ * There are two ways to reach it and one fact tells them apart: an instance either stopped when
+ * nothing had asked it to, or was still up and never answered. Reading that off the unit is what
+ * keeps this from being a second copy of the branches below, drifting out of step with them.
+ */
+export function describeInstanceFailure({
+  unit,
+  tracker,
+  healthCheck,
+  guestPort,
+}: {
+  unit: UnitStatus;
+  tracker: HealthTracker;
+  healthCheck: HealthCheck;
+  guestPort: GuestPort;
+}): string {
+  if (!unit.active) {
+    return unit.exitCode === undefined
+      ? 'the microVM stopped without being asked to'
+      : `the microVM stopped without being asked to, exit code ${unit.exitCode}`;
+  }
+  return `nothing answered on port ${guestPort} inside the guest: ${tracker.consecutiveFailures} health probes failed after the ${healthCheck.gracePeriodMs}ms grace period`;
 }
 
 export type LifecycleInputs = {

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -221,7 +221,7 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
 });
 
 /** Only a failure has anything to say: every other state is its own account of itself. */
-const verdict = ({
+function verdict({
   state,
   status,
   health,
@@ -231,8 +231,8 @@ const verdict = ({
   status: UnitStatus;
   health: HealthTracker;
   record: InstanceRecord;
-}) =>
-  state === 'failed'
+}): string | undefined {
+  return state === 'failed'
     ? describeInstanceFailure({
         unit: status,
         tracker: health,
@@ -240,6 +240,7 @@ const verdict = ({
         guestPort: record.guestPort,
       })
     : undefined;
+}
 
 const probed = ({ record, nowMs }: { record: InstanceRecord; nowMs: number }) =>
   Effect.gen(function* () {

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -68,7 +68,7 @@ export const stopInstance = Effect.fn('stopInstance')(function* ({
   yield* setState({ appId, state: 'stopped' });
 });
 
-const setState = ({
+function setState({
   appId,
   state,
   stopRequested,
@@ -76,8 +76,8 @@ const setState = ({
   appId: AppId;
   state: InstanceState;
   stopRequested?: boolean;
-}) =>
-  AgentState.updateRecord({
+}) {
+  return AgentState.updateRecord({
     appId,
     change: (record) => ({
       ...record,
@@ -85,8 +85,9 @@ const setState = ({
       ...(stopRequested === undefined ? {} : { stopRequested }),
     }),
   });
+}
 
-const isStartable = ({
+function isStartable({
   existing,
   nowMs,
   desired,
@@ -94,7 +95,7 @@ const isStartable = ({
   existing: InstanceRecord | undefined;
   nowMs: number;
   desired: DesiredInstance;
-}) => {
+}): boolean {
   if (!existing) {
     return true;
   }
@@ -103,7 +104,7 @@ const isStartable = ({
     existing.startAttempts.attempts <= policy.maxRestarts &&
     isReadyToRetry({ window: existing.startAttempts, nowMs, policy })
   );
-};
+}
 
 /**
  * One entry per digest: two apps deploying the same bytes share the image, and fetching it
@@ -242,8 +243,8 @@ function verdict({
     : undefined;
 }
 
-const probed = ({ record, nowMs }: { record: InstanceRecord; nowMs: number }) =>
-  Effect.gen(function* () {
+function probed({ record, nowMs }: { record: InstanceRecord; nowMs: number }) {
+  return Effect.gen(function* () {
     const healthy = yield* probeInstance({
       guestIpv4: record.guestIpv4,
       guestPort: record.guestPort,
@@ -264,6 +265,7 @@ const probed = ({ record, nowMs }: { record: InstanceRecord; nowMs: number }) =>
       healthyThreshold: record.healthCheck.healthyThreshold,
     });
   });
+}
 
 /** Probes the tenants that are due, then settles each state from systemd and the probe together. */
 export const refreshStates = Effect.gen(function* () {

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -6,7 +6,9 @@ import { reportedMessage } from '#lib/failure.ts';
 import { probeInstance } from '#lib/health/probe.ts';
 import {
   applyProbe,
+  describeInstanceFailure,
   evaluateInstanceState,
+  type HealthTracker,
   initialTracker,
   nextProbeDelayMs,
 } from '#lib/health/state.ts';
@@ -18,7 +20,7 @@ import {
 } from '#lib/report/instance-record.ts';
 import { ensureArtifactImage } from '#lib/vm/artifacts.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
-import { UNKNOWN_UNIT } from '#lib/vm/unit-status.ts';
+import { UNKNOWN_UNIT, type UnitStatus } from '#lib/vm/unit-status.ts';
 import { flush } from '#lib/volumes/zerofs.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
@@ -218,6 +220,27 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
   });
 });
 
+/** Only a failure has anything to say: every other state is its own account of itself. */
+const verdict = ({
+  state,
+  status,
+  health,
+  record,
+}: {
+  state: InstanceState;
+  status: UnitStatus;
+  health: HealthTracker;
+  record: InstanceRecord;
+}) =>
+  state === 'failed'
+    ? describeInstanceFailure({
+        unit: status,
+        tracker: health,
+        healthCheck: record.healthCheck,
+        guestPort: record.guestPort,
+      })
+    : undefined;
+
 const probed = ({ record, nowMs }: { record: InstanceRecord; nowMs: number }) =>
   Effect.gen(function* () {
     const healthy = yield* probeInstance({
@@ -271,6 +294,9 @@ export const refreshStates = Effect.gen(function* () {
           ...(changed && status.exitCode !== undefined && !status.active
             ? { lastExitCode: status.exitCode }
             : {}),
+          // Cleared as readily as it is written: a message outliving the state it explains is
+          // read as an account of the state that replaced it.
+          ...(changed ? { message: verdict({ state, status, health, record }) } : {}),
         });
         if (changed) {
           yield* Effect.logInfo('instance state changed').pipe(

--- a/apps/agent/tests/lib/health/state.test.ts
+++ b/apps/agent/tests/lib/health/state.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { DEFAULT_HEALTH_CHECK, type HealthCheck } from '@repo/protocol';
+import { DEFAULT_GUEST_PORT, DEFAULT_HEALTH_CHECK, type HealthCheck } from '@repo/protocol';
 import {
   applyProbe,
+  describeInstanceFailure,
   evaluateInstanceState,
   initialTracker,
   nextProbeDelayMs,
@@ -314,5 +315,37 @@ describe('thresholds are honoured', () => {
         healthCheck: check({ healthyThreshold: TWO_SUCCESSES }),
       }),
     ).toBe('running');
+  });
+});
+
+describe('a failure accounts for itself', () => {
+  const failure = (unit: UnitStatus, tracker: Tracker) =>
+    describeInstanceFailure({
+      unit,
+      tracker,
+      healthCheck: check(),
+      guestPort: DEFAULT_GUEST_PORT,
+    });
+
+  test('a VM that stopped names the code it stopped with', () => {
+    expect(failure(exited, initialTracker())).toBe(
+      'the microVM stopped without being asked to, exit code 0',
+    );
+  });
+
+  // systemd has nothing to report for a unit it has already been asked to forget, and an owner
+  // told only that a number is missing learns less than one told the VM stopped.
+  test('and one whose code systemd no longer has still says what happened', () => {
+    expect(failure({ ...crashed, exitCode: undefined }, initialTracker())).toBe(
+      'the microVM stopped without being asked to',
+    );
+  });
+
+  test('a guest nobody could reach names the port and what was spent trying', () => {
+    const tracker = { ...initialTracker(), consecutiveFailures: UNHEALTHY_RUN };
+
+    expect(failure(active, tracker)).toBe(
+      `nothing answered on port ${DEFAULT_GUEST_PORT} inside the guest: ${UNHEALTHY_RUN} health probes failed after the ${GRACE_MS}ms grace period`,
+    );
   });
 });

--- a/apps/agent/tests/lib/health/state.test.ts
+++ b/apps/agent/tests/lib/health/state.test.ts
@@ -319,16 +319,17 @@ describe('thresholds are honoured', () => {
 });
 
 describe('a failure accounts for itself', () => {
-  const failure = (unit: UnitStatus, tracker: Tracker) =>
-    describeInstanceFailure({
+  function failure({ unit, tracker }: { unit: UnitStatus; tracker: Tracker }): string {
+    return describeInstanceFailure({
       unit,
       tracker,
       healthCheck: check(),
       guestPort: DEFAULT_GUEST_PORT,
     });
+  }
 
   test('a VM that stopped names the code it stopped with', () => {
-    expect(failure(exited, initialTracker())).toBe(
+    expect(failure({ unit: exited, tracker: initialTracker() })).toBe(
       'the microVM stopped without being asked to, exit code 0',
     );
   });
@@ -336,7 +337,7 @@ describe('a failure accounts for itself', () => {
   // systemd has nothing to report for a unit it has already been asked to forget, and an owner
   // told only that a number is missing learns less than one told the VM stopped.
   test('and one whose code systemd no longer has still says what happened', () => {
-    expect(failure({ ...crashed, exitCode: undefined }, initialTracker())).toBe(
+    expect(failure({ unit: { ...crashed, exitCode: undefined }, tracker: initialTracker() })).toBe(
       'the microVM stopped without being asked to',
     );
   });
@@ -344,7 +345,7 @@ describe('a failure accounts for itself', () => {
   test('a guest nobody could reach names the port and what was spent trying', () => {
     const tracker = { ...initialTracker(), consecutiveFailures: UNHEALTHY_RUN };
 
-    expect(failure(active, tracker)).toBe(
+    expect(failure({ unit: active, tracker })).toBe(
       `nothing answered on port ${DEFAULT_GUEST_PORT} inside the guest: ${UNHEALTHY_RUN} health probes failed after the ${GRACE_MS}ms grace period`,
     );
   });


### PR DESCRIPTION
Follow-on from #220, which published `deployments.message` — and then found it empty for the failure that prompted it.

`startInstance` writes a message when a boot cannot be requested at all. Nothing else ever did: `refreshStates` computes a new state and stores it bare, so every failure the state machine *concludes* — a microVM that stopped without being asked to, a guest nothing could reach before its grace period ran out — reaches the owner as a state badge with nothing behind it. That is the common case, not the rare one.

An instance reaches `failed` two ways and one fact tells them apart: whether its unit is still up. Reading that keeps the explanation from becoming a second copy of the branches in `evaluateInstanceState`, drifting out of step with them.

```
the microVM stopped without being asked to, exit code 137
nothing answered on port 3000 inside the guest: 3 health probes failed after the 30000ms grace period
```

The message is cleared on any other state change, so one cannot outlive what it explains.