### PR TITLE
feat(dashboard): the environment is a table of rows, not a textarea

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "bun run --bun vite dev --port 3001",
     "build": "bun run --bun vite build",
+    "test": "bun test",
     "check:types": "bun run --bun tsc"
   },
   "dependencies": {

--- a/apps/dashboard/src/components/apps/deploy-environment-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-environment-field.tsx
@@ -1,7 +1,10 @@
-import { Field, FieldDescription, FieldError, FieldLabel } from '@repo/ui/components/field';
-import { Textarea } from '@repo/ui/components/textarea';
+import { Field, FieldDescription, FieldError, FieldTitle } from '@repo/ui/components/field';
+import { EnvironmentTable } from '#components/apps/environment-table.tsx';
+import { storedVariables } from '#lib/environment-variables.ts';
 import { type DeployFormApi, validateEnvironment } from '#lib/hooks/use-deploy-form.ts';
 import type { AppSummary } from '#queries/apps.ts';
+
+const TITLE_ID = 'deploy-environment-title';
 
 export function DeployEnvironmentField({
   api,
@@ -13,14 +16,16 @@ export function DeployEnvironmentField({
   return (
     <api.Field name="environment" validators={{ onChange: validateEnvironment }}>
       {(field) => (
-        <Field data-invalid={field.state.meta.errors.length > 0 || undefined}>
-          <FieldLabel htmlFor="deploy-environment">Environment</FieldLabel>
-          <Textarea
-            id="deploy-environment"
-            value={field.state.value ?? ''}
-            onChange={(event) => field.handleChange(event.target.value)}
-            placeholder={'OPENCLAW_STATE_DIR=/app/data/.openclaw'}
-            className="font-mono"
+        <Field
+          aria-labelledby={TITLE_ID}
+          data-invalid={field.state.meta.errors.length > 0 || undefined}
+        >
+          <FieldTitle id={TITLE_ID}>Environment</FieldTitle>
+          {/* Seeded from the app rather than held in the form until something is edited: the app
+              is read while the dialog is already open, and defaults are fixed when it mounts. */}
+          <EnvironmentTable
+            variables={field.state.value ?? storedVariables(replacing)}
+            onChange={field.handleChange}
           />
           {field.state.meta.errors.length > 0 ? (
             <FieldError>{field.state.meta.errors[0]}</FieldError>
@@ -33,12 +38,9 @@ export function DeployEnvironmentField({
   );
 }
 
-// A value cannot be shown once it is set — the api returns the names and nothing else — so what
-// this says is what leaving the box alone will do.
 function describeEnvironment(replacing: AppSummary | undefined): string {
-  const names = Object.keys(replacing?.config.environment ?? {});
-  if (names.length === 0) {
-    return 'One NAME=value per line. What the binary runs with.';
+  if (replacing === undefined) {
+    return 'What the binary runs with.';
   }
-  return `One NAME=value per line. What is not named here is left as it is — ${names.join(', ')} are set.`;
+  return 'What the binary runs with. A value already set can be replaced but never read back, and a row removed here is a variable the app stops running with.';
 }

--- a/apps/dashboard/src/components/apps/environment-row.tsx
+++ b/apps/dashboard/src/components/apps/environment-row.tsx
@@ -1,0 +1,86 @@
+import { Button } from '@repo/ui/components/button';
+import { Input } from '@repo/ui/components/input';
+import { TableCell, TableRow } from '@repo/ui/components/table';
+import { EyeIcon, EyeOffIcon, Trash2Icon } from 'lucide-react';
+import { useState } from 'react';
+import { SealedValuePopover } from '#components/apps/sealed-value-popover.tsx';
+import type { EnvironmentVariable } from '#lib/environment-variables.ts';
+
+const HIDDEN_VALUE = '••••••••••••';
+
+export function EnvironmentRow({
+  variable,
+  onChange,
+  onRemove,
+}: {
+  variable: EnvironmentVariable;
+  onChange: (variable: EnvironmentVariable) => void;
+  onRemove: () => void;
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const named = variable.name.trim();
+
+  // A stored variable is identified by its name, so renaming one would be removing it and adding
+  // another under a name whose value nobody can supply.
+  return (
+    <TableRow>
+      <TableCell className="w-1/2 p-1">
+        <Input
+          value={variable.name}
+          onChange={(event) => onChange({ ...variable, name: event.target.value })}
+          disabled={variable.sealed}
+          placeholder="NAME"
+          aria-label="Variable name"
+          title={variable.name}
+          autoComplete="off"
+          spellCheck={false}
+          className="font-mono"
+        />
+      </TableCell>
+      <TableCell className="w-1/2 p-1">
+        {variable.sealed ? (
+          <span className="px-2.5 font-mono text-muted-foreground">{HIDDEN_VALUE}</span>
+        ) : (
+          <Input
+            type={revealed ? 'text' : 'password'}
+            value={variable.value}
+            onChange={(event) => onChange({ ...variable, value: event.target.value })}
+            aria-label={named === '' ? 'Variable value' : `Value of ${named}`}
+            autoComplete="off"
+            spellCheck={false}
+            className="font-mono"
+          />
+        )}
+      </TableCell>
+      <TableCell className="w-px p-1">
+        <div className="flex items-center gap-0.5">
+          {variable.sealed ? (
+            <SealedValuePopover
+              name={named}
+              onReplace={() => onChange({ ...variable, value: '', sealed: false })}
+            />
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={revealed ? 'Hide the value' : 'Show the value'}
+              onClick={() => setRevealed(!revealed)}
+            >
+              {revealed ? <EyeOffIcon /> : <EyeIcon />}
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={named === '' ? 'Remove this variable' : `Remove ${named}`}
+            onClick={onRemove}
+          >
+            <Trash2Icon />
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/apps/dashboard/src/components/apps/environment-table.tsx
+++ b/apps/dashboard/src/components/apps/environment-table.tsx
@@ -1,0 +1,70 @@
+import { Button } from '@repo/ui/components/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@repo/ui/components/table';
+import { PlusIcon } from 'lucide-react';
+import { EnvironmentRow } from '#components/apps/environment-row.tsx';
+import { blankVariable, type EnvironmentVariable } from '#lib/environment-variables.ts';
+
+export function EnvironmentTable({
+  variables,
+  onChange,
+}: {
+  variables: readonly EnvironmentVariable[];
+  onChange: (variables: EnvironmentVariable[]) => void;
+}) {
+  function replace(replacement: EnvironmentVariable): void {
+    onChange(
+      variables.map((variable) => (variable.id === replacement.id ? replacement : variable)),
+    );
+  }
+
+  function remove(id: string): void {
+    onChange(variables.filter((variable) => variable.id !== id));
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="px-1 font-normal text-muted-foreground text-xs">Name</TableHead>
+            <TableHead className="px-1 font-normal text-muted-foreground text-xs">Value</TableHead>
+            <TableHead className="w-px" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {variables.map((variable) => (
+            <EnvironmentRow
+              key={variable.id}
+              variable={variable}
+              onChange={replace}
+              onRemove={() => remove(variable.id)}
+            />
+          ))}
+          {variables.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={3} className="whitespace-normal px-1 text-muted-foreground">
+                Nothing set — the binary runs with whatever the guest gives it.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onChange([...variables, blankVariable()])}
+      >
+        <PlusIcon data-icon="inline-start" />
+        Add a variable
+      </Button>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/apps/sealed-value-popover.tsx
+++ b/apps/dashboard/src/components/apps/sealed-value-popover.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@repo/ui/components/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '@repo/ui/components/popover';
+import { EyeOffIcon } from 'lucide-react';
+
+/**
+ * Why a stored value has no eye to toggle. The button looks like the one on every other row and
+ * answers instead of doing nothing, because a control that is simply dead is one an owner tries
+ * again.
+ */
+export function SealedValuePopover({ name, onReplace }: { name: string; onReplace: () => void }) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="text-muted-foreground"
+            aria-label={`Why ${name} cannot be shown`}
+          />
+        }
+      >
+        <EyeOffIcon />
+      </PopoverTrigger>
+      <PopoverContent align="end">
+        <PopoverHeader>
+          <PopoverTitle>Sealed</PopoverTitle>
+          <PopoverDescription>
+            This value was encrypted when it was set, and nothing here can read it back — not this
+            page, and not nibrun. Replacing it is the only way to change what the app runs with.
+          </PopoverDescription>
+        </PopoverHeader>
+        <Button type="button" variant="outline" size="sm" onClick={onReplace}>
+          Replace the value
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/dashboard/src/lib/environment-variables.ts
+++ b/apps/dashboard/src/lib/environment-variables.ts
@@ -1,0 +1,81 @@
+import type { EnvironmentEdit } from '@repo/app-operations';
+import type { AppSummary } from '#queries/apps.ts';
+
+/**
+ * A row of the environment table. `sealed` is a variable the app already runs with: the api
+ * returns its name and never its value, so there is nothing to show for it and nothing this end
+ * could send for it — which is exactly what leaves it as it is.
+ */
+export type EnvironmentVariable = {
+  id: string;
+  name: string;
+  value: string;
+  sealed: boolean;
+};
+
+/** What the app runs with now, as rows: every name it has, none of their values. */
+export function storedVariables(app: AppSummary | undefined): EnvironmentVariable[] {
+  return storedNames(app).map((name) => ({ id: name, name, value: '', sealed: true }));
+}
+
+// A name is what identifies a stored variable, so a fresh row cannot be keyed by one: it has no
+// name until it is typed, and two of them would collide before anything could say so.
+export function blankVariable(): EnvironmentVariable {
+  return { id: crypto.randomUUID(), name: '', value: '', sealed: false };
+}
+
+/** A row nobody has filled in yet is not a variable, and is not sent as one. */
+export function filledVariables(variables: readonly EnvironmentVariable[]): EnvironmentVariable[] {
+  return variables.filter(
+    (variable) => variable.sealed || variable.name.trim().length > 0 || variable.value.length > 0,
+  );
+}
+
+/**
+ * What the table changed, and nothing else: the values that were typed, and a `null` for every
+ * variable the app has that no row does any more. A row still sealed is left out — the value
+ * behind it is one this end has never seen, and saying nothing is what keeps it.
+ *
+ * A table nobody has touched is not an empty one. The rows are seeded from the app as the field
+ * renders and only reach the form once something is edited, so no rows at all is a deploy with
+ * nothing to say about the environment rather than one asking for every variable to go.
+ */
+export function environmentEdits({
+  variables,
+  stored,
+}: {
+  variables: readonly EnvironmentVariable[] | undefined;
+  stored: readonly string[];
+}): EnvironmentEdit[] {
+  if (variables === undefined) {
+    return [];
+  }
+
+  const rows = filledVariables(variables);
+  const named = new Set(rows.map((variable) => variable.name.trim()));
+
+  return [
+    ...rows
+      .filter((variable) => !variable.sealed)
+      .map((variable) => ({ name: variable.name.trim(), value: variable.value })),
+    ...stored.filter((name) => !named.has(name)).map((name) => ({ name, value: null })),
+  ];
+}
+
+/** The names an app runs with now, which is what a row going missing is measured against. */
+export function storedNames(app: AppSummary | undefined): string[] {
+  return Object.keys(app?.config.environment ?? {});
+}
+
+/** The first name two rows share, which is a mistake nothing downstream could report. */
+export function repeatedName(variables: readonly EnvironmentVariable[]): string | undefined {
+  const seen = new Set<string>();
+  for (const variable of filledVariables(variables)) {
+    const name = variable.name.trim();
+    if (seen.has(name)) {
+      return name;
+    }
+    seen.add(name);
+  }
+  return undefined;
+}

--- a/apps/dashboard/src/lib/hooks/use-deploy-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy-form.ts
@@ -1,10 +1,17 @@
 import {
   InvalidEnvironmentError,
-  parseEnvironment,
+  parseEnvironmentPatch,
   type UploadableBinary,
 } from '@repo/app-operations';
 import { DEFAULT_GUEST_PORT, FilenameSchema, Value } from '@repo/protocol';
 import { type ReactFormExtendedApi, useForm } from '@tanstack/react-form';
+import {
+  type EnvironmentVariable,
+  environmentEdits,
+  filledVariables,
+  repeatedName,
+  storedNames,
+} from '#lib/environment-variables.ts';
 import { useApps } from '#lib/hooks/use-apps.ts';
 import type { DeployRequest } from '#lib/hooks/use-deploy.ts';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
@@ -15,7 +22,7 @@ export type DeployFormValues = {
   name: string;
   port: string | undefined;
   args: string | undefined;
-  environment: string | undefined;
+  environment: EnvironmentVariable[] | undefined;
 };
 
 export type DeployFormApi = ReactFormExtendedApi<
@@ -65,20 +72,29 @@ export function validatePort({ value }: { value: string | undefined }): string |
     : 'Ports are whole numbers.';
 }
 
-export function validateEnvironment({ value }: { value: string | undefined }): string | undefined {
+export function validateEnvironment({
+  value,
+}: {
+  value: EnvironmentVariable[] | undefined;
+}): string | undefined {
+  const variables = filledVariables(value ?? []);
+  if (variables.some((variable) => variable.name.trim().length === 0)) {
+    return 'A variable needs a name.';
+  }
+
+  // Two rows under one name are one variable by the time they are a record, so the row that lost
+  // would go without a word — and which of them lost is not something a form should decide.
+  const repeated = repeatedName(variables);
+  if (repeated !== undefined) {
+    return `Two rows name ${repeated}; one of them has to go.`;
+  }
+
   try {
-    parseEnvironment({ set: assignments(value ?? ''), remove: [] });
+    parseEnvironmentPatch(environmentEdits({ variables, stored: [] }));
     return undefined;
   } catch (failure) {
     return failure instanceof InvalidEnvironmentError ? failure.message : undefined;
   }
-}
-
-function assignments(onePerLine: string): string[] {
-  return onePerLine
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
 }
 
 export function useDeployForm({ appId }: { appId: string | undefined }): DeployFormState {
@@ -117,21 +133,23 @@ function asDeployRequest({
   replacing: AppSummary | undefined;
 }): DeployRequest | undefined {
   const binary = value.binary === undefined ? undefined : uploadableFrom(value.binary);
-  const entered = assignments(value.environment ?? '');
   const port = Number(value.port ?? replacing?.config.guestPort ?? DEFAULT_GUEST_PORT);
   if (binary === undefined || !Number.isInteger(port)) {
     return undefined;
   }
 
+  const edits = environmentEdits({
+    variables: value.environment,
+    stored: storedNames(replacing),
+  });
+
   return {
     binary,
     args: tenantArguments(value.args ?? replacing?.config.args.join('\n') ?? ''),
-    // An empty box changes nothing, and a full one only the variables it names: the form cannot
-    // show a value it is not allowed to read, so what it says nothing about has to be what it
-    // leaves alone. Taking a variable away is `nib run --unset` until this box is a table.
-    ...(entered.length === 0
-      ? {}
-      : { environment: parseEnvironment({ set: entered, remove: [] }) }),
+    // Only what the table changed. A row still sealed holds a value this end has never read, so
+    // it is sent as nothing at all — which is what leaves it alone — and a name the app has that
+    // the table no longer does goes as null, the only way to say a variable should be removed.
+    ...(edits.length === 0 ? {} : { environment: parseEnvironmentPatch(edits) }),
     app: replacing?.slug,
     name: replacing === undefined ? value.name.trim() || undefined : undefined,
     port,

--- a/apps/dashboard/tests/lib/environment-variables.test.ts
+++ b/apps/dashboard/tests/lib/environment-variables.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'bun:test';
+import { REDACTED } from '@repo/protocol';
+import {
+  type EnvironmentVariable,
+  environmentEdits,
+  repeatedName,
+  storedVariables,
+} from '#lib/environment-variables.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+const STORED = ['TOKEN', 'LOG_LEVEL'];
+
+// The one field any of this reads; the rest of an app response is nothing to do with it.
+const APP = {
+  config: { environment: { TOKEN: REDACTED, LOG_LEVEL: REDACTED } },
+} as unknown as AppSummary;
+
+function rows(): EnvironmentVariable[] {
+  return storedVariables(APP);
+}
+
+function edits(variables: readonly EnvironmentVariable[] | undefined) {
+  return environmentEdits({ variables, stored: STORED });
+}
+
+/**
+ * The whole of what a deploy says about an app's environment is decided here, and every way of
+ * getting it wrong erases a secret: an owner cannot read one back, so nothing downstream can put
+ * back what this leaves out by mistake.
+ */
+test('a table nobody touched says nothing at all', () => {
+  expect(edits(undefined)).toEqual([]);
+});
+
+test('rows still sealed are left out, which is what keeps their values', () => {
+  expect(edits(rows())).toEqual([]);
+});
+
+test('a value that was typed is sent as that value', () => {
+  const replaced = rows().map((variable) =>
+    variable.name === 'TOKEN' ? { ...variable, value: 'sk-new', sealed: false } : variable,
+  );
+
+  expect(edits(replaced)).toEqual([{ name: 'TOKEN', value: 'sk-new' }]);
+});
+
+// The only way to say a variable should go: an empty value is a value, and a row that is simply
+// absent would read as one to leave alone.
+test('a name the app has that the table no longer does is sent as null', () => {
+  const removed = rows().filter((variable) => variable.name !== 'LOG_LEVEL');
+
+  expect(edits(removed)).toEqual([{ name: 'LOG_LEVEL', value: null }]);
+});
+
+test('a variable added alongside them is sent with the rest', () => {
+  const added = [...rows(), { id: 'new', name: ' PORT ', value: '8080', sealed: false }];
+
+  expect(edits(added)).toEqual([{ name: 'PORT', value: '8080' }]);
+});
+
+test('a row nobody filled in is not a variable', () => {
+  const blank = [...rows(), { id: 'new', name: '', value: '', sealed: false }];
+
+  expect(edits(blank)).toEqual([]);
+});
+
+test('two rows under one name are found before either is sent', () => {
+  const twice = [...rows(), { id: 'new', name: 'TOKEN', value: 'sk-other', sealed: false }];
+
+  expect(repeatedName(twice)).toBe('TOKEN');
+});

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "types": ["vite/client", "react", "react-dom"]
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "tests", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Stacked on #231.

One row per variable: a new one has a hidden value with an eye to reveal it, and one the app already has arrives sealed — the eye answers with why it cannot be shown and offers to replace it. A deploy sends only what the table changed, and a table nobody touched sends no environment at all.