### PR TITLE
fix(dashboard): allow suffixed env files

### DIFF
--- a/apps/dashboard/src/components/apps/env-file-picker.test.tsx
+++ b/apps/dashboard/src/components/apps/env-file-picker.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { EnvFilePicker } from '#components/apps/env-file-picker.tsx';
+
+function ignoreLoadedEnvironment(): void {}
+
+describe('environment file picker', () => {
+  test('lets the native picker select suffixed dotenv files', () => {
+    const markup = renderToStaticMarkup(<EnvFilePicker onLoad={ignoreLoadedEnvironment} />);
+
+    expect(markup).toContain('type="file"');
+    expect(markup).not.toContain('accept=');
+  });
+});

--- a/apps/dashboard/src/components/apps/env-file-picker.tsx
+++ b/apps/dashboard/src/components/apps/env-file-picker.tsx
@@ -41,7 +41,6 @@ export function EnvFilePicker({ onLoad }: { onLoad: (entries: EnvironmentAssignm
       <input
         ref={input}
         type="file"
-        accept=".env,text/plain"
         className="sr-only"
         tabIndex={-1}
         aria-hidden


### PR DESCRIPTION
Allow dotenv files such as `.env.nibrun` and `.env.production` to be selected by the deployment picker. Their contents remain subject to the existing dotenv parser validation.