### PR TITLE
feat(cli): nib apps update changes how an app starts, not its binary

### DIFF
--- a/packages/cli/src/command-tree.gen.ts
+++ b/packages/cli/src/command-tree.gen.ts
@@ -13,6 +13,7 @@ import type { command as appsListCmd } from './commands/apps/list.ts';
 import type { command as appsLogsCmd } from './commands/apps/logs.ts';
 import type { command as appsResumeCmd } from './commands/apps/resume.ts';
 import type { command as appsSuspendCmd } from './commands/apps/suspend.ts';
+import type { command as appsUpdateCmd } from './commands/apps/update.ts';
 import type { command as loginCmd } from './commands/login.ts';
 import type { command as runCommandCmd } from './commands/run/[command].ts';
 
@@ -86,6 +87,12 @@ declare module '@parshjs/core' {
       rootOptions: {};
     };
     'apps suspend': {
+      parents: {
+        'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
+      };
+      rootOptions: {};
+    };
+    'apps update': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
@@ -195,6 +202,12 @@ export const commandTree: RuntimeNode = {
         'suspend': {
           segment: { kind: 'literal', value: 'suspend' },
           command: { path: 'apps suspend', load: () => import('./commands/apps/suspend.ts').then((m) => m.command) },
+          literalChildren: {},
+          paramChild: null,
+        },
+        'update': {
+          segment: { kind: 'literal', value: 'update' },
+          command: { path: 'apps update', load: () => import('./commands/apps/update.ts').then((m) => m.command) },
           literalChildren: {},
           paramChild: null,
         },

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -1,0 +1,45 @@
+import { defineCommand } from '@parshjs/core';
+import { z } from 'zod';
+import { SHARED_OPTIONS } from '#config.ts';
+import { selectApp } from '#lib/apps.ts';
+import { parseArguments } from '#lib/command-line.ts';
+import { requireSignedIn } from '#lib/credentials.ts';
+import { createUi, isInteractive } from '#lib/ui.ts';
+import { updateApp } from '#lib/update.ts';
+
+export const command = defineCommand('apps update', {
+  description:
+    'Change how the app starts and run it again on the binary it already has. Nothing is uploaded, and whatever no flag names is left as it is.',
+  options: {
+    args: {
+      schema: z.string().optional(),
+      description:
+        'Arguments to start the binary with, quoted as one value: --args "serve --verbose". An empty value runs it bare.',
+    },
+    [SHARED_OPTIONS.port.name]: SHARED_OPTIONS.port.option,
+    [SHARED_OPTIONS.env.name]: SHARED_OPTIONS.env.option,
+    [SHARED_OPTIONS.unset.name]: SHARED_OPTIONS.unset.option,
+    [SHARED_OPTIONS.detach.name]: SHARED_OPTIONS.detach.option,
+  },
+  beforeHandler: ({ context }) => requireSignedIn(context),
+  handler: async ({ options, parents, context, print }) => {
+    const { args, ...given } = options;
+    const { api } = context;
+    const interactive = isInteractive();
+    const ui = createUi({ print, interactive });
+
+    ui.open('nib apps update');
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
+
+    await updateApp({
+      api,
+      ui,
+      slug,
+      args: args === undefined ? undefined : parseArguments(args),
+      port: given[SHARED_OPTIONS.port.name],
+      env: given[SHARED_OPTIONS.env.name],
+      unset: given[SHARED_OPTIONS.unset.name],
+      detach: given[SHARED_OPTIONS.detach.name],
+    });
+  },
+});

--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -22,24 +22,10 @@ export const command = defineCommand('run [command]', {
       schema: z.string().optional(),
       description: 'Name for the new app. Defaults to the binary filename.',
     },
-    port: {
-      schema: z.number().int().optional(),
-      description: 'Port the binary listens on inside the guest.',
-    },
-    env: {
-      schema: z.array(z.string()).optional(),
-      description:
-        'Set an environment variable for the binary, as NAME=value. Repeatable. Anything the app already has and this does not name is left as it is.',
-    },
-    unset: {
-      schema: z.array(z.string()).optional(),
-      description: 'Remove an environment variable from the app, by name. Repeatable.',
-    },
-    detach: {
-      schema: z.boolean().optional(),
-      aliases: ['d'],
-      description: 'Return once the deployment is created instead of waiting for it to serve.',
-    },
+    [SHARED_OPTIONS.port.name]: SHARED_OPTIONS.port.option,
+    [SHARED_OPTIONS.env.name]: SHARED_OPTIONS.env.option,
+    [SHARED_OPTIONS.unset.name]: SHARED_OPTIONS.unset.option,
+    [SHARED_OPTIONS.detach.name]: SHARED_OPTIONS.detach.option,
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
   handler: async ({ params, options, context, print }) => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -26,4 +26,34 @@ export const SHARED_OPTIONS = {
       description: 'Read this deployment instead of looking up the app latest.',
     },
   },
+  port: {
+    name: 'port',
+    option: {
+      schema: z.number().int().optional(),
+      description: 'Port the binary listens on inside the guest.',
+    },
+  },
+  env: {
+    name: 'env',
+    option: {
+      schema: z.array(z.string()).optional(),
+      description:
+        'Set an environment variable for the binary, as NAME=value. Repeatable. Anything the app already has and this does not name is left as it is.',
+    },
+  },
+  unset: {
+    name: 'unset',
+    option: {
+      schema: z.array(z.string()).optional(),
+      description: 'Remove an environment variable from the app, by name. Repeatable.',
+    },
+  },
+  detach: {
+    name: 'detach',
+    option: {
+      schema: z.boolean().optional(),
+      aliases: ['d'],
+      description: 'Return once the deployment is created instead of waiting for it to serve.',
+    },
+  },
 } as const satisfies Record<string, { name: string; option: CommandOption }>;

