### PR TITLE
feat(api,cli): an environment patch edits the variables it names, and only those

### DIFF
--- a/apps/api/src/db/queries.gen.d.ts
+++ b/apps/api/src/db/queries.gen.d.ts
@@ -261,10 +261,6 @@ export interface IInsertPatchedAppConfigResult {
     id: string;
 }
 
-/** Result of query `CarryEnvironmentForward`. */
-export interface ICarryEnvironmentForwardResult {
-}
-
 /** Result of query `TouchAppAfterConfigPatch`. */
 export interface ITouchAppAfterConfigPatchResult {
     id: import("@repo/protocol").AppId;
@@ -684,7 +680,6 @@ export interface Queries {
     SelectAppForConfigUpdate: ISelectAppForConfigUpdateResult;
     SelectCurrentAppConfig: ISelectCurrentAppConfigResult;
     InsertPatchedAppConfig: IInsertPatchedAppConfigResult;
-    CarryEnvironmentForward: ICarryEnvironmentForwardResult;
     TouchAppAfterConfigPatch: ITouchAppAfterConfigPatchResult;
     SelectFinishableDeletion: ISelectFinishableDeletionResult;
     SelectFinishableDeletions: ISelectFinishableDeletionsResult;

--- a/apps/api/src/lib/app-config.ts
+++ b/apps/api/src/lib/app-config.ts
@@ -5,7 +5,9 @@ import {
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
   REDACTED,
+  type SecretString,
   type TenantEnvironment,
+  type TenantEnvironmentPatch,
 } from '@repo/protocol';
 import type { Queries } from '#db/queries.gen.d.ts';
 import type { SealedEnvironment } from '#lib/tenant-secrets.ts';
@@ -25,23 +27,56 @@ export type PublicAppConfig = OwnedAppConfig & {
   environment: RedactedEnvironment;
 };
 
-// `environment` absent means leave it as it is, where an absent `args` means the same as an empty
-// one. They differ because a deploy always states its arguments and almost never restates a
-// secret — and restating one it could not read would be how an owner erases it by accident.
-export type AppConfigPatch = Partial<OwnedAppConfig> & {
+// What an app is created with: the whole environment, because there is not yet one to edit.
+export type NewAppConfig = Partial<OwnedAppConfig> & {
   environment?: TenantEnvironment | undefined;
+};
+
+// `environment` is an edit, where `args` is always the whole list: a deploy states its arguments
+// every time and can restate none of its secrets, so a variable it says nothing about is one it
+// is leaving alone.
+export type AppConfigPatch = Partial<OwnedAppConfig> & {
+  environment?: TenantEnvironmentPatch | undefined;
 };
 
 export type StoredAppConfig = Omit<PublicAppConfig, 'environment'> & {
   environment: SealedEnvironment;
 };
 
+/**
+ * What a patch does to an app's environment: the variables it sets, sealed, and the ones it
+ * removes. Anything it named neither way is untouched — which is most of them.
+ */
+export type SealedEnvironmentPatch = {
+  set: SealedEnvironment;
+  removed: readonly string[];
+};
+
 // What a repository takes, as against what an owner sent. Every one of these is a record of
 // strings, so the branding on `TenantEnvironment` and `SealedSecret` is the only thing standing
 // between a plaintext value, a `[redacted]` placeholder and the ciphertext that may be stored.
 export type SealedConfigPatch = Partial<OwnedAppConfig> & {
-  environment?: SealedEnvironment | undefined;
+  environment?: SealedEnvironmentPatch | undefined;
 };
+
+/** The two halves of an edit: what it sets, and the names it takes away. */
+export function splitEnvironmentPatch(environment: TenantEnvironmentPatch): {
+  set: TenantEnvironment;
+  removed: string[];
+} {
+  const set: Record<string, SecretString> = {};
+  const removed: string[] = [];
+
+  for (const [name, value] of Object.entries(environment)) {
+    if (value === null) {
+      removed.push(name);
+    } else {
+      set[name] = value;
+    }
+  }
+
+  return { set, removed };
+}
 
 // Keys named once here, types taken from the schema, so renaming a column fails to compile
 // rather than silently reading undefined.

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -263,18 +263,18 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
         throw new Error('Inserting into nibrun.app_configs returned no row.');
       }
 
-      if (patch.environment === undefined) {
-        // Copied rather than read and rewritten: the api has no reason to open a value it is
-        // only carrying forward, so the ciphertext never leaves the database.
-        await tx.CarryEnvironmentForward`
-          INSERT INTO nibrun.app_config_environment (config_id, name, value)
-          SELECT ${inserted.id}, e.name, e.value
-          FROM nibrun.app_config_environment e
-          WHERE e.config_id = ${current.id}
-        `;
-      } else {
-        await insertEnvironment({ tx, configId: inserted.id, environment: patch.environment });
-      }
+      // Everything the patch said nothing about, which is every variable there is when it said
+      // nothing at all. A name it sets or removes is left out of the copy: one row per name per
+      // version, and for a name it sets that row is the one inserted below.
+      const environment = patch.environment ?? { set: {}, removed: [] };
+      const edited = new Set([...Object.keys(environment.set), ...environment.removed]);
+      await carryEnvironmentForward({
+        tx,
+        fromConfigId: current.id,
+        toConfigId: inserted.id,
+        names: current.environment_names.filter((name) => !edited.has(name)),
+      });
+      await insertEnvironment({ tx, configId: inserted.id, environment: environment.set });
 
       // Reconfiguring an app changes the app, but the new version lands in another table, so
       // nothing would move `updated_at` without this.
@@ -427,6 +427,36 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
       return app ?? null;
     });
   }
