### PR TITLE
feat(infra): a SQL console on the database, for admins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,15 @@ API_DB_NAME=nibrun
 # Loopback only (127.0.0.1); SSH-tunnel from your laptop to reach it remotely.
 API_DB_PORT=5432
 
+# --- Database console ---
+# pgweb, a SQL console on the database above, reached over the compose network as
+# the same superuser role and pinned to that one connection. Loopback only
+# (127.0.0.1); SSH-tunnel from your laptop to reach it remotely. No login here,
+# like Dozzle — production adds one from SSM (docker-compose.prod.yml), which is
+# why there is nothing to fill in below.
+
+PGWEB_PORT=8081
+
 # --- Object storage ---
 # Backed by MinIO in the stack; the api talks plain S3 to it at http://minio:9000.
 # The credentials double as MinIO's root user, so the key needs 3+ characters and

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -93,6 +93,22 @@ services:
     volumes:
       - ./dozzle/data:/data
 
+  # Loopback only here as in local, so this login is not what stands between a
+  # SQL console and the internet — the absence of any route to it is. It exists
+  # because the session behind it is the cluster superuser's, and a port
+  # published by mistake should not be the last thing that mattered.
+  #
+  # The credentials themselves rather than a hash, unlike Dozzle's user list and
+  # the log dashboard's basic_auth: pgweb compares what the browser sends against
+  # what it was given, so there is nothing on the box to hash. Both halves are
+  # SSM parameters, read into .env by on_box_deploy.sh — the username as much as
+  # the password, since nothing publishes this console and an unguessable name
+  # costs an admin nothing that looking up the password did not already.
+  pgweb:
+    environment:
+      - PGWEB_AUTH_USER=${PGWEB_AUTH_USER}
+      - PGWEB_AUTH_PASS=${PGWEB_AUTH_PASS}
+
   # Both exist only to stand in for S3 locally. An inactive profile is how a
   # service gets switched off from an override file.
   minio:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
-# Local stack: Postgres, MinIO, the API, and Dozzle. Copy .env.example to .env
-# first.
+# Local stack: Postgres, MinIO, the API, VictoriaLogs, Dozzle and pgweb. Copy
+# .env.example to .env first.
 #
 # Anything truly opinionated (internal service URLs, container ports, bucket
 # bootstrap) lives here, not in .env.
@@ -189,6 +189,47 @@ services:
       timeout: 5s
       retries: 5
     restart: always
+    networks:
+      - nibrun
+
+  # A SQL console on the api's database, for admins. Loopback only in local and
+  # production alike, and with no site in the Caddyfile: it connects as the role
+  # that owns the database — the cluster superuser, which is what lets pg-backup
+  # dump roles — so an SSM port-forward, which already costs AWS credentials, is
+  # the whole way in. The login production adds (docker-compose.prod.yml) is a
+  # second lock on that door rather than the door itself.
+  #
+  # sslmode is spelled out because pgweb only infers `disable` for a host
+  # literally named localhost or 127.0.0.1. Any other host falls through to
+  # lib/pq's default of `require`, which this Postgres, serving no TLS, refuses.
+  pgweb:
+    image: sosedoff/pgweb:0.17.0
+    container_name: pgweb
+    command:
+      - --lock-session
+    environment:
+      - PGWEB_DATABASE_URL=postgresql://${API_DB_USER}:${API_DB_PASSWORD}@postgres-db:5432/${API_DB_NAME}?sslmode=disable
+    ports:
+      - "127.0.0.1:${PGWEB_PORT}:8081"
+    healthcheck:
+      # /api/connection rather than /api/info: info sits on pgweb's allowlist for
+      # its own database check and keeps answering once the connection is gone,
+      # where this round-trips to Postgres. Credentials because basic auth covers
+      # every route including this one; they are unset locally, where there is no
+      # login, and curl sends an empty pair that pgweb ignores.
+      test:
+        [
+          "CMD-SHELL",
+          "curl -fsS -o /dev/null -u $$PGWEB_AUTH_USER:$$PGWEB_AUTH_PASS http://127.0.0.1:8081/api/connection",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: always
+    depends_on:
+      postgres-db:
+        condition: service_healthy
     networks:
       - nibrun
 

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -7,9 +7,9 @@ an instance has no Bun; everything CI runs lives in `@repo/internal-scripts`.
 The Terraform explains itself — read it rather than a description of it here.
 
 Config carries its component's prefix (`API_`, `POSTGRES_`, `PG_BACKUP_`, `CADDY_`, `DOZZLE_`,
-`VICTORIALOGS_`) unless more than one component reads it, and keeps one name from the Terraform
-output through the SSM command to the `.env` the box writes. Nothing is aliased in transit, so
-nothing can drift.
+`VICTORIALOGS_`, `PGWEB_`) unless more than one component reads it, and keeps one name from the
+Terraform output through the SSM command to the `.env` the box writes. Nothing is aliased in
+transit, so nothing can drift.
 
 ## First run
 

