### PR TITLE
feat(dashboard): the suspend button waits for the microVM

### DIFF
--- a/apps/dashboard/src/components/apps/app-status-badge.tsx
+++ b/apps/dashboard/src/components/apps/app-status-badge.tsx
@@ -22,17 +22,17 @@ export function AppStatusBadge({ app }: { app: AppSummary }) {
   if (status.isPending) {
     return <Skeleton className="h-5 w-20 rounded-2xl" />;
   }
-  if (status.isError) {
+  if (status.isError || status.status === undefined) {
     return <Badge variant="outline">unknown</Badge>;
   }
 
-  switch (status.data.kind) {
+  switch (status.status.kind) {
     case 'app':
-      return <AppStateBadge state={status.data.state} />;
+      return <AppStateBadge state={status.status.state} />;
     case 'deployment':
-      return <DeploymentStateBadge state={status.data.state} />;
+      return <DeploymentStateBadge state={status.status.state} />;
     case 'transition':
-      return <Badge variant="outline">{status.data.label}</Badge>;
+      return <Badge variant="outline">{status.status.label}</Badge>;
     case 'never-deployed':
       return <Badge variant="outline">never deployed</Badge>;
   }

--- a/apps/dashboard/src/components/apps/suspend-app-button.tsx
+++ b/apps/dashboard/src/components/apps/suspend-app-button.tsx
@@ -1,19 +1,31 @@
 import { Button } from '@repo/ui/components/button';
 import { Spinner } from '@repo/ui/components/spinner';
 import { PauseIcon, PlayIcon } from 'lucide-react';
+import type { AppTransition } from '#lib/app-status.ts';
 import { useApp } from '#lib/hooks/use-app.ts';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
+import { useAppStatus } from '#lib/hooks/use-app-status.ts';
 import { useAppSuspension } from '#lib/hooks/use-app-suspension.ts';
 import { useFailureToast } from '#lib/hooks/use-failure-toast.ts';
+
+/** What the button says while the host is catching up with what it was last pressed for. */
+const WHILE_MOVING: Record<AppTransition, string> = {
+  suspending: 'Suspending',
+  resuming: 'Resuming',
+};
 
 /**
  * One button rather than two, because there is one thing to say about a running app and one about
  * a suspended one. Nothing here is confirmed: what suspending costs is the app's uptime, and the
  * undo is this same button.
+ *
+ * It stays down until the microVM has actually stopped or come back, because until then the app
+ * row it would read to decide what to do next says something the host has not done yet.
  */
 export function SuspendAppButton() {
   const appId = useAppId();
   const app = useApp(appId);
+  const status = useAppStatus(app.data);
   const suspension = useAppSuspension(appId);
   useFailureToast(suspension.error?.message);
 
@@ -22,19 +34,17 @@ export function SuspendAppButton() {
   const Icon = suspended ? PlayIcon : PauseIcon;
   // An app on its way out is not one to take offline, and the api refuses it either way.
   const going = state === 'deleting' || state === 'deleted';
+  const moving = status.status?.kind === 'transition' ? status.status.label : undefined;
+  const waiting = suspension.isPending || moving !== undefined;
 
   return (
     <Button
       variant="outline"
-      disabled={state === undefined || going || suspension.isPending}
+      disabled={state === undefined || going || waiting}
       onClick={() => suspension.mutate(suspended ? 'active' : 'suspended')}
     >
-      {suspension.isPending ? (
-        <Spinner data-icon="inline-start" />
-      ) : (
-        <Icon data-icon="inline-start" />
-      )}
-      {suspended ? 'Resume' : 'Suspend'}
+      {waiting ? <Spinner data-icon="inline-start" /> : <Icon data-icon="inline-start" />}
+      {moving ? WHILE_MOVING[moving] : suspended ? 'Resume' : 'Suspend'}
     </Button>
   );
 }

--- a/apps/dashboard/src/lib/app-status.ts
+++ b/apps/dashboard/src/lib/app-status.ts
@@ -9,10 +9,13 @@ import type { AppState, DeploymentState } from '@repo/protocol';
  * whole point of this — an app is not suspended because someone pressed suspend, it is suspended
  * once the thing serving it has stopped.
  */
+/** The two moments the app row and the release disagree, named for what is happening. */
+export type AppTransition = 'suspending' | 'resuming';
+
 export type AppStatus =
   | { readonly kind: 'app'; readonly state: AppState }
   | { readonly kind: 'deployment'; readonly state: DeploymentState }
-  | { readonly kind: 'transition'; readonly label: 'suspending' | 'resuming' }
+  | { readonly kind: 'transition'; readonly label: AppTransition }
   | { readonly kind: 'never-deployed' };
 
 const SUSPENDED: AppStatus = { kind: 'app', state: 'suspended' };

--- a/apps/dashboard/src/lib/hooks/use-app-status.ts
+++ b/apps/dashboard/src/lib/hooks/use-app-status.ts
@@ -1,4 +1,4 @@
-import { type UseQueryResult, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { type AppStatus, appStatus, isSettling } from '#lib/app-status.ts';
 import type { AppSummary } from '#queries/apps.ts';
 import { type DeploymentSummary, deploymentsQueryOptions } from '#queries/deployments.ts';
@@ -9,6 +9,13 @@ import { type DeploymentSummary, deploymentsQueryOptions } from '#queries/deploy
  */
 const SETTLING_POLL_MS = 2_000;
 
+export type AppStatusResult = {
+  /** Absent until there is an app and a release to read one from, which is what `isPending` says. */
+  readonly status: AppStatus | undefined;
+  readonly isPending: boolean;
+  readonly isError: boolean;
+};
+
 /**
  * An app being deleted says everything about itself, so its releases are not read at all — the
  * query is skipped rather than asked and discarded.
@@ -17,16 +24,34 @@ function readsDeployments(app: AppSummary): boolean {
   return app.state === 'active' || app.state === 'suspended';
 }
 
-export function useAppStatus(app: AppSummary): UseQueryResult<AppStatus, Error> {
-  function statusOf(deployments: DeploymentSummary[] | undefined): AppStatus {
-    return appStatus({ appState: app.state, deploymentState: deployments?.[0]?.state });
-  }
+function statusOf({
+  app,
+  deployments,
+}: {
+  app: AppSummary;
+  deployments: DeploymentSummary[] | undefined;
+}): AppStatus {
+  return appStatus({ appState: app.state, deploymentState: deployments?.[0]?.state });
+}
 
-  return useQuery({
-    ...deploymentsQueryOptions(readsDeployments(app) ? app.id : undefined),
-    select: statusOf,
-    // The raw rows, not what `select` made of them: this is handed the query rather than the
-    // value a caller sees.
-    refetchInterval: (query) => (isSettling(statusOf(query.state.data)) ? SETTLING_POLL_MS : false),
+/**
+ * Derived here rather than in `select`, so the one place the app and its releases are read
+ * together is the one place they are put together — and `refetchInterval`, which is handed the
+ * query and so the rows rather than what a caller sees, asks the same question the same way.
+ */
+export function useAppStatus(app: AppSummary | undefined): AppStatusResult {
+  const deployments = useQuery({
+    ...deploymentsQueryOptions(app && readsDeployments(app) ? app.id : undefined),
+    refetchInterval: (query) =>
+      app && isSettling(statusOf({ app, deployments: query.state.data }))
+        ? SETTLING_POLL_MS
+        : false,
   });
+
+  return {
+    isPending: deployments.isPending,
+    isError: deployments.isError,
+    status:
+      app && deployments.isSuccess ? statusOf({ app, deployments: deployments.data }) : undefined,
+  };
 }


### PR DESCRIPTION
The button went back to being pressable the moment the app row moved, which is before the host has stopped or started anything — so the next press was for a state the app was not in yet. It now stays disabled and spinning while the release catches up, and says `Suspending` or `Resuming` while it does.

A deploy coming up is left alone: suspending an app mid-deploy is a thing an owner may want, so only the two states this button itself causes hold it down.

The status is also derived in the hook body rather than in `select` — `refetchInterval` is handed the query and so the raw rows, and nothing kept that in step with what the caller reads.