### PR TITLE
fix(api): release deleted app hostnames

### DIFF
--- a/apps/api/src/db/migrations/0022_deleted_apps_release_hostnames.sql
+++ b/apps/api/src/db/migrations/0022_deleted_apps_release_hostnames.sql
@@ -1,0 +1,14 @@
+-- Hostnames are part of what a deleted app leaves behind. The app row itself stays so its slug
+-- is never issued again, which means the hostname rows cannot rely on their cascading foreign
+-- key to disappear.
+--
+-- Including them here makes the same retryable cleanup that removes binaries and exports also
+-- find deleted apps from before hostname cleanup existed.
+
+CREATE OR REPLACE VIEW nibrun.purgeable_apps AS
+  SELECT a.id AS app_id
+  FROM nibrun.apps a
+  WHERE a.state = 'deleted'
+    AND (EXISTS (SELECT 1 FROM nibrun.artifacts ar WHERE ar.app_id = a.id)
+      OR EXISTS (SELECT 1 FROM nibrun.exports e WHERE e.app_id = a.id)
+      OR EXISTS (SELECT 1 FROM nibrun.app_hostnames h WHERE h.app_id = a.id));

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -128,6 +128,19 @@ export interface ISelectPendingCustomHostnamesResult {
     created_at: Date;
 }
 
