### PR TITLE
feat(cli,dashboard): an app is addressed by the domain its owner brought

### DIFF
--- a/packages/app-operations/src/deploy.ts
+++ b/packages/app-operations/src/deploy.ts
@@ -99,7 +99,7 @@ export async function deploy({
     appId: app.id,
     slug: app.slug,
     deploymentId: deployment.id,
-    url: `https://${platformHostname(app.hostnames)}`,
+    url: `https://${servingHostname(app.hostnames)}`,
   };
 }
 
@@ -263,10 +263,22 @@ export async function awaitDeploymentSettled({
   );
 }
 
-function platformHostname(hostnames: ReadonlyArray<{ hostname: string; kind: string }>): string {
-  const platform = hostnames.find((entry) => entry.kind === 'platform') ?? hostnames[0];
-  if (!platform) {
+/**
+ * The address to hand back, preferring a domain the owner brought: the platform hostname is what
+ * nibrun issued, but a custom one is what they call their app.
+ *
+ * Active only. A brought domain is pending until the edge holds a certificate for it, and a link
+ * that does not resolve yet is worse than the one that does.
+ */
+function servingHostname(
+  hostnames: ReadonlyArray<{ hostname: string; kind: string; state: string }>,
+): string {
+  const serving =
+    hostnames.find((entry) => entry.kind === 'custom' && entry.state === 'active') ??
+    hostnames.find((entry) => entry.kind === 'platform') ??
+    hostnames[0];
+  if (!serving) {
     throw new ApiError('The app was created without a hostname.');
   }
-  return platform.hostname;
+  return serving.hostname;
 }

--- a/packages/app-operations/tests/deploy.test.ts
+++ b/packages/app-operations/tests/deploy.test.ts
@@ -15,16 +15,30 @@ const PART_BYTES = 262_144;
 const REFUSED = 403;
 
 type Sent = { what: string; body?: unknown };
+type HostnameRow = { hostname: string; kind: string; state: string };
+
+const PLATFORM: HostnameRow = { hostname: `${SLUG}.nibrun.app`, kind: 'platform', state: 'active' };
+const PENDING_CUSTOM: HostnameRow = {
+  hostname: 'not-pointed-here-yet.example',
+  kind: 'custom',
+  state: 'pending',
+};
 
 function apiHolding({
   apps,
   sent,
   completed = { id: ARTIFACT_ID, digest: DIGEST },
+  hostnames = [PENDING_CUSTOM, PLATFORM],
 }: {
   apps: Array<{ id: string; slug: string }>;
   sent: Sent[];
   completed?: { id: string; digest: string } | null;
+  hostnames?: HostnameRow[];
 }): PublicApiClient {
+  function app(id: string) {
+    return { id, slug: SLUG, hostnames };
+  }
+
   function addressed({ appId }: { appId: string }) {
     function artifact() {
       return {
@@ -62,17 +76,6 @@ function apiHolding({
     },
   });
   return { api: { apps: route } } as unknown as PublicApiClient;
-}
-
-function app(id: string) {
-  return {
-    id,
-    slug: SLUG,
-    hostnames: [
-      { hostname: 'someone-else.example', kind: 'custom' },
-      { hostname: `${SLUG}.nibrun.app`, kind: 'platform' },
-    ],
-  };
 }
 
 function binary() {
@@ -124,6 +127,41 @@ test('a slug names the app the release lands on', async () => {
     deploymentId: 'deployment-1',
     url: `https://${SLUG}.nibrun.app`,
   });
+});
+
+test('a domain the owner brought is the address handed back, once it is serving', async () => {
+  const sent: Sent[] = [];
+  storeAnswering({ sent });
+
+  const deployed = await deploy({
+    api: apiHolding({
+      apps: [{ id: APP_ID, slug: SLUG }],
+      sent,
+      hostnames: [PLATFORM, { hostname: 'shop.example.com', kind: 'custom', state: 'active' }],
+    }),
+    binary: binary(),
+    args: [],
+    app: SLUG,
+  });
+
+  expect(deployed.url).toBe('https://shop.example.com');
+});
+
+// The link is offered the moment the deploy lands, and a brought domain is pending until the edge
+// holds a certificate for it — so preferring one too early hands out an address that does not
+// resolve.
+test('a domain still waiting on its records is not the one handed back', async () => {
+  const sent: Sent[] = [];
+  storeAnswering({ sent });
+
+  const deployed = await deploy({
+    api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent }),
+    binary: binary(),
+    args: [],
+    app: SLUG,
+  });
+
+  expect(deployed.url).toBe(`https://${SLUG}.nibrun.app`);
 });
 
 test('naming no app creates one, named after the binary when nothing else says', async () => {


### PR DESCRIPTION
"Serving at" and the CLI's deploy line both handed back the platform hostname even when the app had a domain of its own. They prefer the brought one now.

Active only — a pending domain has no certificate yet, so offering it would be offering a link that does not resolve.