### PR TITLE
feat(api): nibrun sets the restart budget, not the owner

### DIFF
--- a/apps/api/src/lib/app-config.ts
+++ b/apps/api/src/lib/app-config.ts
@@ -4,8 +4,6 @@ import {
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
-  type HealthCheck,
-  type InstanceResources,
   REDACTED,
   type SecretString,
   type TenantEnvironment,
@@ -22,17 +20,15 @@ export const VOLUME_SIZE_BYTES = 8_589_934_592;
 // database and only opened where desired state is built, so there is nothing here to return.
 export type RedactedEnvironment = Record<string, typeof REDACTED>;
 
-// What an owner may send. Nibrun sizes the machine an app runs on and decides when it is alive,
-// so `resources` and `healthCheck` are read back beside the volume size rather than written, and
-// leaving them out here is what keeps them out of every write shape below.
-type OwnedAppConfig = Omit<AppConfig, 'environment' | 'resources' | 'healthCheck'>;
-
-export type PublicAppConfig = OwnedAppConfig & {
+export type PublicAppConfig = Omit<AppConfig, 'environment'> & {
   volumeSizeBytes: number;
-  resources: InstanceResources;
-  healthCheck: HealthCheck;
   environment: RedactedEnvironment;
 };
+
+// How the binary is started, which is the whole of what an owner chooses. The machine it starts
+// on — vCPUs, memory, filesystem, health probe, restart budget — is nibrun's, and leaving it out
+// of this one type is what keeps it out of every write shape below.
+type OwnedAppConfig = Pick<AppConfig, 'guestPort' | 'args'>;
 
 // What an app is created with: the whole environment, because there is not yet one to edit.
 export type NewAppConfig = Partial<OwnedAppConfig> & {
@@ -118,9 +114,9 @@ export function configWithDefaults(
     volumeSizeBytes: VOLUME_SIZE_BYTES,
     resources: DEFAULT_INSTANCE_RESOURCES,
     healthCheck: DEFAULT_HEALTH_CHECK,
+    restartPolicy: DEFAULT_RESTART_POLICY,
     guestPort: patch.guestPort ?? DEFAULT_GUEST_PORT,
     args: patch.args ?? [],
-    restartPolicy: patch.restartPolicy ?? DEFAULT_RESTART_POLICY,
   };
 }
 

--- a/apps/api/src/routes/api/apps/model.ts
+++ b/apps/api/src/routes/api/apps/model.ts
@@ -4,8 +4,6 @@ import {
   AppHostnameStateSchema,
   AppSchema,
   ByteSizeSchema,
-  HealthCheckSchema,
-  InstanceResourcesSchema,
   MIN_HOSTNAMES,
   REDACTED,
   TenantEnvironmentPatchSchema,
@@ -15,29 +13,23 @@ import { t } from 'elysia';
 
 const MAX_APP_NAME_LENGTH = 128;
 
-// What an owner may actually send. `environment` comes out because it is written and read in
-// different shapes and each half says its own below; `resources` and `healthCheck` come out
-// because nibrun sizes the machine and decides when it is alive.
-const OwnedAppConfigSchema = t.Omit(AppConfigSchema, ['environment', 'resources', 'healthCheck']);
-
 // Which variables are set, never what they hold: the values are sealed in the database and only
 // opened on their way to the host, so there is nothing here that could return one.
 const RedactedEnvironmentSchema = t.Record(t.String(), t.Literal(REDACTED), {
   description: 'The variables this app runs with. Values are never returned.',
 });
 
-// The api sizes the machine an app gets and probes it on its own terms, so all of this is read
-// back but never set. It is added on top of what an owner owns rather than omitted from it,
-// which is what keeps it out of the write shapes below without naming it twice.
+// Everything an app runs with, plus the filesystem the api sized for it. `environment` is written
+// and read in different shapes, so it is taken out and each half says its own.
 export const PublicAppConfigSchema = t.Composite([
-  OwnedAppConfigSchema,
-  t.Object({
-    volumeSizeBytes: ByteSizeSchema,
-    resources: InstanceResourcesSchema,
-    healthCheck: HealthCheckSchema,
-    environment: RedactedEnvironmentSchema,
-  }),
+  t.Omit(AppConfigSchema, ['environment']),
+  t.Object({ volumeSizeBytes: ByteSizeSchema, environment: RedactedEnvironmentSchema }),
 ]);
+
+// How the binary is started, which is the whole of what an owner chooses. The machine it starts
+// on — vCPUs, memory, filesystem, health probe, restart budget — is nibrun's, and naming the two
+// that are not is what turns a request for the rest into an answer rather than silence.
+const OwnedAppConfigSchema = t.Pick(AppConfigSchema, ['guestPort', 'args']);
 
 // Strict: every field is optional, so without this a misspelled one is silently no request at
 // all and the caller is told 200.

--- a/apps/api/tests/controllers/apps.test.ts
+++ b/apps/api/tests/controllers/apps.test.ts
@@ -15,6 +15,14 @@ const A_HEALTH_CHECK = {
   unhealthyThreshold: 3,
 };
 
+const A_RESTART_POLICY = {
+  maxRestarts: 100,
+  initialBackoffMs: 500,
+  maxBackoffMs: 30_000,
+  backoffFactor: 2,
+  resetAfterMs: 60_000,
+};
+
 const OWNED_ROUTES = [
   { method: 'GET', url: APPS_URL },
   { method: 'POST', url: APPS_URL, body: { name: 'pocketbase' } },
@@ -139,6 +147,18 @@ describe('a malformed request is a bad request', () => {
     expect(response.status).toBe(StatusMap['Bad Request']);
   });
 
+  // A tenant that set its own budget could ask to be restarted forever, and an app that crashes
+  // on every boot would then be a host's problem rather than its owner's.
+  test('patching the restart policy is refused, because the api owns it', async () => {
+    const response = await sendJson({
+      method: 'PATCH',
+      url: APP_URL,
+      body: { restartPolicy: A_RESTART_POLICY },
+    });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
   test('creating an app that asks for its own machine resources', async () => {
     const response = await sendJson({
       method: 'POST',
@@ -154,6 +174,16 @@ describe('a malformed request is a bad request', () => {
       method: 'POST',
       url: APPS_URL,
       body: { name: 'pocketbase', config: { healthCheck: A_HEALTH_CHECK } },
+    });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
+  test('creating an app that asks for its own restart policy', async () => {
+    const response = await sendJson({
+      method: 'POST',
+      url: APPS_URL,
+      body: { name: 'pocketbase', config: { restartPolicy: A_RESTART_POLICY } },
     });
 
     expect(response.status).toBe(StatusMap['Bad Request']);

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -101,6 +101,8 @@ Worth saying out loud before recommending it:
   reaches for the tenant first.
 - **Health is a TCP connect** to `PORT`, and not something you configure. A process that accepts
   connections while broken reads as healthy.
+- **A crash loop is fatal.** The guest restarts your process on a fixed budget you do not set;
+  once it runs out the app is `failed` rather than restarted forever.
 
 It fits a single-binary app that owns its own state — an internal tool, a small SaaS, a demo, a
 side project. It does not fit anything that needs to be several machines.


### PR DESCRIPTION
Stacked on #263.

A tenant that sets its own restart budget can ask to be restarted forever, which makes an app that crashes on every boot a host's problem rather than its owner's.

With this, the only config an owner sends is `guestPort`, `args` and `environment` — how the binary is started. So the write shape becomes a `Pick` of those rather than an `Omit` that grew a field per PR.