### PR TITLE
fix(agent): guests resolve hostnames through public DNS

### DIFF
--- a/apps/agent/src/lib/network/firewall.ts
+++ b/apps/agent/src/lib/network/firewall.ts
@@ -7,8 +7,6 @@ const TAP_MATCH = `"${TAP_NAME_PREFIX}*"`;
 export const INSTANCE_METADATA_ADDRESS_V4 = '169.254.169.254';
 export const INSTANCE_METADATA_ADDRESS_V6 = 'fd00:ec2::254';
 
-const DNS_PORT = 53;
-
 /** nft rejects the name `dstnat` on the output hook, and the whole ruleset with it. */
 const OUTPUT_NAT_PRIORITY = -100;
 
@@ -38,7 +36,6 @@ export type FirewallState = {
   readonly instances: readonly ForwardedInstance[];
   readonly controlPlaneCidrsV4: readonly string[];
   readonly controlPlaneCidrsV6: readonly string[];
-  readonly guestDnsServers: readonly string[];
 };
 
 const set = (values: readonly string[]) => `{ ${values.join(', ')} }`;
@@ -48,12 +45,6 @@ const chain = ({ header, rules }: { header: string; rules: readonly string[] }) 
   ...rules.map((rule) => `${RULE_INDENT}${rule}`),
   `${CHAIN_INDENT}}`,
 ];
-
-const resolverRules = (guestDnsServers: readonly string[]) =>
-  guestDnsServers.flatMap((server) => [
-    `iifname ${TAP_MATCH} ip daddr ${server} udp dport ${DNS_PORT} accept`,
-    `iifname ${TAP_MATCH} ip daddr ${server} tcp dport ${DNS_PORT} accept`,
-  ]);
 
 /**
  * Rendered whole and applied with `nft -f`, so the rules are a function of state rather than a
@@ -67,7 +58,7 @@ export function renderRuleset(state: FirewallState): string {
     `table ip ${NFTABLES_TABLE} {`,
     ...forwardChainV4(state),
     '',
-    ...inputChainV4(state),
+    ...inputChainV4(),
     '',
     ...natChainsV4(state),
     '}',
@@ -83,13 +74,12 @@ export function renderRuleset(state: FirewallState): string {
   ].join('\n')}\n`;
 }
 
-function forwardChainV4({ controlPlaneCidrsV4, guestDnsServers }: FirewallState): string[] {
+function forwardChainV4({ controlPlaneCidrsV4 }: FirewallState): string[] {
   return chain({
     header: 'forward {',
     rules: [
       'type filter hook forward priority filter; policy accept;',
       'ct state established,related accept',
-      ...resolverRules(guestDnsServers),
       `iifname ${TAP_MATCH} ip daddr ${INSTANCE_METADATA_ADDRESS_V4} drop comment "instance metadata endpoint"`,
       `iifname ${TAP_MATCH} oifname ${TAP_MATCH} drop comment "guest to guest"`,
       `iifname ${TAP_MATCH} ip daddr ${GUEST_NETWORK_CIDR} drop comment "guest to guest"`,
@@ -102,13 +92,12 @@ function forwardChainV4({ controlPlaneCidrsV4, guestDnsServers }: FirewallState)
 }
 
 /** Guest traffic to the host's own tap address never reaches the forward hook. */
