### PR TITLE
feat(infra): the two names that serve nothing send visitors somewhere that does

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -103,6 +103,7 @@ jobs:
           # Still APP_DOMAIN on purpose: the repository variable is read outside this repo
           # too, so it is not ours alone to rename.
           TF_VAR_app_host_domain: ${{ vars.APP_DOMAIN }}
+          TF_VAR_www_hostname: ${{ vars.WWW_HOSTNAME }}
           TF_VAR_api_github_client_id: ${{ vars.API_GITHUB_CLIENT_ID }}
           TF_VAR_api_github_client_secret: ${{ secrets.API_GITHUB_CLIENT_SECRET }}
           TF_VAR_caddy_tls_cert: ${{ vars.CADDY_TLS_CERT }}
@@ -173,6 +174,7 @@ jobs:
       EXPORTS_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).exports_bucket }}
       API_HOSTNAME: ${{ fromJSON(needs.terraform.outputs.values).api_hostname }}
       APP_HOST_DOMAIN: ${{ fromJSON(needs.terraform.outputs.values).app_host_domain }}
+      WWW_HOSTNAME: ${{ fromJSON(needs.terraform.outputs.values).www_hostname }}
       CONTROL_PLANE_INTERNAL_URL: ${{ fromJSON(needs.terraform.outputs.values).control_plane_internal_url }}
       LOG_INGEST_URL: ${{ fromJSON(needs.terraform.outputs.values).log_ingest_url }}
       VPC_IPV4_CIDR_BLOCK: ${{ fromJSON(needs.terraform.outputs.values).vpc_ipv4_cidr_block }}

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -67,6 +67,7 @@ jobs:
           # Still APP_DOMAIN on purpose: the repository variable is read outside this repo
           # too, so it is not ours alone to rename.
           TF_VAR_app_host_domain: ${{ vars.APP_DOMAIN }}
+          TF_VAR_www_hostname: ${{ vars.WWW_HOSTNAME }}
           TF_VAR_api_github_client_id: ${{ vars.API_GITHUB_CLIENT_ID }}
           TF_VAR_api_github_client_secret: ${{ secrets.API_GITHUB_CLIENT_SECRET }}
           TF_VAR_caddy_tls_cert: ${{ vars.CADDY_TLS_CERT }}

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -61,6 +61,11 @@ Custom domains, in the `app_domain` zone only:
   Authenticated Origin Pulls still applies — global AOP covers custom hostnames on a
   Cloudflare-for-SaaS zone — so what is given up is the origin proving itself to the edge, not
   the edge proving itself to the origin, which is the half `security_group.tf` rests on.
+- The apex redirects to the marketing site from the app-host proxy, and reaching it takes two
+  things here: `<app_domain>` A → `app_host_public_ips`, **proxied**, since the bare name has no
+  record of its own; and an **Origin Certificate** naming `<app_domain>` beside `*.<app_domain>`,
+  because a wildcard does not cover the bare name and the zone is Full (strict) — without the
+  reissue the apex answers `526`. `fallback.<app_domain>` needs neither and works as it stands.
 - An **API token** scoped to *Zone → SSL and Certificates → Edit* on this zone and nothing else,
   as the `CLOUDFLARE_API_TOKEN` repository secret, with the zone id as `CLOUDFLARE_ZONE_ID`.
 

