### PR TITLE
docs: the readme argues for the shape instead of listing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,20 @@ to run and somewhere to read and write files.
 
 For an app that five people use, most of the rest is ceremony:
 
-| What it usually gets | What you get here |
+| What it usually gets | What it actually needs |
 | --- | --- |
-| ❌ ~~A container image~~ | ✅ A Firecracker microVM of its own |
-| ❌ ~~A build pipeline, a YAML file~~ | ✅ The binary you already built |
-| ❌ ~~A managed Postgres~~ | ✅ A SQLite file on a disk that persists |
-| ❌ ~~An object storage bucket~~ | ✅ Uploads on that same disk |
-| ❌ ~~A DNS record, a certificate~~ | ✅ An HTTPS subdomain the moment it boots |
-| ❌ ~~A load balancer, for one instance~~ | ✅ One instance, one writer |
+| ❌ ~~A container image~~ | ✅ **A machine to run on** |
+| ❌ ~~A managed Postgres~~ | ✅ **A disk to write to** |
+| ❌ ~~An object storage bucket~~ | |
+| ❌ ~~A load balancer, for one instance~~ | |
+| ❌ ~~A build pipeline~~ | |
+| ❌ ~~A YAML file you copied~~ | |
 
-nibrun is those two things, and nothing else. If your app needs to be more than one machine, it
-has outgrown this — and that is not a roadmap, it is the design.
+nibrun is those two things and nothing else: a Firecracker microVM of its own, and a `data/`
+directory that survives every redeploy. It answers on an HTTPS subdomain the moment it boots.
+
+If your app needs to be more than one machine, it has outgrown this — and that is not a roadmap,
+it is the design.
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Small apps don't need to scale. They need a machine and a disk.
 
 ## Why
 
-`bun build --compile` already collapses a whole application into one executable — no
-`node_modules`, no runtime to install on the other side. The only two things it still needs are
-somewhere to run and somewhere to read and write files.
+A compiled binary is already a whole application in one file — `go build`, `cargo build`,
+`bun build --compile`. Nothing to install on the other side. The only two things it still needs
+are somewhere to run and somewhere to read and write files.
 
 A container image, a managed Postgres, an object store and a load balancer in front of a single
 instance are not infrastructure for an app five people use. They are overhead you carry because
@@ -46,7 +46,7 @@ roadmap item.
 ## Get started
 
 Create an HTTP app (use the [bun-full-stack-starter](https://github.com/ilbertt/bun-full-stack-starter)
-template) and compile it to a single binary. Then deploy it:
+template) and compile it to a single Linux x86_64 binary. Then deploy it:
 
 ### Use the dashboard
 
@@ -70,12 +70,6 @@ contract, the commands and the tradeoffs:
 ```sh
 npx skills add ilbertt/nibrun
 ```
