### PR TITLE
feat(api): nibrun sizes the machine, not the owner

### DIFF
--- a/apps/api/src/lib/app-config.ts
+++ b/apps/api/src/lib/app-config.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
+  type InstanceResources,
   REDACTED,
   type SecretString,
   type TenantEnvironment,
@@ -20,10 +21,14 @@ export const VOLUME_SIZE_BYTES = 8_589_934_592;
 // database and only opened where desired state is built, so there is nothing here to return.
 export type RedactedEnvironment = Record<string, typeof REDACTED>;
 
-type OwnedAppConfig = Omit<AppConfig, 'environment'>;
+// What an owner may send. Nibrun sizes the machine an app runs on, so `resources` is read back
+// beside the volume size rather than written, and leaving it out here is what keeps it out of
+// every write shape below.
+type OwnedAppConfig = Omit<AppConfig, 'environment' | 'resources'>;
 
 export type PublicAppConfig = OwnedAppConfig & {
   volumeSizeBytes: number;
+  resources: InstanceResources;
   environment: RedactedEnvironment;
 };
 
@@ -109,9 +114,9 @@ export function configWithDefaults(
 ): Omit<PublicAppConfig, 'environment'> {
   return {
     volumeSizeBytes: VOLUME_SIZE_BYTES,
+    resources: DEFAULT_INSTANCE_RESOURCES,
     guestPort: patch.guestPort ?? DEFAULT_GUEST_PORT,
     args: patch.args ?? [],
-    resources: patch.resources ?? DEFAULT_INSTANCE_RESOURCES,
     healthCheck: patch.healthCheck ?? DEFAULT_HEALTH_CHECK,
     restartPolicy: patch.restartPolicy ?? DEFAULT_RESTART_POLICY,
   };

--- a/apps/api/src/routes/api/apps/model.ts
+++ b/apps/api/src/routes/api/apps/model.ts
@@ -4,6 +4,7 @@ import {
   AppHostnameStateSchema,
   AppSchema,
   ByteSizeSchema,
+  InstanceResourcesSchema,
   MIN_HOSTNAMES,
   REDACTED,
   TenantEnvironmentPatchSchema,
@@ -13,9 +14,10 @@ import { t } from 'elysia';
 
 const MAX_APP_NAME_LENGTH = 128;
 
-// `environment` is written and read in different shapes, so it is taken out here and each half
-// says its own.
-const OwnedAppConfigSchema = t.Omit(AppConfigSchema, ['environment']);
+// What an owner may actually send. `environment` comes out because it is written and read in
+// different shapes and each half says its own below; `resources` comes out because nibrun sizes
+// the machine, the same way it sizes the filesystem.
+const OwnedAppConfigSchema = t.Omit(AppConfigSchema, ['environment', 'resources']);
 
 // Which variables are set, never what they hold: the values are sealed in the database and only
 // opened on their way to the host, so there is nothing here that could return one.
@@ -23,12 +25,16 @@ const RedactedEnvironmentSchema = t.Record(t.String(), t.Literal(REDACTED), {
   description: 'The variables this app runs with. Values are never returned.',
 });
 
-// The api sizes an app's filesystem, so the size is read back but never set. It is added on
-// top of what an owner owns rather than omitted from it, which is what keeps it out of the
-// patch shape below without naming it twice.
+// The api sizes the machine an app gets — its vCPUs, its memory, its filesystem — so all three
+// are read back but never set. They are added on top of what an owner owns rather than omitted
+// from it, which is what keeps them out of the write shapes below without naming them twice.
 export const PublicAppConfigSchema = t.Composite([
   OwnedAppConfigSchema,
-  t.Object({ volumeSizeBytes: ByteSizeSchema, environment: RedactedEnvironmentSchema }),
+  t.Object({
+    volumeSizeBytes: ByteSizeSchema,
+    resources: InstanceResourcesSchema,
+    environment: RedactedEnvironmentSchema,
+  }),
 ]);
 
 // Strict: every field is optional, so without this a misspelled one is silently no request at

--- a/apps/api/tests/controllers/apps.test.ts
+++ b/apps/api/tests/controllers/apps.test.ts
@@ -103,6 +103,29 @@ describe('a malformed request is a bad request', () => {
     expect(response.status).toBe(StatusMap['Bad Request']);
   });
 
+  // The rest of the machine is the api's to size for the same reason the filesystem is, and a
+  // request asking for a bigger one has to be told so rather than answered 200 by a schema that
+  // dropped the field.
+  test('patching the machine resources is refused, because the api owns them', async () => {
+    const response = await sendJson({
+      method: 'PATCH',
+      url: APP_URL,
+      body: { resources: { vcpuCount: 4, memoryMib: 4096 } },
+    });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
+  test('creating an app that asks for its own machine resources', async () => {
+    const response = await sendJson({
+      method: 'POST',
+      url: APPS_URL,
+      body: { name: 'pocketbase', config: { resources: { vcpuCount: 4, memoryMib: 4096 } } },
+    });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
   test('creating an app with a field it does not have', async () => {
     const response = await sendJson({
       method: 'POST',

--- a/packages/protocol/src/domain/instance.ts
+++ b/packages/protocol/src/domain/instance.ts
@@ -10,8 +10,8 @@ const DEFAULT_VCPU_COUNT = 1;
 
 // The divisor on a host's usable memory: it decides how many apps a host carries and what one
 // costs. 256 leaves a Bun server several times its resident baseline while doubling density
-// against the 512 it replaces, and an app that needs more sets its own. Only new apps start
-// here — an existing one keeps the value already on its config.
+// against the 512 it replaces. Only new apps start here — an existing one keeps the value
+// already on its config, and no owner can ask for another.
 const DEFAULT_MEMORY_MIB = 256;
 
 const MIN_HEALTH_PROBE_MS = 100;

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -90,14 +90,15 @@ Or drag the binary onto [app.nibrun.com](https://app.nibrun.com) — same thing,
 
 Worth saying out loud before recommending it:
 
-- **One microVM per app.** No horizontal scaling and no load balancing. Vertical only.
+- **One microVM per app, one size.** No horizontal scaling, no load balancing, no resizing.
 - **A deploy is a replace.** The old VM is stopped before the new one starts, because they share
   one volume — so there are a few seconds of downtime, and no blue/green or canary.
 - **A local disk, not a distributed one.** Ideal for SQLite, uploads, caches. It is not
   replicated, so an export (`nib apps export`) is your backup.
 - **The binary is the unit.** The guest boots yours and nothing else — no sidecar, no cron
   container, no managed database next to it.
-- **256 MiB and 1 vCPU by default**, and the OOM killer reaches for the tenant first.
+- **256 MiB and 1 vCPU**, sized by nibrun rather than configured by you, and the OOM killer
+  reaches for the tenant first.
 - **Health is a TCP connect** to `PORT` by default. A process that accepts connections while
   broken reads as healthy.
 


### PR DESCRIPTION
Machine resources are the api's to decide, the same way the filesystem size already is. `resources` comes out of the write shapes and stays in the read one, so a create or patch carrying it is a 400 instead of a silently-dropped field.

Existing apps keep whatever their columns hold — a patch carries them forward untouched.

Rebased onto #259, which lowered the memory default to 256 MiB on the argument that "an app that needs more sets its own". This removes that escape hatch, so the comment on `DEFAULT_MEMORY_MIB` no longer claims it — worth a look, since it weakens the case for 256 over 512.