### PR TITLE
feat(app-operations): a release can reuse the binary the app already runs

### DIFF
--- a/packages/app-operations/src/apps.ts
+++ b/packages/app-operations/src/apps.ts
@@ -25,12 +25,27 @@ export async function latestDeployment({
   api: PublicApiClient;
   appId: string;
 }): Promise<string> {
+  return (await newestDeployment({ api, appId })).id;
+}
+
+/**
+ * The binary the app is running, read back off the release that pinned it.
+ *
+ * An artifact rather than the id the deployment carries: what a caller does with this is release
+ * it again, and the digest is the only thing that says which binary that is.
+ */
+export async function currentArtifact({ api, appId }: { api: PublicApiClient; appId: string }) {
+  const { artifactId } = await newestDeployment({ api, appId });
+  return unwrap(await api.api.apps({ appId }).artifacts({ artifactId }).get());
+}
+
+async function newestDeployment({ api, appId }: { api: PublicApiClient; appId: string }) {
   const { deployments } = unwrap(await api.api.apps({ appId }).deployments.get());
   const newest = deployments[0];
   if (!newest) {
     throw new ApiError(NO_DEPLOYMENTS);
   }
-  return newest.id;
+  return newest;
 }
 
 /**

--- a/packages/app-operations/src/deploy.ts
+++ b/packages/app-operations/src/deploy.ts
@@ -1,14 +1,14 @@
 import type { PublicApiClient } from '@repo/api-client/public';
 import { ApiError, unwrap } from '@repo/api-client/unwrap';
-import {
-  type DeploymentState,
-  type Filename,
-  GuestPortSchema,
-  type TenantArguments,
-  type TenantEnvironmentPatch,
-  Value,
-} from '@repo/protocol';
+import type { DeploymentState, Filename, TenantArguments } from '@repo/protocol';
 import { appBySlug } from '#apps.ts';
+import {
+  type ConfigEdit,
+  configPatch,
+  type Deployed,
+  type DeployStep,
+  servingHostname,
+} from '#release.ts';
 import { streamedUpload, type UploadProgress, type UploadTransport } from '#upload.ts';
 import { pause } from '#wait.ts';
 
@@ -25,11 +25,6 @@ export type UploadableBinary = {
   body: Blob;
 };
 
-export type DeployStep =
-  | { kind: 'app'; appId: string; slug: string }
-  | { kind: 'artifact'; artifactId: string; digest: string }
-  | { kind: 'deployment'; deploymentId: string };
-
 /**
  * The wait around the upload, given what the upload is doing rather than a line to print: how far
  * along it is reads as a spinner in one place and a meter in another, and neither belongs here.
@@ -39,24 +34,18 @@ export type UploadWait = (input: {
   task: (report: (progress: UploadProgress) => void) => Promise<void>;
 }) => Promise<void>;
 
-export type DeployInput = {
+export type DeployInput = ConfigEdit & {
   api: PublicApiClient;
   binary: UploadableBinary;
+  // Required where the rest of the edit is optional: what the caller typed is what the binary is
+  // asked to run with, and carrying over the last release's arguments because none were given
+  // this time would run something nobody asked for.
   args: TenantArguments;
   app?: string | undefined;
   name?: string | undefined;
-  port?: number | undefined;
-  environment?: TenantEnvironmentPatch | undefined;
   onStep?: ((step: DeployStep) => void) | undefined;
   whileUploading?: UploadWait | undefined;
   upload?: UploadTransport | undefined;
-};
-
-export type Deployed = {
-  appId: string;
-  slug: string;
-  deploymentId: string;
-  url: string;
 };
 
 /**
@@ -69,17 +58,15 @@ export type Deployed = {
 export async function deploy({
   api,
   binary,
-  args,
   app: slug,
   name,
-  port,
-  environment,
   onStep,
   whileUploading = unwatched,
   upload = streamedUpload,
+  ...edit
 }: DeployInput): Promise<Deployed> {
   const target = slug === undefined ? null : await appBySlug({ api, slug });
-  const config = configPatch({ args, port, environment });
+  const config = configPatch(edit);
 
   const app =
     target === null
@@ -197,30 +184,6 @@ function mebibytes(bytes: number): string {
   return `${(bytes / BYTES_PER_MEBIBYTE).toFixed(SIZE_DECIMALS)} MB`;
 }
 
-/**
- * `args` is always written, empty included: what the caller typed is what the binary is asked to
- * run with, and carrying over the last deploy's arguments because none were given this time
- * would run something nobody asked for.
- */
-// `environment` is an edit where `args` is the whole list, so an absent one changes no variable
-// while an absent `args` would clear them all. A deploy cannot read a value back to restate it,
-// which is why saying nothing about a variable has to be how it survives.
-function configPatch({
-  args,
-  port,
-  environment,
-}: {
-  args: TenantArguments;
-  port: number | undefined;
-  environment: TenantEnvironmentPatch | undefined;
-}) {
-  return {
-    args,
-    ...(port !== undefined && { guestPort: Value.Parse(GuestPortSchema, port) }),
-    ...(environment !== undefined && { environment }),
-  };
-}
-
 /** What a caller needs of a release that has stopped moving: which end it reached, and why. */
 export type SettledDeployment = {
   id: string;
@@ -261,24 +224,4 @@ export async function awaitDeploymentSettled({
   throw new ApiError(
     `Deployment ${deploymentId} was still starting after ${SERVING_TIMEOUT_MS}ms.`,
   );
-}
-
-/**
- * The address to hand back, preferring a domain the owner brought: the platform hostname is what
- * nibrun issued, but a custom one is what they call their app.
- *
- * Active only. A brought domain is pending until the edge holds a certificate for it, and a link
- * that does not resolve yet is worse than the one that does.
- */
-function servingHostname(
-  hostnames: ReadonlyArray<{ hostname: string; kind: string; state: string }>,
-): string {
-  const serving =
-    hostnames.find((entry) => entry.kind === 'custom' && entry.state === 'active') ??
-    hostnames.find((entry) => entry.kind === 'platform') ??
-    hostnames[0];
-  if (!serving) {
-    throw new ApiError('The app was created without a hostname.');
-  }
-  return serving.hostname;
 }

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -1,12 +1,10 @@
 /** biome-ignore-all lint/performance/noBarrelFile: index is the only allowed file where we can export other files */
 
-export { addressedDeployment, appBySlug, latestDeployment } from '#apps.ts';
+export { addressedDeployment, appBySlug, currentArtifact, latestDeployment } from '#apps.ts';
 export { deleteApp } from '#delete.ts';
 export {
   awaitDeploymentSettled,
-  type Deployed,
   type DeployInput,
-  type DeployStep,
   deploy,
   describeUnservedDeployment,
   type SettledDeployment,
@@ -20,5 +18,7 @@ export { InvalidEnvironmentError, InvalidPathError } from '#errors.ts';
 export { awaitExportBundle, type ExportBundle, requestExport } from '#exports.ts';
 export { guestPath, readDirectory } from '#filesystem.ts';
 export { type FollowInput, followLogs } from '#logs.ts';
+export { type RedeployInput, redeploy } from '#redeploy.ts';
+export type { ConfigEdit, Deployed, DeployStep } from '#release.ts';
 export { resumeApp, suspendApp } from '#suspend.ts';
 export { streamedUpload, type UploadProgress, type UploadTransport } from '#upload.ts';

--- a/packages/app-operations/src/redeploy.ts
+++ b/packages/app-operations/src/redeploy.ts
@@ -1,0 +1,53 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { unwrap } from '@repo/api-client/unwrap';
+import { appBySlug, currentArtifact } from '#apps.ts';
+import {
+  type ConfigEdit,
+  configPatch,
+  type Deployed,
+  type DeployStep,
+  servingHostname,
+} from '#release.ts';
+
+export type RedeployInput = ConfigEdit & {
+  api: PublicApiClient;
+  app: string;
+  onStep?: ((step: DeployStep) => void) | undefined;
+};
+
+/**
+ * Release the binary the app is already running, with whatever this changes about how it starts.
+ *
+ * The bytes are in the store from the deploy that put them there, so an owner changing a variable
+ * or an argument is not asked for the binary a second time — the app is reconfigured and the same
+ * artifact is released against it.
+ *
+ * Which artifact that is gets read before the config is written: an app that has never been
+ * deployed has no binary to run again, and finding that out afterwards would leave it configured
+ * for a release nobody made.
+ */
+export async function redeploy({
+  api,
+  app: slug,
+  onStep,
+  ...edit
+}: RedeployInput): Promise<Deployed> {
+  const target = await appBySlug({ api, slug });
+  const artifact = await currentArtifact({ api, appId: target.id });
+
+  const app = unwrap(await api.api.apps({ appId: target.id }).patch(configPatch(edit)));
+  onStep?.({ kind: 'app', appId: app.id, slug: app.slug });
+  onStep?.({ kind: 'artifact', artifactId: artifact.id, digest: artifact.digest });
+
+  const deployment = unwrap(
+    await api.api.apps({ appId: app.id }).deployments.post({ artifactId: artifact.id }),
+  );
+  onStep?.({ kind: 'deployment', deploymentId: deployment.id });
+
+  return {
+    appId: app.id,
+    slug: app.slug,
+    deploymentId: deployment.id,
+    url: `https://${servingHostname(app.hostnames)}`,
+  };
+}

--- a/packages/app-operations/src/release.ts
+++ b/packages/app-operations/src/release.ts
@@ -1,0 +1,62 @@
+import { ApiError } from '@repo/api-client/unwrap';
+import {
+  GuestPortSchema,
+  type TenantArguments,
+  type TenantEnvironmentPatch,
+  Value,
+} from '@repo/protocol';
+
+/** Where a release landed and what to reach it at, whichever way it was asked for. */
+export type Deployed = {
+  appId: string;
+  slug: string;
+  deploymentId: string;
+  url: string;
+};
+
+export type DeployStep =
+  | { kind: 'app'; appId: string; slug: string }
+  | { kind: 'artifact'; artifactId: string; digest: string }
+  | { kind: 'deployment'; deploymentId: string };
+
+/**
+ * What a release is asked to change about the way the binary is started. Everything absent is
+ * left as the app has it, which is what lets one variable be changed without restating the rest.
+ *
+ * `environment` is an edit where `args` is the whole list — a caller cannot read a secret back to
+ * restate it, so saying nothing about a variable has to be how it survives, while saying nothing
+ * about arguments can only mean the ones already there.
+ */
+export type ConfigEdit = {
+  args?: TenantArguments | undefined;
+  port?: number | undefined;
+  environment?: TenantEnvironmentPatch | undefined;
+};
+
+export function configPatch({ args, port, environment }: ConfigEdit) {
+  return {
+    ...(args !== undefined && { args }),
+    ...(port !== undefined && { guestPort: Value.Parse(GuestPortSchema, port) }),
+    ...(environment !== undefined && { environment }),
+  };
+}
+
+/**
+ * The address to hand back, preferring a domain the owner brought: the platform hostname is what
+ * nibrun issued, but a custom one is what they call their app.
+ *
+ * Active only. A brought domain is pending until the edge holds a certificate for it, and a link
+ * that does not resolve yet is worse than the one that does.
+ */
+export function servingHostname(
+  hostnames: ReadonlyArray<{ hostname: string; kind: string; state: string }>,
+): string {
+  const serving =
+    hostnames.find((entry) => entry.kind === 'custom' && entry.state === 'active') ??
+    hostnames.find((entry) => entry.kind === 'platform') ??
+    hostnames[0];
+  if (!serving) {
+    throw new ApiError('The app was created without a hostname.');
+  }
+  return serving.hostname;
+}

--- a/packages/app-operations/tests/apps.test.ts
+++ b/packages/app-operations/tests/apps.test.ts
@@ -1,16 +1,20 @@
 import { expect, test } from 'bun:test';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { addressedDeployment, appBySlug, latestDeployment } from '#apps.ts';
+import { addressedDeployment, appBySlug, currentArtifact, latestDeployment } from '#apps.ts';
 
 function apiHolding({
   apps,
   deployments = [],
 }: {
   apps: Array<{ id: string; slug: string }>;
-  deployments?: Array<{ id: string }>;
+  deployments?: Array<{ id: string; artifactId?: string }>;
 }): PublicApiClient {
   function underApp() {
     return {
+      artifacts: ({ artifactId }: { artifactId: string }) => ({
+        get: () =>
+          Promise.resolve({ data: { id: artifactId, digest: 'sha256:abcd' }, error: null }),
+      }),
       deployments: { get: () => Promise.resolve({ data: { deployments }, error: null }) },
     };
   }
@@ -52,6 +56,28 @@ test('an app that has never been deployed has no newest deployment', async () =>
   const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter' }] });
 
   await expect(latestDeployment({ api, appId: 'app-1' })).rejects.toThrow(
+    'This app has never been deployed.',
+  );
+});
+
+// The newest release is what the app is running, so the artifact it pinned is the binary a
+// release again has to name.
+test('the binary an app is running is the one its newest release pinned', async () => {
+  const api = apiHolding({
+    apps: [{ id: 'app-1', slug: 'quiet-otter' }],
+    deployments: [
+      { id: 'deployment-2', artifactId: 'artifact-2' },
+      { id: 'deployment-1', artifactId: 'artifact-1' },
+    ],
+  });
+
+  expect(await currentArtifact({ api, appId: 'app-1' })).toMatchObject({ id: 'artifact-2' });
+});
+
+test('an app that has never been deployed is running no binary', async () => {
+  const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter' }] });
+
+  await expect(currentArtifact({ api, appId: 'app-1' })).rejects.toThrow(
     'This app has never been deployed.',
   );
 });

--- a/packages/app-operations/tests/deploy.test.ts
+++ b/packages/app-operations/tests/deploy.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import type { PublicApiClient } from '@repo/api-client/public';
 import type { Filename } from '@repo/protocol';
-import { type DeployStep, deploy, describeUnservedDeployment } from '#deploy.ts';
+import { deploy, describeUnservedDeployment } from '#deploy.ts';
+import type { DeployStep } from '#release.ts';
 import type { UploadProgress } from '#upload.ts';
 
 const SLUG = 'quiet-otter';

--- a/packages/app-operations/tests/redeploy.test.ts
+++ b/packages/app-operations/tests/redeploy.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from 'bun:test';
+import type { PublicApiClient } from '@repo/api-client/public';
+import { parseEnvironmentPatch } from '#environment.ts';
+import { redeploy } from '#redeploy.ts';
+import type { DeployStep } from '#release.ts';
+
+const SLUG = 'quiet-otter';
+const APP_ID = 'app-1';
+const ARTIFACT_ID = 'artifact-1';
+const DIGEST = 'sha256:abcd';
+const PORT = 8080;
+const TOKEN_SET = parseEnvironmentPatch([{ name: 'TOKEN', value: 'shh' }]);
+
+type Sent = { what: string; body?: unknown };
+type HostnameRow = { hostname: string; kind: string; state: string };
+
+const PLATFORM: HostnameRow = { hostname: `${SLUG}.nibrun.app`, kind: 'platform', state: 'active' };
+
+function apiHolding({
+  sent,
+  deployments = [{ id: 'deployment-1', artifactId: ARTIFACT_ID }],
+  hostnames = [PLATFORM],
+}: {
+  sent: Sent[];
+  deployments?: Array<{ id: string; artifactId: string }>;
+  hostnames?: HostnameRow[];
+}): PublicApiClient {
+  function underApp({ appId }: { appId: string }) {
+    function artifact({ artifactId }: { artifactId: string }) {
+      return {
+        get: () => {
+          sent.push({ what: 'artifact read', body: artifactId });
+          return Promise.resolve({
+            data: { id: artifactId, digest: DIGEST, originalFileName: 'my-server' },
+            error: null,
+          });
+        },
+      };
+    }
+    return {
+      patch: (body: unknown) => {
+        sent.push({ what: 'app patch', body });
+        return Promise.resolve({ data: { id: appId, slug: SLUG, hostnames }, error: null });
+      },
+      artifacts: artifact,
+      deployments: {
+        get: () => {
+          sent.push({ what: 'deployments read' });
+          return Promise.resolve({ data: { deployments }, error: null });
+        },
+        post: (body: unknown) => {
+          sent.push({ what: 'deployment', body });
+          return Promise.resolve({ data: { id: 'deployment-2' }, error: null });
+        },
+      },
+    };
+  }
+
+  return {
+    api: {
+      apps: Object.assign(underApp, {
+        get: () => Promise.resolve({ data: { apps: [{ id: APP_ID, slug: SLUG }] }, error: null }),
+      }),
+    },
+  } as unknown as PublicApiClient;
+}
+
+test('the binary the app is running is the one released again', async () => {
+  const sent: Sent[] = [];
+
+  const deployed = await redeploy({ api: apiHolding({ sent }), app: SLUG, args: ['serve'] });
+
+  expect(sent.at(-1)).toEqual({ what: 'deployment', body: { artifactId: ARTIFACT_ID } });
+  expect(deployed).toEqual({
+    appId: APP_ID,
+    slug: SLUG,
+    deploymentId: 'deployment-2',
+    url: `https://${SLUG}.nibrun.app`,
+  });
+});
+
+// A deployment snapshots the app's config as it stands, so the flags a caller just typed only run
+// if they were written first.
+test('config is written before the deployment that snapshots it', async () => {
+  const sent: Sent[] = [];
+
+  await redeploy({
+    api: apiHolding({ sent }),
+    app: SLUG,
+    args: ['serve'],
+    port: PORT,
+    environment: TOKEN_SET,
+  });
+
+  expect(sent.filter((each) => each.what === 'app patch')).toEqual([
+    {
+      what: 'app patch',
+      body: { args: ['serve'], guestPort: PORT, environment: { TOKEN: 'shh' } },
+    },
+  ]);
+  expect(sent.at(-1)?.what).toBe('deployment');
+});
+
+// Every field of the edit is one the caller may have said nothing about, and an app is reachable
+// again only if what it was already running survives being reconfigured.
+test('what the caller left out is left alone', async () => {
+  const sent: Sent[] = [];
+
+  await redeploy({ api: apiHolding({ sent }), app: SLUG, environment: TOKEN_SET });
+
+  expect(sent.find((each) => each.what === 'app patch')?.body).toEqual({
+    environment: TOKEN_SET,
+  });
+});
+
+// An app configured for a release nobody made is worse than one nothing happened to.
+test('an app that has never been deployed is refused before its config moves', async () => {
+  const sent: Sent[] = [];
+
+  const attempt = redeploy({
+    api: apiHolding({ sent, deployments: [] }),
+    app: SLUG,
+    args: ['serve'],
+  });
+
+  await expect(attempt).rejects.toThrow('This app has never been deployed.');
+  expect(sent.map((each) => each.what)).not.toContain('app patch');
+});
+
+test('a slug naming nothing is said to name nothing', async () => {
+  const attempt = redeploy({ api: apiHolding({ sent: [] }), app: 'loud-badger', args: [] });
+
+  await expect(attempt).rejects.toThrow('No app with slug loud-badger.');
+});
+
+test('each step is announced, the artifact among them', async () => {
+  const steps: DeployStep[] = [];
+
+  await redeploy({
+    api: apiHolding({ sent: [] }),
+    app: SLUG,
+    args: [],
+    onStep: (step) => steps.push(step),
+  });
+
+  expect(steps).toEqual([
+    { kind: 'app', appId: APP_ID, slug: SLUG },
+    { kind: 'artifact', artifactId: ARTIFACT_ID, digest: DIGEST },
+    { kind: 'deployment', deploymentId: 'deployment-2' },
+  ]);
+});


### PR DESCRIPTION
The bytes are in the store from the deploy that put them there, so changing a variable or an argument need not ask for the binary a second time.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>