-
-## The contract
-
-Your binary listens on `PORT`, on `0.0.0.0`, and writes whatever it wants to keep under `./data`.
-That is the whole interface — no SDK to import, no agent to run beside it. The
-[full guest contract](./skills/deploy-to-nibrun/SKILL.md#the-guest-contract) is one table.
 
 ## Take it with you
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ A compiled binary is already a whole application in one file. Whatever language 
 nothing has to be installed on the other side. The only two things it still needs are somewhere
 to run and somewhere to read and write files.
 
-A container image, a managed Postgres, an object store and a load balancer in front of a single
-instance are not infrastructure for an app five people use. They are overhead you carry because
-that is the shape every platform requires.
+For an app that five people use, most of the rest is ceremony:
 
-nibrun is the machine and the disk, and nothing else.
+| What it usually gets | What it actually needs |
+| --- | --- |
+| ~~A container image~~<br>~~A managed Postgres~~<br>~~An object storage bucket~~<br>~~A load balancer, for one instance~~<br>~~A build pipeline~~<br>~~A YAML file you copied~~ | **A machine to run on**<br>**A disk to write to** |
+
+nibrun is those two things, and nothing else.
 
 ## What you get
 
@@ -27,16 +29,15 @@ nibrun is the machine and the disk, and nothing else.
 | --- | --- |
 | **A machine to itself** | One Firecracker microVM per app. Nothing else runs inside it. |
 | **A filesystem that persists** | `data/` is yours — a SQLite file, uploads, both. It survives every redeploy. |
-| **A URL right away** | An HTTPS subdomain, the moment it boots. |
+| **A URL right away** | An HTTPS subdomain the moment it boots. No DNS to point, no certificate to renew. |
 | **A way out** | The binary and its whole disk, as one `.tar.gz`, whenever you want it. |
-| ~~Autoscaling~~ | One instance per app, single writer. That is the whole concurrency model. |
-| ~~A load balancer~~ | There is one place your app runs. |
-| ~~A managed database~~ | Your database is a file on your disk. |
-| ~~Object storage~~ | Your uploads are files on your disk. |
-| ~~A Dockerfile~~ | No YAML and no build pipeline either. You deploy the binary you built. |
 
-The struck-through rows are not a roadmap. An app that genuinely needs one of them is better off
-somewhere else.
+## What it doesn't do
+
+One instance per app, single writer. No autoscaling, no load balancing, no multi-region. An app
+that needs those has outgrown this and should go somewhere else.
+
+That is not a roadmap. It is the design.
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ For an app that five people use, most of the rest is ceremony:
 | ❌ ~~A build pipeline~~ | |
 | ❌ ~~A YAML file you copied~~ | |
 
+## What you get
+
 nibrun is those two things and nothing else: a Firecracker microVM of its own, and a `data/`
 directory that survives every redeploy. It answers on an HTTPS subdomain the moment it boots.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For an app that five people use, most of the rest is ceremony:
 | ❌ ~~A build pipeline~~ | |
 | ❌ ~~A YAML file you copied~~ | |
 
-## What you get
+## What it is
 
 nibrun is those two things and nothing else: a Firecracker microVM of its own, and a `data/`
 directory that survives every redeploy. It answers on an HTTPS subdomain the moment it boots.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Small apps don't need to scale. They need a machine and a disk.
 
 ## Why
 
-A compiled binary is already a whole application in one file — `go build`, `cargo build`,
-`bun build --compile`. Nothing to install on the other side. The only two things it still needs
-are somewhere to run and somewhere to read and write files.
+A compiled binary is already a whole application in one file. Whatever language produced it,
+nothing has to be installed on the other side. The only two things it still needs are somewhere
+to run and somewhere to read and write files.
 
 A container image, a managed Postgres, an object store and a load balancer in front of a single
 instance are not infrastructure for an app five people use. They are overhead you carry because

--- a/README.md
+++ b/README.md
@@ -29,19 +29,14 @@ nibrun is the machine and the disk, and nothing else.
 | **A filesystem that persists** | `data/` is yours — a SQLite file, uploads, both. It survives every redeploy. |
 | **A URL right away** | An HTTPS subdomain, the moment it boots. |
 | **A way out** | The binary and its whole disk, as one `.tar.gz`, whenever you want it. |
+| ~~Autoscaling~~ | One instance per app, single writer. That is the whole concurrency model. |
+| ~~A load balancer~~ | There is one place your app runs. |
+| ~~A managed database~~ | Your database is a file on your disk. |
+| ~~Object storage~~ | Your uploads are files on your disk. |
+| ~~A Dockerfile~~ | No YAML and no build pipeline either. You deploy the binary you built. |
 
-## What you don't get
-
-On purpose:
-
-- **No autoscaling.** One instance per app, single writer. That is the whole concurrency model.
-- **No load balancer, no service discovery.** There is one place your app runs.
-- **No managed database.** Your database is a file on your disk.
-- **No object storage.** Your uploads are files on your disk.
-- **No Dockerfile, no YAML, no build pipeline.** You deploy the binary you built.
-
-An app that genuinely needs one of these is better off somewhere else. That is an answer, not a
-roadmap item.
+The struck-through rows are not a roadmap. An app that genuinely needs one of them is better off
+somewhere else.
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -17,27 +17,17 @@ to run and somewhere to read and write files.
 
 For an app that five people use, most of the rest is ceremony:
 
-| What it usually gets | What it actually needs |
+| What it usually gets | What you get here |
 | --- | --- |
-| ~~A container image~~<br>~~A managed Postgres~~<br>~~An object storage bucket~~<br>~~A load balancer, for one instance~~<br>~~A build pipeline~~<br>~~A YAML file you copied~~ | **A machine to run on**<br>**A disk to write to** |
+| ❌ ~~A container image~~ | ✅ A Firecracker microVM of its own |
+| ❌ ~~A build pipeline, a YAML file~~ | ✅ The binary you already built |
+| ❌ ~~A managed Postgres~~ | ✅ A SQLite file on a disk that persists |
+| ❌ ~~An object storage bucket~~ | ✅ Uploads on that same disk |
+| ❌ ~~A DNS record, a certificate~~ | ✅ An HTTPS subdomain the moment it boots |
+| ❌ ~~A load balancer, for one instance~~ | ✅ One instance, one writer |
 
-nibrun is those two things, and nothing else.
-
-## What you get
-
-| | |
-| --- | --- |
-| **A machine to itself** | One Firecracker microVM per app. Nothing else runs inside it. |
-| **A filesystem that persists** | `data/` is yours — a SQLite file, uploads, both. It survives every redeploy. |
-| **A URL right away** | An HTTPS subdomain the moment it boots. No DNS to point, no certificate to renew. |
-| **A way out** | The binary and its whole disk, as one `.tar.gz`, whenever you want it. |
-
-## What it doesn't do
-
-One instance per app, single writer. No autoscaling, no load balancing, no multi-region. An app
-that needs those has outgrown this and should go somewhere else.
-
-That is not a roadmap. It is the design.
+nibrun is those two things, and nothing else. If your app needs to be more than one machine, it
+has outgrown this — and that is not a roadmap, it is the design.
 
 ## Get started
 
@@ -72,7 +62,7 @@ npx skills add ilbertt/nibrun
 ```sh
 nib apps export .
 tar -xzf my-app.tar.gz
-PORT=3000 ./my-server
+./my-server
 ```
 
 The same binary you uploaded, and the same bytes that were on the disk. There is no managed

--- a/README.md
+++ b/README.md
@@ -7,8 +7,41 @@
 
 </div>
 
-Each binary gets a microVM of its own, a persistent filesystem, and an HTTPS URL. No Dockerfile,
-no YAML, no cluster.
+Small apps don't need to scale. They need a machine and a disk.
+
+## Why
+
+`bun build --compile` already collapses a whole application into one executable — no
+`node_modules`, no runtime to install on the other side. The only two things it still needs are
+somewhere to run and somewhere to read and write files.
+
+A container image, a managed Postgres, an object store and a load balancer in front of a single
+instance are not infrastructure for an app five people use. They are overhead you carry because
+that is the shape every platform requires.
+
+nibrun is the machine and the disk, and nothing else.
+
+## What you get
+
+| | |
+| --- | --- |
+| **A machine to itself** | One Firecracker microVM per app. Nothing else runs inside it. |
+| **A filesystem that persists** | `data/` is yours — a SQLite file, uploads, both. It survives every redeploy. |
+| **A URL right away** | An HTTPS subdomain, the moment it boots. |
+| **A way out** | The binary and its whole disk, as one `.tar.gz`, whenever you want it. |
+
+## What you don't get
+
+On purpose:
+
+- **No autoscaling.** One instance per app, single writer. That is the whole concurrency model.
+- **No load balancer, no service discovery.** There is one place your app runs.
+- **No managed database.** Your database is a file on your disk.
+- **No object storage.** Your uploads are files on your disk.
+- **No Dockerfile, no YAML, no build pipeline.** You deploy the binary you built.
+
+An app that genuinely needs one of these is better off somewhere else. That is an answer, not a
+roadmap item.
 
 ## Get started
 
@@ -37,3 +70,20 @@ contract, the commands and the tradeoffs:
 ```sh
 npx skills add ilbertt/nibrun
 ```
+
+## The contract
+
+Your binary listens on `PORT`, on `0.0.0.0`, and writes whatever it wants to keep under `./data`.
+That is the whole interface — no SDK to import, no agent to run beside it. The
+[full guest contract](./skills/deploy-to-nibrun/SKILL.md#the-guest-contract) is one table.
+
+## Take it with you
+
+```sh
+nib apps export .
+tar -xzf my-app.tar.gz
+PORT=3000 ./my-server
+```
+
+The same binary you uploaded, and the same bytes that were on the disk. There is no managed
+database to migrate off, because there never was one.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,23 @@ it is the design.
 Create an HTTP app (use the [bun-full-stack-starter](https://github.com/ilbertt/bun-full-stack-starter)
 template) and compile it to a single Linux x86_64 binary. Then deploy it:
 
-### Use the dashboard
+### For Agents
 
-Drag the binary onto [app.nibrun.com](https://app.nibrun.com).
+Prepare the app and deploy it to nibrun using the [`deploy-to-nibrun`](./skills/deploy-to-nibrun/SKILL.md) skill.
 
-### Use the CLI
+Install it using:
+
+```sh
+npx skills add ilbertt/nibrun
+```
+
+### For Humans
+
+**Use the dashboard**
+
+Drag and drop the binary onto [app.nibrun.com](https://app.nibrun.com).
+
+**Use the CLI**
 
 ```sh
 curl -fsSL https://nibrun.com/install.sh | sh
@@ -51,15 +63,6 @@ curl -fsSL https://nibrun.com/install.sh | sh
 
 ```sh
 nib run ./my-server
-```
-
-### Let an agent do it
-
-[`skills/deploy-to-nibrun`](./skills/deploy-to-nibrun/SKILL.md) teaches an agent the guest
-contract, the commands and the tradeoffs:
-
-```sh
-npx skills add ilbertt/nibrun
 ```
 
 ## Take it with you


### PR DESCRIPTION
The readme stated what nibrun gives you but never why that shape is the point. It now leads with the argument — a compiled binary only needs a machine and a disk — and says plainly what nibrun refuses to be, so someone who needs a load balancer can leave on the first screen.

The guest contract stays in the skill; the readme points at it rather than duplicating the table.