### PR TITLE
feat(dashboard): a new app's environment can come from a .env file

### DIFF
--- a/apps/dashboard/src/components/apps/deploy-environment-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-environment-field.tsx
@@ -1,6 +1,7 @@
 import { Field, FieldDescription, FieldError, FieldTitle } from '@repo/ui/components/field';
+import { EnvFilePicker } from '#components/apps/env-file-picker.tsx';
 import { EnvironmentTable } from '#components/apps/environment-table.tsx';
-import { storedVariables } from '#lib/environment-variables.ts';
+import { storedVariables, withEntries } from '#lib/environment-variables.ts';
 import { type DeployFormApi, validateEnvironment } from '#lib/hooks/use-deploy-form.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
@@ -15,25 +16,32 @@ export function DeployEnvironmentField({
 }) {
   return (
     <api.Field name="environment" validators={{ onChange: validateEnvironment }}>
-      {(field) => (
-        <Field
-          aria-labelledby={TITLE_ID}
-          data-invalid={field.state.meta.errors.length > 0 || undefined}
-        >
-          <FieldTitle id={TITLE_ID}>Environment</FieldTitle>
-          {/* Seeded from the app rather than held in the form until something is edited: the app
-              is read while the dialog is already open, and defaults are fixed when it mounts. */}
-          <EnvironmentTable
-            variables={field.state.value ?? storedVariables(replacing)}
-            onChange={field.handleChange}
-          />
-          {field.state.meta.errors.length > 0 ? (
-            <FieldError>{field.state.meta.errors[0]}</FieldError>
-          ) : (
-            <FieldDescription>{describeEnvironment(replacing)}</FieldDescription>
-          )}
-        </Field>
-      )}
+      {(field) => {
+        // Seeded from the app rather than held as a default: the app is read while the dialog is
+        // already open, and a form's defaults are fixed when it mounts.
+        const variables = field.state.value ?? storedVariables(replacing);
+
+        return (
+          <Field
+            aria-labelledby={TITLE_ID}
+            data-invalid={field.state.meta.errors.length > 0 || undefined}
+          >
+            <FieldTitle id={TITLE_ID}>Environment</FieldTitle>
+            <EnvironmentTable variables={variables} onChange={field.handleChange}>
+              {replacing === undefined && (
+                <EnvFilePicker
+                  onLoad={(entries) => field.handleChange(withEntries({ variables, entries }))}
+                />
+              )}
+            </EnvironmentTable>
+            {field.state.meta.errors.length > 0 ? (
+              <FieldError>{field.state.meta.errors[0]}</FieldError>
+            ) : (
+              <FieldDescription>{describeEnvironment(replacing)}</FieldDescription>
+            )}
+          </Field>
+        );
+      }}
     </api.Field>
   );
 }

--- a/apps/dashboard/src/components/apps/env-file-picker.tsx
+++ b/apps/dashboard/src/components/apps/env-file-picker.tsx
@@ -1,0 +1,58 @@
+import {
+  type EnvironmentAssignment,
+  InvalidEnvironmentError,
+  parseEnvFile,
+} from '@repo/app-operations';
+import { Button } from '@repo/ui/components/button';
+import { FileUpIcon } from 'lucide-react';
+import { useRef } from 'react';
+import { toast } from 'sonner';
+
+/** Only where an app is being created: a file cannot say anything about a value it never saw. */
+export function EnvFilePicker({ onLoad }: { onLoad: (entries: EnvironmentAssignment[]) => void }) {
+  const input = useRef<HTMLInputElement>(null);
+
+  async function load(file: File | undefined): Promise<void> {
+    if (file === undefined) {
+      return;
+    }
+
+    try {
+      onLoad(parseEnvFile(await file.text()));
+    } catch (failure) {
+      toast.error(
+        failure instanceof InvalidEnvironmentError
+          ? failure.message
+          : `${file.name} could not be read.`,
+      );
+    }
+
+    // A file input reports no change for the file it already holds, so a file that was corrected
+    // and picked again would do nothing at all.
+    if (input.current !== null) {
+      input.current.value = '';
+    }
+  }
+
+  return (
+    <>
+      {/* Named by the button rather than by a label of its own: what the button says is what
+          this does, and two names for one control is one name too many. */}
+      <input
+        ref={input}
+        type="file"
+        accept=".env,text/plain"
+        className="sr-only"
+        tabIndex={-1}
+        aria-hidden
+        onChange={(event) => {
+          void load(event.target.files?.[0]);
+        }}
+      />
+      <Button type="button" variant="ghost" size="sm" onClick={() => input.current?.click()}>
+        <FileUpIcon data-icon="inline-start" />
+        Load a .env file
+      </Button>
+    </>
+  );
+}