-function inputChainV4({ guestDnsServers }: FirewallState): string[] {
+function inputChainV4(): string[] {
   return chain({
     header: 'input {',
     rules: [
       'type filter hook input priority filter; policy accept;',
       `iifname ${TAP_MATCH} ct state established,related accept`,
-      ...resolverRules(guestDnsServers),
       `iifname ${TAP_MATCH} drop comment "guest to host"`,
     ],
   });

--- a/apps/agent/src/lib/reconcile/network.ts
+++ b/apps/agent/src/lib/reconcile/network.ts
@@ -45,7 +45,6 @@ export const applyNetwork = Effect.gen(function* () {
     instances: yield* forwards,
     controlPlaneCidrsV4: config.controlPlaneCidrsV4,
     controlPlaneCidrsV6: config.controlPlaneCidrsV6,
-    guestDnsServers: config.guestDnsServers,
   }).pipe(
     Effect.andThen(AgentState.modify((current) => ({ ...current, isolated: true }))),
     Effect.catchAll((error) =>

--- a/apps/agent/src/lib/vm/instance-env.ts
+++ b/apps/agent/src/lib/vm/instance-env.ts
@@ -16,6 +16,10 @@ const TENANT_PREFIX = 'ENV_';
 
 const FORBIDDEN_VALUE_CHARACTERS = /[\n\r\0]/;
 
+// Public rather than the VPC's: the guest network is cut off from every private destination, and
+// a resolver inside one would mean opening that back up for whatever else answers on the address.
+const DNS_SERVERS = ['1.1.1.1', '1.0.0.1'];
+
 export class UnrepresentableEnvironment extends Data.TaggedError('UnrepresentableEnvironment')<{
   readonly variableName: string;
 }> {
@@ -35,13 +39,11 @@ export function renderInstanceEnv({
   args,
   environment,
   restartPolicy,
-  dnsServers,
 }: {
   guestPort: GuestPort;
   args: TenantArguments;
   environment: TenantEnvironment;
   restartPolicy: RestartPolicy;
-  dnsServers: readonly string[];
 }): Either.Either<string, UnrepresentableEnvironment> {
   const lines = [
     `${RUNTIME_PREFIX}PORT=${guestPort}`,
@@ -50,10 +52,8 @@ export function renderInstanceEnv({
     `${RUNTIME_PREFIX}MAX_BACKOFF_MS=${restartPolicy.maxBackoffMs}`,
     `${RUNTIME_PREFIX}BACKOFF_FACTOR=${restartPolicy.backoffFactor}`,
     `${RUNTIME_PREFIX}RESET_AFTER_MS=${restartPolicy.resetAfterMs}`,
+    `${RUNTIME_PREFIX}DNS=${DNS_SERVERS.join(',')}`,
   ];
-  if (dnsServers.length > 0) {
-    lines.push(`${RUNTIME_PREFIX}DNS=${dnsServers.join(',')}`);
-  }
   // Numbered rather than delimited: a format with no quoting cannot carry a separator an
   // argument might itself contain, and the guest refuses a gap rather than shifting the rest down.
   for (const [index, argument] of args.entries()) {
@@ -84,7 +84,6 @@ export const buildInstanceConfigImage = ({
   args: TenantArguments;
   environment: TenantEnvironment;
   restartPolicy: RestartPolicy;
-  dnsServers: readonly string[];
 }) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;

--- a/apps/agent/src/services/agent-config.service.ts
+++ b/apps/agent/src/services/agent-config.service.ts
@@ -109,7 +109,6 @@ export class AgentConfig extends Effect.Service<AgentConfig>()('AgentConfig', {
       awsRegion: yield* required('AGENT_AWS_REGION'),
       controlPlaneCidrsV4: yield* requiredList('AGENT_CONTROL_PLANE_CIDRS_V4'),
       controlPlaneCidrsV6: yield* requiredList('AGENT_CONTROL_PLANE_CIDRS_V6'),
-      guestDnsServers: yield* list('AGENT_GUEST_DNS_SERVERS'),
     } as const;
   }),
 }) {}

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -60,7 +60,6 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
         args: desired.config.args,
         environment: desired.config.environment,
         restartPolicy: desired.config.restartPolicy,
-        dnsServers: config.guestDnsServers,
       });
 
       yield* writeJsonFile({

--- a/apps/agent/tests/lib/network/firewall.test.ts
+++ b/apps/agent/tests/lib/network/firewall.test.ts
@@ -8,8 +8,6 @@ import {
   renderRuleset,
 } from '#lib/network/firewall.ts';
 
-const DNS_PORT = 53;
-
 // The ranges the blanket v6 rule covers, to assert that a VPC's range is not among them.
 const PRIVATE_DESTINATIONS_V6_SAMPLE = ['::1', 'fe80:', 'fc', 'fd'];
 
@@ -28,7 +26,6 @@ function state(overrides: Partial<FirewallState> = {}): FirewallState {
     instances: [],
     controlPlaneCidrsV4: [],
     controlPlaneCidrsV6: [],
-    guestDnsServers: [],
     ...overrides,
   };
 }
@@ -81,20 +78,6 @@ describe('the three isolation rules are never optional', () => {
     expect(dropsFrom(renderRuleset(state())).some((line) => line.includes('guest to host'))).toBe(
       true,
     );
-  });
-
-  // A resolver accepted by address alone opens every port on it. Harmless for a VPC resolver,
-  // and a hole in the guest-to-host drop the moment the address given is one of the host's own.
-  test('a named resolver is reachable on port 53 and not on everything else', () => {
-    const input = renderRuleset(state({ guestDnsServers: ['10.0.0.2'] }))
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line.includes('10.0.0.2') && line.endsWith('accept'));
-
-    expect(input.length).toBeGreaterThan(0);
-    for (const rule of input) {
-      expect(rule).toContain(`dport ${DNS_PORT}`);
-    }
   });
 });
 
@@ -196,14 +179,5 @@ describe('the ruleset is a function of state, not a history of edits', () => {
   test('rendering twice from the same state is byte-identical', () => {
     const input = state({ instances: [instance], controlPlaneCidrsV4: ['203.0.113.0/24'] });
     expect(renderRuleset(input)).toBe(renderRuleset(input));
-  });
-
-  test('a named DNS resolver is allowed out before the blanket private drop', () => {
-    const ruleset = renderRuleset(state({ guestDnsServers: ['10.0.0.2'] }));
-    const lines = ruleset.split('\n').map((line) => line.trim());
-    const accept = lines.findIndex((line) => line.startsWith('iifname "nbr*" ip daddr 10.0.0.2'));
-    const drop = lines.findIndex((line) => line.includes('private destinations'));
-    expect(accept).toBeGreaterThan(-1);
-    expect(accept).toBeLessThan(drop);
   });
 });

--- a/apps/agent/tests/lib/vm/instance-env.test.ts
+++ b/apps/agent/tests/lib/vm/instance-env.test.ts
@@ -23,7 +23,6 @@ function attempt(overrides: Overrides = {}) {
     args: [],
     environment: {},
     restartPolicy: DEFAULT_RESTART_POLICY,
-    dnsServers: [],
     ...overrides,
   });
 }
