### PR TITLE
feat: an app's binary is handed the hostname it answers on

### DIFF
--- a/apps/agent/src/lib/vm/instance-env.ts
+++ b/apps/agent/src/lib/vm/instance-env.ts
@@ -1,5 +1,12 @@
 import { FileSystem, Path } from '@effect/platform';
-import type { GuestPort, RestartPolicy, TenantArguments, TenantEnvironment } from '@repo/protocol';
+import type {
+  AppHostname,
+  GuestPort,
+  Hostname,
+  RestartPolicy,
+  TenantArguments,
+  TenantEnvironment,
+} from '@repo/protocol';
 import { Data, Effect, Either } from 'effect';
 import { stdoutOf } from '#services/command-runner.service.ts';
 
@@ -20,6 +27,17 @@ const FORBIDDEN_VALUE_CHARACTERS = /[\n\r\0]/;
 // a resolver inside one would mean opening that back up for whatever else answers on the address.
 const DNS_SERVERS = ['1.1.1.1', '1.0.0.1'];
 
+/**
+ * The name nibrun issued the app, never one its owner brought: it is the hostname the app is
+ * always reachable at, and the only one that cannot be taken away underneath a running binary.
+ *
+ * Undefined has no meaning beyond a control plane that sent none — the runtime reads the line as
+ * optional, which is what lets a host adopt the guest image that reads it before this writes it.
+ */
+function platformHostname(hostnames: AppHostname[]): Hostname | undefined {
+  return hostnames.find((each) => each.kind === 'platform')?.hostname;
+}
+
 export class UnrepresentableEnvironment extends Data.TaggedError('UnrepresentableEnvironment')<{
   readonly variableName: string;
 }> {
@@ -36,17 +54,21 @@ export class UnrepresentableEnvironment extends Data.TaggedError('Unrepresentabl
  */
 export function renderInstanceEnv({
   guestPort,
+  hostnames,
   args,
   environment,
   restartPolicy,
 }: {
   guestPort: GuestPort;
+  hostnames: AppHostname[];
   args: TenantArguments;
   environment: TenantEnvironment;
   restartPolicy: RestartPolicy;
 }): Either.Either<string, UnrepresentableEnvironment> {
+  const hostname = platformHostname(hostnames);
   const lines = [
     `${RUNTIME_PREFIX}PORT=${guestPort}`,
+    ...(hostname === undefined ? [] : [`${RUNTIME_PREFIX}HOSTNAME=${hostname}`]),
     `${RUNTIME_PREFIX}MAX_RESTARTS=${restartPolicy.maxRestarts}`,
     `${RUNTIME_PREFIX}INITIAL_BACKOFF_MS=${restartPolicy.initialBackoffMs}`,
     `${RUNTIME_PREFIX}MAX_BACKOFF_MS=${restartPolicy.maxBackoffMs}`,
@@ -81,6 +103,7 @@ export const buildInstanceConfigImage = ({
 }: {
   workingDir: string;
   guestPort: GuestPort;
+  hostnames: AppHostname[];
   args: TenantArguments;
   environment: TenantEnvironment;
   restartPolicy: RestartPolicy;

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -57,6 +57,7 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       const instanceConfigImagePath = yield* buildInstanceConfigImage({
         workingDir: directory,
         guestPort: desired.config.guestPort,
+        hostnames: desired.hostnames,
         args: desired.config.args,
         environment: desired.config.environment,
         restartPolicy: desired.config.restartPolicy,

--- a/apps/agent/tests/lib/vm/instance-env.test.ts
+++ b/apps/agent/tests/lib/vm/instance-env.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  type AppHostname,
   DEFAULT_GUEST_PORT,
   DEFAULT_RESTART_POLICY,
   GuestPortSchema,
+  HostnameSchema,
   SecretStringSchema,
   Value,
 } from '@repo/protocol';
@@ -10,6 +12,14 @@ import { Either } from 'effect';
 import { renderInstanceEnv } from '#lib/vm/instance-env.ts';
 
 const NON_DEFAULT_PORT = 8080;
+
+const PLATFORM_HOSTNAME = 'my-app.nibrun.app';
+
+function hostname({ name, kind }: { name: string; kind: AppHostname['kind'] }): AppHostname {
+  return { hostname: Value.Parse(HostnameSchema, name), kind };
+}
+
+const PLATFORM = hostname({ name: PLATFORM_HOSTNAME, kind: 'platform' });
 
 function secret(value: string) {
   return Value.Parse(SecretStringSchema, value);
@@ -20,6 +30,7 @@ type Overrides = Partial<Parameters<typeof renderInstanceEnv>[0]>;
 function attempt(overrides: Overrides = {}) {
   return renderInstanceEnv({
     guestPort: DEFAULT_GUEST_PORT,
+    hostnames: [PLATFORM],
     args: [],
     environment: {},
     restartPolicy: DEFAULT_RESTART_POLICY,
@@ -39,9 +50,10 @@ function refusedVariable(overrides: Overrides) {
 // apps/runtime/src/config.c accepts NIBRUN_ and ENV_ and rejects every other line, so these
 // assertions are the boot contract rather than a formatting preference.
 describe('what apps/runtime parses off the config drive', () => {
-  test('the runtime keys it requires are all present', () => {
+  test('every key it writes is one the runtime knows', () => {
     expect(render().split('\n').filter(Boolean)).toEqual([
       `NIBRUN_PORT=${DEFAULT_GUEST_PORT}`,
+      `NIBRUN_HOSTNAME=${PLATFORM_HOSTNAME}`,
       `NIBRUN_MAX_RESTARTS=${DEFAULT_RESTART_POLICY.maxRestarts}`,
       `NIBRUN_INITIAL_BACKOFF_MS=${DEFAULT_RESTART_POLICY.initialBackoffMs}`,
       `NIBRUN_MAX_BACKOFF_MS=${DEFAULT_RESTART_POLICY.maxBackoffMs}`,
@@ -71,6 +83,22 @@ describe('what apps/runtime parses off the config drive', () => {
 
   test('an empty value stays an empty value', () => {
     expect(render({ environment: { EMPTY: secret('') } })).toContain('ENV_EMPTY=\n');
+  });
+
+  // The app answers on every hostname it holds, but only this one was issued by nibrun and
+  // cannot be taken away, so it is the one a binary can safely address itself by.
+  test('the hostname written is the platform one, whatever else the app answers on', () => {
+    const rendered = render({
+      hostnames: [hostname({ name: 'www.example.com', kind: 'custom' }), PLATFORM],
+    });
+    expect(rendered).toContain(`NIBRUN_HOSTNAME=${PLATFORM_HOSTNAME}\n`);
+    expect(rendered).not.toContain('www.example.com');
+  });
+
+  // A guest image older than this agent rejects a key it does not know, and would fail every
+  // boot on the fleet. Optional there, omitted here, so the two can be deployed apart.
+  test('an app with no platform hostname is sent no line rather than an empty one', () => {
+    expect(render({ hostnames: [] })).not.toContain('NIBRUN_HOSTNAME');
   });
 
   test('a non-default port is the one written', () => {

--- a/apps/runtime/src/config.c
+++ b/apps/runtime/src/config.c
@@ -15,6 +15,9 @@
 #define RUNTIME_PREFIX "NIBRUN_"
 #define ARGUMENT_KEY_PREFIX "ARG_"
 #define TENANT_PREFIX "ENV_"
+#define HOSTNAME_KEY "HOSTNAME"
+/* The one runtime key the tenant is handed under its own name, so it is spelled once. */
+#define HOSTNAME_VARIABLE RUNTIME_PREFIX HOSTNAME_KEY
 
 #define MIN_PORT 1
 #define MAX_PORT 65535
@@ -23,13 +26,15 @@
 #define MIN_BACKOFF_FACTOR 1.0
 #define MAX_BACKOFF_FACTOR 1000.0
 
-/* PORT, HOME and TMPDIR, on top of whatever the tenant configured. */
-#define BASE_VARIABLES 3
+/* PORT, NIBRUN_HOSTNAME, HOME and TMPDIR, on top of whatever the tenant configured. */
+#define BASE_VARIABLES 4
 
 enum field_type {
   FIELD_UNSIGNED,
   FIELD_BACKOFF_FACTOR,
   FIELD_NAMESERVERS,
+  /* `minimum` and `maximum` bound its length rather than its value. */
+  FIELD_TEXT,
 };
 
 struct field {
@@ -54,6 +59,8 @@ static const struct field FIELDS[] = {
     {"RESET_AFTER_MS", FIELD_UNSIGNED, offsetof(struct instance_config, restart_policy.reset_after_ms), 0,
      MAX_DURATION_MS, true},
     {"DNS", FIELD_NAMESERVERS, 0, 0, 0, false},
+    {HOSTNAME_KEY, FIELD_TEXT, offsetof(struct instance_config, hostname), 1, CONFIG_MAX_HOSTNAME,
+     false},
 };
 
 #define FIELD_COUNT (sizeof(FIELDS) / sizeof(FIELDS[0]))
@@ -148,6 +155,16 @@ static bool assign(struct instance_config *config, const struct field *field, ch
     }
     case FIELD_NAMESERVERS:
       return parse_nameservers(config, value);
+    case FIELD_TEXT: {
+      size_t length = strlen(value);
+      if (length < field->minimum || length > field->maximum) {
+        log_line("%s%s is not between %u and %u bytes", RUNTIME_PREFIX, field->key, field->minimum,
+                 field->maximum);
+        return false;
+      }
+      *(char **)target = value;
+      return true;
+    }
   }
   return false;
 }
@@ -363,14 +380,26 @@ char *const *config_build_argv(const struct instance_config *config, const char 
 char *const *config_build_environment(const struct instance_config *config) {
   static char *environment[CONFIG_MAX_TENANT_VARIABLES + BASE_VARIABLES + 1];
   static char port_variable[sizeof("PORT=65535")];
+  static char hostname_variable[sizeof(HOSTNAME_VARIABLE "=") + CONFIG_MAX_HOSTNAME];
 
   snprintf(port_variable, sizeof(port_variable), "PORT=%u", config->port);
   size_t count = 0;
   environment[count++] = port_variable;
+  if (config->hostname != NULL) {
+    snprintf(hostname_variable, sizeof(hostname_variable), "%s=%s", HOSTNAME_VARIABLE,
+             config->hostname);
+    environment[count++] = hostname_variable;
+  }
 
   for (size_t index = 0; index < config->tenant_variable_count; index++) {
     if (is_named(config->tenant_environment[index], "PORT")) {
       log_line("ignoring the tenant's own PORT; this instance is served on %u", config->port);
+      continue;
+    }
+    /* Dropped whether or not one was written: the name belongs to the platform, so a
+     * value the tenant set would read as issued by it. */
+    if (is_named(config->tenant_environment[index], HOSTNAME_VARIABLE)) {
+      log_line("ignoring the tenant's own %s; the platform owns that name", HOSTNAME_VARIABLE);
       continue;
     }
     environment[count++] = config->tenant_environment[index];

--- a/apps/runtime/src/config.h
+++ b/apps/runtime/src/config.h
@@ -20,6 +20,8 @@
  * one rather than papered over. */
 
 #define CONFIG_MAX_BYTES (128 * 1024)
+/* Mirrors MAX_HOSTNAME_LENGTH in packages/protocol, which refuses to write a longer one. */
+#define CONFIG_MAX_HOSTNAME 253
 #define CONFIG_MAX_TENANT_VARIABLES 256
 /* Mirrors MAX_ARGUMENTS in packages/protocol, which refuses to write more. */
 #define CONFIG_MAX_ARGUMENTS 64
@@ -36,6 +38,11 @@ struct restart_policy {
 
 struct instance_config {
   uint32_t port;
+  /* The hostname nibrun issued the app, handed to the tenant so a binary can build
+   * its own absolute URLs. NULL when the writer sent none, which is what lets a host
+   * adopt this image before the agent that writes it — every other key here is
+   * required, and an agent older than the image would fail every boot. */
+  char *hostname;
   struct restart_policy restart_policy;
   char *nameservers[CONFIG_MAX_NAMESERVERS];
   size_t nameserver_count;
@@ -59,9 +66,11 @@ bool config_read_file(struct instance_config *config, const char *path, char *bu
 /* argv for execve: the binary, then the parsed arguments, then NULL. */
 char *const *config_build_argv(const struct instance_config *config, const char *executable);
 
-/* The environment the tenant is exec'd with: PORT, which the platform owns because
- * it is the port the agent probes and routes to, then the tenant's own variables,
- * then defaults for anything they did not set. */
+/* The environment the tenant is exec'd with: PORT and NIBRUN_HOSTNAME, which the
+ * platform owns because they are the port the agent probes and the name the edge
+ * routes to, then the tenant's own variables, then defaults for anything they did
+ * not set. A tenant variable of either name is dropped rather than exported: it
+ * would describe an instance that does not exist. */
 char *const *config_build_environment(const struct instance_config *config);
 
 #endif

--- a/apps/runtime/test.sh
+++ b/apps/runtime/test.sh
@@ -75,8 +75,8 @@ for _ in $(seq 1 60); do
   sleep 1
 done
 
-require 'the tenant runs unprivileged, in /app, on the port the config named' \
-  contains "$report" 'PORT=8080 HOME=/app CWD=/app UID=65534 GID=65534'
+require 'the tenant runs unprivileged, in /app, on the port and under the name the config gave it' \
+  contains "$report" 'PORT=8080 NIBRUN_HOSTNAME=boot-test.nibrun.app HOME=/app CWD=/app UID=65534 GID=65534'
 
 mounts=$(docker exec "$container" cat /proc/1/mounts)
 require 'the artifact is read-only and the data filesystem is not' \

--- a/apps/runtime/tests/boot.sh
+++ b/apps/runtime/tests/boot.sh
@@ -19,6 +19,7 @@ cp /fake-tenant /images/artifact/server
 
 cat >/images/config/instance.env <<'ENV'
 NIBRUN_PORT=8080
+NIBRUN_HOSTNAME=boot-test.nibrun.app
 NIBRUN_MAX_RESTARTS=5
 NIBRUN_INITIAL_BACKOFF_MS=100
 NIBRUN_MAX_BACKOFF_MS=1000

--- a/apps/runtime/tests/fake-tenant.c
+++ b/apps/runtime/tests/fake-tenant.c
@@ -39,10 +39,12 @@ static void report(const char *record) {
     _exit(UNWRITABLE_EXIT_CODE);
   }
   const char *port = getenv("PORT");
+  const char *hostname = getenv("NIBRUN_HOSTNAME");
   const char *home = getenv("HOME");
   char line[512];
-  snprintf(line, sizeof(line), "PORT=%s HOME=%s CWD=%s UID=%d GID=%d\n", port == NULL ? "" : port,
-           home == NULL ? "" : home, directory, (int)getuid(), (int)getgid());
+  snprintf(line, sizeof(line), "PORT=%s NIBRUN_HOSTNAME=%s HOME=%s CWD=%s UID=%d GID=%d\n",
+           port == NULL ? "" : port, hostname == NULL ? "" : hostname, home == NULL ? "" : home,
+           directory, (int)getuid(), (int)getgid());
   append(record, line);
 }
 

--- a/apps/runtime/tests/test-config.c
+++ b/apps/runtime/tests/test-config.c
@@ -83,6 +83,38 @@ static void accepts_a_fractional_backoff_factor(void) {
   EXPECT(config.restart_policy.backoff_factor == 1.5);
 }
 
+/* The name the platform issued, and the one thing here a tenant binary needs in order
+ * to address itself. Optional, so a host may adopt this image before the agent that
+ * writes it. */
+static void carries_the_hostname_to_the_tenant(void) {
+  struct instance_config config;
+  EXPECT(parse(&config, REQUIRED "NIBRUN_HOSTNAME=my-app.nibrun.app\n"));
+
+  const char *issued = value_of(config_build_environment(&config), "NIBRUN_HOSTNAME");
+  EXPECT(issued != NULL && strcmp(issued, "my-app.nibrun.app") == 0);
+
+  EXPECT(parse(&config, REQUIRED));
+  EXPECT(config.hostname == NULL);
+  EXPECT(value_of(config_build_environment(&config), "NIBRUN_HOSTNAME") == NULL);
+}
+
+/* Their own would name an instance nobody is served by, and the prefix cannot keep the
+ * two apart here: both reach execve under the one name. */
+static void drops_a_tenant_hostname(void) {
+  struct instance_config config;
+  EXPECT(parse(&config, REQUIRED "NIBRUN_HOSTNAME=mine.nibrun.app\n"
+                                 "ENV_NIBRUN_HOSTNAME=elsewhere.example\n"));
+
+  char *const *environment = config_build_environment(&config);
+  EXPECT(strcmp(value_of(environment, "NIBRUN_HOSTNAME"), "mine.nibrun.app") == 0);
+
+  size_t count = 0;
+  while (environment[count] != NULL) {
+    count++;
+  }
+  EXPECT(count == 4); /* PORT, NIBRUN_HOSTNAME, HOME, TMPDIR */
+}
+
 static void accepts_an_ipv6_nameserver(void) {
   struct instance_config config;
   EXPECT(parse(&config, REQUIRED "NIBRUN_DNS=2606:4700:4700::1111\n"));
@@ -102,6 +134,18 @@ static void rejects_a_broken_file(void) {
   EXPECT(rejects(REQUIRED "NIBRUN_DNS=not-an-address\n"));
   EXPECT(rejects(REQUIRED "NIBRUN_DNS=\n"));
   EXPECT(rejects(REQUIRED "NIBRUN_DNS=1.1.1.1,8.8.8.8,9.9.9.9,1.0.0.1\n"));
+  EXPECT(rejects(REQUIRED "NIBRUN_HOSTNAME=\n"));
+}
+
+static void rejects_a_hostname_that_does_not_fit(void) {
+  static char text[CONFIG_MAX_BYTES];
+  size_t used = (size_t)snprintf(text, sizeof(text), "%sNIBRUN_HOSTNAME=", REQUIRED);
+  for (int index = 0; index <= CONFIG_MAX_HOSTNAME; index++) {
+    text[used++] = 'a';
+  }
+  text[used++] = '\n';
+  text[used] = '\0';
+  EXPECT(rejects(text));
 }
 
 static void rejects_a_value_that_is_not_a_number(void) {
@@ -214,8 +258,11 @@ int main(void) {
   accepts_a_file_without_a_trailing_newline();
   accepts_a_fractional_backoff_factor();
   accepts_an_ipv6_nameserver();
+  carries_the_hostname_to_the_tenant();
+  drops_a_tenant_hostname();
   rejects_a_broken_file();
   rejects_a_value_that_is_not_a_number();
+  rejects_a_hostname_that_does_not_fit();
   rejects_a_value_containing_a_newline();
   rejects_a_nul_byte();
   rejects_too_many_tenant_variables();

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -18,13 +18,24 @@ Everything the binary can count on, and nothing else:
 | Working directory | `/app` |
 | Persistent volume | `/app/data` — 8 GiB, survives every redeploy |
 | Port | `PORT` is set by the guest; the app **must** listen on it, on `0.0.0.0` |
+| Own hostname | `NIBRUN_HOSTNAME` is set by the guest to the app's own `<slug>.nibrun.app` |
 | Ephemeral | `TMPDIR=/tmp` is a tmpfs and is lost on restart. So is everything outside `/app/data` |
 | Resources | 1 vCPU, 512 MiB RAM |
 | `HOME` | `/app` |
 | URL | `https://<slug>.nibrun.app`, live as soon as it boots |
 
 An app that writes its SQLite file and its uploads under `./data` and reads `PORT` needs no
-configuration to run here. A `PORT` you set yourself is ignored — the guest owns it.
+configuration to run here. A `PORT` or `NIBRUN_HOSTNAME` you set yourself is ignored — the guest
+owns both.
+
+A binary that needs its own absolute URL — an OAuth redirect, a webhook it registers, a link in
+an email — builds it from `NIBRUN_HOSTNAME` rather than being told it, and falls back to whatever
+it uses when it is not on nibrun:
+
+```ts
+const hostname = process.env.NIBRUN_HOSTNAME;
+const baseUrl = hostname ? `https://${hostname}` : `http://localhost:${port}`;
+```
 
 ## Deploying
 
@@ -61,11 +72,9 @@ Environment variables are an **edit**, not a replacement — anything a deploy d
 alone, so secrets are set once:
 
 ```sh
-nib run ./my-server --app my-app --env BASE_URL=https://my-app.nibrun.app --env LOG_LEVEL=debug
+nib run ./my-server --app my-app --env STRIPE_SECRET_KEY=sk_live_... --env LOG_LEVEL=debug
 nib run ./my-server --app my-app --unset LOG_LEVEL
 ```
-
-`BASE_URL` is the usual chicken-and-egg: deploy once, read the URL it prints, then set it.
 
 `nib --help` lists the rest — logs, domains, filesystem, export, delete.
 


### PR DESCRIPTION
`NIBRUN_HOSTNAME` is set in every guest, to the platform hostname the app is served under, so a binary builds its own absolute URLs — an OAuth redirect, a webhook it registers, a link in an email — instead of being told them through a variable set on a second deploy. The skill documents it as part of the guest contract, and no longer suggests the `BASE_URL` chicken-and-egg.

It is the hostname nibrun issued, never a domain the owner brought: that is the one name that cannot be taken away underneath a running binary. Like `PORT`, the guest owns it and a tenant variable of that name is dropped.

## Merging this needs two steps

The runtime rejects a `NIBRUN_` key it does not know, and rejecting it fails the boot — so the fleet must run the new guest image *before* the agent writes the line. The key is optional in the runtime precisely so the two can be deployed apart.

1. merge `feat(runtime): a tenant is told the hostname it is served under` — cd publishes a guest image under a new version
2. adopt it: set `guestImage` in `infra/app-host/versions.json` to that version
3. merge `feat(agent): an app's binary is handed the hostname it answers on`

Merging both at once leaves every deploy and restart failing to boot until step 2 lands. Happy to split this into two PRs instead if you would rather the ordering be enforced rather than remembered.