--- a/apps/dashboard/src/components/apps/environment-row.tsx
+++ b/apps/dashboard/src/components/apps/environment-row.tsx
@@ -3,10 +3,24 @@ import { Input } from '@repo/ui/components/input';
 import { TableCell, TableRow } from '@repo/ui/components/table';
 import { EyeIcon, EyeOffIcon, Trash2Icon } from 'lucide-react';
 import { useState } from 'react';
-import { SealedValuePopover } from '#components/apps/sealed-value-popover.tsx';
+import { HiddenValuePopover } from '#components/apps/hidden-value-popover.tsx';
 import type { EnvironmentVariable } from '#lib/environment-variables.ts';
 
 const HIDDEN_VALUE = '••••••••••••';
+
+const SEALED = {
+  title: 'Sealed',
+  description:
+    'This value was encrypted when it was set, and nothing here can read it back — not this page, and not nibrun. Replacing it is the only way to change what the app runs with.',
+};
+
+// A row is one line high, so a value with more than one in it can be carried and sent but never
+// shown: an input would drop the line breaks the moment it was typed in.
+const MANY_LINES = {
+  title: 'Several lines',
+  description:
+    'This value spans several lines, which is more than a row can show. It is deployed exactly as the file had it; replace it to change what the app runs with.',
+};
 
 export function EnvironmentRow({
   variable,
@@ -19,6 +33,7 @@ export function EnvironmentRow({
 }) {
   const [revealed, setRevealed] = useState(false);
   const named = variable.name.trim();
+  const hidden = variable.sealed ? SEALED : variable.value.includes('\n') ? MANY_LINES : undefined;
 
   // A stored variable is identified by its name, so renaming one would be removing it and adding
   // another under a name whose value nobody can supply.
@@ -38,9 +53,7 @@ export function EnvironmentRow({
         />
       </TableCell>
       <TableCell className="w-1/2 p-1">
-        {variable.sealed ? (
-          <span className="px-2.5 font-mono text-muted-foreground">{HIDDEN_VALUE}</span>
-        ) : (
+        {hidden === undefined ? (
           <Input
             type={revealed ? 'text' : 'password'}
             value={variable.value}
@@ -50,16 +63,13 @@ export function EnvironmentRow({
             spellCheck={false}
             className="font-mono"
           />
+        ) : (
+          <span className="px-2.5 font-mono text-muted-foreground">{HIDDEN_VALUE}</span>
         )}
       </TableCell>
       <TableCell className="w-px p-1">
         <div className="flex items-center gap-0.5">
-          {variable.sealed ? (
-            <SealedValuePopover
-              name={named}
-              onReplace={() => onChange({ ...variable, value: '', sealed: false })}
-            />
-          ) : (
+          {hidden === undefined ? (
             <Button
               type="button"
               variant="ghost"
@@ -69,6 +79,13 @@ export function EnvironmentRow({
             >
               {revealed ? <EyeOffIcon /> : <EyeIcon />}
             </Button>
+          ) : (
+            <HiddenValuePopover
+              name={named}
+              title={hidden.title}
+              description={hidden.description}
+              onReplace={() => onChange({ ...variable, value: '', sealed: false })}
+            />
           )}
           <Button
             type="button"

--- a/apps/dashboard/src/components/apps/environment-table.tsx
+++ b/apps/dashboard/src/components/apps/environment-table.tsx
@@ -8,15 +8,18 @@ import {
   TableRow,
 } from '@repo/ui/components/table';
 import { PlusIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { EnvironmentRow } from '#components/apps/environment-row.tsx';
 import { blankVariable, type EnvironmentVariable } from '#lib/environment-variables.ts';
 
 export function EnvironmentTable({
   variables,
   onChange,
+  children,
 }: {
   variables: readonly EnvironmentVariable[];
   onChange: (variables: EnvironmentVariable[]) => void;
+  children?: ReactNode;
 }) {
   function replace(replacement: EnvironmentVariable): void {
     onChange(
@@ -56,15 +59,18 @@ export function EnvironmentTable({
           )}
         </TableBody>
       </Table>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={() => onChange([...variables, blankVariable()])}
-      >
-        <PlusIcon data-icon="inline-start" />
-        Add a variable
-      </Button>
+      <div className="flex flex-wrap items-center gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onChange([...variables, blankVariable()])}
+        >
+          <PlusIcon data-icon="inline-start" />
+          Add a variable
+        </Button>
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/components/apps/hidden-value-popover.tsx
+++ b/apps/dashboard/src/components/apps/hidden-value-popover.tsx
@@ -10,11 +10,20 @@ import {
 import { EyeOffIcon } from 'lucide-react';
 
 /**
- * Why a stored value has no eye to toggle. The button looks like the one on every other row and
- * answers instead of doing nothing, because a control that is simply dead is one an owner tries
- * again.
+ * Why a value has no eye to toggle. The button looks like the one on every other row and answers
+ * instead of doing nothing, because a control that is simply dead is one an owner tries again.
  */
-export function SealedValuePopover({ name, onReplace }: { name: string; onReplace: () => void }) {
+export function HiddenValuePopover({
+  name,
+  title,
+  description,
+  onReplace,
+}: {
+  name: string;
+  title: string;
+  description: string;
+  onReplace: () => void;
+}) {
   return (
     <Popover>
       <PopoverTrigger
@@ -32,11 +41,8 @@ export function SealedValuePopover({ name, onReplace }: { name: string; onReplac
       </PopoverTrigger>
       <PopoverContent align="end">
         <PopoverHeader>
-          <PopoverTitle>Sealed</PopoverTitle>
-          <PopoverDescription>
-            This value was encrypted when it was set, and nothing here can read it back — not this
-            page, and not nibrun. Replacing it is the only way to change what the app runs with.
-          </PopoverDescription>
+          <PopoverTitle>{title}</PopoverTitle>
+          <PopoverDescription>{description}</PopoverDescription>
         </PopoverHeader>
         <Button type="button" variant="outline" size="sm" onClick={onReplace}>
           Replace the value

--- a/apps/dashboard/src/lib/environment-variables.ts
+++ b/apps/dashboard/src/lib/environment-variables.ts
@@ -1,4 +1,4 @@
-import type { EnvironmentEdit } from '@repo/app-operations';
+import type { EnvironmentAssignment, EnvironmentEdit } from '@repo/app-operations';
 import type { AppSummary } from '#queries/apps.ts';
 
 /**
@@ -78,4 +78,30 @@ export function repeatedName(variables: readonly EnvironmentVariable[]): string 
     seen.add(name);
   }
   return undefined;
+}
+
+/**
+ * The rows a file leaves behind: a name it sets lands on the row that already had that name, one
+ * it does not is added, and a row nobody has typed into makes way. Picking a file fills the table
+ * in — it does not add a variable beside a half-typed one.
+ */
+export function withEntries({
+  variables,
+  entries,
+}: {
+  variables: readonly EnvironmentVariable[];
+  entries: readonly EnvironmentAssignment[];
+}): EnvironmentVariable[] {
+  const loaded = new Map(entries.map((entry) => [entry.name, entry.value]));
+  const filled = filledVariables(variables).map((variable) => {
+    const name = variable.name.trim();
+    if (!loaded.has(name)) {
+      return variable;
+    }
+    const value = loaded.get(name) ?? '';
+    loaded.delete(name);
+    return { ...variable, value, sealed: false };
+  });
+
+  return [...filled, ...[...loaded].map(([name, value]) => ({ ...blankVariable(), name, value }))];
 }

--- a/apps/dashboard/tests/lib/environment-variables.test.ts
+++ b/apps/dashboard/tests/lib/environment-variables.test.ts
@@ -5,6 +5,7 @@ import {
   environmentEdits,
   repeatedName,
   storedVariables,
+  withEntries,
 } from '#lib/environment-variables.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
@@ -68,4 +69,31 @@ test('two rows under one name are found before either is sent', () => {
   const twice = [...rows(), { id: 'new', name: 'TOKEN', value: 'sk-other', sealed: false }];
 
   expect(repeatedName(twice)).toBe('TOKEN');
+});
+
+test('a file lands on the rows that share its names and adds the rest', () => {
+  const typed = [{ id: 'a', name: 'PORT', value: '3000', sealed: false }];
+
+  expect(
+    withEntries({
+      variables: typed,
+      entries: [
+        { name: 'PORT', value: '8080' },
+        { name: 'TOKEN', value: 'sk-1' },
+      ],
+    }).map(({ name, value }) => ({ name, value })),
+  ).toEqual([
+    { name: 'PORT', value: '8080' },
+    { name: 'TOKEN', value: 'sk-1' },
+  ]);
+});
+
+// Picking a file fills the table in rather than adding beside the row that was open when it was
+// picked, which is otherwise what the blank row at the end becomes.
+test('a row nobody typed into makes way for it', () => {
+  const blank = [{ id: 'a', name: '', value: '', sealed: false }];
+
+  expect(
+    withEntries({ variables: blank, entries: [{ name: 'PORT', value: '8080' }] }),
+  ).toHaveLength(1);
 });

--- a/packages/app-operations/src/env-file.ts
+++ b/packages/app-operations/src/env-file.ts
@@ -1,0 +1,145 @@
+import { InvalidEnvironmentError } from '#errors.ts';
+
+/** A variable a file sets, and the text it sets it to. A file never removes one. */
+export type EnvironmentAssignment = { name: string; value: string };
+
+const COMMENT = '#';
+const EXPORT = 'export ';
+const ASSIGNMENT = '=';
+const ESCAPE = '\\';
+const QUOTES = new Set(['"', "'"]);
+const DOUBLE_QUOTE = '"';
+const INLINE_COMMENT = /\s#/;
+
+const ESCAPED: Record<string, string> = {
+  n: '\n',
+  r: '\r',
+  t: '\t',
+  '\\': '\\',
+  '"': '"',
+};
+
+/**
+ * A `.env` file as the variables it sets, taking it for what such a file already is everywhere
+ * else: blank lines and `#` comments are skipped, `export` in front of a name is allowed, a value
+ * may be quoted, and a quoted one may run over several lines.
+ *
+ * A line that is none of those is refused rather than skipped. Someone who picked a file on
+ * purpose is better told which line could not be read than left with variables quietly missing
+ * from what they thought they had loaded.
+ */
+export function parseEnvFile(text: string): EnvironmentAssignment[] {
+  const lines = text.split(/\r?\n/);
+  const entries: EnvironmentAssignment[] = [];
+
+  let index = 0;
+  while (index < lines.length) {
+    const line = lines[index] ?? '';
+    const trimmed = line.trim();
+    index++;
+
+    if (trimmed === '' || trimmed.startsWith(COMMENT)) {
+      continue;
+    }
+
+    const assignment = trimmed.startsWith(EXPORT) ? trimmed.slice(EXPORT.length) : trimmed;
+    const at = assignment.indexOf(ASSIGNMENT);
+    if (at <= 0) {
+      throw new InvalidEnvironmentError(`Line ${index} of the file is not NAME=value: ${trimmed}`);
+    }
+
+    // Read off the line as it was written rather than off the trimmed copy, so that whatever a
+    // quoted value holds at either end is what was quoted.
+    const name = assignment.slice(0, at).trim();
+    const written = line.slice(line.indexOf(ASSIGNMENT) + 1).trimStart();
+    const quote = written[0];
+
+    if (quote === undefined || !QUOTES.has(quote)) {
+      entries.push({ name, value: unquoted(written) });
+      continue;
+    }
+
+    const quoted = gather({ lines, from: index, opened: written.slice(1), quote, name });
+    entries.push({ name, value: quoted.value });
+    index = quoted.index;
+  }
+
+  return entries;
+}
+
+/**
+ * A quoted value, however many lines it takes to close it. Only double quotes carry escapes, as
+ * they do in a shell: inside single quotes a backslash is a backslash, and a path that ends in
+ * one would otherwise swallow the quote that closes it.
+ */
+function gather({
+  lines,
+  from,
+  opened,
+  quote,
+  name,
+}: {
+  lines: readonly string[];
+  from: number;
+  opened: string;
+  quote: string;
+  name: string;
+}): { value: string; index: number } {
+  const escapes = quote === DOUBLE_QUOTE;
+  let body = opened;
+  let index = from;
+
+  while (closesAt({ body, quote, escapes }) === -1) {
+    if (index >= lines.length) {
+      throw new InvalidEnvironmentError(`A value opened with ${quote} is never closed: ${name}`);
+    }
+    body += `\n${lines[index]}`;
+    index++;
+  }
+
+  const closed = body.slice(0, closesAt({ body, quote, escapes }));
+  return { value: escapes ? unescaped(closed) : closed, index };
+}
+
+function closesAt({
+  body,
+  quote,
+  escapes,
+}: {
+  body: string;
+  quote: string;
+  escapes: boolean;
+}): number {
+  for (let at = 0; at < body.length; at++) {
+    if (escapes && body[at] === ESCAPE) {
+      at++;
+      continue;
+    }
+    if (body[at] === quote) {
+      return at;
+    }
+  }
+  return -1;
+}
+
+function unescaped(value: string): string {
+  let plain = '';
+  for (let at = 0; at < value.length; at++) {
+    const character = value[at] ?? '';
+    const next = value[at + 1];
+    if (character === ESCAPE && next !== undefined && next in ESCAPED) {
+      plain += ESCAPED[next];
+      at++;
+      continue;
+    }
+    plain += character;
+  }
+  return plain;
+}
+
+// What follows a `#` after whitespace is a comment, as it is in the files this reads: a value
+// that has to hold one says so by being quoted.
+function unquoted(written: string): string {
+  const at = written.search(INLINE_COMMENT);
+  return (at === -1 ? written : written.slice(0, at)).trim();
+}

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -14,11 +14,8 @@ export {
   type UploadWait,
 } from '#deploy.ts';
 export { type AddDomainInput, addDomain, type RemoveDomainInput, removeDomain } from '#domains.ts';
-export {
-  type EnvironmentEdit,
-  parseEnvironment,
-  parseEnvironmentPatch,
-} from '#environment.ts';
+export { type EnvironmentAssignment, parseEnvFile } from '#env-file.ts';
+export { type EnvironmentEdit, parseEnvironment, parseEnvironmentPatch } from '#environment.ts';
 export { InvalidEnvironmentError, InvalidPathError } from '#errors.ts';
 export { awaitExportBundle, type ExportBundle, requestExport } from '#exports.ts';
 export { guestPath, readDirectory } from '#filesystem.ts';

--- a/packages/app-operations/tests/env-file.test.ts
+++ b/packages/app-operations/tests/env-file.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { parseEnvFile } from '#env-file.ts';
+import { InvalidEnvironmentError } from '#errors.ts';
+
+test('a name and a value per line', () => {
+  expect(parseEnvFile('PORT=8080\nLOG_LEVEL=debug')).toEqual([
+    { name: 'PORT', value: '8080' },
+    { name: 'LOG_LEVEL', value: 'debug' },
+  ]);
+});
+
+test('blank lines and comments set nothing', () => {
+  expect(parseEnvFile('# what this app runs with\n\nPORT=8080\n')).toEqual([
+    { name: 'PORT', value: '8080' },
+  ]);
+});
+
+// A file that was written to be sourced by a shell is still a file someone will pick here.
+test('a name may be exported', () => {
+  expect(parseEnvFile('export TOKEN=sk-1')).toEqual([{ name: 'TOKEN', value: 'sk-1' }]);
+});
+
+test('only the first separator separates', () => {
+  expect(parseEnvFile('TOKEN=a=b=c')).toEqual([{ name: 'TOKEN', value: 'a=b=c' }]);
+});
+
+test('what follows a # is a comment on the value, not part of it', () => {
+  expect(parseEnvFile('PORT=8080 # what it listens on')).toEqual([{ name: 'PORT', value: '8080' }]);
+});
+
+describe('a quoted value is taken as it was written', () => {
+  test('quotes keep the spaces they hold', () => {
+    expect(parseEnvFile('GREETING="  hello  "')).toEqual([
+      { name: 'GREETING', value: '  hello  ' },
+    ]);
+  });
+
+  test('a # inside quotes is part of the value', () => {
+    expect(parseEnvFile('TOKEN="sk-#-1"')).toEqual([{ name: 'TOKEN', value: 'sk-#-1' }]);
+  });
+
+  test('double quotes carry escapes', () => {
+    expect(parseEnvFile('KEY="one\\ntwo"')).toEqual([{ name: 'KEY', value: 'one\ntwo' }]);
+  });
+
+  // A backslash is a backslash inside single quotes, as it is in a shell — a Windows path ending
+  // in one would otherwise swallow the quote that closes it.
+  test('single quotes carry none', () => {
+    expect(parseEnvFile("DIR='C:\\data\\'")).toEqual([{ name: 'DIR', value: 'C:\\data\\' }]);
+  });
+
+  // A private key is the reason this is worth reading: it arrives as lines, and every one of them
+  // belongs to the value.
+  test('a quoted value may run over several lines', () => {
+    const file = 'KEY="-----BEGIN-----\nabc\ndef\n-----END-----"\nPORT=8080';
+
+    expect(parseEnvFile(file)).toEqual([
+      { name: 'KEY', value: '-----BEGIN-----\nabc\ndef\n-----END-----' },
+      { name: 'PORT', value: '8080' },
+    ]);
+  });
+});
+
+describe('what is refused rather than skipped', () => {
+  test('a line that sets nothing', () => {
+    expect(() => parseEnvFile('PORT=8080\njust a sentence')).toThrow(InvalidEnvironmentError);
+  });
+
+  test('a value with no name', () => {
+    expect(() => parseEnvFile('=orphaned')).toThrow(InvalidEnvironmentError);
+  });
+
+  test('a quote nothing closes', () => {
+    expect(() => parseEnvFile('KEY="never closed')).toThrow(InvalidEnvironmentError);
+  });
+});


### PR DESCRIPTION
Stacked on #232.

Creating an app can take the .env file the binary was developed against: what it sets fills the table in, and a line that is not a variable is refused by name rather than skipped.