+}
+
+/**
+ * The variables a new config version inherits from the one before it, copied rather than read and
+ * rewritten: the api has no reason to open a value it is only carrying forward, so the ciphertext
+ * never leaves the database.
+ *
+ * Untagged for the reason the insert below is.
+ */
+async function carryEnvironmentForward({
+  tx,
+  fromConfigId,
+  toConfigId,
+  names,
+}: {
+  tx: TypedSQL<Queries>;
+  fromConfigId: string;
+  toConfigId: string;
+  names: readonly string[];
+}): Promise<void> {
+  if (names.length === 0) {
+    return;
+  }
+
+  await tx`
+    INSERT INTO nibrun.app_config_environment (config_id, name, value)
+    SELECT ${toConfigId}, e.name, e.value
+    FROM nibrun.app_config_environment e
+    WHERE e.config_id = ${fromConfigId} AND e.name = ANY(${tx.array([...names], TEXT_ARRAY)})
+  `;
 }
 
 /**

--- a/apps/api/src/routes/api/apps/model.ts
+++ b/apps/api/src/routes/api/apps/model.ts
@@ -6,6 +6,7 @@ import {
   ByteSizeSchema,
   MIN_HOSTNAMES,
   REDACTED,
+  TenantEnvironmentPatchSchema,
   TenantEnvironmentSchema,
 } from '@repo/protocol';
 import { t } from 'elysia';
@@ -33,10 +34,17 @@ export const PublicAppConfigSchema = t.Composite([
 // Strict: every field is optional, so without this a misspelled one is silently no request at
 // all and the caller is told 200.
 //
-// Omitting `environment` leaves the one already stored alone, where omitting `args` replaces it
-// with none. They differ because a caller cannot read a secret back to restate it, so treating
-// silence as "none" would be how a deploy erases one nobody meant to touch.
+// `environment` is an edit rather than a replacement, where `args` is always the whole list. They
+// differ because a caller cannot read a secret back to restate it: a variable it says nothing
+// about is one it is leaving alone, and removing one is `null`.
 export const AppConfigPatchSchema = t.Partial(
+  t.Composite([OwnedAppConfigSchema, t.Object({ environment: TenantEnvironmentPatchSchema })]),
+  { additionalProperties: false },
+);
+
+// An app being created has nothing to leave alone and nothing to remove, so what it is given is
+// the whole environment rather than an edit to one.
+const NewAppConfigSchema = t.Partial(
   t.Composite([OwnedAppConfigSchema, t.Object({ environment: TenantEnvironmentSchema })]),
   { additionalProperties: false },
 );
@@ -75,7 +83,7 @@ export const ListAppsResponseSchema = t.Object({ apps: t.Array(AppResponseSchema
 export const CreateAppRequestSchema = t.Object(
   {
     name: t.String({ minLength: 1, maxLength: MAX_APP_NAME_LENGTH }),
-    config: t.Optional(AppConfigPatchSchema),
+    config: t.Optional(NewAppConfigSchema),
   },
   { additionalProperties: false },
 );

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -1,14 +1,23 @@
-import type { App, AppId, OwnerId, ReportedVolume } from '@repo/protocol';
+import {
+  type App,
+  type AppId,
+  type OwnerId,
+  REDACTED,
+  type ReportedVolume,
+  type TenantEnvironment,
+} from '@repo/protocol';
 import {
   type AppConfigPatch,
   configWithDefaults,
+  type NewAppConfig,
   type PublicAppConfig,
   type SealedConfigPatch,
+  splitEnvironmentPatch,
   toAppConfig,
 } from '#lib/app-config.ts';
 import { type PublicAppHostname, platformHostname, toAppHostname } from '#lib/app-hostname.ts';
 import { deriveAppSlug } from '#lib/app-slug.ts';
-import { ConflictError, NotFoundError } from '#lib/errors.ts';
+import { BadRequestError, ConflictError, NotFoundError } from '#lib/errors.ts';
 import { isUniqueViolation } from '#lib/pg-errors.ts';
 import { sealEnvironment, type TenantSecretsKey } from '#lib/tenant-secrets.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
@@ -113,14 +122,13 @@ export class AppsService extends Service {
   }: {
     ownerId: OwnerId;
     name: string;
-    config?: AppConfigPatch;
+    config?: NewAppConfig;
   }): Promise<PublicApp> {
+    const environment = config?.environment ?? {};
+    refuseRedactedValues(environment);
     const appConfig = {
       ...configWithDefaults(config),
-      environment: sealEnvironment({
-        key: this.secretsKey,
-        environment: config?.environment ?? {},
-      }),
+      environment: sealEnvironment({ key: this.secretsKey, environment }),
     };
 
     for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt++) {
@@ -144,14 +152,17 @@ export class AppsService extends Service {
     throw new ConflictError('Could not mint a free hostname for the app.');
   }
 
-  // Absent stays absent: the repository reads that as "carry the previous version's" rather than
-  // as an empty environment, which is what stops a deploy that says nothing erasing a secret.
   private sealed({ environment, ...rest }: AppConfigPatch): SealedConfigPatch {
+    if (environment === undefined) {
+      return rest;
+    }
+
+    const { set, removed } = splitEnvironmentPatch(environment);
+    refuseRedactedValues(set);
+
     return {
       ...rest,
-      ...(environment !== undefined && {
-        environment: sealEnvironment({ key: this.secretsKey, environment }),
-      }),
+      environment: { set: sealEnvironment({ key: this.secretsKey, environment: set }), removed },
     };
   }
 
@@ -307,6 +318,22 @@ export class AppsService extends Service {
       this.logger.info('app deleted without a filesystem to tear down', { appId });
     }
     return finished;
+  }
+}
+
+/**
+ * `[redacted]` is what every read returns in place of a value, so a caller sending it as one is a
+ * caller echoing what it read. Stored, it would overwrite the secret with the word — and the app
+ * would go on running, on the wrong value, with nothing said.
+ */
+function refuseRedactedValues(environment: TenantEnvironment): void {
+  const echoed = Object.entries(environment)
+    .filter(([, value]) => value === REDACTED)
+    .map(([name]) => name);
+  if (echoed.length > 0) {
+    throw new BadRequestError(
+      `${REDACTED} is what a read returns in place of a value, so it cannot be set as one: ${echoed.join(', ')}.`,
+    );
   }
 }
 