+/** Result of query `SelectDisposableAppHostnames`. */
+export interface ISelectDisposableAppHostnamesResult {
+    hostname: IAppHostnamesColumns["hostname"];
+    kind: IAppHostnamesColumns["kind"];
+    /** The custom hostname this row is projected onto at the edge. Absent for a platform hostname, which the wildcard already covers. */
+    cloudflare_id: IAppHostnamesColumns["cloudflare_id"];
+}
+
+/** Result of query `DeleteDisposableAppHostname`. */
+export interface IDeleteDisposableAppHostnameResult {
+    hostname: IAppHostnamesColumns["hostname"];
+}
+
 /** Result of query `SelectAppOwnership`. */
 export interface ISelectAppOwnershipResult {
     id: IAppsColumns["id"];
@@ -687,6 +700,8 @@ export interface Queries {
     UpdateCustomAppHostnameState: IUpdateCustomAppHostnameStateResult;
     DeleteCustomAppHostname: IDeleteCustomAppHostnameResult;
     SelectPendingCustomHostnames: ISelectPendingCustomHostnamesResult;
+    SelectDisposableAppHostnames: ISelectDisposableAppHostnamesResult;
+    DeleteDisposableAppHostname: IDeleteDisposableAppHostnameResult;
     SelectAppOwnership: ISelectAppOwnershipResult;
     InsertApp: IInsertAppResult;
     InsertAppConfig: IInsertAppConfigResult;

--- a/apps/api/src/lib/cloudflare/client.ts
+++ b/apps/api/src/lib/cloudflare/client.ts
@@ -1,6 +1,7 @@
 const API_BASE = 'https://api.cloudflare.com/client/v4/';
 
 const MAX_ERROR_BODY = 256;
+const HTTP_NOT_FOUND = 404;
 
 /**
  * Where Cloudflare answers the challenge on the owner's behalf. They point `_acme-challenge` at
@@ -10,9 +11,12 @@ const MAX_ERROR_BODY = 256;
 const DCV_DELEGATION_SUFFIX = 'dcv.cloudflare.com';
 
 export class CloudflareError extends Error {
+  readonly status: number;
+
   constructor({ status, body }: { status: number; body: string }) {
     super(`cloudflare answered ${status}: ${body}`);
     this.name = 'CloudflareError';
+    this.status = status;
   }
 }
 
@@ -72,7 +76,13 @@ export class CloudflareClient {
   }
 
   async deleteCustomHostname({ id }: { id: string }): Promise<void> {
-    await this.#request({ method: 'DELETE', path: `custom_hostnames/${id}` });
+    try {
+      await this.#request({ method: 'DELETE', path: `custom_hostnames/${id}` });
+    } catch (error) {
+      if (!(error instanceof CloudflareError) || error.status !== HTTP_NOT_FOUND) {
+        throw error;
+      }
+    }
   }
 
   /**

--- a/apps/api/src/repositories/app-hostnames.repository.ts
+++ b/apps/api/src/repositories/app-hostnames.repository.ts
@@ -5,6 +5,7 @@ import { Repository } from '#repositories/repository.ts';
 export type AppHostnameRow = Queries['SelectAppHostnamesByApp'];
 export type OwnedAppHostnameRow = Queries['SelectAppHostnamesByOwner'];
 export type PendingHostnameRow = Queries['SelectPendingCustomHostnames'];
+export type DisposableAppHostnameRow = Queries['SelectDisposableAppHostnames'];
 
 type OwnedApp = { appId: AppId; ownerId: OwnerId };
 
@@ -30,6 +31,8 @@ export abstract class AppHostnamesRepositoryContract {
   abstract setCustomState(input: { hostname: Hostname; state: AppHostnameState }): Promise<boolean>;
   abstract removeCustom(input: OwnedApp & { hostname: Hostname }): Promise<string | null>;
   abstract listPendingCustom(input: { limit: number }): Promise<PendingHostnameRow[]>;
+  abstract listDisposable(input: { appId: AppId }): Promise<DisposableAppHostnameRow[]>;
+  abstract removeDisposable(input: { appId: AppId; hostname: Hostname }): Promise<boolean>;
 }
 
 export class AppHostnamesRepository extends Repository implements AppHostnamesRepositoryContract {
@@ -143,5 +146,33 @@ export class AppHostnamesRepository extends Repository implements AppHostnamesRe
       ORDER BY h.id
       LIMIT ${limit}
     `;
+  }
+
+  listDisposable({ appId }: { appId: AppId }): Promise<DisposableAppHostnameRow[]> {
+    return this.sql.SelectDisposableAppHostnames`
+      SELECT h.hostname, h.kind, h.cloudflare_id
+      FROM nibrun.app_hostnames h
+      JOIN nibrun.apps a ON a.id = h.app_id
+      WHERE h.app_id = ${appId} AND a.state IN ('deleting', 'deleted')
+      ORDER BY h.id
+    `;
+  }
+
+  async removeDisposable({
+    appId,
+    hostname,
+  }: {
+    appId: AppId;
+    hostname: Hostname;
+  }): Promise<boolean> {
+    const [removed] = await this.sql.DeleteDisposableAppHostname`
+      DELETE FROM nibrun.app_hostnames h
+      USING nibrun.apps a
+      WHERE h.app_id = a.id
+        AND h.app_id = ${appId} AND h.hostname = ${hostname}
+        AND a.state IN ('deleting', 'deleted')
+      RETURNING h.hostname
+    `;
+    return removed !== undefined;
   }
 }

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -28,6 +28,7 @@ import type {
 } from '#repositories/app-hostnames.repository.ts';
 import type { AppRow, AppsRepositoryContract } from '#repositories/apps.repository.ts';
 import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
+import type { CustomHostnamesRepositoryContract } from '#repositories/custom-hostnames.repository.ts';
 import type { ExportsRepositoryContract } from '#repositories/exports.repository.ts';
 import { Service } from '#services/service.ts';
 
@@ -51,8 +52,13 @@ const SLUG_CONSTRAINTS = [
 // a signal that something other than luck is wrong.
 const MAX_SLUG_ATTEMPTS = 5;
 
-/** Reading them back is all an app needs of its hostnames; the rest is the hostnames' own. */
-export type AppHostnameReads = Pick<AppHostnamesRepositoryContract, 'listByOwner' | 'listByApp'>;
+/** What an app needs from its hostnames while it lives and while it is being removed. */
+export type AppHostnameAccess = Pick<
+  AppHostnamesRepositoryContract,
+  'listByOwner' | 'listByApp' | 'listDisposable' | 'removeDisposable'
+>;
+
+export type CustomHostnameRemoval = Pick<CustomHostnamesRepositoryContract, 'remove'>;
 
 /** What deleting an app needs from the exports it leaves behind, and nothing else. */
 export type ExportCancellation = Pick<ExportsRepositoryContract, 'failInFlight'>;
@@ -81,7 +87,8 @@ const FINISH_BATCH = 8;
 
 export class AppsService extends Service {
   private readonly appsRepo: AppsRepositoryContract;
-  private readonly hostnamesRepo: AppHostnameReads;
+  private readonly hostnamesRepo: AppHostnameAccess;
+  private readonly customHostnamesRepo: CustomHostnameRemoval;
   private readonly exportsRepo: ExportCancellation;
   private readonly artifactStorageRepo: ObjectRemoval;
   private readonly exportStorageRepo: ObjectRemoval;
@@ -91,6 +98,7 @@ export class AppsService extends Service {
   constructor({
     appsRepo,
     hostnamesRepo,
+    customHostnamesRepo,
     exportsRepo,
     artifactStorageRepo,
     exportStorageRepo,
@@ -98,7 +106,8 @@ export class AppsService extends Service {
     secretsKey,
   }: {
     appsRepo: AppsRepositoryContract;
-    hostnamesRepo: AppHostnameReads;
+    hostnamesRepo: AppHostnameAccess;
+    customHostnamesRepo: CustomHostnameRemoval;
     exportsRepo: ExportCancellation;
     artifactStorageRepo: ObjectRemoval;
     exportStorageRepo: ObjectRemoval;
@@ -108,6 +117,7 @@ export class AppsService extends Service {
     super();
     this.appsRepo = appsRepo;
     this.hostnamesRepo = hostnamesRepo;
+    this.customHostnamesRepo = customHostnamesRepo;
     this.exportsRepo = exportsRepo;
     this.artifactStorageRepo = artifactStorageRepo;
     this.exportStorageRepo = exportStorageRepo;
@@ -251,6 +261,7 @@ export class AppsService extends Service {
    */
   private async purgeApp({ appId }: { appId: AppId }): Promise<void> {
     try {
+      await this.releaseHostnames({ appId });
       const leftovers = await this.appsRepo.listLeftovers({ appId });
       await Promise.all([
         ...leftovers.exports.map((objectKey) => this.exportStorageRepo.remove({ objectKey })),
@@ -280,12 +291,35 @@ export class AppsService extends Service {
   async delete({ appId, ownerId }: OwnedApp): Promise<PublicApp> {
     const app = requireApp(await this.appsRepo.updateState({ appId, ownerId, state: 'deleting' }));
     await this.exportsRepo.failInFlight({ appId, message: APP_DELETED });
-    const [torndown, hostnames] = await Promise.all([
+    const hostnames = await this.hostnamesRepo.listByApp({ appId, ownerId });
+    const [torndown] = await Promise.all([
       this.finishIfNothingToTearDown({ appId }),
-      this.hostnamesRepo.listByApp({ appId, ownerId }),
+      this.releaseHostnames({ appId }),
     ]);
 
     return toPublicApp({ app: torndown ? { ...app, state: 'deleted' } : app, hostnames });
+  }
+
+  private async releaseHostnames({ appId }: { appId: AppId }): Promise<void> {
+    const hostnames = await this.hostnamesRepo.listDisposable({ appId });
+    for (const hostname of hostnames) {
+      try {
+        if (hostname.cloudflare_id) {
+          await this.customHostnamesRepo.remove({ cloudflareId: hostname.cloudflare_id });
+        }
+        await this.hostnamesRepo.removeDisposable({ appId, hostname: hostname.hostname });
+        this.logger.info('deleted app hostname released', {
+          appId,
+          hostname: hostname.hostname,
+        });
+      } catch (error) {
+        this.logger.error('releasing a deleted app hostname failed', {
+          appId,
+          hostname: hostname.hostname,
+          error,
+        });
+      }
+    }
   }
 
   /**

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -62,6 +62,7 @@ const deploymentsService = new DeploymentsService({ deploymentsRepo: deployments
 const appsService = new AppsService({
   appsRepo: appsRepository,
   hostnamesRepo: appHostnamesRepository,
+  customHostnamesRepo: customHostnamesRepository,
   exportsRepo: exportsRepository,
   artifactStorageRepo: artifactStorageRepository,
   exportStorageRepo: exportStorageRepository,

--- a/apps/api/tests/lib/cloudflare.test.ts
+++ b/apps/api/tests/lib/cloudflare.test.ts
@@ -6,6 +6,7 @@ const API_TOKEN = 'token-1';
 const HOSTNAME = 'app.example.dev';
 const HTTP_OK = 200;
 const HTTP_BAD_GATEWAY = 502;
+const HTTP_NOT_FOUND = 404;
 
 const realFetch = globalThis.fetch;
 
@@ -96,6 +97,27 @@ describe('a refusal is an error however the edge phrases it', () => {
     answering([{ status: HTTP_BAD_GATEWAY, body: undefined }]);
 
     await expect(client().createCustomHostname({ hostname: HOSTNAME })).rejects.toBeInstanceOf(
+      CloudflareError,
+    );
+  });
+});
+
+describe('deleting a hostname is safe to repeat', () => {
+  test('one already absent is the requested outcome', async () => {
+    answering([
+      {
+        status: HTTP_NOT_FOUND,
+        body: { success: false, result: null, errors: [{ code: 1436, message: 'not found' }] },
+      },
+    ]);
+
+    await expect(client().deleteCustomHostname({ id: 'ch-1' })).resolves.toBeUndefined();
+  });
+
+  test('other failures still leave the cleanup to retry', async () => {
+    answering([{ status: HTTP_BAD_GATEWAY, body: undefined }]);
+
+    await expect(client().deleteCustomHostname({ id: 'ch-1' })).rejects.toBeInstanceOf(
       CloudflareError,
     );
   });

--- a/apps/api/tests/repositories/apps.test.ts
+++ b/apps/api/tests/repositories/apps.test.ts
@@ -137,4 +137,11 @@ describe('a config patch carries forward every variable it says nothing about', 
     expect(rows.map((row) => row.name)).toEqual(['LOG_LEVEL', 'TOKEN']);
     expect(opened(rows[1]?.value)).toBe(FIRST_TOKEN);
   });
+
+  test('a deleted app with only its hostname left is still purgeable', async () => {
+    await repo.updateState({ appId, ownerId, state: 'deleting' });
+    await repo.finishDeleting({ appId });
+
+    expect(await repo.listPurgeable({ limit: 8 })).toEqual([appId]);
+  });
 });

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -26,6 +26,7 @@ import { BadRequestError, ConflictError, NotFoundError } from '#lib/errors.ts';
 import { openSecret, sealedFromStore } from '#lib/tenant-secrets.ts';
 import type {
   AppHostnameRow,
+  DisposableAppHostnameRow,
   OwnedAppHostnameRow,
 } from '#repositories/app-hostnames.repository.ts';
 import type {
@@ -35,8 +36,9 @@ import type {
   Leftovers,
 } from '#repositories/apps.repository.ts';
 import {
-  type AppHostnameReads,
+  type AppHostnameAccess,
   AppsService,
+  type CustomHostnameRemoval,
   type ExportCancellation,
   type ObjectRemoval,
 } from '#services/apps.service.ts';
@@ -64,6 +66,8 @@ function asPatch(entries: Record<string, string | null>): TenantEnvironmentPatch
 }
 
 const APP_NAME = 'pocketbase';
+const BROUGHT_HOSTNAME = Value.Parse(HostnameSchema, 'pocketbase.example.dev');
+const CLOUDFLARE_ID = 'ch-1';
 
 // Restated rather than imported from the implementation: that the bound exists and how many
 // rolls it allows is the contract this file holds the service to.
@@ -222,13 +226,44 @@ class StubAppsRepository implements AppsRepositoryContract {
  * still find.
  */
 /** Every read answers empty, which is what an app belonging to somebody else looks like. */
-class StubHostnameReads implements AppHostnameReads {
+class StubHostnameAccess implements AppHostnameAccess {
+  readonly disposable = new Map<AppId, DisposableAppHostnameRow[]>();
+  readonly removed: Hostname[] = [];
+
   listByOwner(): Promise<OwnedAppHostnameRow[]> {
     return Promise.resolve([]);
   }
 
   listByApp(): Promise<AppHostnameRow[]> {
     return Promise.resolve([]);
+  }
+
+  listDisposable({ appId }: { appId: AppId }): Promise<DisposableAppHostnameRow[]> {
+    return Promise.resolve(this.disposable.get(appId) ?? []);
+  }
+
+  removeDisposable({ appId, hostname }: { appId: AppId; hostname: Hostname }): Promise<boolean> {
+    const before = this.disposable.get(appId) ?? [];
+    const after = before.filter((row) => row.hostname !== hostname);
+    this.disposable.set(appId, after);
+    if (before.length === after.length) {
+      return Promise.resolve(false);
+    }
+    this.removed.push(hostname);
+    return Promise.resolve(true);
+  }
+}
+
+class StubCustomHostnameRemoval implements CustomHostnameRemoval {
+  readonly removed: string[] = [];
+  readonly failures = new Set<string>();
+
+  remove({ cloudflareId }: { cloudflareId: string }): Promise<void> {
+    if (this.failures.has(cloudflareId)) {
+      return Promise.reject(new Error(`the edge refused ${cloudflareId}`));
+    }
+    this.removed.push(cloudflareId);
+    return Promise.resolve();
   }
 }
 
@@ -273,18 +308,23 @@ class StubExportCancellation implements ExportCancellation {
 
 function serviceWith({
   appsRepo,
+  hostnamesRepo = new StubHostnameAccess(),
+  customHostnamesRepo = new StubCustomHostnameRemoval(),
   exportsRepo = new StubExportCancellation(),
   artifactStorageRepo = new StubObjectStorage({ trace: [] }),
   exportStorageRepo = new StubObjectStorage({ trace: [] }),
 }: {
   appsRepo: AppsRepositoryContract;
+  hostnamesRepo?: AppHostnameAccess;
+  customHostnamesRepo?: CustomHostnameRemoval;
   exportsRepo?: ExportCancellation;
   artifactStorageRepo?: ObjectRemoval;
   exportStorageRepo?: ObjectRemoval;
 }) {
   return new AppsService({
     appsRepo,
-    hostnamesRepo: new StubHostnameReads(),
+    hostnamesRepo,
+    customHostnamesRepo,
     exportsRepo,
     artifactStorageRepo,
     exportStorageRepo,
@@ -614,6 +654,61 @@ describe('an app is deleted when its filesystem is gone, not when it is asked fo
     await serviceWith({ appsRepo }).completeDeletions({ volumes: [reportedVolume('deleted')] });
 
     expect(appsRepo.deleted).toEqual([]);
+  });
+});
+
+describe('deleting an app releases every hostname it held', () => {
+  function appHostnames(): DisposableAppHostnameRow[] {
+    return [
+      {
+        hostname: Value.Parse(HostnameSchema, `${APP_NAME}.${APP_HOST_DOMAIN}`),
+        kind: 'platform',
+        cloudflare_id: null,
+      },
+      { hostname: BROUGHT_HOSTNAME, kind: 'custom', cloudflare_id: CLOUDFLARE_ID },
+    ];
+  }
+
+  test('the platform name and a custom domain are both free when deletion returns', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    const hostnamesRepo = new StubHostnameAccess();
+    const edge = new StubCustomHostnameRemoval();
+    appsRepo.owns = true;
+    hostnamesRepo.disposable.set(APP_ID, appHostnames());
+
+    await serviceWith({ appsRepo, hostnamesRepo, customHostnamesRepo: edge }).delete({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+    });
+
+    expect(hostnamesRepo.removed).toEqual([
+      Value.Parse(HostnameSchema, `${APP_NAME}.${APP_HOST_DOMAIN}`),
+      BROUGHT_HOSTNAME,
+    ]);
+    expect(edge.removed).toEqual([CLOUDFLARE_ID]);
+  });
+
+  test('an edge failure keeps its row for the deleted-app sweep to retry', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    const hostnamesRepo = new StubHostnameAccess();
+    const edge = new StubCustomHostnameRemoval();
+    appsRepo.owns = true;
+    hostnamesRepo.disposable.set(APP_ID, appHostnames());
+    edge.failures.add(CLOUDFLARE_ID);
+    const apps = serviceWith({ appsRepo, hostnamesRepo, customHostnamesRepo: edge });
+
+    await apps.delete({ appId: APP_ID, ownerId: OWNER_ID });
+
+    expect(hostnamesRepo.disposable.get(APP_ID)).toEqual([
+      { hostname: BROUGHT_HOSTNAME, kind: 'custom', cloudflare_id: CLOUDFLARE_ID },
+    ]);
+
+    edge.failures.delete(CLOUDFLARE_ID);
+    appsRepo.purgeable.push(APP_ID);
+    await apps.purgeDeleted();
+
+    expect(hostnamesRepo.disposable.get(APP_ID)).toEqual([]);
+    expect(edge.removed).toEqual([CLOUDFLARE_ID]);
   });
 });
 

--- a/apps/api/tests/services/hostnames.test.ts
+++ b/apps/api/tests/services/hostnames.test.ts
@@ -78,6 +78,9 @@ class StubHostnamesRepository implements AppHostnamesRepositoryContract {
     return Promise.resolve(this.pending);
   }
 
+  listDisposable = notAsked;
+  removeDisposable = notAsked;
+
   // Reads an app makes of its own hostnames; nothing here asks for them.
   listByOwner = notAsked;
   listByApp = notAsked;


### PR DESCRIPTION
Release platform and custom hostname claims when an app is deleted, and make previously stranded claims discoverable by the retryable purge.