### PR TITLE
feat(dashboard): deploying onto an app can keep the binary it runs

### DIFF
--- a/apps/dashboard/src/components/apps/binary-drop-zone.tsx
+++ b/apps/dashboard/src/components/apps/binary-drop-zone.tsx
@@ -7,10 +7,12 @@ export const BINARY_INPUT_ID = 'deploy-binary';
 export function BinaryDropZone({
   binary,
   invalid,
+  keeping,
   onPick,
 }: {
   binary: File | undefined;
   invalid: boolean;
+  keeping: boolean;
   onPick: (binary: File | undefined) => void;
 }) {
   const picker = useBinaryPicker({ onPick });
@@ -37,7 +39,11 @@ export function BinaryDropZone({
         {binary === undefined ? (
           <>
             <UploadIcon className="size-4 shrink-0 text-muted-foreground" />
-            <span>Drop the binary here, or browse for it.</span>
+            <span>
+              {keeping
+                ? 'Drop a binary here to replace the one it runs.'
+                : 'Drop the binary here, or browse for it.'}
+            </span>
           </>
         ) : (
           <>

--- a/apps/dashboard/src/components/apps/deploy-binary-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-binary-field.tsx
@@ -1,11 +1,24 @@
 import { Field, FieldDescription, FieldError, FieldLabel } from '@repo/ui/components/field';
 import { BINARY_INPUT_ID, BinaryDropZone } from '#components/apps/binary-drop-zone.tsx';
 import { formatBytes } from '#lib/format-bytes.ts';
-import { type DeployFormApi, validateBinary } from '#lib/hooks/use-deploy-form.ts';
+import {
+  type DeployFormApi,
+  validateBinary,
+  validateKeptBinary,
+} from '#lib/hooks/use-deploy-form.ts';
+import type { AppSummary } from '#queries/apps.ts';
 
-export function DeployBinaryField({ api }: { api: DeployFormApi }) {
+export function DeployBinaryField({
+  api,
+  replacing,
+}: {
+  api: DeployFormApi;
+  replacing: AppSummary | undefined;
+}) {
+  const validate = replacing === undefined ? validateBinary : validateKeptBinary;
+
   return (
-    <api.Field name="binary" validators={{ onMount: validateBinary, onChange: validateBinary }}>
+    <api.Field name="binary" validators={{ onMount: validate, onChange: validate }}>
       {(field) => {
         const rejected = field.state.value !== undefined && field.state.meta.errors.length > 0;
         return (
@@ -14,12 +27,15 @@ export function DeployBinaryField({ api }: { api: DeployFormApi }) {
             <BinaryDropZone
               binary={field.state.value}
               invalid={rejected}
+              keeping={replacing !== undefined}
               onPick={field.handleChange}
             />
             {rejected ? (
               <FieldError>{field.state.meta.errors[0]}</FieldError>
             ) : (
-              <FieldDescription>{describeBinary(field.state.value)}</FieldDescription>
+              <FieldDescription>
+                {describeBinary({ binary: field.state.value, replacing })}
+              </FieldDescription>
             )}
           </Field>
         );
@@ -28,8 +44,17 @@ export function DeployBinaryField({ api }: { api: DeployFormApi }) {
   );
 }
 
-function describeBinary(binary: File | undefined): string {
-  return binary === undefined
+function describeBinary({
+  binary,
+  replacing,
+}: {
+  binary: File | undefined;
+  replacing: AppSummary | undefined;
+}): string {
+  if (binary !== undefined) {
+    return `${formatBytes(binary.size)}, uploaded straight to the store.`;
+  }
+  return replacing === undefined
     ? 'The compiled binary to run in the guest.'
-    : `${formatBytes(binary.size)}, uploaded straight to the store.`;
+    : 'Leave it empty and the app runs the binary it already has, with what you change here.';
 }

--- a/apps/dashboard/src/components/apps/deploy-dialog-content.tsx
+++ b/apps/dashboard/src/components/apps/deploy-dialog-content.tsx
@@ -35,11 +35,11 @@ export function DeployDialogContent({ appId }: { appId?: string }) {
       </DialogTrigger>
       <DialogContent showCloseButton={!running} className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Deploy a binary</DialogTitle>
+          <DialogTitle>{appId === undefined ? 'Deploy a binary' : 'Deploy'}</DialogTitle>
           <DialogDescription>
             {run.phase === 'idle'
-              ? 'The binary is uploaded to the store, then released as what the app runs.'
-              : 'The binary is on its way. Closing this does not stop it.'}
+              ? describeDeploy(appId)
+              : 'The release is on its way. Closing this does not stop it.'}
           </DialogDescription>
         </DialogHeader>
         <DialogBody>
@@ -52,4 +52,10 @@ export function DeployDialogContent({ appId }: { appId?: string }) {
       </DialogContent>
     </Dialog>
   );
+}
+
+function describeDeploy(appId: string | undefined): string {
+  return appId === undefined
+    ? 'The binary is uploaded to the store, then released as what the app runs.'
+    : 'The app is released again with whatever this leaves it set to. A binary replaces the one it runs; without one, it keeps it.';
 }

--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -8,6 +8,7 @@ import { Button } from '@repo/ui/components/button';
 import { Field, FieldDescription, FieldError, FieldLabel } from '@repo/ui/components/field';
 import { Input } from '@repo/ui/components/input';
 import { Textarea } from '@repo/ui/components/textarea';
+import { useStore } from '@tanstack/react-form';
 import { DeployBinaryField } from '#components/apps/deploy-binary-field.tsx';
 import { DeployEnvironmentField } from '#components/apps/deploy-environment-field.tsx';
 import { DeployNameField } from '#components/apps/deploy-name-field.tsx';
@@ -27,6 +28,7 @@ export function DeployForm({
     binary,
     suggested,
   });
+  const picked = useStore(api.store, (state) => state.values.binary !== undefined);
 
   return (
     <form
@@ -36,7 +38,7 @@ export function DeployForm({
         void api.handleSubmit();
       }}
     >
-      <DeployBinaryField api={api} />
+      <DeployBinaryField api={api} replacing={replacing} />
 
       {!locked && <DeployNameField api={api} />}
 
@@ -101,15 +103,18 @@ export function DeployForm({
 
       {replacing !== undefined && (
         <p className="wrap-anywhere rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
-          This replaces the binary <span className="font-medium font-mono">{replacing.slug}</span>{' '}
-          is running. Its hostnames and everything on its volume stay as they are.
+          This restarts <span className="font-medium font-mono">{replacing.slug}</span>
+          {picked ? ' on the binary above' : ' on the binary it already runs'}. Its hostnames and
+          everything on its volume stay as they are.
         </p>
       )}
 
       <api.Subscribe selector={(state) => state.canSubmit}>
         {(canSubmit) => (
           <Button type="submit" size="lg" disabled={!canSubmit || !targetResolved}>
-            <span className="truncate">{submitLabel({ replacing: replacing?.slug, locked })}</span>
+            <span className="truncate">
+              {submitLabel({ replacing: replacing?.slug, locked, picked })}
+            </span>
           </Button>
         )}
       </api.Subscribe>
@@ -120,12 +125,14 @@ export function DeployForm({
 function submitLabel({
   replacing,
   locked,
+  picked,
 }: {
   replacing: string | undefined;
   locked: boolean;
+  picked: boolean;
 }): string {
   if (replacing !== undefined) {
-    return `Replace what ${replacing} runs`;
+    return picked ? `Replace what ${replacing} runs` : `Redeploy ${replacing}`;
   }
   return locked ? 'Reading the app…' : 'Create the app and deploy';
 }

--- a/apps/dashboard/src/components/apps/deploy-progress.tsx
+++ b/apps/dashboard/src/components/apps/deploy-progress.tsx
@@ -72,6 +72,9 @@ function waitingOn(phase: DeployPhase): string | undefined {
   if (phase === 'uploading') {
     return 'uploading the binary';
   }
+  if (phase === 'releasing') {
+    return 'releasing the binary the app already has';
+  }
   return phase === 'settling' ? 'waiting for the guest to answer' : undefined;
 }
 

--- a/apps/dashboard/src/lib/hooks/use-deploy-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy-form.ts
@@ -13,7 +13,7 @@ import {
   storedNames,
 } from '#lib/environment-variables.ts';
 import { useApps } from '#lib/hooks/use-apps.ts';
-import type { DeployRequest } from '#lib/hooks/use-deploy.ts';
+import type { ReleaseRequest } from '#lib/hooks/use-deploy.ts';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
@@ -67,7 +67,16 @@ export function validateBinary({ value }: { value: File | undefined }): string |
   if (value === undefined) {
     return 'Pick the binary to deploy.';
   }
-  return Value.Check(FilenameSchema, value.name)
+  return validateBinaryName(value);
+}
+
+/** What an app already running one asks of the field: a name it could keep, or nothing at all. */
+export function validateKeptBinary({ value }: { value: File | undefined }): string | undefined {
+  return value === undefined ? undefined : validateBinaryName(value);
+}
+
+function validateBinaryName(binary: File): string | undefined {
+  return Value.Check(FilenameSchema, binary.name)
     ? undefined
     : 'That file cannot be named inside an export. Rename it and pick it again.';
 }
@@ -124,7 +133,7 @@ export function useDeployForm({
     // this form after it has been read out of storage, so there is nothing to arrive later.
     defaultValues: { ...UNTOUCHED, binary, name: suggested?.name ?? UNTOUCHED.name },
     onSubmit: ({ value }) => {
-      const request = targetResolved ? asDeployRequest({ value, replacing }) : undefined;
+      const request = targetResolved ? asReleaseRequest({ value, replacing }) : undefined;
       if (request !== undefined) {
         start(request);
       }
@@ -141,16 +150,20 @@ export function useDeployForm({
   };
 }
 
-function asDeployRequest({
+/**
+ * The form as the release it asks for. No binary is a release of the one the app already runs,
+ * which only an app that is running one can mean — so a form with neither is a form that has
+ * nothing to deploy, and nothing is what it submits.
+ */
+function asReleaseRequest({
   value,
   replacing,
 }: {
   value: DeployFormValues;
   replacing: AppSummary | undefined;
-}): DeployRequest | undefined {
-  const binary = value.binary === undefined ? undefined : uploadableFrom(value.binary);
+}): ReleaseRequest | undefined {
   const port = Number(value.port ?? replacing?.config.guestPort ?? DEFAULT_GUEST_PORT);
-  if (binary === undefined || !Number.isInteger(port)) {
+  if (!Number.isInteger(port)) {
     return undefined;
   }
 
@@ -159,17 +172,28 @@ function asDeployRequest({
     stored: storedNames(replacing),
   });
 
-  return {
-    binary,
+  const configured = {
     args: tenantArguments(value.args ?? replacing?.config.args.join('\n') ?? ''),
     // Only what the table changed. A row still sealed holds a value this end has never read, so
     // it is sent as nothing at all — which is what leaves it alone — and a name the app has that
     // the table no longer does goes as null, the only way to say a variable should be removed.
     ...(edits.length === 0 ? {} : { environment: parseEnvironmentPatch(edits) }),
-    app: replacing?.slug,
-    name: replacing === undefined ? value.name.trim() || undefined : undefined,
     port,
   };
+
+  if (value.binary === undefined) {
+    return replacing === undefined ? undefined : { ...configured, app: replacing.slug };
+  }
+
+  const binary = uploadableFrom(value.binary);
+  return binary === undefined
+    ? undefined
+    : {
+        ...configured,
+        binary,
+        app: replacing?.slug,
+        name: replacing === undefined ? value.name.trim() || undefined : undefined,
+      };
 }
 
 function uploadableFrom(file: File): UploadableBinary | undefined {

--- a/apps/dashboard/src/lib/hooks/use-deploy.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy.ts
@@ -4,6 +4,7 @@ import {
   type DeployStep,
   deploy,
   describeUnservedDeployment,
+  redeploy,
   type UploadableBinary,
   type UploadProgress,
 } from '@repo/app-operations';
@@ -12,16 +13,28 @@ import { type UseMutationResult, useMutation, useQueryClient } from '@tanstack/r
 import { api } from '#lib/api.ts';
 import { browserUpload } from '#lib/browser-upload.ts';
 
-export type DeployRequest = {
-  binary: UploadableBinary;
+type Configured = {
   args: TenantArguments;
   environment?: TenantEnvironmentPatch | undefined;
-  app: string | undefined;
-  name: string | undefined;
   port: number;
 };
 
-export type DeployMutation = UseMutationResult<Deployed, Error, DeployRequest>;
+export type DeployRequest = Configured & {
+  binary: UploadableBinary;
+  app: string | undefined;
+  name: string | undefined;
+};
+
+/** The same release without a binary to upload, which only an app already running one can ask for. */
+export type RedeployRequest = Configured & { app: string };
+
+export type ReleaseRequest = DeployRequest | RedeployRequest;
+
+export function carriesBinary(request: ReleaseRequest): request is DeployRequest {
+  return 'binary' in request;
+}
+
+export type DeployMutation = UseMutationResult<Deployed, Error, ReleaseRequest>;
 
 export function useDeploy({
   onStep,
@@ -34,15 +47,17 @@ export function useDeploy({
 }): DeployMutation {
   const queryClient = useQueryClient();
 
-  return useMutation<Deployed, Error, DeployRequest>({
+  return useMutation<Deployed, Error, ReleaseRequest>({
     mutationFn: async (request) => {
-      const deployed = await deploy({
-        api,
-        ...request,
-        onStep,
-        upload: browserUpload,
-        whileUploading: ({ task }) => task(onProgress),
-      });
+      const deployed = carriesBinary(request)
+        ? await deploy({
+            api,
+            ...request,
+            onStep,
+            upload: browserUpload,
+            whileUploading: ({ task }) => task(onProgress),
+          })
+        : await redeploy({ api, ...request, onStep });
       const settled = await awaitDeploymentSettled({
         api,
         appId: deployed.appId,

--- a/apps/dashboard/src/lib/hooks/use-run-app.ts
+++ b/apps/dashboard/src/lib/hooks/use-run-app.ts
@@ -1,8 +1,8 @@
 import type { Deployed, DeployStep, UploadProgress } from '@repo/app-operations';
 import { useState } from 'react';
-import { type DeployRequest, useDeploy } from '#lib/hooks/use-deploy.ts';
+import { carriesBinary, type ReleaseRequest, useDeploy } from '#lib/hooks/use-deploy.ts';
 
-export type DeployPhase = 'idle' | 'uploading' | 'settling' | 'done' | 'failed';
+export type DeployPhase = 'idle' | 'uploading' | 'releasing' | 'settling' | 'done' | 'failed';
 
 export type DeployRun = {
   phase: DeployPhase;
@@ -10,13 +10,16 @@ export type DeployRun = {
   progress: UploadProgress | undefined;
   deployed: Deployed | undefined;
   reason: string | undefined;
-  start: (request: DeployRequest) => void;
+  start: (request: ReleaseRequest) => void;
   reset: () => void;
 };
 
 export function useRunApp({ onDeployed }: { onDeployed: (() => void) | undefined }): DeployRun {
   const [steps, setSteps] = useState<readonly DeployStep[]>([]);
   const [progress, setProgress] = useState<UploadProgress | undefined>(undefined);
+  // What the run was asked for, because the steps cannot say it: a release that reuses the stored
+  // binary reports the same artifact as one that just uploaded it.
+  const [uploading, setUploading] = useState(false);
   const run = useDeploy({
     onStep: (step) => setSteps((seen) => [...seen, step]),
     onProgress: setProgress,
@@ -24,7 +27,7 @@ export function useRunApp({ onDeployed }: { onDeployed: (() => void) | undefined
   });
 
   return {
-    phase: phaseOf({ status: run.status, steps }),
+    phase: phaseOf({ status: run.status, steps, uploading }),
     steps,
     progress,
     deployed: run.data,
@@ -32,6 +35,7 @@ export function useRunApp({ onDeployed }: { onDeployed: (() => void) | undefined
     start: (request) => {
       setSteps([]);
       setProgress(undefined);
+      setUploading(carriesBinary(request));
       run.mutate(request);
     },
     reset: () => {
@@ -45,9 +49,11 @@ export function useRunApp({ onDeployed }: { onDeployed: (() => void) | undefined
 function phaseOf({
   status,
   steps,
+  uploading,
 }: {
   status: 'idle' | 'pending' | 'success' | 'error';
   steps: readonly DeployStep[];
+  uploading: boolean;
 }): DeployPhase {
   if (status === 'success') {
     return 'done';
@@ -58,5 +64,8 @@ function phaseOf({
   if (status === 'idle') {
     return 'idle';
   }
-  return steps.some((step) => step.kind === 'deployment') ? 'settling' : 'uploading';
+  if (steps.some((step) => step.kind === 'deployment')) {
+    return 'settling';
+  }
+  return uploading ? 'uploading' : 'releasing';
 }


### PR DESCRIPTION
The deploy dialog is where an app's arguments and environment already live, so leaving the binary empty releases the stored one against them.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>