### PR TITLE
feat(www): the landing page points at the repo

### DIFF
--- a/apps/www/src/components/github-link.tsx
+++ b/apps/www/src/components/github-link.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@repo/ui/components/button';
+
+const REPO_URL = 'https://github.com/ilbertt/nibrun';
+
+// A new tab, unlike the sign-in beside it: this one leaves nibrun entirely, and taking the page
+// with it would cost anyone mid-drop the binary they already picked.
+export function GithubLink() {
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      aria-label="nibrun on GitHub"
+      render={<a href={REPO_URL} target="_blank" rel="noreferrer" />}
+    >
+      <GithubMark />
+    </Button>
+  );
+}
+
+function GithubMark() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { BinaryDrop } from '#components/binary-drop.tsx';
 import { DashboardLink } from '#components/dashboard-link.tsx';
 import { GetStartedHints } from '#components/get-started-hints.tsx';
+import { GithubLink } from '#components/github-link.tsx';
 import { Hero } from '#components/hero.tsx';
 import { PageBackdrop } from '#components/page-backdrop.tsx';
 import { WhatYouGet } from '#components/what-you-get.tsx';
@@ -14,7 +15,8 @@ function RouteComponent() {
     <>
       <PageBackdrop />
       <main className="mx-auto flex w-full max-w-5xl flex-col items-center px-6">
-        <header className="flex w-full justify-end py-5">
+        <header className="flex w-full items-center justify-end gap-1 py-5">
+          <GithubLink />
           <DashboardLink />
         </header>
         {/* Short of the viewport on purpose: the section below has to peek, or nobody scrolls. */}


### PR DESCRIPTION
The landing page had no way to reach the source. It does now: the GitHub mark
sits in the header beside Sign in, opening the repo in a new tab so nobody
mid-drop loses the binary they already picked.

Picked the header over a footer — it's above the fold, and it costs the page no
new section. lucide dropped brand icons in v1, so the mark is a local SVG.