### PR TITLE
chore(infra): bump zerofs to v2.3.1

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -102,7 +102,7 @@ credentials, and the gap is wider than the test count suggests.
   the checkpoint, its server and its device go on every way out. That ZeroFS answers `checkpoint
   create` by sealing the open segment and flushing metadata *before* it records — which is why the
   export no longer flushes first, and under `ignore_fsync` is the whole durability guarantee — is
-  read from ZeroFS v2.2.1's source rather than observed here. A version bump has to re-read it.
+  read from ZeroFS v2.3.1's source rather than observed here. A version bump has to re-read it.
 - **The read-only checkpoint server has never been started.** Whether
   `nibrun-zerofs-checkpoint@.service` and `checkpoint.toml` between them produce a listening NBD
   socket — the `%i` expansion, the `ExecStartPost` wait, ZeroFS's own `${VAR}` substitution — is a

--- a/apps/agent/src/lib/exports/checkpoint.ts
+++ b/apps/agent/src/lib/exports/checkpoint.ts
@@ -61,7 +61,7 @@ export const releaseCheckpoint = Effect.fn('releaseCheckpoint')(
  *
  * No `flush` before the checkpoint. `checkpoint create` seals the open data segment and flushes
  * the metadata memtable through the very same flush coordinator the admin `flush` RPC drives
- * (ZeroFS v2.2.1, `CheckpointManager::create_checkpoint`), so a flush here would be a second
+ * (ZeroFS v2.3.1, `CheckpointManager::create_checkpoint`), so a flush here would be a second
  * round trip against a barrier the next call takes anyway — inside the one window where the
  * tenant cannot write. It is load-bearing rather than belt-and-braces: with `ignore_fsync` that
  * barrier is the entire durability guarantee, so a ZeroFS bump that moved it would silently cost

--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -1,8 +1,8 @@
 {
   "zerofs": {
-    "version": "v2.2.1",
-    "url": "https://github.com/Barre/ZeroFS/releases/download/v2.2.1/zerofs-pgo-multiplatform.tar.gz",
-    "sha256": "d4ae4e4e9bc0a6f4cc4253b6a9fc6c9b57feda6dc0f0cb7443f9264b2eeec621",
+    "version": "v2.3.1",
+    "url": "https://github.com/Barre/ZeroFS/releases/download/v2.3.1/zerofs-pgo-multiplatform.tar.gz",
+    "sha256": "7a7d083f58677ccf5480850347fcf570e364baf48573bbd51f6f8d412972df3a",
     "member": "zerofs-linux-amd64-pgo"
   },
   "firecracker": {


### PR DESCRIPTION
Reapplies #268, which #269 reverted during an incident.

**Correction to the original rationale:** v2.3.1 was the *trigger* of that outage, not the defect. The same `EXT4-fs (vdd): unable to read superblock` failure reproduces on v2.2.1 after the rollback. Root cause is the NBD reconnect path — a ZeroFS restart leaves `nbd-client -persist` holding devices that are attached with the correct size but error on every read:

```
I/O error, dev nbd4, sector 0 op 0x0:(READ)
nbd4: unable to read partition table
```

Any ZeroFS restart does this, whatever the version. Tracked separately; it is the thing that actually needs fixing.

So v2.3.1 is **unproven, not proven guilty** — it still deserves a gate, because the bump remains unvalidated against a real host.

**Merge this BEFORE the rebuild (#260).** The app host takes a new instance id on rebuild, so a new `hosts/${instance_id}` prefix, and ZeroFS creates that store under whatever version is pinned at the time. Pinned first, v2.3.1 creates its own store — the condition worth testing. Pinned after, v2.3.1 inherits a store v2.2.1 wrote, which is the configuration that already failed once.

Order: **this → #260 → rebuild → smoke test → onboard apps.**

**Gate before any real app lands.** Deploy one throwaway app and confirm its guest reaches `running` with `/dev/vdd` mounted:

```
sudo journalctl -u 'nibrun-vm@*' -n 50 --no-pager
```

Fail looks like `EXT4-fs (vdd): unable to read superblock`. On fail, revert and rebuild — no tenant data is at risk while the platform is empty.

Checkpoint semantics re-verified: `CheckpointManager::create_checkpoint` is byte-identical to v2.2.1, so the export's no-flush-before-checkpoint optimisation still holds.