### PR TITLE
feat(api): nibrun decides when an app is alive, not the owner

### DIFF
--- a/apps/api/src/lib/app-config.ts
+++ b/apps/api/src/lib/app-config.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
+  type HealthCheck,
   type InstanceResources,
   REDACTED,
   type SecretString,
@@ -21,14 +22,15 @@ export const VOLUME_SIZE_BYTES = 8_589_934_592;
 // database and only opened where desired state is built, so there is nothing here to return.
 export type RedactedEnvironment = Record<string, typeof REDACTED>;
 
-// What an owner may send. Nibrun sizes the machine an app runs on, so `resources` is read back
-// beside the volume size rather than written, and leaving it out here is what keeps it out of
-// every write shape below.
-type OwnedAppConfig = Omit<AppConfig, 'environment' | 'resources'>;
+// What an owner may send. Nibrun sizes the machine an app runs on and decides when it is alive,
+// so `resources` and `healthCheck` are read back beside the volume size rather than written, and
+// leaving them out here is what keeps them out of every write shape below.
+type OwnedAppConfig = Omit<AppConfig, 'environment' | 'resources' | 'healthCheck'>;
 
 export type PublicAppConfig = OwnedAppConfig & {
   volumeSizeBytes: number;
   resources: InstanceResources;
+  healthCheck: HealthCheck;
   environment: RedactedEnvironment;
 };
 
@@ -115,9 +117,9 @@ export function configWithDefaults(
   return {
     volumeSizeBytes: VOLUME_SIZE_BYTES,
     resources: DEFAULT_INSTANCE_RESOURCES,
+    healthCheck: DEFAULT_HEALTH_CHECK,
     guestPort: patch.guestPort ?? DEFAULT_GUEST_PORT,
     args: patch.args ?? [],
-    healthCheck: patch.healthCheck ?? DEFAULT_HEALTH_CHECK,
     restartPolicy: patch.restartPolicy ?? DEFAULT_RESTART_POLICY,
   };
 }

--- a/apps/api/src/routes/api/apps/model.ts
+++ b/apps/api/src/routes/api/apps/model.ts
@@ -4,6 +4,7 @@ import {
   AppHostnameStateSchema,
   AppSchema,
   ByteSizeSchema,
+  HealthCheckSchema,
   InstanceResourcesSchema,
   MIN_HOSTNAMES,
   REDACTED,
@@ -15,9 +16,9 @@ import { t } from 'elysia';
 const MAX_APP_NAME_LENGTH = 128;
 
 // What an owner may actually send. `environment` comes out because it is written and read in
-// different shapes and each half says its own below; `resources` comes out because nibrun sizes
-// the machine, the same way it sizes the filesystem.
-const OwnedAppConfigSchema = t.Omit(AppConfigSchema, ['environment', 'resources']);
+// different shapes and each half says its own below; `resources` and `healthCheck` come out
+// because nibrun sizes the machine and decides when it is alive.
+const OwnedAppConfigSchema = t.Omit(AppConfigSchema, ['environment', 'resources', 'healthCheck']);
 
 // Which variables are set, never what they hold: the values are sealed in the database and only
 // opened on their way to the host, so there is nothing here that could return one.
@@ -25,14 +26,15 @@ const RedactedEnvironmentSchema = t.Record(t.String(), t.Literal(REDACTED), {
   description: 'The variables this app runs with. Values are never returned.',
 });
 
-// The api sizes the machine an app gets — its vCPUs, its memory, its filesystem — so all three
-// are read back but never set. They are added on top of what an owner owns rather than omitted
-// from it, which is what keeps them out of the write shapes below without naming them twice.
+// The api sizes the machine an app gets and probes it on its own terms, so all of this is read
+// back but never set. It is added on top of what an owner owns rather than omitted from it,
+// which is what keeps it out of the write shapes below without naming it twice.
 export const PublicAppConfigSchema = t.Composite([
   OwnedAppConfigSchema,
   t.Object({
     volumeSizeBytes: ByteSizeSchema,
     resources: InstanceResourcesSchema,
+    healthCheck: HealthCheckSchema,
     environment: RedactedEnvironmentSchema,
   }),
 ]);

--- a/apps/api/tests/controllers/apps.test.ts
+++ b/apps/api/tests/controllers/apps.test.ts
@@ -5,6 +5,16 @@ import { ORIGIN, sendJson } from '#tests/controllers/support/api.ts';
 const APPS_URL = `${ORIGIN}/api/apps`;
 const APP_URL = `${APPS_URL}/app-1`;
 
+// Well-formed on its own terms, so what refuses it is the api owning the field rather than the
+// value being wrong.
+const A_HEALTH_CHECK = {
+  intervalMs: 1_000,
+  timeoutMs: 500,
+  gracePeriodMs: 10_000,
+  healthyThreshold: 1,
+  unhealthyThreshold: 3,
+};
+
 const OWNED_ROUTES = [
   { method: 'GET', url: APPS_URL },
   { method: 'POST', url: APPS_URL, body: { name: 'pocketbase' } },
@@ -116,11 +126,34 @@ describe('a malformed request is a bad request', () => {
     expect(response.status).toBe(StatusMap['Bad Request']);
   });
 
+  // A TCP connect to `PORT` is the whole probe, and how often it runs and how many failures
+  // condemn an instance are nibrun's to decide — an app that could set its own thresholds could
+  // also make itself unkillable.
+  test('patching the health check is refused, because the api owns it', async () => {
+    const response = await sendJson({
+      method: 'PATCH',
+      url: APP_URL,
+      body: { healthCheck: { ...A_HEALTH_CHECK, path: '/healthz' } },
+    });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
   test('creating an app that asks for its own machine resources', async () => {
     const response = await sendJson({
       method: 'POST',
       url: APPS_URL,
       body: { name: 'pocketbase', config: { resources: { vcpuCount: 4, memoryMib: 4096 } } },
+    });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
+  test('creating an app that asks for its own health check', async () => {
+    const response = await sendJson({
+      method: 'POST',
+      url: APPS_URL,
+      body: { name: 'pocketbase', config: { healthCheck: A_HEALTH_CHECK } },
     });
 
     expect(response.status).toBe(StatusMap['Bad Request']);

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -99,8 +99,8 @@ Worth saying out loud before recommending it:
   container, no managed database next to it.
 - **256 MiB and 1 vCPU**, sized by nibrun rather than configured by you, and the OOM killer
   reaches for the tenant first.
-- **Health is a TCP connect** to `PORT` by default. A process that accepts connections while
-  broken reads as healthy.
+- **Health is a TCP connect** to `PORT`, and not something you configure. A process that accepts
+  connections while broken reads as healthy.
 
 It fits a single-binary app that owns its own state — an internal tool, a small SaaS, a demo, a
 side project. It does not fit anything that needs to be several machines.


### PR DESCRIPTION
Stacked on #261.

When an app is alive is nibrun's judgement, not its owner's: the probe, how often it runs, and how many failures condemn an instance. `healthCheck` moves to the read side beside `resources`, so a create or patch carrying it is a 400.

Worth knowing before merging: `healthCheck.path` is the one field here a tenant has a real reason to want. Without it the probe is a bare TCP connect, and an app that accepts connections while broken reads as healthy — that tradeoff becomes permanent.