@@ -48,6 +47,7 @@ describe('what apps/runtime parses off the config drive', () => {
       `NIBRUN_MAX_BACKOFF_MS=${DEFAULT_RESTART_POLICY.maxBackoffMs}`,
       `NIBRUN_BACKOFF_FACTOR=${DEFAULT_RESTART_POLICY.backoffFactor}`,
       `NIBRUN_RESET_AFTER_MS=${DEFAULT_RESTART_POLICY.resetAfterMs}`,
+      'NIBRUN_DNS=1.1.1.1,1.0.0.1',
     ]);
   });
 
@@ -62,13 +62,6 @@ describe('what apps/runtime parses off the config drive', () => {
     const rendered = render({ environment: { NIBRUN_PORT: secret('9999') } });
     expect(rendered).toContain(`NIBRUN_PORT=${DEFAULT_GUEST_PORT}\n`);
     expect(rendered).toContain('ENV_NIBRUN_PORT=9999\n');
-  });
-
-  test('nameservers are one comma-joined line, and absent when there are none', () => {
-    expect(render({ dnsServers: ['1.1.1.1', '8.8.8.8'] })).toContain(
-      'NIBRUN_DNS=1.1.1.1,8.8.8.8\n',
-    );
-    expect(render()).not.toContain('NIBRUN_DNS');
   });
 
   test('values are raw bytes, not quoted or escaped', () => {


### PR DESCRIPTION
`AGENT_GUEST_DNS_SERVERS` was set on no host and defaulted to none, so every tenant booted with an empty `/etc/resolv.conf`. Egress worked; DNS never did.

Nameservers are now fixed at 1.1.1.1 and 1.0.0.1. The variable is gone, and so are the firewall rules that only existed to reach a resolver inside a private range.