### PR TITLE
feat(dashboard): deleting an app is a slide, not a typed phrase

### DIFF
--- a/apps/dashboard/src/components/apps/delete-app-dialog.tsx
+++ b/apps/dashboard/src/components/apps/delete-app-dialog.tsx
@@ -1,6 +1,5 @@
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -11,28 +10,23 @@ import {
   AlertDialogTrigger,
 } from '@repo/ui/components/alert-dialog';
 import { Button } from '@repo/ui/components/button';
-import { Field, FieldError, FieldLabel } from '@repo/ui/components/field';
-import { Input } from '@repo/ui/components/input';
-import { Spinner } from '@repo/ui/components/spinner';
+import { Field, FieldError } from '@repo/ui/components/field';
+import { SlideToDelete } from '@repo/ui/custom/slide-to-delete';
 import { Trash2Icon, TriangleAlertIcon } from 'lucide-react';
-import { useState } from 'react';
 import { useApp } from '#lib/hooks/use-app.ts';
 import { useAppDeletion } from '#lib/hooks/use-app-deletion.ts';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
-
-const CONFIRMATION_PHRASE = 'delete permanently';
 
 export function DeleteAppDialog() {
   const appId = useAppId();
   const app = useApp(appId);
   const deletion = useAppDeletion(appId);
-  const [typed, setTyped] = useState('');
 
   const slug = app.data?.slug;
   const alreadyDeleting = app.data?.state === 'deleting';
 
   return (
-    <AlertDialog onOpenChange={() => setTyped('')}>
+    <AlertDialog>
       <AlertDialogTrigger
         render={<Button variant="destructive" disabled={slug === undefined || alreadyDeleting} />}
       >
@@ -80,35 +74,19 @@ export function DeleteAppDialog() {
         </dl>
 
         <Field data-invalid={deletion.isError || undefined}>
-          <FieldLabel htmlFor="delete-confirmation">
-            Type <span className="font-mono">{CONFIRMATION_PHRASE}</span> to delete {slug}
-          </FieldLabel>
-          <Input
-            id="delete-confirmation"
-            value={typed}
-            onChange={(event) => setTyped(event.target.value)}
-            placeholder={CONFIRMATION_PHRASE}
-            autoComplete="off"
+          <SlideToDelete
+            label={`Slide to delete ${slug}`}
+            pendingLabel={`Deleting ${slug}…`}
+            pending={deletion.isPending}
+            onDelete={() => deletion.mutate()}
           />
           {deletion.isError && <FieldError>{deletion.error.message}</FieldError>}
         </Field>
 
         <AlertDialogFooter>
           <AlertDialogCancel disabled={deletion.isPending}>Keep the app</AlertDialogCancel>
-          <AlertDialogAction
-            variant="destructive"
-            disabled={!saysDeletePermanently(typed) || deletion.isPending}
-            onClick={() => deletion.mutate()}
-          >
-            {deletion.isPending && <Spinner />}
-            Delete {slug}
-          </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
   );
-}
-
-function saysDeletePermanently(typed: string): boolean {
-  return typed.trim().toLowerCase() === CONFIRMATION_PHRASE;
 }

--- a/packages/ui/src/custom/slide-to-delete.tsx
+++ b/packages/ui/src/custom/slide-to-delete.tsx
@@ -1,0 +1,127 @@
+import { Spinner } from '@repo/ui/components/spinner';
+import { cn } from '@repo/ui/lib/utils';
+import { Trash2Icon } from 'lucide-react';
+import { type KeyboardEvent, type PointerEvent, useRef, useState } from 'react';
+
+const KEYBOARD_STEP = 0.25;
+const LABEL_FADE_RATE = 1.6;
+const FULL_PERCENT = 100;
+
+export function SlideToDelete({
+  label,
+  pendingLabel,
+  pending,
+  onDelete,
+}: {
+  label: string;
+  pendingLabel: string;
+  pending: boolean;
+  onDelete: () => void;
+}) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const grabOffset = useRef(0);
+  const [dragged, setDragged] = useState(0);
+  const [dragging, setDragging] = useState(false);
+
+  const progress = pending ? 1 : dragged;
+  const travelled = `calc(${progress} * (100% - var(--slide-handle-size)))`;
+
+  function slideTo(next: number): void {
+    if (next < 1) {
+      setDragged(Math.max(0, next));
+      return;
+    }
+    // Only `pending` holds the handle at the end, so a deletion that comes back
+    // with an error leaves the slider armed at the start for another attempt.
+    setDragged(0);
+    setDragging(false);
+    onDelete();
+  }
+
+  function grabHandle(event: PointerEvent<HTMLDivElement>): void {
+    if (pending) {
+      return;
+    }
+    event.currentTarget.setPointerCapture(event.pointerId);
+    grabOffset.current = event.clientX - event.currentTarget.getBoundingClientRect().left;
+    setDragging(true);
+  }
+
+  function dragHandle(event: PointerEvent<HTMLDivElement>): void {
+    const track = trackRef.current;
+    if (!dragging || track === null) {
+      return;
+    }
+    const travel = track.clientWidth - event.currentTarget.offsetWidth;
+    if (travel <= 0) {
+      return;
+    }
+    slideTo((event.clientX - track.getBoundingClientRect().left - grabOffset.current) / travel);
+  }
+
+  function releaseHandle(): void {
+    setDragging(false);
+    setDragged(0);
+  }
+
+  function stepHandle(event: KeyboardEvent<HTMLDivElement>): void {
+    // No End key: reaching the far end takes repeated presses, so the keyboard
+    // asks for the same deliberate effort the drag does.
+    const stepped = {
+      ArrowRight: dragged + KEYBOARD_STEP,
+      ArrowUp: dragged + KEYBOARD_STEP,
+      ArrowLeft: dragged - KEYBOARD_STEP,
+      ArrowDown: dragged - KEYBOARD_STEP,
+      Home: 0,
+    }[event.key];
+    if (stepped === undefined || pending) {
+      return;
+    }
+    event.preventDefault();
+    slideTo(stepped);
+  }
+
+  return (
+    <div
+      ref={trackRef}
+      className="relative h-(--slide-handle-size) w-full touch-none select-none rounded-full bg-muted [--slide-handle-size:2.75rem]"
+    >
+      <div
+        className="absolute inset-y-0 left-0 rounded-full bg-destructive/15"
+        style={{ width: `calc(${travelled} + var(--slide-handle-size))` }}
+      />
+      <span
+        className={cn(
+          'pointer-events-none absolute inset-0 flex items-center justify-center gap-2 pr-4 pl-(--slide-handle-size) text-sm',
+          pending ? 'text-destructive' : 'text-muted-foreground',
+        )}
+        style={{ opacity: pending ? 1 : Math.max(0, 1 - progress * LABEL_FADE_RATE) }}
+      >
+        {pending && <Spinner />}
+        <span className="truncate px-2">{pending ? pendingLabel : label}</span>
+      </span>
+      <div
+        role="slider"
+        tabIndex={pending ? -1 : 0}
+        aria-label={label}
+        aria-disabled={pending || undefined}
+        aria-orientation="horizontal"
+        aria-valuemin={0}
+        aria-valuemax={FULL_PERCENT}
+        aria-valuenow={Math.round(progress * FULL_PERCENT)}
+        onPointerDown={grabHandle}
+        onPointerMove={dragHandle}
+        onPointerUp={releaseHandle}
+        onPointerCancel={releaseHandle}
+        onKeyDown={stepHandle}
+        className={cn(
+          'absolute top-0 flex size-(--slide-handle-size) items-center justify-center rounded-full bg-destructive text-destructive-foreground outline-none focus-visible:ring-3 focus-visible:ring-destructive/30',
+          pending ? 'cursor-not-allowed' : 'cursor-grab active:cursor-grabbing',
+        )}
+        style={{ left: travelled }}
+      >
+        <Trash2Icon />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Confirming an app deletion is now a slide-to-delete handle instead of typing `delete permanently`, taking after [j2only/slide-unlock](https://github.com/j2only/slide-unlock) — without its animations.

The slider is keyboard-operable (arrows step, no `End`, so it stays as deliberate as the drag), and a failed deletion re-arms it back at the start.