### PR TITLE
fix(dashboard): an export dialog keeps its width, so an export id wraps instead of escaping

### DIFF
--- a/apps/dashboard/src/components/apps/delete-app-dialog.tsx
+++ b/apps/dashboard/src/components/apps/delete-app-dialog.tsx
@@ -52,12 +52,12 @@ export function DeleteAppDialog() {
 
         <dl className="flex flex-col gap-2 rounded-2xl bg-muted px-3 py-2 text-sm">
           <div className="flex justify-between gap-4">
-            <dt className="text-muted-foreground">app</dt>
+            <dt className="shrink-0 text-muted-foreground">app</dt>
             <dd className="truncate font-mono">{slug}</dd>
           </div>
           <div className="flex justify-between gap-4">
-            <dt className="text-muted-foreground">hostnames</dt>
-            <dd className="flex min-w-0 flex-col items-end font-mono">
+            <dt className="shrink-0 text-muted-foreground">hostnames</dt>
+            <dd className="flex min-w-0 flex-col text-right font-mono">
               {app.data?.hostnames.map((each) => (
                 <span key={each.hostname} className="truncate">
                   {each.hostname}
@@ -66,15 +66,15 @@ export function DeleteAppDialog() {
             </dd>
           </div>
           <div className="flex justify-between gap-4">
-            <dt className="text-muted-foreground">volume</dt>
+            <dt className="shrink-0 text-muted-foreground">volume</dt>
             <dd>everything on it</dd>
           </div>
           <div className="flex justify-between gap-4">
-            <dt className="text-muted-foreground">binaries</dt>
+            <dt className="shrink-0 text-muted-foreground">binaries</dt>
             <dd>every one ever uploaded</dd>
           </div>
           <div className="flex justify-between gap-4">
-            <dt className="text-muted-foreground">exports</dt>
+            <dt className="shrink-0 text-muted-foreground">exports</dt>
             <dd>every bundle ever taken</dd>
           </div>
         </dl>

--- a/apps/dashboard/src/components/apps/export-app-dialog.tsx
+++ b/apps/dashboard/src/components/apps/export-app-dialog.tsx
@@ -41,9 +41,9 @@ export function ExportAppDialog() {
         </p>
 
         {run.isPending && (
-          <div className="flex items-center gap-2 rounded-2xl bg-muted px-3 py-2 text-sm">
-            <Spinner className="shrink-0" />
-            <span className="truncate font-mono">
+          <div className="flex items-start gap-2 rounded-2xl bg-muted px-3 py-2 text-sm">
+            <Spinner className="mt-0.5 shrink-0" />
+            <span className="wrap-anywhere font-mono">
               {run.exportId === undefined
                 ? 'asking for an export'
                 : `preparing export ${run.exportId}`}
@@ -62,7 +62,7 @@ export function ExportAppDialog() {
         {run.reason !== undefined && (
           <p className="flex items-start gap-2 rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
             <TriangleAlertIcon className="mt-0.5 size-4 shrink-0" />
-            <span>{run.reason}</span>
+            <span className="wrap-anywhere">{run.reason}</span>
           </p>
         )}
 

--- a/apps/dashboard/src/components/apps/export-app-dialog.tsx
+++ b/apps/dashboard/src/components/apps/export-app-dialog.tsx
@@ -41,13 +41,14 @@ export function ExportAppDialog() {
         </p>
 
         {run.isPending && (
-          <div className="flex items-start gap-2 rounded-2xl bg-muted px-3 py-2 text-sm">
-            <Spinner className="mt-0.5 shrink-0" />
-            <span className="wrap-anywhere font-mono">
-              {run.exportId === undefined
-                ? 'asking for an export'
-                : `preparing export ${run.exportId}`}
+          <div className="flex flex-col gap-1 rounded-2xl bg-muted px-3 py-2 text-sm">
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <Spinner className="shrink-0" />
+              {run.exportId === undefined ? 'asking for an export' : 'preparing export'}
             </span>
+            {run.exportId !== undefined && (
+              <span className="wrap-anywhere font-mono">{run.exportId}</span>
+            )}
           </div>
         )}
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -242,3 +242,17 @@ body {
     @apply font-sans;
   }
 }
+
+@layer base {
+  /* The popup is `grid` and its items default to `min-width: auto`, so a digest or an id long
+     enough sizes its item past the popup and spills onto the page. Set here rather than on
+     `DialogContent` because that file is the shadcn CLI's output. Content held in one line by
+     `white-space: nowrap` — a button's label — is out of reach of both and still needs handling
+     where it is written. */
+  :is([data-slot="dialog-content"], [data-slot="alert-dialog-content"]) {
+    overflow-wrap: anywhere;
+  }
+  :is([data-slot="dialog-content"], [data-slot="alert-dialog-content"]) > * {
+    min-width: 0;
+  }
+}


### PR DESCRIPTION
The popup lays its children out with `grid`, whose items default to `min-width: auto`, so an id or digest long enough sized its item past the popup and spilled onto the page, dragging the footer buttons with it.

Two rules in `globals.css` now make that impossible for every dialog rather than one call site at a time — `min-width: 0` so nothing can widen the popup, `overflow-wrap: anywhere` so a long token breaks rather than painting outside its box. They live there because the dialog components are the shadcn CLI's output.

Content held in one line by `white-space: nowrap` is out of their reach and still needs handling where it is written: the export id gets its own line so it reads whole, and the delete dialog's truncation finally has a width to clip against.