### PR TITLE
fix(infra): tenant filesystems are stored under the host's index, not its id

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -167,6 +167,7 @@ jobs:
       DEPLOY_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).deploy_bucket }}
       APP_HOST_DEPLOY_GROUP: ${{ fromJSON(needs.terraform.outputs.values).app_host_deploy_group }}
       APP_HOST_DATA_VOLUME_IDS: ${{ fromJSON(needs.terraform.outputs.values).app_host_data_volume_ids }}
+      APP_HOST_INDEXES: ${{ fromJSON(needs.terraform.outputs.values).app_host_indexes }}
       SSM_SECRET_PREFIX: ${{ fromJSON(needs.terraform.outputs.values).ssm_secret_prefix }}
       GUEST_IMAGES_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).guest_images_bucket }}
       FILESYSTEMS_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).filesystems_bucket }}

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -13,7 +13,7 @@ cd "$(dirname "$0")"
 
 log() { echo "=== [on_box_deploy $(date -u +%H:%M:%S)] $* ==="; }
 
-: "${AWS_REGION:?}" "${SSM_SECRET_PREFIX:?}" "${DATA_VOLUME_ID:?}" \
+: "${AWS_REGION:?}" "${SSM_SECRET_PREFIX:?}" "${DATA_VOLUME_ID:?}" "${HOST_INDEX:?}" \
   "${AGENT_VERSION:?}" "${AGENT_URL:?}" \
   "${ZEROFS_VERSION:?}" "${ZEROFS_URL:?}" "${ZEROFS_SHA256:?}" "${ZEROFS_MEMBER:?}" \
   "${FIRECRACKER_VERSION:?}" "${FIRECRACKER_URL:?}" "${FIRECRACKER_SHA256:?}" \
@@ -29,16 +29,14 @@ log() { echo "=== [on_box_deploy $(date -u +%H:%M:%S)] $* ==="; }
 # the correct state before any tenant app exists.
 GUEST_IMAGE_VERSION="${GUEST_IMAGE_VERSION:-}"
 
-# Composed here rather than in CI because the prefix is scoped to this host and
-# the instance id is only known on it. ZeroFS opens exactly one prefix read-write
-# fleet-wide, and this is what makes that true by construction.
-instance_id=$(
-  token=$(curl -fsS -X PUT http://169.254.169.254/latest/api/token \
-    -H 'X-aws-ec2-metadata-token-ttl-seconds: 60')
-  curl -fsS -H "X-aws-ec2-metadata-token: $token" \
-    http://169.254.169.254/latest/meta-data/instance-id
-)
-NIBRUN_FILESYSTEMS_URL="s3://${FILESYSTEMS_BUCKET}/hosts/${instance_id}"
+# The host's index, not its instance id. Replacing an instance is how this fleet
+# is maintained, and a prefix named for the id the host is about to lose hands its
+# replacement an empty store while every tenant filesystem stays behind under a
+# name nothing reads again — silently, because a host that finds no volume simply
+# formats a new one. One index per host is also what keeps ZeroFS's one
+# read-write prefix fleet-wide true, which is the property the instance id was
+# picked for in the first place.
+NIBRUN_FILESYSTEMS_URL="s3://${FILESYSTEMS_BUCKET}/hosts/${HOST_INDEX}"
 
 NIBRUN_DIR=/opt/nibrun
 VERSIONS_DIR="$NIBRUN_DIR/versions"

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -133,6 +133,17 @@ output "app_host_data_volume_ids" {
   value       = { for index, host in aws_instance.app_host : host.id => aws_ebs_volume.app_host_data[index].id }
 }
 
