### PR TITLE
docs(www): llms.txt says 256 MiB, the actual default

### DIFF
--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -5,7 +5,7 @@
 
 ## What you get
 
-- **A machine to itself.** One microVM per app, 1 vCPU and 512 MiB by default. Nothing else runs in it.
+- **A machine to itself.** One microVM per app, 1 vCPU and 256 MiB by default. Nothing else runs in it.
 - **Just write to the disk.** `data/` is yours — a SQLite file, uploads, both. 8 GiB, and it survives every redeploy.
 - **Take it all with you.** One click: the binary and its whole disk, as one `.tar.gz`.
 - **A URL right away.** `https://<slug>.nibrun.app`, the moment it boots.


### PR DESCRIPTION
`llms.txt` still advertised 512 MiB per app. The default has been `DEFAULT_MEMORY_MIB = 256` since #259; the skill doc was already correct.

Grepped the rest of the repo for other stale memory claims — README, the www components, and the dashboard state no memory figure at all, so this was the only one. (The neighbouring 8 GiB disk claim matches `VOLUME_SIZE_BYTES`.)