--- a/apps/api/tests/repositories/apps.test.ts
+++ b/apps/api/tests/repositories/apps.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { withTypes } from '@ilbertt/bun-sqlgen';
+import {
+  type AppId,
+  DnsLabelSchema,
+  HostnameSchema,
+  type OwnerId,
+  OwnerIdSchema,
+  type TenantEnvironment,
+  TenantEnvironmentSchema,
+  Value,
+} from '@repo/protocol';
+import type { SQL } from 'bun';
+import type { Queries } from '#db/queries.gen.d.ts';
+import { configWithDefaults, type SealedEnvironmentPatch } from '#lib/app-config.ts';
+import { openSecret, sealEnvironment, sealedFromStore } from '#lib/tenant-secrets.ts';
+import { AppsRepository } from '#repositories/apps.repository.ts';
+import { startTestDatabase, stopTestDatabase } from '#tests/support/database.ts';
+import { TEST_SECRETS_KEY } from '#tests/support/secrets.ts';
+
+const DATABASE_START_TIMEOUT_MS = 180_000;
+
+const OWNER_ID = Value.Parse(OwnerIdSchema, 'owner');
+const APP_SLUG = Value.Parse(DnsLabelSchema, 'pocketbase');
+const PLATFORM = Value.Parse(HostnameSchema, 'pocketbase.apps.example.com');
+
+const FIRST_TOKEN = 'sk-sealed-once';
+
+function environment(entries: Record<string, string>): TenantEnvironment {
+  return Value.Parse(TenantEnvironmentSchema, entries);
+}
+
+function sealed(entries: Record<string, string>) {
+  return sealEnvironment({ key: TEST_SECRETS_KEY, environment: environment(entries) });
+}
+
+/**
+ * A config version is what a deployment pins and its variables are part of that version, so a
+ * patch writes a new version rather than editing one. Which of the previous version's variables
+ * the new one inherits is SQL, and the ciphertext an owner cannot restate is what rides on it —
+ * so this is exercised against the database rather than a fake.
+ */
+describe('a config patch carries forward every variable it says nothing about', () => {
+  let sql: SQL;
+  let repo: AppsRepository;
+  let appId: AppId;
+  let ownerId: OwnerId;
+
+  // Long enough to pull the image, which the first run on a fresh machine does inside this hook.
+  beforeAll(async () => {
+    sql = await startTestDatabase();
+    await sql.unsafe(
+      `INSERT INTO auth."user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+       VALUES ($1, 'owner', 'owner@example.com', true, now(), now())`,
+      [OWNER_ID],
+    );
+
+    repo = new AppsRepository(withTypes<Queries>(sql));
+    const created = await repo.create({
+      ownerId: OWNER_ID,
+      slug: APP_SLUG,
+      hostname: PLATFORM,
+      config: {
+        ...configWithDefaults(),
+        environment: sealed({ TOKEN: FIRST_TOKEN, LOG_LEVEL: 'debug' }),
+      },
+    });
+    appId = created.app.id;
+    ownerId = created.app.owner_id;
+  }, DATABASE_START_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await stopTestDatabase(sql);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  /** As it is stored: ciphertext, which is the only form any of this ever reaches the column in. */
+  async function storedEnvironment(): Promise<Record<string, string>> {
+    const rows = (await sql.unsafe(
+      `SELECT e.name, e.value
+       FROM nibrun.app_config_environment e
+       WHERE e.config_id = (
+         SELECT c.id FROM nibrun.app_configs c WHERE c.app_id = $1 ORDER BY c.id DESC LIMIT 1
+       )`,
+      [appId],
+    )) as Array<{ name: string; value: string }>;
+    return Object.fromEntries(rows.map((row) => [row.name, row.value]));
+  }
+
+  function patchEnvironment(environment: SealedEnvironmentPatch) {
+    return repo.updateConfig({ appId, ownerId, patch: { environment } });
+  }
+
+  function opened(value: string | undefined): string {
+    return openSecret({ key: TEST_SECRETS_KEY, sealed: sealedFromStore(value ?? '') });
+  }
+
+  test('a patch that says nothing about the environment keeps all of it', async () => {
+    const before = await storedEnvironment();
+
+    await repo.updateConfig({ appId, ownerId, patch: { args: ['serve'] } });
+
+    expect(await storedEnvironment()).toEqual(before);
+  });
+
+  // The same ciphertext rather than the same value: a variable nobody edited is never opened, so
+  // a new envelope for it would mean the api had read a secret it had no reason to.
+  test('a name not in the patch arrives at the new version as the bytes the old one held', async () => {
+    const before = await storedEnvironment();
+
+    await patchEnvironment({ set: sealed({ LOG_LEVEL: 'info' }), removed: [] });
+    const after = await storedEnvironment();
+
+    expect(after.TOKEN).toBe(before.TOKEN);
+    expect(opened(after.TOKEN)).toBe(FIRST_TOKEN);
+    expect(opened(after.LOG_LEVEL)).toBe('info');
+  });
+
+  test('a name the patch removes is a variable the app stops running with', async () => {
+    await patchEnvironment({ set: {}, removed: ['LOG_LEVEL'] });
+
+    expect(Object.keys(await storedEnvironment())).toEqual(['TOKEN']);
+  });
+
+  // Every patch above appended a version. What the first deployment was launched with is the
+  // first of them, and none of this may have reached back and edited it.
+  test('the version this app was created with still holds what it was created with', async () => {
+    const rows = (await sql.unsafe(
+      `SELECT e.name, e.value
+       FROM nibrun.app_config_environment e
+       WHERE e.config_id = (
+         SELECT c.id FROM nibrun.app_configs c WHERE c.app_id = $1 ORDER BY c.id ASC LIMIT 1
+       )
+       ORDER BY e.name`,
+      [appId],
+    )) as Array<{ name: string; value: string }>;
+
+    expect(rows.map((row) => row.name)).toEqual(['LOG_LEVEL', 'TOKEN']);
+    expect(opened(rows[1]?.value)).toBe(FIRST_TOKEN);
+  });
+});

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -13,13 +13,15 @@ import {
   REDACTED,
   type ReportedVolume,
   type TenantEnvironment,
+  type TenantEnvironmentPatch,
+  TenantEnvironmentPatchSchema,
   TenantEnvironmentSchema,
   Value,
   VolumeIdSchema,
 } from '@repo/protocol';
 import { SQL } from 'bun';
-import type { AppConfigPatch, SealedConfigPatch, StoredAppConfig } from '#lib/app-config.ts';
-import { ConflictError, NotFoundError } from '#lib/errors.ts';
+import type { NewAppConfig, SealedConfigPatch, StoredAppConfig } from '#lib/app-config.ts';
+import { BadRequestError, ConflictError, NotFoundError } from '#lib/errors.ts';
 import { openSecret, sealedFromStore } from '#lib/tenant-secrets.ts';
 import type {
   AppHostnameRow,
@@ -50,9 +52,14 @@ import { TEST_SECRETS_KEY } from '#tests/support/secrets.ts';
 
 const SECRET = 'sk-not-in-any-response';
 
-// The branded record a controller parses before the service ever sees one.
+// The branded records a controller parses before the service ever sees one: the whole of an
+// environment for an app being created, and an edit to one for an app that exists.
 function asEnvironment(entries: Record<string, string>): TenantEnvironment {
   return Value.Parse(TenantEnvironmentSchema, entries);
+}
+
+function asPatch(entries: Record<string, string | null>): TenantEnvironmentPatch {
+  return Value.Parse(TenantEnvironmentPatchSchema, entries);
 }
 
 const APP_NAME = 'pocketbase';
@@ -290,7 +297,7 @@ function createApp({
   config,
 }: {
   appsRepo: AppsRepositoryContract;
-  config?: AppConfigPatch;
+  config?: NewAppConfig;
 }) {
   return serviceWith({ appsRepo }).create({ ownerId: OWNER_ID, name: APP_NAME, config });
 }
@@ -410,7 +417,7 @@ describe('an app is created with the environment it was given, and never reports
   });
 });
 
