### PR TITLE
Revert "chore(infra): bump zerofs to v2.3.1"

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -102,7 +102,7 @@ credentials, and the gap is wider than the test count suggests.
   the checkpoint, its server and its device go on every way out. That ZeroFS answers `checkpoint
   create` by sealing the open segment and flushing metadata *before* it records — which is why the
   export no longer flushes first, and under `ignore_fsync` is the whole durability guarantee — is
-  read from ZeroFS v2.3.1's source rather than observed here. A version bump has to re-read it.
+  read from ZeroFS v2.2.1's source rather than observed here. A version bump has to re-read it.
 - **The read-only checkpoint server has never been started.** Whether
   `nibrun-zerofs-checkpoint@.service` and `checkpoint.toml` between them produce a listening NBD
   socket — the `%i` expansion, the `ExecStartPost` wait, ZeroFS's own `${VAR}` substitution — is a

--- a/apps/agent/src/lib/exports/checkpoint.ts
+++ b/apps/agent/src/lib/exports/checkpoint.ts
@@ -61,7 +61,7 @@ export const releaseCheckpoint = Effect.fn('releaseCheckpoint')(
  *
  * No `flush` before the checkpoint. `checkpoint create` seals the open data segment and flushes
  * the metadata memtable through the very same flush coordinator the admin `flush` RPC drives
- * (ZeroFS v2.3.1, `CheckpointManager::create_checkpoint`), so a flush here would be a second
+ * (ZeroFS v2.2.1, `CheckpointManager::create_checkpoint`), so a flush here would be a second
  * round trip against a barrier the next call takes anyway — inside the one window where the
  * tenant cannot write. It is load-bearing rather than belt-and-braces: with `ignore_fsync` that
  * barrier is the entire durability guarantee, so a ZeroFS bump that moved it would silently cost

--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -1,8 +1,8 @@
 {
   "zerofs": {
-    "version": "v2.3.1",
-    "url": "https://github.com/Barre/ZeroFS/releases/download/v2.3.1/zerofs-pgo-multiplatform.tar.gz",
-    "sha256": "7a7d083f58677ccf5480850347fcf570e364baf48573bbd51f6f8d412972df3a",
+    "version": "v2.2.1",
+    "url": "https://github.com/Barre/ZeroFS/releases/download/v2.2.1/zerofs-pgo-multiplatform.tar.gz",
+    "sha256": "d4ae4e4e9bc0a6f4cc4253b6a9fc6c9b57feda6dc0f0cb7443f9264b2eeec621",
     "member": "zerofs-linux-amd64-pgo"
   },
   "firecracker": {


### PR DESCRIPTION
v2.3.1 breaks every tenant disk. Guests get EIO reading the ext4 superblock through the NBD export and reboot-loop:

```
Failed to execute In virtio block request: FileEngine(Sync(Transfer(IOError(... code: 5 ...))))
I/O error, dev vdd, sector 2 op 0x0:(READ)
EXT4-fs (vdd): unable to read superblock
```

Reverts to v2.2.1. Merging redeploys and restarts ZeroFS again.