### PR TITLE
feat(dashboard): with no apps, deploy from the middle of the page

### DIFF
--- a/apps/dashboard/src/components/apps/no-apps-empty.tsx
+++ b/apps/dashboard/src/components/apps/no-apps-empty.tsx
@@ -1,11 +1,15 @@
 import {
   Empty,
-  EmptyDescription,
+  EmptyContent,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
 } from '@repo/ui/components/empty';
+import { CopyButton } from '@repo/ui/custom/copy-button';
 import { BoxIcon } from 'lucide-react';
+import { DeployDialog } from '#components/apps/deploy-dialog.tsx';
+
+const INSTALL_COMMAND = 'curl -fsSL https://nibrun.com/install.sh | sh';
 
 export function NoAppsEmpty() {
   return (
@@ -15,10 +19,19 @@ export function NoAppsEmpty() {
           <BoxIcon />
         </EmptyMedia>
         <EmptyTitle>You have no apps</EmptyTitle>
-        <EmptyDescription>
-          <code className="font-mono">nib run</code> is what makes one.
-        </EmptyDescription>
       </EmptyHeader>
+      <EmptyContent>
+        <DeployDialog />
+        <div className="flex w-full flex-col gap-2">
+          <p className="text-muted-foreground">Alternatively, use the CLI:</p>
+          <div className="flex items-center gap-1 rounded-lg border bg-muted/40 py-1 pr-1 pl-3">
+            <code className="flex-1 select-all break-words text-left font-mono text-xs">
+              {INSTALL_COMMAND}
+            </code>
+            <CopyButton value={INSTALL_COMMAND} />
+          </div>
+        </div>
+      </EmptyContent>
     </Empty>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/apps/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/apps/index.tsx
@@ -1,15 +1,20 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { AppsList } from '#components/apps/apps-list.tsx';
 import { DeployDialog } from '#components/apps/deploy-dialog.tsx';
+import { useApps } from '#lib/hooks/use-apps.ts';
 
 export const Route = createFileRoute('/(dashboard)/apps/')({ component: RouteComponent });
 
 function RouteComponent() {
+  const apps = useApps();
+  const noApps = apps.data?.length === 0;
+
   return (
     <div className="@container/main flex flex-col gap-4 p-4 md:gap-6 md:p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="font-medium text-base">Apps</h1>
-        <DeployDialog />
+        {/* The empty state puts its own Deploy button in the middle of the page. */}
+        {noApps ? null : <DeployDialog />}
       </div>
       <AppsList />
     </div>


### PR DESCRIPTION
The empty apps page now carries the Deploy button itself, plus the CLI install command as an alternative. The header's Deploy button steps aside while it shows.

Also drops "`nib run` is what makes one.", which read as a non-sequitur next to a Deploy button.