-describe('a config patch only replaces the environment when it names one', () => {
+describe('a config patch edits the environment rather than replacing it', () => {
   test('a patch that says nothing about it carries no environment at all', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
     appsRepo.owns = true;
@@ -418,12 +425,12 @@ describe('a config patch only replaces the environment when it names one', () =>
 
     await service.updateConfig({ appId: APP_ID, ownerId: OWNER_ID, patch: { args: ['serve'] } });
 
-    // Absent rather than empty: the repository reads absence as "keep the stored one", and an
-    // empty object would erase every variable the app has.
+    // Absent rather than empty: the repository reads absence as "carry every variable forward",
+    // and there is no shape of empty that means anything else.
     expect('environment' in (appsRepo.offeredPatches[0] ?? {})).toBe(false);
   });
 
-  test('a patch naming one replaces it, sealed', async () => {
+  test('a patch setting one seals the value and takes nothing away', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
     appsRepo.owns = true;
     const service = serviceWith({ appsRepo });
@@ -431,16 +438,19 @@ describe('a config patch only replaces the environment when it names one', () =>
     await service.updateConfig({
       appId: APP_ID,
       ownerId: OWNER_ID,
-      patch: { environment: asEnvironment({ TOKEN: SECRET }) },
+      patch: { environment: asPatch({ TOKEN: SECRET }) },
     });
 
-    const sealed = appsRepo.offeredPatches[0]?.environment ?? {};
-    expect(openSecret({ key: TEST_SECRETS_KEY, sealed: sealedFromStore(sealed.TOKEN ?? '') })).toBe(
-      SECRET,
-    );
+    const environment = appsRepo.offeredPatches[0]?.environment;
+    expect(
+      openSecret({ key: TEST_SECRETS_KEY, sealed: sealedFromStore(environment?.set.TOKEN ?? '') }),
+    ).toBe(SECRET);
+    expect(environment?.removed).toEqual([]);
   });
 
-  test('a patch emptying it says so, and that is not the same as silence', async () => {
+  // The name and nothing else: an empty value is a value, so saying a variable should go cannot
+  // be done by giving it one.
+  test('a variable is removed by naming it with no value', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
     appsRepo.owns = true;
     const service = serviceWith({ appsRepo });
@@ -448,10 +458,57 @@ describe('a config patch only replaces the environment when it names one', () =>
     await service.updateConfig({
       appId: APP_ID,
       ownerId: OWNER_ID,
-      patch: { environment: asEnvironment({}) },
+      patch: { environment: asPatch({ TOKEN: null }) },
     });
 
-    expect(appsRepo.offeredPatches[0]?.environment).toEqual({});
+    expect(appsRepo.offeredPatches[0]?.environment).toEqual({ set: {}, removed: ['TOKEN'] });
+  });
+
+  test('the two halves of one patch reach the repository apart', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.owns = true;
+    const service = serviceWith({ appsRepo });
+
+    await service.updateConfig({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      patch: { environment: asPatch({ TOKEN: SECRET, GONE: null }) },
+    });
+
+    const environment = appsRepo.offeredPatches[0]?.environment;
+    expect(Object.keys(environment?.set ?? {})).toEqual(['TOKEN']);
+    expect(environment?.removed).toEqual(['GONE']);
+  });
+});
+
+/**
+ * `[redacted]` is what an owner reads in place of every value, so a caller sending it as one is
+ * echoing what it read rather than setting anything. Stored, it would overwrite the secret with
+ * the word and leave the app running on it, with nothing said.
+ */
+describe('the placeholder a read returns cannot be set as a value', () => {
+  test('a patch carrying it is refused before anything is sealed', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.owns = true;
+    const service = serviceWith({ appsRepo });
+
+    await expect(
+      service.updateConfig({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        patch: { environment: asPatch({ TOKEN: REDACTED }) },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(appsRepo.offeredPatches).toHaveLength(0);
+  });
+
+  test('and so is an app created with it', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+
+    await expect(
+      createApp({ appsRepo, config: { environment: asEnvironment({ TOKEN: REDACTED }) } }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(appsRepo.offeredConfigs).toHaveLength(0);
   });
 });
 

--- a/apps/dashboard/src/components/apps/deploy-environment-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-environment-field.tsx
@@ -40,5 +40,5 @@ function describeEnvironment(replacing: AppSummary | undefined): string {
   if (names.length === 0) {
     return 'One NAME=value per line. What the binary runs with.';
   }
-  return `One NAME=value per line. Empty keeps ${names.join(', ')} as they are; listing any replaces the lot.`;
+  return `One NAME=value per line. What is not named here is left as it is — ${names.join(', ')} are set.`;
 }

--- a/apps/dashboard/src/lib/hooks/use-deploy-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy-form.ts
@@ -67,7 +67,7 @@ export function validatePort({ value }: { value: string | undefined }): string |
 
 export function validateEnvironment({ value }: { value: string | undefined }): string | undefined {
   try {
-    parseEnvironment(assignments(value ?? ''));
+    parseEnvironment({ set: assignments(value ?? ''), remove: [] });
     return undefined;
   } catch (failure) {
     return failure instanceof InvalidEnvironmentError ? failure.message : undefined;
@@ -126,11 +126,12 @@ function asDeployRequest({
   return {
     binary,
     args: tenantArguments(value.args ?? replacing?.config.args.join('\n') ?? ''),
-    // An empty box leaves the stored variables alone rather than clearing them: the form cannot
-    // show a value it is not allowed to read, so an owner who is shown nothing and sends nothing
-    // must not be taken to mean "remove them all". Removing one is done by listing the ones that
-    // stay, which is a deliberate act rather than an empty field.
-    ...(entered.length === 0 ? {} : { environment: parseEnvironment(entered) }),
+    // An empty box changes nothing, and a full one only the variables it names: the form cannot
+    // show a value it is not allowed to read, so what it says nothing about has to be what it
+    // leaves alone. Taking a variable away is `nib run --unset` until this box is a table.
+    ...(entered.length === 0
+      ? {}
+      : { environment: parseEnvironment({ set: entered, remove: [] }) }),
     app: replacing?.slug,
     name: replacing === undefined ? value.name.trim() || undefined : undefined,
     port,

--- a/apps/dashboard/src/lib/hooks/use-deploy.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy.ts
@@ -7,7 +7,7 @@ import {
   type UploadableBinary,
   type UploadProgress,
 } from '@repo/app-operations';
-import type { TenantArguments, TenantEnvironment } from '@repo/protocol';
+import type { TenantArguments, TenantEnvironmentPatch } from '@repo/protocol';
 import { type UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '#lib/api.ts';
 import { browserUpload } from '#lib/browser-upload.ts';
@@ -15,7 +15,7 @@ import { browserUpload } from '#lib/browser-upload.ts';
 export type DeployRequest = {
   binary: UploadableBinary;
   args: TenantArguments;
-  environment?: TenantEnvironment | undefined;
+  environment?: TenantEnvironmentPatch | undefined;
   app: string | undefined;
   name: string | undefined;
   port: number;

--- a/packages/app-operations/src/deploy.ts
+++ b/packages/app-operations/src/deploy.ts
@@ -5,7 +5,7 @@ import {
   type Filename,
   GuestPortSchema,
   type TenantArguments,
-  type TenantEnvironment,
+  type TenantEnvironmentPatch,
   Value,
 } from '@repo/protocol';
 import { appBySlug } from '#apps.ts';
@@ -46,7 +46,7 @@ export type DeployInput = {
   app?: string | undefined;
   name?: string | undefined;
   port?: number | undefined;
-  environment?: TenantEnvironment | undefined;
+  environment?: TenantEnvironmentPatch | undefined;
   onStep?: ((step: DeployStep) => void) | undefined;
   whileUploading?: UploadWait | undefined;
   upload?: UploadTransport | undefined;
@@ -202,9 +202,9 @@ function mebibytes(bytes: number): string {
  * run with, and carrying over the last deploy's arguments because none were given this time
  * would run something nobody asked for.
  */
-// `environment` is sent only when there is one to send: the api reads its absence as "leave the
-// stored one alone", where an absent `args` would mean none. A deploy cannot restate a secret it
-// is not allowed to read back, so saying nothing has to be how it leaves one untouched.
+// `environment` is an edit where `args` is the whole list, so an absent one changes no variable
+// while an absent `args` would clear them all. A deploy cannot read a value back to restate it,
+// which is why saying nothing about a variable has to be how it survives.
 function configPatch({
   args,
   port,
@@ -212,7 +212,7 @@ function configPatch({
 }: {
   args: TenantArguments;
   port: number | undefined;
-  environment: TenantEnvironment | undefined;
+  environment: TenantEnvironmentPatch | undefined;
 }) {
   return {
     args,

--- a/packages/app-operations/src/environment.ts
+++ b/packages/app-operations/src/environment.ts
@@ -1,35 +1,61 @@
-import { type TenantEnvironment, TenantEnvironmentSchema, Value } from '@repo/protocol';
+import { type TenantEnvironmentPatch, TenantEnvironmentPatchSchema, Value } from '@repo/protocol';
 import { InvalidEnvironmentError } from '#errors.ts';
 
 const ASSIGNMENT = '=';
 
-/**
- * `NAME=value` per entry, split at the first `=` only: a value is arbitrary text and secrets
- * routinely hold one, so anything after the first belongs to what was set rather than separating
- * it. A name given twice takes its last value, as the same words would in a shell.
- */
-export function parseEnvironment(assignments: readonly string[]): TenantEnvironment {
-  const entries = assignments.map((assignment) => {
-    const at = assignment.indexOf(ASSIGNMENT);
-    if (at <= 0) {
-      throw new InvalidEnvironmentError(
-        `An environment variable is given as NAME=value, and this has no name: ${assignment}`,
-      );
-    }
-    return [assignment.slice(0, at).trim(), assignment.slice(at + 1)] as const;
-  });
+/** A variable and what is to become of it: the text it is set to, or `null` to remove it. */
+export type EnvironmentEdit = { name: string; value: string | null };
 
+/**
+ * What a command line said about an app's environment: `NAME=value` for each variable it sets and
+ * a bare name for each it removes.
+ *
+ * An assignment is split at the first `=` only: a value is arbitrary text and secrets routinely
+ * hold one, so anything after the first belongs to what was set rather than separating it. A name
+ * given twice takes its last value, as the same words would in a shell.
+ */
+export function parseEnvironment({
+  set,
+  remove,
+}: {
+  set: readonly string[];
+  remove: readonly string[];
+}): TenantEnvironmentPatch {
+  return parseEnvironmentPatch([
+    ...set.map(assigned),
+    ...remove.map((name) => ({ name: name.trim(), value: null })),
+  ]);
+}
+
+/**
+ * The same edits from a caller that already holds the two halves apart — a form with a field for
+ * each — so that what a name may be is answered in one place whatever it was typed into.
+ */
+export function parseEnvironmentPatch(edits: readonly EnvironmentEdit[]): TenantEnvironmentPatch {
   // Checked before it is parsed, never by parsing: a name the schema does not allow is no part of
   // the record, so parsing drops it and then succeeds — which reads as a variable accepted and
   // then silently not set.
-  const refused = entries
-    .map(([name]) => name)
-    .filter((name) => !Value.Check(TenantEnvironmentSchema, { [name]: '' }));
+  const refused = edits
+    .map(({ name }) => name)
+    .filter((name) => !Value.Check(TenantEnvironmentPatchSchema, { [name]: null }));
   if (refused.length > 0) {
     throw new InvalidEnvironmentError(
       `An environment variable's name must start with a letter or underscore and hold only letters, digits and underscores: ${refused.join(', ')}`,
     );
   }
 
-  return Value.Parse(TenantEnvironmentSchema, Object.fromEntries(entries));
+  return Value.Parse(
+    TenantEnvironmentPatchSchema,
+    Object.fromEntries(edits.map(({ name, value }) => [name, value])),
+  );
+}
+
+function assigned(assignment: string): EnvironmentEdit {
+  const at = assignment.indexOf(ASSIGNMENT);
+  if (at <= 0) {
+    throw new InvalidEnvironmentError(
+      `An environment variable is given as NAME=value, and this has no name: ${assignment}`,
+    );
+  }
+  return { name: assignment.slice(0, at).trim(), value: assignment.slice(at + 1) };
 }

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -14,7 +14,11 @@ export {
   type UploadWait,
 } from '#deploy.ts';
 export { type AddDomainInput, addDomain, type RemoveDomainInput, removeDomain } from '#domains.ts';
-export { parseEnvironment } from '#environment.ts';
+export {
+  type EnvironmentEdit,
+  parseEnvironment,
+  parseEnvironmentPatch,
+} from '#environment.ts';
 export { InvalidEnvironmentError, InvalidPathError } from '#errors.ts';
 export { awaitExportBundle, type ExportBundle, requestExport } from '#exports.ts';
 export { guestPath, readDirectory } from '#filesystem.ts';

--- a/packages/app-operations/tests/environment.test.ts
+++ b/packages/app-operations/tests/environment.test.ts
@@ -1,49 +1,87 @@
 import { describe, expect, test } from 'bun:test';
-import { parseEnvironment } from '#environment.ts';
+import { parseEnvironment, parseEnvironmentPatch } from '#environment.ts';
 import { InvalidEnvironmentError } from '#errors.ts';
 
 // The values come back branded as secrets, which is not what a literal in an expectation is.
-function parsed(assignments: string[]): Record<string, string> {
-  return parseEnvironment(assignments);
+function parsed({
+  set = [],
+  remove = [],
+}: {
+  set?: string[];
+  remove?: string[];
+}): Record<string, string | null> {
+  return parseEnvironment({ set, remove });
 }
 
 test('a name and a value become one entry', () => {
-  expect(parsed(['OPENCLAW_STATE_DIR=/app/data/.openclaw'])).toEqual({
+  expect(parsed({ set: ['OPENCLAW_STATE_DIR=/app/data/.openclaw'] })).toEqual({
     OPENCLAW_STATE_DIR: '/app/data/.openclaw',
   });
 });
 
-test('several are one environment', () => {
-  expect(parsed(['A=1', 'B=2'])).toEqual({ A: '1', B: '2' });
+test('several are one edit', () => {
+  expect(parsed({ set: ['A=1', 'B=2'] })).toEqual({ A: '1', B: '2' });
 });
 
 // A value is arbitrary text and secrets routinely hold an `=`, so only the first one separates.
 test('only the first separator separates', () => {
-  expect(parsed(['TOKEN=a=b=c'])).toEqual({ TOKEN: 'a=b=c' });
+  expect(parsed({ set: ['TOKEN=a=b=c'] })).toEqual({ TOKEN: 'a=b=c' });
 });
 
 test('an empty value is a value', () => {
-  expect(parsed(['EMPTY='])).toEqual({ EMPTY: '' });
+  expect(parsed({ set: ['EMPTY='] })).toEqual({ EMPTY: '' });
 });
 
 test('the last value given for a name is the one it takes', () => {
-  expect(parsed(['PORT=1', 'PORT=2'])).toEqual({ PORT: '2' });
+  expect(parsed({ set: ['PORT=1', 'PORT=2'] })).toEqual({ PORT: '2' });
+});
+
+// A name alone cannot mean "set this to nothing": an empty value is a value, and the only way to
+// say a variable should go is to say nothing about what it holds.
+test('a name to remove is that name and no value', () => {
+  expect(parsed({ set: ['A=1'], remove: ['B'] })).toEqual({ A: '1', B: null });
 });
 
 describe('what is refused as something that was typed wrong', () => {
   test('a word with no value', () => {
-    expect(() => parseEnvironment(['JUST_A_NAME'])).toThrow(InvalidEnvironmentError);
+    expect(() => parsed({ set: ['JUST_A_NAME'] })).toThrow(InvalidEnvironmentError);
   });
 
   test('a value with no name', () => {
-    expect(() => parseEnvironment(['=orphaned'])).toThrow(InvalidEnvironmentError);
+    expect(() => parsed({ set: ['=orphaned'] })).toThrow(InvalidEnvironmentError);
   });
 
   test('a name a shell would not accept either', () => {
-    expect(() => parseEnvironment(['NOT-A-NAME=1'])).toThrow(InvalidEnvironmentError);
+    expect(() => parsed({ set: ['NOT-A-NAME=1'] })).toThrow(InvalidEnvironmentError);
   });
 
   test('a name that starts with a digit', () => {
-    expect(() => parseEnvironment(['1ST=1'])).toThrow(InvalidEnvironmentError);
+    expect(() => parsed({ set: ['1ST=1'] })).toThrow(InvalidEnvironmentError);
+  });
+
+  // Removing is the same name in the same place, so it is held to the same rule.
+  test('a name to remove that could never have been set', () => {
+    expect(() => parsed({ remove: ['NOT-A-NAME'] })).toThrow(InvalidEnvironmentError);
+  });
+});
+
+describe('an edit given as a name and a value already apart', () => {
+  function edited(edits: Array<{ name: string; value: string | null }>) {
+    return parseEnvironmentPatch(edits) as Record<string, string | null>;
+  }
+
+  test('a value sets the variable and null removes it', () => {
+    expect(
+      edited([
+        { name: 'TOKEN', value: 'sk-1' },
+        { name: 'GONE', value: null },
+      ]),
+    ).toEqual({ TOKEN: 'sk-1', GONE: null });
+  });
+
+  // The same refusal wherever a name was typed: a form with a field for each half must not accept
+  // what the command line would not.
+  test('a name a shell would not accept either is refused here too', () => {
+    expect(() => edited([{ name: 'NOT-A-NAME', value: '1' }])).toThrow(InvalidEnvironmentError);
   });
 });

--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -29,7 +29,11 @@ export const command = defineCommand('run [command]', {
     env: {
       schema: z.array(z.string()).optional(),
       description:
-        'Set an environment variable for the binary, as NAME=value. Repeatable. Given at all, these replace the ones the app already has.',
+        'Set an environment variable for the binary, as NAME=value. Repeatable. Anything the app already has and this does not name is left as it is.',
+    },
+    unset: {
+      schema: z.array(z.string()).optional(),
+      description: 'Remove an environment variable from the app, by name. Repeatable.',
     },
     detach: {
       schema: z.boolean().optional(),

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -14,7 +14,7 @@ import {
   type Filename,
   FilenameSchema,
   type TenantArguments,
-  type TenantEnvironment,
+  type TenantEnvironmentPatch,
   Value,
 } from '@repo/protocol';
 import { UsageError } from '#lib/errors.ts';
@@ -42,8 +42,10 @@ export async function deploy({
   name,
   port,
   env,
+  unset,
   detach,
 }: DeployInput): Promise<void> {
+  const environment = asEnvironment({ env, unset });
   const deployed = await startDeployment({
     api,
     binary,
@@ -51,7 +53,7 @@ export async function deploy({
     app,
     name,
     port,
-    ...(env !== undefined && { environment: asEnvironment(env) }),
+    ...(environment !== undefined && { environment }),
     onStep: (step) => announce({ step, ui }),
     whileUploading: ({ message, task }) => {
       const startedAt = Date.now();
@@ -114,12 +116,25 @@ export async function openBinary(path: string): Promise<UploadableBinary> {
 }
 
 /**
+ * Undefined where neither flag was given, which is what leaves the app's environment alone: an
+ * empty edit would be a request to change nothing, sent on every deploy that mentions none.
+ *
  * The shared parser does not know what a command line is, so what it refuses is reported here in
  * the words `nib` refuses anything else in.
  */
-function asEnvironment(assignments: string[]): TenantEnvironment {
+function asEnvironment({
+  env = [],
+  unset = [],
+}: {
+  env?: string[] | undefined;
+  unset?: string[] | undefined;
+}): TenantEnvironmentPatch | undefined {
+  if (env.length === 0 && unset.length === 0) {
+    return undefined;
+  }
+
   try {
-    return parseEnvironment(assignments);
+    return parseEnvironment({ set: env, remove: unset });
   } catch (failure) {
     if (failure instanceof InvalidEnvironmentError) {
       throw new UsageError(failure.message);

--- a/packages/cli/src/lib/plan.ts
+++ b/packages/cli/src/lib/plan.ts
@@ -11,6 +11,7 @@ export type RunOptions = {
   name?: string | undefined;
   port?: number | undefined;
   env?: string[] | undefined;
+  unset?: string[] | undefined;
 };
 
 type Plan = {

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -13,5 +13,8 @@ The model is desired state, never commands. Nothing here may be shaped like `sta
   TypeBox is the only dependency, and this package must acquire no side effects and no client.
 - Types derive from schemas (`typeof XSchema.static`), state enums from one `const` array. Never
   hand-write a type a schema already describes.
-- Absent means unknown or not applicable. **No field is ever `null`.**
+- Absent means unknown or not applicable. **No field is ever `null`.** The one exception is
+  `TenantEnvironmentPatchSchema`, which is an owner editing their app rather than anything a host
+  is sent: there absent means "leave this variable as it is", so removing one needs a word of its
+  own.
 - **Log shipping, when it is built, gets its own path.** A log burst must never delay a stop.

--- a/packages/protocol/src/domain/app.ts
+++ b/packages/protocol/src/domain/app.ts
@@ -58,6 +58,22 @@ export const TenantEnvironmentSchema = Type.Record(
 
 export type TenantEnvironment = typeof TenantEnvironmentSchema.static;
 
+/**
+ * An edit to an app's environment rather than the whole of one: a variable named is set to what it
+ * is given, one given `null` is removed, and one not named is left exactly as it is. That is what
+ * lets an owner change one variable without restating values they are not allowed to read back.
+ *
+ * The one schema here whose values may be `null`, and only ever sent by an owner — a host is told
+ * the environment an instance runs with, in full, and never an edit to one.
+ */
+export const TenantEnvironmentPatchSchema = Type.Record(
+  Type.String({ pattern: ENVIRONMENT_NAME_PATTERN }),
+  Type.Union([SecretStringSchema, Type.Null()]),
+  { additionalProperties: false },
+);
+
+export type TenantEnvironmentPatch = typeof TenantEnvironmentPatchSchema.static;
+
 // What the user configured, snapshotted into every deployment so a rollback replays exactly
 // what ran rather than whatever the app happens to be configured with now.
 // argv[1..] for the tenant binary; argv[0] is always the binary itself. Empty for anything

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -84,6 +84,8 @@ export {
   type TenantArguments,
   TenantArgumentsSchema,
   type TenantEnvironment,
+  type TenantEnvironmentPatch,
+  TenantEnvironmentPatchSchema,
   TenantEnvironmentSchema,
 } from '#domain/app.ts';
 export {


### PR DESCRIPTION
First of three. An owner cannot read a value back, so a deploy that had to state the whole environment could never leave one alone.

`environment` in a config patch is now an edit rather than a replacement: a variable it names is set, one it names with `null` is removed, and one it does not name is untouched. Untouched values are copied ciphertext to ciphertext, so the api never opens a secret it is only carrying forward.

`nib run --env` follows — it sets what it names and leaves the rest — and `--unset NAME` takes over the removal that replacing the lot used to be the only way to do.