+# What a host's tenant filesystems are stored under, and deliberately not the
+# instance id. Replacing an instance is how this fleet is maintained — a spot
+# rebuild, a type change, an ami roll — and a prefix named for the id the host is
+# about to lose points its replacement at an empty store while the tenant data
+# stays behind under a name nothing reads again. The index is what `count`
+# numbers rather than what AWS assigns, so it survives all of it.
+output "app_host_indexes" {
+  description = "Instance id to the index the host occupies. Names its ZeroFS storage prefix."
+  value       = { for index, host in aws_instance.app_host : host.id => index }
+}
+
 output "exports_bucket" {
   description = "Downloadable app exports. Written by app hosts, read by the api only to sign a download URL."
   value       = aws_s3_bucket.exports.bucket

--- a/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
+++ b/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
@@ -18,6 +18,11 @@ const revision = requiredEnv('GITHUB_SHA');
 // from a map keyed by instance id rather than a single output.
 const dataVolumeIds = JSON.parse(requiredEnv('APP_HOST_DATA_VOLUME_IDS')) as Record<string, string>;
 
+// Keyed by instance id like the volumes above, but what it carries is the host's
+// index — which is the point. See the app_host_indexes output for why the storage
+// prefix must not be named after the id the map is keyed by.
+const hostIndexes = JSON.parse(requiredEnv('APP_HOST_INDEXES')) as Record<string, number>;
+
 const versions = await readAppHostVersions();
 
 // Every name here is the name the box reads, and every version is the one pinned
@@ -74,14 +79,14 @@ if [ "$(cloud-init status | awk '{print $2}')" = "error" ]; then
 fi
 timeout 900 bash -c 'until [ -f /opt/nibrun-app-host-bootstrap.done ]; do echo waiting for instance bootstrap; sleep 5; done'`;
 
-const remoteScript = ({ dataVolumeId }: { dataVolumeId: string }) => `
+const remoteScript = ({ dataVolumeId, hostIndex }: { dataVolumeId: string; hostIndex: number }) => `
 set -euo pipefail
 ${awaitBootstrap}
 mkdir -p /opt/nibrun/bundle
 aws s3 cp ${quote(bundleUrl)} /tmp/app-host-bundle.tar.gz
 tar xzf /tmp/app-host-bundle.tar.gz --overwrite -C /opt/nibrun/bundle
 cd /opt/nibrun/bundle
-export ${exportLine({ ...sharedEnv, DATA_VOLUME_ID: dataVolumeId })}
+export ${exportLine({ ...sharedEnv, DATA_VOLUME_ID: dataVolumeId, HOST_INDEX: String(hostIndex) })}
 bash on_box_deploy.sh
 `;
 
@@ -91,6 +96,13 @@ async function deployTo({ instanceId }: { instanceId: string }) {
     return { instanceId, status: 'NoDataVolume', stdout: '', stderr: '' };
   }
 
+  // Compared against undefined rather than tested for truth: host 0 is the first
+  // one there is, and the only one there is today.
+  const hostIndex = hostIndexes[instanceId];
+  if (hostIndex === undefined) {
+    return { instanceId, status: 'NoHostIndex', stdout: '', stderr: '' };
+  }
+
   console.log(`[${instanceId}] waiting for SSM registration...`);
   if (!(await waitForSsmRegistration({ instanceId }))) {
     return { instanceId, status: 'NotRegistered', stdout: '', stderr: '' };
@@ -98,7 +110,7 @@ async function deployTo({ instanceId }: { instanceId: string }) {
 
   const commandId = await sendCommand({
     instanceIds: [instanceId],
-    script: remoteScript({ dataVolumeId }),
+    script: remoteScript({ dataVolumeId, hostIndex }),
     comment: `Deploy ${optionalEnv('GITHUB_SHA') ?? 'manual'}`,
   });
   console.log(`[${instanceId}] SSM command: ${commandId}`);


### PR DESCRIPTION
`on_box_deploy.sh` named the ZeroFS prefix `hosts/${instance_id}`, resolved from
IMDS on the box. Replacing an app host is how this fleet is maintained — a spot
rebuild, a type change, an ami roll — and the instance id is the one identifier a
replacement is guaranteed not to keep.

This is not theoretical. It happened during #260's rebuild an hour ago:

```
i-075393332c4a2afde/   55 objects   6,925,506 bytes   <- old host, orphaned
i-03738d79b4aae4939/   15 objects      57,554 bytes   <- new host, born empty
```

The new host opened an empty prefix, the agent found no volume for the app and
logged `volume formatted`, and every tenant filesystem stayed behind under a name
nothing reads again. Nothing failed and nothing warned, because a host with no
volumes is indistinguishable from a host whose volumes are new.

It also contradicts what `app_host.tf` says the design is — that the local volume
is disposable *because* "S3 is the source of truth and a host can be rebuilt from
it." A rebuild is exactly when the existing data has to be reattached.

The index is what `count` numbers rather than what AWS assigns, so it survives
instance replacement. It is plumbed the same way `DATA_VOLUME_ID` already is:
a Terraform output keyed by instance id, looked up per host by the deploy.
`instance_id` had no other use in the script, so the IMDS round trip goes with it.

**Migration.** The current host's prefix holds ~1 MB across 79 objects — a
freshly formatted volume for one app and nothing else, since the data that
mattered was already lost in the rebuild above and the orphan has since been
deleted. Merging points the host at `hosts/0`, which starts empty. If anything
has been deployed since, copy the prefix across before this lands:

```
aws s3 cp --recursive s3://<filesystems-bucket>/hosts/i-03738d79b4aae4939/ s3://<filesystems-bucket>/hosts/0/
```

I have not verified that a SlateDB store survives being copied to a different
prefix, so treat that as a thing to test rather than a procedure to trust — on an
empty host it is cheaper to just let it start fresh.

**Not addressed here:** the same silent-reformat behaviour would hide any future
version of this bug. An agent that finds a volume missing where the control plane
says one should exist has more to say than `volume formatted`, but that is a
change to the agent's reconcile path rather than to the prefix.