### PR TITLE
chore(infra): adopt the guest image that knows NIBRUN_HOSTNAME

### DIFF
--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -16,5 +16,5 @@
     "url": "https://github.com/caddyserver/caddy/releases/download/v2.11.4/caddy_2.11.4_linux_amd64.tar.gz",
     "sha256": "527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9"
   },
-  "guestImage": "6.1.180-88272af88c5a"
+  "guestImage": "6.1.180-11776f08683c"
 }


### PR DESCRIPTION
Every microVM that boots on the fleet right now dies at init:

```
[nibrun] instance.env line 2 sets NIBRUN_HOSTNAME, which this runtime does not know
[ 0.198818] reboot: Restarting system
```

The agent has written that line since #248. The hosts are pinned to `6.1.180-88272af88c5a`, built from the runtime before the key existed, and `config.c` returns false for a `NIBRUN_` key it does not know — which fails the boot. #248's own description called for three steps in order and this is step 2, which went out after step 3 instead of before it.

`6.1.180-11776f08683c` is what main builds and it has been in the bucket since 11:26 UTC.

The apps still up are the ones nothing has restarted; a deploy, a restart or a resume kills one, and the release then goes `failed`, which is terminal. This needs a host roll to take effect, and the apps already failed need a redeploy after it.

Worth a follow-up: the guest refusing an unknown `NIBRUN_` key is what makes the agent and the image a lockstep pair. Ignoring one with a warning would have made this a non-event.