--- a/packages/cli/src/lib/command-line.test.ts
+++ b/packages/cli/src/lib/command-line.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { parseCommandLine } from '#lib/command-line.ts';
+import { parseArguments, parseCommandLine } from '#lib/command-line.ts';
 
 test('a binary on its own is a command line with nothing to add', () => {
   expect(parseCommandLine('./my-server')).toEqual({ binaryPath: './my-server', args: [] });
@@ -51,4 +51,13 @@ test('a quote nothing closes is refused rather than guessed at', () => {
 
 test('a command line naming nothing is refused', () => {
   expect(() => parseCommandLine('   ')).toThrow('Name the binary to run.');
+});
+
+// `--args` carries the rest of the line without a binary in front of it, read the same way.
+test('arguments without a binary in front of them are all arguments', () => {
+  expect(parseArguments('serve --port 8080')).toEqual(['serve', '--port', '8080']);
+});
+
+test('an empty value is a binary asked to run bare', () => {
+  expect(parseArguments('')).toEqual([]);
 });

--- a/packages/cli/src/lib/command-line.ts
+++ b/packages/cli/src/lib/command-line.ts
@@ -29,6 +29,15 @@ export function parseCommandLine(line: string): CommandLine {
 }
 
 /**
+ * The same line without a binary in front of it, which is what `--args` carries. Quoted as one
+ * value for the same reason the positional is: a bare list cannot be told apart from this
+ * program's own flags.
+ */
+export function parseArguments(line: string): TenantArguments {
+  return tokenize(line);
+}
+
+/**
  * The shell's own rules, applied a second time to the string the shell handed over whole. Only
  * the part that separates arguments: nothing here expands a variable, a glob or a `$(…)`, so a
  * tenant argument that contains one arrives at the guest exactly as written.

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -1,29 +1,13 @@
 import { basename } from 'node:path';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { ApiError } from '@repo/api-client/unwrap';
-import {
-  awaitDeploymentSettled,
-  type DeployStep,
-  describeUnservedDeployment,
-  InvalidEnvironmentError,
-  parseEnvironment,
-  deploy as startDeployment,
-  type UploadableBinary,
-} from '@repo/app-operations';
-import {
-  type Filename,
-  FilenameSchema,
-  type TenantArguments,
-  type TenantEnvironmentPatch,
-  Value,
-} from '@repo/protocol';
+import { deploy as startDeployment, type UploadableBinary } from '@repo/app-operations';
+import { type Filename, FilenameSchema, type TenantArguments, Value } from '@repo/protocol';
+import { environmentEdit } from '#lib/environment.ts';
 import { UsageError } from '#lib/errors.ts';
 import type { RunOptions } from '#lib/plan.ts';
+import { announce, awaitServing } from '#lib/release.ts';
 import type { Ui } from '#lib/ui.ts';
 import { describeProgress } from '#lib/upload-progress.ts';
-
-const MS_PER_SECOND = 1_000;
-const ELAPSED_DECIMALS = 1;
 
 export type DeployInput = RunOptions & {
   api: PublicApiClient;
@@ -45,7 +29,7 @@ export async function deploy({
   unset,
   detach,
 }: DeployInput): Promise<void> {
-  const environment = asEnvironment({ env, unset });
+  const environment = environmentEdit({ env, unset });
   const deployed = await startDeployment({
     api,
     binary,
@@ -69,38 +53,7 @@ export async function deploy({
     },
   });
 
-  if (detach === true) {
-    ui.done(`${deployed.url} — deployment ${deployed.deploymentId} is starting`);
-    return;
-  }
-
-  const startedAt = Date.now();
-  const settled = await ui.waitingFor({
-    message: `starting deployment ${deployed.deploymentId}`,
-    task: () =>
-      awaitDeploymentSettled({
-        api,
-        appId: deployed.appId,
-        deploymentId: deployed.deploymentId,
-      }),
-  });
-  if (settled.state !== 'active') {
-    throw new ApiError(describeUnservedDeployment(settled));
-  }
-  ui.done(`${deployed.url} — ready in ${elapsed(Date.now() - startedAt)}`);
-}
-
-function announce({ step, ui }: { step: DeployStep; ui: Ui }): void {
-  if (step.kind === 'app') {
-    ui.step(`app ${step.slug}`);
-  }
-  if (step.kind === 'artifact') {
-    ui.step(`artifact ${step.digest}`);
-  }
-}
-
-function elapsed(ms: number): string {
-  return `${(ms / MS_PER_SECOND).toFixed(ELAPSED_DECIMALS)}s`;
+  await awaitServing({ api, ui, deployed, detach });
 }
 
 /**
@@ -113,34 +66,6 @@ export async function openBinary(path: string): Promise<UploadableBinary> {
     throw new UsageError(`No such file: ${path}`);
   }
   return { name: asFilename(basename(path)), body };
-}
-
-/**
- * Undefined where neither flag was given, which is what leaves the app's environment alone: an
- * empty edit would be a request to change nothing, sent on every deploy that mentions none.
- *
- * The shared parser does not know what a command line is, so what it refuses is reported here in
- * the words `nib` refuses anything else in.
- */
-function asEnvironment({
-  env = [],
-  unset = [],
-}: {
-  env?: string[] | undefined;
-  unset?: string[] | undefined;
-}): TenantEnvironmentPatch | undefined {
-  if (env.length === 0 && unset.length === 0) {
-    return undefined;
-  }
-
-  try {
-    return parseEnvironment({ set: env, remove: unset });
-  } catch (failure) {
-    if (failure instanceof InvalidEnvironmentError) {
-      throw new UsageError(failure.message);
-    }
-    throw failure;
-  }
 }
 
 /**

--- a/packages/cli/src/lib/environment.ts
+++ b/packages/cli/src/lib/environment.ts
@@ -1,0 +1,31 @@
+import { InvalidEnvironmentError, parseEnvironment } from '@repo/app-operations';
+import type { TenantEnvironmentPatch } from '@repo/protocol';
+import { UsageError } from '#lib/errors.ts';
+
+/**
+ * Undefined where neither flag was given, which is what leaves the app's environment alone: an
+ * empty edit would be a request to change nothing, sent on every release that mentions none.
+ *
+ * The shared parser does not know what a command line is, so what it refuses is reported here in
+ * the words `nib` refuses anything else in.
+ */
+export function environmentEdit({
+  env = [],
+  unset = [],
+}: {
+  env?: string[] | undefined;
+  unset?: string[] | undefined;
+}): TenantEnvironmentPatch | undefined {
+  if (env.length === 0 && unset.length === 0) {
+    return undefined;
+  }
+
+  try {
+    return parseEnvironment({ set: env, remove: unset });
+  } catch (failure) {
+    if (failure instanceof InvalidEnvironmentError) {
+      throw new UsageError(failure.message);
+    }
+    throw failure;
+  }
+}

--- a/packages/cli/src/lib/release.ts
+++ b/packages/cli/src/lib/release.ts
@@ -1,0 +1,61 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { ApiError } from '@repo/api-client/unwrap';
+import {
+  awaitDeploymentSettled,
+  type Deployed,
+  type DeployStep,
+  describeUnservedDeployment,
+} from '@repo/app-operations';
+import type { Ui } from '#lib/ui.ts';
+
+const MS_PER_SECOND = 1_000;
+const ELAPSED_DECIMALS = 1;
+
+export function announce({ step, ui }: { step: DeployStep; ui: Ui }): void {
+  if (step.kind === 'app') {
+    ui.step(`app ${step.slug}`);
+  }
+  if (step.kind === 'artifact') {
+    ui.step(`artifact ${step.digest}`);
+  }
+}
+
+/**
+ * Wait for the release to answer, then say where it answers. Detached, the address is still what
+ * is printed — a caller who did not want the wait still wants the app.
+ */
+export async function awaitServing({
+  api,
+  ui,
+  deployed,
+  detach,
+}: {
+  api: PublicApiClient;
+  ui: Ui;
+  deployed: Deployed;
+  detach: boolean | undefined;
+}): Promise<void> {
+  if (detach === true) {
+    ui.done(`${deployed.url} — deployment ${deployed.deploymentId} is starting`);
+    return;
+  }
+
+  const startedAt = Date.now();
+  const settled = await ui.waitingFor({
+    message: `starting deployment ${deployed.deploymentId}`,
+    task: () =>
+      awaitDeploymentSettled({
+        api,
+        appId: deployed.appId,
+        deploymentId: deployed.deploymentId,
+      }),
+  });
+  if (settled.state !== 'active') {
+    throw new ApiError(describeUnservedDeployment(settled));
+  }
+  ui.done(`${deployed.url} — ready in ${elapsed(Date.now() - startedAt)}`);
+}
+
+function elapsed(ms: number): string {
+  return `${(ms / MS_PER_SECOND).toFixed(ELAPSED_DECIMALS)}s`;
+}

--- a/packages/cli/src/lib/update.test.ts
+++ b/packages/cli/src/lib/update.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from 'bun:test';
+import type { PublicApiClient } from '@repo/api-client/public';
+import type { Ui } from '#lib/ui.ts';
+import { updateApp } from '#lib/update.ts';
+
+const SLUG = 'quiet-otter';
+const ARTIFACT_ID = 'artifact-1';
+
+function apiHolding({ patched }: { patched: unknown[] }): PublicApiClient {
+  function underApp({ appId }: { appId: string }) {
+    return {
+      patch: (body: unknown) => {
+        patched.push(body);
+        return Promise.resolve({
+          data: {
+            id: appId,
+            slug: SLUG,
+            hostnames: [{ hostname: `${SLUG}.nibrun.app`, kind: 'platform', state: 'active' }],
+          },
+          error: null,
+        });
+      },
+      artifacts: ({ artifactId }: { artifactId: string }) => ({
+        get: () =>
+          Promise.resolve({ data: { id: artifactId, digest: 'sha256:abcd' }, error: null }),
+      }),
+      deployments: Object.assign(
+        ({ deploymentId }: { deploymentId: string }) => ({
+          get: () => Promise.resolve({ data: { id: deploymentId, state: 'active' }, error: null }),
+        }),
+        {
+          get: () =>
+            Promise.resolve({
+              data: { deployments: [{ id: 'deployment-1', artifactId: ARTIFACT_ID }] },
+              error: null,
+            }),
+          post: () => Promise.resolve({ data: { id: 'deployment-2' }, error: null }),
+        },
+      ),
+    };
+  }
+
+  return {
+    api: {
+      apps: Object.assign(underApp, {
+        get: () => Promise.resolve({ data: { apps: [{ id: 'app-1', slug: SLUG }] }, error: null }),
+      }),
+    },
+  } as unknown as PublicApiClient;
+}
+
+function uiSaying(said: string[]): Ui {
+  return {
+    open: () => {},
+    step: (message) => said.push(message),
+    done: (message) => said.push(message),
+    waitingFor: ({ task }) => task(() => {}),
+  };
+}
+
+test('the flags that were given are the whole of what the app is asked to change', async () => {
+  const patched: unknown[] = [];
+
+  await updateApp({
+    api: apiHolding({ patched }),
+    ui: uiSaying([]),
+    slug: SLUG,
+    env: ['TOKEN=shh'],
+    unset: ['STALE'],
+  });
+
+  expect(patched).toEqual([{ environment: { TOKEN: 'shh', STALE: null } }]);
+});
+
+// Reading a bare `nib apps redeploy --env X=y` as "and start it bare" would take the app down on
+// the way to setting a variable.
+test('arguments nobody named are not arguments cleared', async () => {
+  const patched: unknown[] = [];
+
+  await updateApp({
+    api: apiHolding({ patched }),
+    ui: uiSaying([]),
+    slug: SLUG,
+    port: 8080,
+  });
+
+  expect(patched).toEqual([{ guestPort: 8080 }]);
+});
+
+// The difference `--args ""` exists to make: an empty list is a binary asked to run bare, where
+// no list at all is a caller who said nothing about arguments.
+test('an empty list of arguments is arguments cleared', async () => {
+  const patched: unknown[] = [];
+
+  await updateApp({ api: apiHolding({ patched }), ui: uiSaying([]), slug: SLUG, args: [] });
+
+  expect(patched).toEqual([{ args: [] }]);
+});
+
+test('a name the shell would not accept as a variable is refused in this program own words', () => {
+  const attempt = updateApp({
+    api: apiHolding({ patched: [] }),
+    ui: uiSaying([]),
+    slug: SLUG,
+    env: ['9LIVES=cat'],
+  });
+
+  return expect(attempt).rejects.toThrow('9LIVES');
+});
+
+test('the binary being run again is named, and so is where it answers', async () => {
+  const said: string[] = [];
+
+  await updateApp({ api: apiHolding({ patched: [] }), ui: uiSaying(said), slug: SLUG, args: [] });
+
+  expect(said).toEqual([
+    `app ${SLUG}`,
+    'artifact sha256:abcd',
+    expect.stringContaining(`https://${SLUG}.nibrun.app`),
+  ]);
+});

--- a/packages/cli/src/lib/update.ts
+++ b/packages/cli/src/lib/update.ts
@@ -1,0 +1,46 @@
+import type { PublicApiClient } from '@repo/api-client/public';
+import { redeploy } from '@repo/app-operations';
+import type { TenantArguments } from '@repo/protocol';
+import { environmentEdit } from '#lib/environment.ts';
+import { announce, awaitServing } from '#lib/release.ts';
+import type { Ui } from '#lib/ui.ts';
+
+export type UpdateInput = {
+  api: PublicApiClient;
+  ui: Ui;
+  slug: string;
+  args?: TenantArguments | undefined;
+  port?: number | undefined;
+  env?: string[] | undefined;
+  unset?: string[] | undefined;
+  detach?: boolean | undefined;
+};
+
+/**
+ * Reconfigure the app by whatever the flags named, and run it again on the binary it already has.
+ *
+ * Everything unnamed is left as the app has it, arguments included: a caller changing one variable
+ * has said nothing about how the binary is started, and reading that as "start it bare" would take
+ * the app down on the way to setting a variable.
+ */
+export async function updateApp({
+  api,
+  ui,
+  slug,
+  args,
+  port,
+  env,
+  unset,
+  detach,
+}: UpdateInput): Promise<void> {
+  const deployed = await redeploy({
+    api,
+    app: slug,
+    args,
+    port,
+    environment: environmentEdit({ env, unset }),
+    onStep: (step) => announce({ step, ui }),
+  });
+
+  await awaitServing({ api, ui, deployed, detach });
+}

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -79,6 +79,14 @@ nib run ./my-server --app my-app --env STRIPE_SECRET_KEY=sk_live_... --env LOG_L
 nib run ./my-server --app my-app --unset LOG_LEVEL
 ```
 
+Changing only how the binary starts is `nib apps update`, which runs the one the app already has
+rather than asking for it again. What no flag names is left alone:
+
+```sh
+nib apps update --app my-app --env LOG_LEVEL=debug
+nib apps update --app my-app --args "serve --verbose"
+```
+
 `nib apps list` finds the slug again when a later session has to redeploy, and `nib apps logs` says
 why one that was created never came up — worth reaching for, since serving is only a TCP connect
 and a broken process can hold the port. `nib --help` lists the rest — domains, filesystem, export,


### PR DESCRIPTION
Changing a variable or an argument no longer means handing over the binary a second time.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>