### PR TITLE
chore(infra): bump zerofs to v2.3.1

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -102,7 +102,7 @@ credentials, and the gap is wider than the test count suggests.
   the checkpoint, its server and its device go on every way out. That ZeroFS answers `checkpoint
   create` by sealing the open segment and flushing metadata *before* it records — which is why the
   export no longer flushes first, and under `ignore_fsync` is the whole durability guarantee — is
-  read from ZeroFS v2.2.1's source rather than observed here. A version bump has to re-read it.
+  read from ZeroFS v2.3.1's source rather than observed here. A version bump has to re-read it.
 - **The read-only checkpoint server has never been started.** Whether
   `nibrun-zerofs-checkpoint@.service` and `checkpoint.toml` between them produce a listening NBD
   socket — the `%i` expansion, the `ExecStartPost` wait, ZeroFS's own `${VAR}` substitution — is a

--- a/apps/agent/src/lib/exports/checkpoint.ts
+++ b/apps/agent/src/lib/exports/checkpoint.ts
@@ -61,7 +61,7 @@ export const releaseCheckpoint = Effect.fn('releaseCheckpoint')(
  *
  * No `flush` before the checkpoint. `checkpoint create` seals the open data segment and flushes
  * the metadata memtable through the very same flush coordinator the admin `flush` RPC drives
- * (ZeroFS v2.2.1, `CheckpointManager::create_checkpoint`), so a flush here would be a second
+ * (ZeroFS v2.3.1, `CheckpointManager::create_checkpoint`), so a flush here would be a second
  * round trip against a barrier the next call takes anyway — inside the one window where the
  * tenant cannot write. It is load-bearing rather than belt-and-braces: with `ignore_fsync` that
  * barrier is the entire durability guarantee, so a ZeroFS bump that moved it would silently cost

--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -1,8 +1,8 @@
 {
   "zerofs": {
-    "version": "v2.2.1",
-    "url": "https://github.com/Barre/ZeroFS/releases/download/v2.2.1/zerofs-pgo-multiplatform.tar.gz",
-    "sha256": "d4ae4e4e9bc0a6f4cc4253b6a9fc6c9b57feda6dc0f0cb7443f9264b2eeec621",
+    "version": "v2.3.1",
+    "url": "https://github.com/Barre/ZeroFS/releases/download/v2.3.1/zerofs-pgo-multiplatform.tar.gz",
+    "sha256": "7a7d083f58677ccf5480850347fcf570e364baf48573bbd51f6f8d412972df3a",
     "member": "zerofs-linux-amd64-pgo"
   },
   "firecracker": {


### PR DESCRIPTION
Picks up v2.3.0's single-PUT segment uploads and fsync coalescing on the path that is our whole durability guarantee.

`CheckpointManager::create_checkpoint` is byte-identical to v2.2.1 — the seal+flush barrier still precedes the `Durable`-scope cut — so the export's no-flush-before-checkpoint optimisation is unaffected. That was the re-read `apps/agent/AGENTS.md` asks for on any bump.

Deploying restarts ZeroFS, which `BindsTo` stops every tenant VM through. They come back on the agent's next reconcile.