### PR TITLE
feat(dashboard): the records a domain waits on read as a table, and copy rather than being retyped

### DIFF
--- a/apps/dashboard/src/components/apps/domain-records.tsx
+++ b/apps/dashboard/src/components/apps/domain-records.tsx
@@ -1,3 +1,12 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@repo/ui/components/table';
+import { CopyButton } from '#components/copy-button.tsx';
 import { useApp } from '#lib/hooks/use-app.ts';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
 import { usePlatformSuffix } from '#lib/hooks/use-platform-suffix.ts';
@@ -6,30 +15,60 @@ import type { AppSummary } from '#queries/apps.ts';
 type Hostname = AppSummary['hostnames'][number];
 
 /**
- * The two records a pending domain is waiting on, laid out the way a DNS provider asks for them.
+ * The records a pending domain is waiting on, under the headings a DNS provider asks for them by.
  *
- * Selectable text rather than a copy button per field: these are pasted into somebody else's
- * form, usually more than once, and often not by the person reading this page.
+ * Copyable and selectable both: a record is pasted into somebody else's form, usually more than
+ * once, and often not by the person reading this page.
  */
 export function DomainRecords({ hostname }: { hostname: Hostname }) {
   const app = useApp(useAppId());
   const suffix = usePlatformSuffix();
 
   return (
-    <dl className="flex flex-col gap-2 rounded-xl bg-muted px-3 py-2 font-mono text-xs">
-      <DomainRecord name={hostname.hostname} value={`${app.data?.slug}.${suffix}`} />
-      {hostname.dcvTarget ? (
-        <DomainRecord name={`_acme-challenge.${hostname.hostname}`} value={hostname.dcvTarget} />
-      ) : null}
-    </dl>
+    // Bordered rather than filled, because a row of this table lights up on hover and has to
+    // have something to light up against.
+    <div className="overflow-hidden rounded-xl border">
+      <Table className="text-xs">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="h-8">Type</TableHead>
+            <TableHead className="h-8">Name</TableHead>
+            <TableHead className="h-8">Value</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <DomainRecord name={hostname.hostname} value={`${app.data?.slug}.${suffix}`} />
+          {hostname.dcvTarget ? (
+            <DomainRecord
+              name={`_acme-challenge.${hostname.hostname}`}
+              value={hostname.dcvTarget}
+            />
+          ) : null}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 
 function DomainRecord({ name, value }: { name: string; value: string }) {
   return (
-    <div className="flex min-w-0 flex-col gap-0.5">
-      <dt className="truncate text-muted-foreground">{name}</dt>
-      <dd className="select-all truncate">CNAME {value}</dd>
-    </div>
+    <TableRow>
+      <TableCell className="font-mono text-muted-foreground">CNAME</TableCell>
+      <CopyableCell value={name} />
+      <CopyableCell value={value} />
+    </TableRow>
+  );
+}
+
+function CopyableCell({ value }: { value: string }) {
+  return (
+    // Wrapping, against the table's own default: a delegation target is fifty characters, and a
+    // row that scrolls sideways on a phone hides the column the reader came for.
+    <TableCell className="whitespace-normal">
+      <span className="flex items-center gap-1">
+        <span className="wrap-anywhere select-all font-mono">{value}</span>
+        <CopyButton value={value} />
+      </span>
+    </TableCell>
   );
 }

--- a/apps/dashboard/src/components/copy-button.tsx
+++ b/apps/dashboard/src/components/copy-button.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@repo/ui/components/button';
+import { CheckIcon, CopyIcon } from 'lucide-react';
+import { useClipboardCopy } from '#lib/hooks/use-clipboard-copy.ts';
+
+export function CopyButton({ value }: { value: string }) {
+  const { copied, copy } = useClipboardCopy(value);
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      aria-label={copied ? `Copied ${value}` : `Copy ${value}`}
+      onClick={copy}
+    >
+      {copied ? <CheckIcon /> : <CopyIcon />}
+    </Button>
+  );
+}

--- a/apps/dashboard/src/lib/hooks/use-clipboard-copy.ts
+++ b/apps/dashboard/src/lib/hooks/use-clipboard-copy.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+const CONFIRMATION_MS = 1500;
+
+export type ClipboardCopy = { copied: boolean; copy: () => void };
+
+/**
+ * A clipboard write is silent, so what is worth holding is that it happened: `copied` is what a
+ * caller shows back, and it lapses on its own so nothing has to clear it.
+ */
+export function useClipboardCopy(value: string): ClipboardCopy {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const lapse = setTimeout(() => setCopied(false), CONFIRMATION_MS);
+    return () => clearTimeout(lapse);
+  }, [copied]);
+
+  return {
+    copied,
+    copy: () => {
+      void navigator.clipboard.writeText(value).then(
+        () => setCopied(true),
+        // Denied, or a page served over plain http. Said out loud rather than left as a button
+        // that does nothing — the text it would have copied is selectable either way.
+        () => toast.error('Could not reach the clipboard. Select the text and copy it.'),
+      );
+    },
+  };
+}


### PR DESCRIPTION
The two records were a stack of `name` over `CNAME value`, which is not how anyone's DNS form asks for them. They are a table now — Type, Name, Value — with a copy button on each of the two fields that get pasted.

Cells wrap rather than the table's default nowrap, so a phone shows all three columns instead of scrolling the Value out of view.