--- a/infra/app-host/caddy/Caddyfile
+++ b/infra/app-host/caddy/Caddyfile
@@ -34,6 +34,23 @@
 # app on it — or one whose agent has not converged yet — still starts.
 import /etc/caddy/rendered/*.caddy
 
+# The two names here that serve nothing: the apex, and the fallback origin the
+# edge resolves a custom hostname to. Both send their visitor to the marketing
+# site rather than to the 404 below.
+#
+# Custom-domain traffic never lands here. It reaches this host naming the brought
+# domain in both the handshake and the request, so it matches a rendered site
+# block, not the address the edge resolved to find the host.
+#
+# The apex needs two things elsewhere before it reaches this block at all: a
+# record of its own, and an origin certificate naming <app_domain> beside the
+# wildcard — the edge validates the name it asked for, and *.<app_domain> does
+# not cover the bare one.
+https://{$APP_HOST_DOMAIN}, https://fallback.{$APP_HOST_DOMAIN} {
+	import origin_tls
+	redir https://{$WWW_HOSTNAME} permanent
+}
+
 # Everything else under the app domain: a hostname whose app is not running
 # here, or not running at all. Caddy orders site blocks most-specific first, so
 # the rendered ones above win and this is what is left.
@@ -41,11 +58,6 @@ import /etc/caddy/rendered/*.caddy
 # It exists so an unknown hostname is answered rather than handled by whatever
 # TLS policy Caddy falls back to — this way every connection the edge makes to
 # this host is one Authenticated Origin Pulls has already checked.
-#
-# The apex is deliberately absent: the origin certificate names *.<app_domain>
-# and not <app_domain>, and serving a redirect there would still mean
-# terminating TLS for a name the certificate does not cover. Cloudflare redirects
-# the apex at the edge, where no origin certificate is involved.
 https://*.{$APP_HOST_DOMAIN} {
 	import origin_tls
 	respond 404

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -19,7 +19,7 @@ log() { echo "=== [on_box_deploy $(date -u +%H:%M:%S)] $* ==="; }
   "${FIRECRACKER_VERSION:?}" "${FIRECRACKER_URL:?}" "${FIRECRACKER_SHA256:?}" \
   "${FIRECRACKER_DIRECTORY:?}" \
   "${CADDY_VERSION:?}" "${CADDY_URL:?}" "${CADDY_SHA256:?}" \
-  "${FILESYSTEMS_BUCKET:?}" "${API_HOSTNAME:?}" "${APP_HOST_DOMAIN:?}" \
+  "${FILESYSTEMS_BUCKET:?}" "${API_HOSTNAME:?}" "${APP_HOST_DOMAIN:?}" "${WWW_HOSTNAME:?}" \
   "${CONTROL_PLANE_INTERNAL_URL:?}" "${LOG_INGEST_URL:?}" \
   "${VPC_IPV4_CIDR_BLOCK:?}" "${VPC_IPV6_CIDR_BLOCK:?}" \
   "${GUEST_IMAGES_BUCKET:?}" "${ARTIFACTS_BUCKET:?}"
@@ -335,6 +335,7 @@ changed_file /etc/caddy/cloudflare-origin-pull-ca.pem && NEEDS_RELOAD+=(caddy) |
 # a fresh ExecStart is guaranteed to re-read the file.
 cat > /etc/caddy/caddy.env.new <<EOF
 APP_HOST_DOMAIN=${APP_HOST_DOMAIN}
+WWW_HOSTNAME=${WWW_HOSTNAME}
 EOF
 changed_file /etc/caddy/caddy.env && NEEDS_RESTART+=(caddy) || true
 

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -18,6 +18,10 @@ output "victorialogs_hostname" {
   value = var.victorialogs_hostname
 }
 
+output "www_hostname" {
+  value = var.www_hostname
+}
+
 output "app_host_domain" {
   description = "User apps are served under this. One wildcard record covers the fleet, so there is nothing per-app in DNS."
   value       = var.app_host_domain

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -261,6 +261,20 @@ variable "cloudflare_zone_id" {
   }
 }
 
+# Where the two names in the app host zone that serve nothing send their visitors:
+# the apex, and the fallback origin. Nothing here provisions it — the marketing
+# site is a Worker of its own — so it enters as configuration, and has no default
+# for the reason api_hostname has none.
+variable "www_hostname" {
+  type        = string
+  description = "Public hostname of the marketing site. CI passes the WWW_HOSTNAME repository variable through."
+
+  validation {
+    condition     = trimspace(var.www_hostname) != ""
+    error_message = "www_hostname must not be empty."
+  }
+}
+
 variable "enable_github_deploy" {
   type        = bool
   description = "Create the GitHub Actions OIDC deploy role. Set false to apply before the bootstrap stack exists, since the role looks up the OIDC provider it creates."

--- a/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
+++ b/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
@@ -28,6 +28,7 @@ const sharedEnv: Record<string, string> = {
   SSM_SECRET_PREFIX: requiredEnv('SSM_SECRET_PREFIX'),
   API_HOSTNAME: requiredEnv('API_HOSTNAME'),
   APP_HOST_DOMAIN: requiredEnv('APP_HOST_DOMAIN'),
+  WWW_HOSTNAME: requiredEnv('WWW_HOSTNAME'),
   CONTROL_PLANE_INTERNAL_URL: requiredEnv('CONTROL_PLANE_INTERNAL_URL'),
   LOG_INGEST_URL: requiredEnv('LOG_INGEST_URL'),
   VPC_IPV4_CIDR_BLOCK: requiredEnv('VPC_IPV4_CIDR_BLOCK'),


### PR DESCRIPTION
The apex and the fallback origin both redirect to the marketing site, from the app-host proxy. `WWW_HOSTNAME` is a new repository variable — the plan fails until it is set.

The apex reaches that block only once it has a record of its own and the origin certificate names the bare domain beside the wildcard; `AGENTS.md` says so. `fallback.<app_domain>` works with what is already there.