--- a/infra/deploy/on_box_deploy.sh
+++ b/infra/deploy/on_box_deploy.sh
@@ -25,6 +25,7 @@ API_PORT="${API_PORT:-3000}"
 API_DB_USER="${API_DB_USER:-nibrun}"
 API_DB_NAME="${API_DB_NAME:-nibrun}"
 API_DB_PORT="${API_DB_PORT:-5432}"
+PGWEB_PORT="${PGWEB_PORT:-8081}"
 API_S3_PORT="${API_S3_PORT:-9000}"
 API_S3_CONSOLE_PORT="${API_S3_CONSOLE_PORT:-9001}"
 DOZZLE_PORT="${DOZZLE_PORT:-8080}"
@@ -50,6 +51,8 @@ API_GITHUB_CLIENT_SECRET="$(secret api_github_client_secret)"
 API_CLOUDFLARE_API_TOKEN="$(secret api_cloudflare_api_token)"
 API_S3_ACCESS_KEY_ID="$(secret api_s3_access_key_id)"
 API_S3_SECRET_ACCESS_KEY="$(secret api_s3_secret_access_key)"
+PGWEB_AUTH_USER="$(secret pgweb_auth_user)"
+PGWEB_AUTH_PASS="$(secret pgweb_auth_pass)"
 
 # Everything written from here on carries a secret: the PEMs below, then .env.
 umask 077
@@ -90,6 +93,10 @@ API_DB_USER=${API_DB_USER}
 API_DB_PASSWORD=${API_DB_PASSWORD}
 API_DB_NAME=${API_DB_NAME}
 API_DB_PORT=${API_DB_PORT}
+
+PGWEB_PORT=${PGWEB_PORT}
+PGWEB_AUTH_USER=${PGWEB_AUTH_USER}
+PGWEB_AUTH_PASS=${PGWEB_AUTH_PASS}
 
 API_S3_ENDPOINT=${API_S3_ENDPOINT}
 ARTIFACTS_BUCKET=${ARTIFACTS_BUCKET}

--- a/infra/terraform/ssm.tf
+++ b/infra/terraform/ssm.tf
@@ -154,6 +154,44 @@ resource "aws_ssm_parameter" "victorialogs_password" {
   }
 }
 
+# pgweb's login, read back exactly like the two above. Both halves, unlike them:
+# nothing publishes this console — an SSM port-forward is the only way to it — so
+# the username is a second unguessable value rather than a name to remember, and
+# an admin who is already looking up one parameter pays nothing to look up two.
+#
+# The credentials, not a hash. Dozzle and Caddy both want bcrypt and both re-salt,
+# which is why the box does that hashing once per deploy; pgweb compares basic
+# auth input directly, so what the box reads is what the container is given.
+resource "random_password" "pgweb_auth_user" {
+  length  = 16
+  special = false
+}
+
+resource "random_password" "pgweb_auth_pass" {
+  length  = 32
+  special = false
+}
+
+resource "aws_ssm_parameter" "pgweb_auth_user" {
+  name  = "${var.ssm_secret_prefix}/pgweb_auth_user"
+  type  = "SecureString"
+  value = random_password.pgweb_auth_user.result
+
+  tags = {
+    Name = "${local.resource_name_prefix}-pgweb-auth-user"
+  }
+}
+
+resource "aws_ssm_parameter" "pgweb_auth_pass" {
+  name  = "${var.ssm_secret_prefix}/pgweb_auth_pass"
+  type  = "SecureString"
+  value = random_password.pgweb_auth_pass.result
+
+  tags = {
+    Name = "${local.resource_name_prefix}-pgweb-auth-pass"
+  }
+}
+
 # --- App hosts ---
 
 # The user-app proxy's TLS material, carried exactly like the control plane


### PR DESCRIPTION
Adds pgweb to the stack so admins can browse and query the database, reached the way Postgres itself already is — loopback-only, over an SSM port-forward, with no site in the Caddyfile and no hostname to reissue the origin certificate for. Production gives it a login from two SSM parameters, because the session behind it is the cluster superuser's.

Two non-obvious bits, commented where they live: `sslmode=disable` is mandatory (pgweb only infers it for a host named `localhost`, and `lib/pq` otherwise defaults to `require`), and the healthcheck hits `/api/connection` rather than `/api/info`, which is on pgweb's allowlist for its own database check and answers even once the connection is gone.

Verified against a real Postgres in both configurations: 401 without credentials and 200 with, `select version()` through the API, `session_lock: true`, and the container healthy either way.

Reaching it:

```
aws ssm start-session --target "$(terraform -chdir=infra/terraform output -raw instance_id)" \
  --document-name AWS-StartPortForwardingSession \
  --parameters '{"portNumber":["8081"],"localPortNumber":["8081"]}'

for p in pgweb_auth_user pgweb_auth_pass; do
  aws ssm get-parameter --name "/nibrun/$p" --with-decryption --query Parameter.Value --output text
done
```