### PR TITLE
feat(www): a blog at /blog, and every post served as markdown

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-router": "catalog:",
     "@tanstack/react-start": "^1.168.46",
     "lucide-react": "catalog:",
+    "marked": "^18.0.11",
     "react": "catalog:",
     "react-dom": "catalog:",
     "tailwindcss": "catalog:"

--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -40,5 +40,7 @@ state; it does not fit anything that has to be several machines.
 
 - [Skill: deploy-to-nibrun](https://github.com/ilbertt/nibrun/blob/main/skills/deploy-to-nibrun/SKILL.md) — the full guest contract, every command, and when not to use nibrun. Install it with `npx skills add ilbertt/nibrun`.
 - [bun-full-stack-starter](https://github.com/ilbertt/bun-full-stack-starter) — a template already shaped for this: an Elysia API and a React SPA compiled into one binary.
+- [Blog](https://nibrun.com/blog) — every post is also served as Markdown, at its own URL with
+  `.md` on the end.
 - [Dashboard](https://app.nibrun.com)
 - [Source](https://github.com/ilbertt/nibrun)

--- a/apps/www/src/components/code-copy-button.tsx
+++ b/apps/www/src/components/code-copy-button.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@repo/ui/components/button';
+import { useClipboardCopy } from '@repo/ui/hooks/use-clipboard-copy';
+import { CheckIcon, CopyIcon } from 'lucide-react';
+
+// Not the shared CopyButton: that one reads the value into its own label, which for a whole
+// snippet would hand a screen reader the snippet instead of the word for the action.
+export function CodeCopyButton({ code }: { code: string }) {
+  const { copied, copy } = useClipboardCopy(code);
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      aria-label={copied ? 'Copied' : 'Copy code'}
+      onClick={copy}
+      // Opaque, because the code scrolls sideways underneath it rather than around it.
+      className="absolute top-2 right-2 bg-muted"
+    >
+      {copied ? <CheckIcon /> : <CopyIcon />}
+    </Button>
+  );
+}

--- a/apps/www/src/components/home-link.tsx
+++ b/apps/www/src/components/home-link.tsx
@@ -1,0 +1,10 @@
+import { BrandMark } from '@repo/ui/custom/brand-mark';
+import { Link } from '@tanstack/react-router';
+
+export function HomeLink() {
+  return (
+    <Link to="/" className="rounded-full text-sm transition-opacity hover:opacity-80">
+      <BrandMark />
+    </Link>
+  );
+}

--- a/apps/www/src/components/site-header.tsx
+++ b/apps/www/src/components/site-header.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@repo/ui/components/button';
+import { Link } from '@tanstack/react-router';
+import type { ReactNode } from 'react';
+import { DashboardLink } from '#components/dashboard-link.tsx';
+import { GithubLink } from '#components/github-link.tsx';
+
+// The left is a slot rather than a fixed home link: the landing page carries the brand mark in
+// its own hero, a few hundred pixels below, and a second one in the header reads as a stutter.
+export function SiteHeader({ left }: { left?: ReactNode }) {
+  return (
+    <header className="flex w-full items-center justify-between gap-1 py-5">
+      <div className="flex items-center gap-1">{left}</div>
+      <div className="flex items-center gap-1">
+        <Button variant="ghost" size="sm" render={<Link to="/blog" />}>
+          Blog
+        </Button>
+        <GithubLink />
+        <DashboardLink />
+      </div>
+    </header>
+  );
+}

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy PocketBase in one click
-description: PocketBase is one file. Most ways to host it want a Dockerfile, a YAML file and a volume you provisioned first.
+description: The database, the auth, the admin UI — one file. Then you try to host it.
 date: 2026-08-26
 ---
 

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -5,16 +5,16 @@ date: 2026-08-26
 ---
 
 [PocketBase](https://pocketbase.io) ships as a single compiled binary. Download it, run it, and
-you have a database, an auth system, file storage, realtime subscriptions and an admin UI — one
+you have a database, an auth system, file storage, realtime subscriptions and an admin UI. One
 process, one directory on disk, no dependencies to install.
 
 Anyone who has self-hosted [Supabase](https://supabase.com) knows that same feature list as half
 a dozen services and a compose file holding them together. PocketBase is roughly that surface
 area, in one file.
 
-Then you go to deploy it, and the file stops mattering.
+Then you go to deploy it, and the easy and quick deployment promise of a single binary stops mattering.
 
-## The detour
+## The current world
 
 There are two ways to get it online, and both spend the simplicity you just bought.
 
@@ -31,21 +31,21 @@ as the thing is up.
 Either way the work is assembling a machine. PocketBase never asked for one to be taken apart.
 It asked for a directory it could write to and a port it could listen on.
 
-## The one click
+## Fulfilling the promise
 
 That is all nibrun hands it.
 
 Grab the Linux build from the [PocketBase releases
-page](https://github.com/pocketbase/pocketbase/releases) — `pocketbase_<version>_linux_amd64.zip`
-— and unzip it. Inside is one file called `pocketbase`. That is the whole application.
+page](https://github.com/pocketbase/pocketbase/releases) (`pocketbase_<version>_linux_amd64.zip`)
+and unzip it. Inside is one file called `pocketbase`. That is the whole application.
 
-Drag it onto [nibrun.com](https://nibrun.com).
+Drag and drop it onto [nibrun.com](https://nibrun.com).
 
 You land on the deploy screen with the binary already attached. Two fields to fill in:
 
-**Guest port** — `8090`
+**Guest port**: `8090`
 
-**Arguments**, one per line:
+**Arguments** (one per line):
 
 ```
 serve
@@ -53,18 +53,20 @@ serve
 --dir=./data/pb_data
 ```
 
-Deploy. A few seconds later PocketBase is answering on `https://<your-app>.nibrun.app`, and the
+Deploy.
+
+A few seconds later PocketBase is answering on `https://<your-app>.nibrun.app`, and the
 admin UI is at `/_/`. There is no certificate to obtain and no OS underneath it that is yours to
 patch.
 
-There is a CLI too, if you would rather not leave the terminal for any of it:
+There is a CLI too, if your mouse click doesn't work anymore:
 
 ```sh
 curl -fsSL https://nibrun.com/install.sh | sh
 nib login
 ```
 
-`nib run` is then the same deploy in one line — same binary, same arguments, same port:
+`nib run` is then the same deploy in one line. Same binary, same arguments, same port:
 
 ```sh
 nib run "./pocketbase serve --http=0.0.0.0:8090 --dir=./data/pb_data" \
@@ -116,12 +118,9 @@ nib apps export ./my-export.tar.gz
 ```
 
 Inside: the binary that was running, the entire `data/` directory as it stood on disk, and a
-`.env` of the variables it was deployed with. Unpack it anywhere and
-`./pocketbase serve --dir=./data/pb_data` is serving the same app again — same records, same
+`.env` of the variables it was deployed with. Unpack it anywhere (Linux! or download the proper pocketbase binary)
+and `./pocketbase serve --dir=./data/pb_data` is serving the same app again. Same records, same
 uploaded files, same superuser accounts, off the same command line as further up this page.
-
-It is also your backup, and the only one — the disk is local and unreplicated, so taking a copy
-now and then is on you.
 
 There is no managed database to migrate off, because there was never a managed database. Leaving
 costs you a download.

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -107,15 +107,6 @@ PocketHost is the honest exception: it is managed PocketBase, and if what you wa
 with none of the operating, it is a good answer. The tradeoff is that the instance is theirs. You
 are on their version, their machine, and their upgrade schedule.
 
-## What it costs
-
-nibrun is free while it is in beta.
-
-Everywhere else, the shape of the bill is the same: a small always-on instance, plus a persistent
-volume, billed separately. Free tiers usually exclude the disk, or sleep the instance, and an
-app with a SQLite file is exactly the kind of app that does not enjoy being slept. Check the
-current numbers yourself — they move — but budget for two line items, not one.
-
 ## Tired of nibrun? Zip and go
 
 One command — or one click in the dashboard — and the whole app comes back as a `.tar.gz`:

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -53,11 +53,6 @@ serve
 --dir=./data/pb_data
 ```
 
-`--dir` is the one to get right: `data/` is the only directory that survives a restart, and
-PocketBase would otherwise write its database beside the binary, where it does not. The port is
-spelled out rather than passed as `$PORT` because nothing shell-like sits in between — it only
-has to match the Guest port field.
-
 Deploy. A few seconds later PocketBase is answering on `https://<your-app>.nibrun.app`, and the
 admin UI is at `/_/`. There is no certificate to obtain and no OS underneath it that is yours to
 patch.

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -121,7 +121,7 @@ current numbers yourself — they move — but budget for two line items, not on
 One command — or one click in the dashboard — and the whole app comes back as a `.tar.gz`:
 
 ```sh
-nib apps export --app pocketbase .
+nib apps export ./my-export.tar.gz
 ```
 
 Inside: the binary that was running, the entire `data/` directory as it stood on disk, and a

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -19,9 +19,9 @@ Then you go to deploy it, and the file stops mattering.
 There are two ways to get it online, and both spend the simplicity you just bought.
 
 Put it on a platform like [Railway](https://railway.com) and the first redeploy eats your
-database, because a container filesystem is not a disk. You buy the disk back as a volume, and
-the volume pins the service to one machine — mentioned in the tone of a limitation, though
-PocketBase was only ever going to be one machine.
+database. A container's filesystem is thrown away and rebuilt on every deploy, so the app comes
+back up looking fine with nothing in it. The fix is a volume: another resource to provision,
+mount, point `--dir` at, and pay for — all so the app can keep a directory.
 
 Take a VM at [DigitalOcean](https://www.digitalocean.com) instead and the app is the easy part.
 What you actually signed up for is the TLS certificate and its renewal, the reverse proxy in

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -4,9 +4,9 @@ description: PocketBase is one file. Most ways to host it want a Dockerfile, a Y
 date: 2026-08-26
 ---
 
-PocketBase ships as a single compiled binary. Download it, run it, and you have a database, an
-auth system, file storage, realtime subscriptions and an admin UI — one process, one directory
-on disk, no dependencies to install.
+[PocketBase](https://pocketbase.io) ships as a single compiled binary. Download it, run it, and
+you have a database, an auth system, file storage, realtime subscriptions and an admin UI — one
+process, one directory on disk, no dependencies to install.
 
 Then you go to host it, and every option asks you to put that one file back inside a container
 image.

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -129,21 +129,8 @@ Inside: the binary that was running, the entire `data/` directory as it stood on
 `./pocketbase serve --dir=./data/pb_data` is serving the same app again — same records, same
 uploaded files, same superuser accounts, off the same command line as further up this page.
 
+It is also your backup, and the only one — the disk is local and unreplicated, so taking a copy
+now and then is on you.
+
 There is no managed database to migrate off, because there was never a managed database. Leaving
 costs you a download.
-
-## What you give up
-
-Worth saying plainly, because it is the design and not a roadmap:
-
-- **One microVM, one size.** 1 vCPU and 256 MiB, and no horizontal scaling. PocketBase is
-  comfortable there for a small app; it is not where you put something with real traffic.
-- **A deploy is a replace.** The old VM stops before the new one starts, because they share the
-  volume. That is a few seconds of downtime, not blue/green.
-- **The disk is local and unreplicated.** The export above doubles as the backup, and taking it
-  is on you.
-- **One process.** No sidecar, no cron container, no separate `pocketbase superuser` invocation
-  against the same volume.
-
-If that list is disqualifying, you have outgrown this. If it is not, PocketBase is one file, and
-running it should take about as long as downloading it.

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -62,7 +62,14 @@ Deploy. A few seconds later PocketBase is answering on `https://<your-app>.nibru
 admin UI is at `/_/`. There is no certificate to obtain and no OS underneath it that is yours to
 patch.
 
-If you would rather stay in a terminal, it is the same thing in one command:
+There is a CLI too, if you would rather not leave the terminal for any of it:
+
+```sh
+curl -fsSL https://nibrun.com/install.sh | sh
+nib login
+```
+
+`nib run` is then the same deploy in one line — same binary, same arguments, same port:
 
 ```sh
 nib run "./pocketbase serve --http=0.0.0.0:8090 --dir=./data/pb_data" \
@@ -71,7 +78,8 @@ nib run "./pocketbase serve --http=0.0.0.0:8090 --dir=./data/pb_data" \
 
 ## Creating the first superuser
 
-On its first start PocketBase prints a one-time installer link to its log. Read it back with:
+On its first start PocketBase prints a one-time installer link to its log. It is under the app's
+Logs tab in the dashboard, or from the terminal:
 
 ```sh
 nib apps logs --app pocketbase

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy PocketBase in one click
-description: The database, the auth, the admin UI — one file. Then you try to host it.
+description: The database, the auth, the admin UI. One file. Then you try to host it.
 date: 2026-08-26
 ---
 
@@ -12,21 +12,22 @@ Anyone who has self-hosted [Supabase](https://supabase.com) knows that same feat
 a dozen services and a compose file holding them together. PocketBase is roughly that surface
 area, in one file.
 
-Then you go to deploy it, and the easy and quick deployment promise of a single binary stops mattering.
+Then you go to deploy it, and the easy and quick deployment promise of a single binary
+stops mattering.
 
 ## The current world
 
-There are two ways to get it online, and both spend the simplicity you just bought.
+There are two ways to get it online today. Both of them take that promise back.
 
 Put it on a platform like [Railway](https://railway.com) and the first redeploy eats your
 database. A container's filesystem is thrown away and rebuilt on every deploy, so the app comes
-back up looking fine with nothing in it. The fix is a volume: another resource to provision,
-mount, point `--dir` at, and pay for — all so the app can keep a directory.
+back up looking fine and completely empty. The fix is a volume. Another resource to provision,
+mount, point `--dir` at, and pay for. All so the app can keep a directory.
 
 Take a VM at [DigitalOcean](https://www.digitalocean.com) instead and the app is the easy part.
 What you actually signed up for is the TLS certificate and its renewal, the reverse proxy in
-front of it, the OS updates, the firewall, and the backups — not for an evening, but for as long
-as the thing is up.
+front of it, the OS updates, the firewall, and the backups. Not for an evening. For as long as
+the thing is up.
 
 Either way the work is assembling a machine. PocketBase never asked for one to be taken apart.
 It asked for a directory it could write to and a port it could listen on.
@@ -82,7 +83,7 @@ Logs tab in the dashboard, or from the terminal:
 nib apps logs --app pocketbase
 ```
 
-The link will look like `http://0.0.0.0:8090/_/#/pbinstal/<token>`, because PocketBase only knows
+The link comes out pointing at `http://0.0.0.0:8090/_/#/pbinstal/<token>`. PocketBase only knows
 the address it was told to bind. Swap the host for your own and keep the rest:
 
 ```
@@ -91,36 +92,37 @@ https://<your-app>.nibrun.app/_/#/pbinstal/<token>
 
 That opens the admin UI and lets you create the first superuser.
 
-## What the alternatives want first
+## How the alternatives compare
 
-Railway and a bare VM are two points on one list. Here is the rest of it, ordered by nothing
-except how much has to exist before your binary gets to run.
+Railway and a bare VM are two points on one list. Here is the rest of it, ordered by how much has
+to exist before your binary gets to run.
 
 | | What you build first | Where the data lives |
 | --- | --- | --- |
-| **nibrun** | Nothing — the binary is the artifact | `data/`, on the same machine |
+| **nibrun** | Nothing. The binary is the artifact | `data/`, on the same machine |
 | **Fly.io** | A Dockerfile, a `fly.toml`, a volume you created and mounted | A Fly volume |
 | **Render** | A Dockerfile, a service definition, a disk on a paid instance | A Render disk |
 | **Railway** | A Dockerfile or a buildpack it guesses at, plus a volume | A Railway volume |
 | **A VPS** | A user, a systemd unit, a reverse proxy, a TLS certificate, a firewall, a backup job | Wherever you put it |
 | **PocketHost** | Nothing, but you are on their PocketBase | Theirs |
 
-PocketHost is the honest exception: it is managed PocketBase, and if what you want is PocketBase
-with none of the operating, it is a good answer. The tradeoff is that the instance is theirs. You
-are on their version, their machine, and their upgrade schedule.
+PocketHost is the honest exception. It is managed PocketBase, and if you want PocketBase without
+running anything yourself, it is a good answer. The tradeoff is that the instance is theirs.
+Their version, their machine, their upgrade schedule.
 
 ## Tired of nibrun? Zip and go
 
-One command — or one click in the dashboard — and the whole app comes back as a `.tar.gz`:
+One command, or one click in the dashboard, and the whole app comes back as a `.tar.gz`:
 
 ```sh
 nib apps export ./my-export.tar.gz
 ```
 
 Inside: the binary that was running, the entire `data/` directory as it stood on disk, and a
-`.env` of the variables it was deployed with. Unpack it anywhere (Linux! or download the proper pocketbase binary)
-and `./pocketbase serve --dir=./data/pb_data` is serving the same app again. Same records, same
-uploaded files, same superuser accounts, off the same command line as further up this page.
+`.env` of the variables it was deployed with. Unpack it anywhere (Linux! or download the proper
+pocketbase binary) and `./pocketbase serve --dir=./data/pb_data` is serving the same app again.
+Same records, same uploaded files, same superuser accounts, off the same command line as further
+up this page.
 
 There is no managed database to migrate off, because there was never a managed database. Leaving
 costs you a download.

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -8,10 +8,42 @@ date: 2026-08-26
 you have a database, an auth system, file storage, realtime subscriptions and an admin UI — one
 process, one directory on disk, no dependencies to install.
 
-Then you go to host it, and every option asks you to put that one file back inside a container
-image.
+Anyone who has self-hosted [Supabase](https://supabase.com) knows that same list as a stack:
+Postgres, GoTrue, PostgREST, Realtime, Storage, Kong, Studio, and a compose file holding them
+together. PocketBase is roughly the same surface area, folded into one file.
+
+Then you go to deploy it, and the file stops mattering.
+
+## The detour
+
+Here is the shortest honest path from that binary to a URL, on the platforms people actually
+reach for.
+
+You write a Dockerfile. It is three lines — a base image, a `COPY`, a `CMD` — and it exists
+entirely so that a platform which only knows how to run images will agree to run your file. Now
+you own it. It rebuilds on every PocketBase release, and a build step sits between you and every
+deploy from here on.
+
+[Railway](https://railway.com) builds it and it boots. You create a collection, add a record,
+push a fix, and the record is gone — a container filesystem is not a disk. So you provision a
+volume, mount it, point `--dir` at the mount, and deploy again. Now it survives.
+
+The volume pins the service to a single machine, which the platform mentions in the tone of a
+limitation. It is not one. PocketBase was only ever going to be one machine.
+
+Or you skip the image entirely and take a VM at [DigitalOcean](https://www.digitalocean.com),
+where the work is not a Dockerfile but a user, a systemd unit, a reverse proxy, a certificate
+that has to renew, a firewall, and a backup job you promise yourself you will write next weekend.
+
+Either way, the evening went to putting a machine back together. That is what every step on both
+lists is. A container is a machine with the disk pulled out and the name taken away, so the
+platform sells the disk back to you as a volume and the name back as a service. A VM is a machine
+with nothing on it yet, so you fit the parts by hand. PocketBase asked for neither. It asked for
+a directory it could write to and a port it could listen on.
 
 ## The one click
+
+That is all nibrun hands it.
 
 Grab the Linux build from the [PocketBase releases
 page](https://github.com/pocketbase/pocketbase/releases) — `pocketbase_<version>_linux_amd64.zip`
@@ -80,8 +112,8 @@ That opens the admin UI and lets you create the first superuser.
 
 ## What the alternatives want first
 
-The comparison is not really about price. It is about how much has to exist before your binary
-gets to run.
+Railway and a bare VM are two points on one list. Here is the rest of it, ordered by nothing
+except how much has to exist before your binary gets to run.
 
 | | What you build first | Where the data lives |
 | --- | --- | --- |
@@ -91,11 +123,6 @@ gets to run.
 | **Railway** | A Dockerfile or a buildpack it guesses at, plus a volume | A Railway volume |
 | **A VPS** | A user, a systemd unit, a reverse proxy, a TLS certificate, a firewall, a backup job | Wherever you put it |
 | **PocketHost** | Nothing, but you are on their PocketBase | Theirs |
-
-The Dockerfile is the part worth staring at. For a Go binary that is already static and already
-Linux, it is a `FROM`, a `COPY`, and a `CMD` — three lines that exist purely to satisfy a platform
-that only knows how to run images. You still get to maintain it, rebuild it on every release, push
-it to a registry, and debug it the first time the base image and the binary disagree about glibc.
 
 PocketHost is the honest exception: it is managed PocketBase, and if what you want is PocketBase
 with none of the operating, it is a good answer. The tradeoff is that the instance is theirs. You

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -1,0 +1,127 @@
+---
+title: Deploy PocketBase in one click
+description: PocketBase is one file. Most ways to host it want a Dockerfile, a YAML file and a volume you provisioned first.
+date: 2026-08-26
+---
+
+PocketBase ships as a single compiled binary. Download it, run it, and you have a database, an
+auth system, file storage, realtime subscriptions and an admin UI — one process, one directory
+on disk, no dependencies to install.
+
+Then you go to host it, and every option asks you to put that one file back inside a container
+image.
+
+## The one click
+
+Grab the Linux build from the [PocketBase releases
+page](https://github.com/pocketbase/pocketbase/releases) — `pocketbase_<version>_linux_amd64.zip`
+— and unzip it. Inside is one file called `pocketbase`. That is the whole application.
+
+Drag it onto [nibrun.com](https://nibrun.com).
+
+You land on the deploy screen with the binary already attached. Two fields to fill in:
+
+**Guest port** — `8090`
+
+**Arguments**, one per line:
+
+```
+serve
+--http=0.0.0.0:8090
+--dir=./data/pb_data
+```
+
+Deploy. A few seconds later PocketBase is answering on `https://<your-app>.nibrun.app`, and the
+admin UI is at `/_/`.
+
+If you would rather stay in a terminal, it is the same thing in one command:
+
+```sh
+nib run "./pocketbase serve --http=0.0.0.0:8090 --dir=./data/pb_data" \
+  --name pocketbase --port 8090
+```
+
+## Why those three arguments
+
+None of them are nibrun-specific ceremony. They are the three defaults PocketBase picks for
+running on your laptop, and all three are wrong on any server.
+
+`serve` is PocketBase's own subcommand — the binary is a multi-command tool, and running it bare
+prints help and exits.
+
+`--http=0.0.0.0:8090` is the important one. PocketBase binds `127.0.0.1` by default, which on a
+machine of its own means nothing outside can reach it. nibrun hands your process a port in `PORT`
+and routes to it, and here you are telling PocketBase to take that port on every interface. The
+port number is written out rather than passed as `$PORT` because there is no shell involved —
+arguments go straight to `exec`, so `8090` has to match the Guest port field. Pick any number
+you like, as long as it is the same in both places.
+
+`--dir=./data/pb_data` is where your database ends up. PocketBase defaults to `pb_data` next to
+the binary, and on nibrun the only directory that survives a restart is `data/`. Point it inside
+and your data outlives every redeploy; leave it at the default and you lose the whole database the
+first time the app restarts. This is the one that bites people, and it bites them a week later.
+
+## Creating the first superuser
+
+On its first start PocketBase prints a one-time installer link to its log. Read it back with:
+
+```sh
+nib apps logs --app pocketbase
+```
+
+The link will look like `http://0.0.0.0:8090/_/#/pbinstal/<token>`, because PocketBase only knows
+the address it was told to bind. Swap the host for your own and keep the rest:
+
+```
+https://<your-app>.nibrun.app/_/#/pbinstal/<token>
+```
+
+That opens the admin UI and lets you create the first superuser.
+
+## What the alternatives want first
+
+The comparison is not really about price. It is about how much has to exist before your binary
+gets to run.
+
+| | What you build first | Where the data lives |
+| --- | --- | --- |
+| **nibrun** | Nothing — the binary is the artifact | `data/`, on the same machine |
+| **Fly.io** | A Dockerfile, a `fly.toml`, a volume you created and mounted | A Fly volume |
+| **Render** | A Dockerfile, a service definition, a disk on a paid instance | A Render disk |
+| **Railway** | A Dockerfile or a buildpack it guesses at, plus a volume | A Railway volume |
+| **A VPS** | A user, a systemd unit, a reverse proxy, a TLS certificate, a firewall, a backup job | Wherever you put it |
+| **PocketHost** | Nothing, but you are on their PocketBase | Theirs |
+
+The Dockerfile is the part worth staring at. For a Go binary that is already static and already
+Linux, it is a `FROM`, a `COPY`, and a `CMD` — three lines that exist purely to satisfy a platform
+that only knows how to run images. You still get to maintain it, rebuild it on every release, push
+it to a registry, and debug it the first time the base image and the binary disagree about glibc.
+
+PocketHost is the honest exception: it is managed PocketBase, and if what you want is PocketBase
+with none of the operating, it is a good answer. The tradeoff is that the instance is theirs. You
+are on their version, their machine, and their upgrade schedule.
+
+## What it costs
+
+nibrun is free while it is in beta.
+
+Everywhere else, the shape of the bill is the same: a small always-on instance, plus a persistent
+volume, billed separately. Free tiers usually exclude the disk, or sleep the instance, and an
+app with a SQLite file is exactly the kind of app that does not enjoy being slept. Check the
+current numbers yourself — they move — but budget for two line items, not one.
+
+## What you give up
+
+Worth saying plainly, because it is the design and not a roadmap:
+
+- **One microVM, one size.** 1 vCPU and 256 MiB, and no horizontal scaling. PocketBase is
+  comfortable there for a small app; it is not where you put something with real traffic.
+- **A deploy is a replace.** The old VM stops before the new one starts, because they share the
+  volume. That is a few seconds of downtime, not blue/green.
+- **The disk is local and unreplicated.** `nib apps export` gives you the binary and the whole
+  `data/` directory as one `.tar.gz`. That is your backup, and you should take it.
+- **One process.** No sidecar, no cron container, no separate `pocketbase superuser` invocation
+  against the same volume.
+
+If that list is disqualifying, you have outgrown this. If it is not, PocketBase is one file, and
+running it should take about as long as downloading it.

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -8,38 +8,28 @@ date: 2026-08-26
 you have a database, an auth system, file storage, realtime subscriptions and an admin UI — one
 process, one directory on disk, no dependencies to install.
 
-Anyone who has self-hosted [Supabase](https://supabase.com) knows that same list as a stack:
-Postgres, GoTrue, PostgREST, Realtime, Storage, Kong, Studio, and a compose file holding them
-together. PocketBase is roughly the same surface area, folded into one file.
+Anyone who has self-hosted [Supabase](https://supabase.com) knows that same feature list as half
+a dozen services and a compose file holding them together. PocketBase is roughly that surface
+area, in one file.
 
 Then you go to deploy it, and the file stops mattering.
 
 ## The detour
 
-Here is the shortest honest path from that binary to a URL, on the platforms people actually
-reach for.
+There are two ways to get it online, and both spend the simplicity you just bought.
 
-You write a Dockerfile. It is three lines — a base image, a `COPY`, a `CMD` — and it exists
-entirely so that a platform which only knows how to run images will agree to run your file. Now
-you own it. It rebuilds on every PocketBase release, and a build step sits between you and every
-deploy from here on.
+Put it on a platform like [Railway](https://railway.com) and the first redeploy eats your
+database, because a container filesystem is not a disk. You buy the disk back as a volume, and
+the volume pins the service to one machine — mentioned in the tone of a limitation, though
+PocketBase was only ever going to be one machine.
 
-[Railway](https://railway.com) builds it and it boots. You create a collection, add a record,
-push a fix, and the record is gone — a container filesystem is not a disk. So you provision a
-volume, mount it, point `--dir` at the mount, and deploy again. Now it survives.
+Take a VM at [DigitalOcean](https://www.digitalocean.com) instead and the app is the easy part.
+What you actually signed up for is the TLS certificate and its renewal, the reverse proxy in
+front of it, the OS updates, the firewall, and the backups — not for an evening, but for as long
+as the thing is up.
 
-The volume pins the service to a single machine, which the platform mentions in the tone of a
-limitation. It is not one. PocketBase was only ever going to be one machine.
-
-Or you skip the image entirely and take a VM at [DigitalOcean](https://www.digitalocean.com),
-where the work is not a Dockerfile but a user, a systemd unit, a reverse proxy, a certificate
-that has to renew, a firewall, and a backup job you promise yourself you will write next weekend.
-
-Either way, the evening went to putting a machine back together. That is what every step on both
-lists is. A container is a machine with the disk pulled out and the name taken away, so the
-platform sells the disk back to you as a volume and the name back as a service. A VM is a machine
-with nothing on it yet, so you fit the parts by hand. PocketBase asked for neither. It asked for
-a directory it could write to and a port it could listen on.
+Either way the work is assembling a machine. PocketBase never asked for one to be taken apart.
+It asked for a directory it could write to and a port it could listen on.
 
 ## The one click
 
@@ -64,7 +54,8 @@ serve
 ```
 
 Deploy. A few seconds later PocketBase is answering on `https://<your-app>.nibrun.app`, and the
-admin UI is at `/_/`.
+admin UI is at `/_/`. There is no certificate to obtain and no OS underneath it that is yours to
+patch.
 
 If you would rather stay in a terminal, it is the same thing in one command:
 

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -53,6 +53,11 @@ serve
 --dir=./data/pb_data
 ```
 
+`--dir` is the one to get right: `data/` is the only directory that survives a restart, and
+PocketBase would otherwise write its database beside the binary, where it does not. The port is
+spelled out rather than passed as `$PORT` because nothing shell-like sits in between — it only
+has to match the Guest port field.
+
 Deploy. A few seconds later PocketBase is answering on `https://<your-app>.nibrun.app`, and the
 admin UI is at `/_/`. There is no certificate to obtain and no OS underneath it that is yours to
 patch.
@@ -63,26 +68,6 @@ If you would rather stay in a terminal, it is the same thing in one command:
 nib run "./pocketbase serve --http=0.0.0.0:8090 --dir=./data/pb_data" \
   --name pocketbase --port 8090
 ```
-
-## Why those three arguments
-
-None of them are nibrun-specific ceremony. They are the three defaults PocketBase picks for
-running on your laptop, and all three are wrong on any server.
-
-`serve` is PocketBase's own subcommand — the binary is a multi-command tool, and running it bare
-prints help and exits.
-
-`--http=0.0.0.0:8090` is the important one. PocketBase binds `127.0.0.1` by default, which on a
-machine of its own means nothing outside can reach it. nibrun hands your process a port in `PORT`
-and routes to it, and here you are telling PocketBase to take that port on every interface. The
-port number is written out rather than passed as `$PORT` because there is no shell involved —
-arguments go straight to `exec`, so `8090` has to match the Guest port field. Pick any number
-you like, as long as it is the same in both places.
-
-`--dir=./data/pb_data` is where your database ends up. PocketBase defaults to `pb_data` next to
-the binary, and on nibrun the only directory that survives a restart is `data/`. Point it inside
-and your data outlives every redeploy; leave it at the default and you lose the whole database the
-first time the app restarts. This is the one that bites people, and it bites them a week later.
 
 ## Creating the first superuser
 
@@ -128,6 +113,22 @@ volume, billed separately. Free tiers usually exclude the disk, or sleep the ins
 app with a SQLite file is exactly the kind of app that does not enjoy being slept. Check the
 current numbers yourself — they move — but budget for two line items, not one.
 
+## Tired of nibrun? Zip and go
+
+One command — or one click in the dashboard — and the whole app comes back as a `.tar.gz`:
+
+```sh
+nib apps export --app pocketbase .
+```
+
+Inside: the binary that was running, the entire `data/` directory as it stood on disk, and a
+`.env` of the variables it was deployed with. Unpack it anywhere and
+`./pocketbase serve --dir=./data/pb_data` is serving the same app again — same records, same
+uploaded files, same superuser accounts, off the same command line as further up this page.
+
+There is no managed database to migrate off, because there was never a managed database. Leaving
+costs you a download.
+
 ## What you give up
 
 Worth saying plainly, because it is the design and not a roadmap:
@@ -136,8 +137,8 @@ Worth saying plainly, because it is the design and not a roadmap:
   comfortable there for a small app; it is not where you put something with real traffic.
 - **A deploy is a replace.** The old VM stops before the new one starts, because they share the
   volume. That is a few seconds of downtime, not blue/green.
-- **The disk is local and unreplicated.** `nib apps export` gives you the binary and the whole
-  `data/` directory as one `.tar.gz`. That is your backup, and you should take it.
+- **The disk is local and unreplicated.** The export above doubles as the backup, and taking it
+  is on you.
 - **One process.** No sidecar, no cron container, no separate `pocketbase superuser` invocation
   against the same volume.
 

--- a/apps/www/src/lib/blog-markdown.ts
+++ b/apps/www/src/lib/blog-markdown.ts
@@ -1,0 +1,18 @@
+import { findPost } from '#lib/blog.ts';
+
+const MARKDOWN_PATH = /^\/blog\/([a-z0-9-]+)\.md$/;
+
+/**
+ * The one URL on this site the worker answers itself. Every page is prerendered to a static file
+ * and served from the edge, but a `.md` prerendered alongside them would be handed back with
+ * whatever content type the extension is guessed to mean — and being read as markdown rather
+ * than downloaded is the entire point of the URL.
+ */
+export function markdownResponse(request: Request): Response | undefined {
+  const slug = MARKDOWN_PATH.exec(new URL(request.url).pathname)?.[1];
+  const post = slug === undefined ? undefined : findPost(slug);
+
+  return post === undefined
+    ? undefined
+    : new Response(post.markdown, { headers: { 'content-type': 'text/markdown; charset=utf-8' } });
+}

--- a/apps/www/src/lib/blog.ts
+++ b/apps/www/src/lib/blog.ts
@@ -1,4 +1,4 @@
-import { marked } from 'marked';
+import { Marked, Renderer } from 'marked';
 
 export type BlogPost = {
   slug: string;
@@ -28,8 +28,21 @@ export function findPost(slug: string): BlogPost | undefined {
   return POSTS.find((post) => post.slug === slug);
 }
 
+const DEFAULT_RENDERER = new Renderer();
+
+// An empty slot rather than a rendered button: copying is a React component with the shared
+// clipboard hook behind it, and this is the element it is portalled into once the page is
+// interactive. The wrapper is what positions it, so it has to come from here and not from CSS.
+const ARTICLE = new Marked({
+  renderer: {
+    code(token) {
+      return `<div class="code-block">${DEFAULT_RENDERER.code(token)}<span data-copy-slot></span></div>`;
+    },
+  },
+});
+
 export function renderPost(post: BlogPost): string {
-  return marked.parse(post.markdown.replace(FRONTMATTER, ''), { async: false });
+  return ARTICLE.parse(post.markdown.replace(FRONTMATTER, ''), { async: false });
 }
 
 // UTC on both sides: the date is a plain `YYYY-MM-DD`, which parses as UTC midnight, and

--- a/apps/www/src/lib/blog.ts
+++ b/apps/www/src/lib/blog.ts
@@ -1,0 +1,92 @@
+import { marked } from 'marked';
+
+export type BlogPost = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  /** The file as it sits in the repo, frontmatter and all — what `/blog/<slug>.md` serves. */
+  markdown: string;
+};
+
+const MARKDOWN_EXTENSION = '.md';
+const FRONTMATTER = /^---\n([\s\S]*?)\n---\n/;
+
+const SOURCES = import.meta.glob('../content/blog/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+// Sorted here rather than at each call site, so a post's position is a property of the set and
+// not of whoever renders it.
+export const POSTS: readonly BlogPost[] = Object.entries(SOURCES)
+  .map(([path, markdown]) => read({ slug: slugOf(path), markdown }))
+  .sort(byNewestFirst);
+
+export function findPost(slug: string): BlogPost | undefined {
+  return POSTS.find((post) => post.slug === slug);
+}
+
+export function renderPost(post: BlogPost): string {
+  return marked.parse(post.markdown.replace(FRONTMATTER, ''), { async: false });
+}
+
+// UTC on both sides: the date is a plain `YYYY-MM-DD`, which parses as UTC midnight, and
+// formatting it in the reader's zone would show the day before it to anyone west of Greenwich.
+const PUBLISHED = new Intl.DateTimeFormat('en-US', { dateStyle: 'long', timeZone: 'UTC' });
+
+export function formatPostDate(date: string): string {
+  return PUBLISHED.format(new Date(date));
+}
+
+// biome-ignore lint/complexity/useMaxParams: a comparator compares two posts
+function byNewestFirst(first: BlogPost, second: BlogPost): number {
+  return second.date.localeCompare(first.date);
+}
+
+function slugOf(path: string): string {
+  return path.slice(path.lastIndexOf('/') + 1, -MARKDOWN_EXTENSION.length);
+}
+
+// Every failure here throws, which fails the build rather than publishing a post with no title.
+function read({ slug, markdown }: { slug: string; markdown: string }): BlogPost {
+  const block = FRONTMATTER.exec(markdown)?.[1];
+  if (block === undefined) {
+    throw new Error(`${slug}${MARKDOWN_EXTENSION} opens with no frontmatter block`);
+  }
+
+  const fields = new Map(block.split('\n').map((line) => field({ slug, line })));
+
+  return {
+    slug,
+    title: required({ slug, fields, key: 'title' }),
+    description: required({ slug, fields, key: 'description' }),
+    date: required({ slug, fields, key: 'date' }),
+    markdown,
+  };
+}
+
+function field({ slug, line }: { slug: string; line: string }): [string, string] {
+  const separator = line.indexOf(':');
+  if (separator < 0) {
+    throw new Error(`${slug}${MARKDOWN_EXTENSION} has a frontmatter line with no key: ${line}`);
+  }
+  return [line.slice(0, separator).trim(), line.slice(separator + 1).trim()];
+}
+
+function required({
+  slug,
+  fields,
+  key,
+}: {
+  slug: string;
+  fields: Map<string, string>;
+  key: string;
+}): string {
+  const value = fields.get(key);
+  if (value === undefined || value === '') {
+    throw new Error(`${slug}${MARKDOWN_EXTENSION} is missing a ${key}`);
+  }
+  return value;
+}

--- a/apps/www/src/lib/page-head.ts
+++ b/apps/www/src/lib/page-head.ts
@@ -1,0 +1,37 @@
+import { SITE_URL } from '#lib/site.ts';
+
+/**
+ * The tags that differ per page, kept in one place because one of them cannot be repeated:
+ * the router dedupes `meta` by name, so a route overriding the root's is free, but it renders
+ * every `link` a match contributes — two routes each declaring a canonical would emit both.
+ */
+export function pageHead({
+  path,
+  title,
+  description,
+  publishedAt,
+}: {
+  path: string;
+  title: string;
+  description: string;
+  publishedAt?: string;
+}) {
+  const url = `${SITE_URL}${path}`;
+
+  return {
+    meta: [
+      { title },
+      { name: 'description', content: description },
+      { property: 'og:type', content: publishedAt === undefined ? 'website' : 'article' },
+      { property: 'og:url', content: url },
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { name: 'twitter:title', content: title },
+      { name: 'twitter:description', content: description },
+      ...(publishedAt === undefined
+        ? []
+        : [{ property: 'article:published_time', content: publishedAt }]),
+    ],
+    links: [{ rel: 'canonical', href: url }],
+  };
+}

--- a/apps/www/src/lib/site-url.ts
+++ b/apps/www/src/lib/site-url.ts
@@ -1,1 +1,0 @@
-export const SITE_URL = 'https://nibrun.com';

--- a/apps/www/src/lib/site.ts
+++ b/apps/www/src/lib/site.ts
@@ -1,0 +1,6 @@
+export const SITE_URL = 'https://nibrun.com';
+
+export const SITE_TITLE = 'nibrun — drop your binary, get a server';
+
+export const SITE_DESCRIPTION =
+  "Small apps don't need to scale. Drop a compiled binary and get a microVM of its own, a filesystem that persists, and an HTTPS URL. Export the binary and the whole disk whenever you want.";

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -10,33 +10,53 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BlogIndexRoute = BlogIndexRouteImport.update({
+  id: '/blog/',
+  path: '/blog/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogSlugRoute = BlogSlugRouteImport.update({
+  id: '/blog/$slug',
+  path: '/blog/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/blog/$slug': typeof BlogSlugRoute
+  '/blog/': typeof BlogIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/blog/$slug': typeof BlogSlugRoute
+  '/blog': typeof BlogIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/blog/$slug': typeof BlogSlugRoute
+  '/blog/': typeof BlogIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/blog/$slug' | '/blog/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/blog/$slug' | '/blog'
+  id: '__root__' | '/' | '/blog/$slug' | '/blog/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  BlogSlugRoute: typeof BlogSlugRoute
+  BlogIndexRoute: typeof BlogIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -48,11 +68,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/blog/': {
+      id: '/blog/'
+      path: '/blog'
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog/$slug': {
+      id: '/blog/$slug'
+      path: '/blog/$slug'
+      fullPath: '/blog/$slug'
+      preLoaderRoute: typeof BlogSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  BlogSlugRoute: BlogSlugRoute,
+  BlogIndexRoute: BlogIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -2,12 +2,9 @@ import { Toaster } from '@repo/ui/components/sonner';
 import appCss from '@repo/ui/globals.css?url';
 import { createRootRoute, HeadContent, Scripts } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
-import { SITE_URL } from '#lib/site-url.ts';
+import { SITE_TITLE, SITE_URL } from '#lib/site.ts';
 import { themeScript } from '#lib/theme-script.ts';
 
-const TITLE = 'nibrun — drop your binary, get a server';
-const DESCRIPTION =
-  "Small apps don't need to scale. Drop a compiled binary and get a microVM of its own, a filesystem that persists, and an HTTPS URL. Export the binary and the whole disk whenever you want.";
 const OG_IMAGE = `${SITE_URL}/og.png`;
 
 export const Route = createRootRoute({
@@ -15,29 +12,20 @@ export const Route = createRootRoute({
     meta: [
       { charSet: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { title: TITLE },
-      { name: 'description', content: DESCRIPTION },
       { name: 'theme-color', media: '(prefers-color-scheme: dark)', content: '#0a1410' },
-      { property: 'og:type', content: 'website' },
-      { property: 'og:url', content: `${SITE_URL}/` },
       { property: 'og:site_name', content: 'nibrun' },
       { property: 'og:locale', content: 'en_US' },
-      { property: 'og:title', content: TITLE },
-      { property: 'og:description', content: DESCRIPTION },
       { property: 'og:image', content: OG_IMAGE },
       { property: 'og:image:type', content: 'image/png' },
       { property: 'og:image:width', content: '1200' },
       { property: 'og:image:height', content: '630' },
-      { property: 'og:image:alt', content: TITLE },
+      { property: 'og:image:alt', content: SITE_TITLE },
       { name: 'twitter:card', content: 'summary_large_image' },
-      { name: 'twitter:title', content: TITLE },
-      { name: 'twitter:description', content: DESCRIPTION },
       { name: 'twitter:image', content: OG_IMAGE },
-      { name: 'twitter:image:alt', content: TITLE },
+      { name: 'twitter:image:alt', content: SITE_TITLE },
     ],
     links: [
       { rel: 'stylesheet', href: appCss },
-      { rel: 'canonical', href: `${SITE_URL}/` },
       {
         rel: 'alternate',
         type: 'text/markdown',

--- a/apps/www/src/routes/blog/$slug.tsx
+++ b/apps/www/src/routes/blog/$slug.tsx
@@ -1,6 +1,9 @@
 import { Button } from '@repo/ui/components/button';
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { ArrowLeftIcon, FileTextIcon } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { CodeCopyButton } from '#components/code-copy-button.tsx';
 import { HomeLink } from '#components/home-link.tsx';
 import { PageBackdrop } from '#components/page-backdrop.tsx';
 import { SiteHeader } from '#components/site-header.tsx';
@@ -45,6 +48,47 @@ export const Route = createFileRoute('/blog/$slug')({
   component: RouteComponent,
 });
 
+type CodeBlock = { key: string; slot: Element; code: string };
+
+/**
+ * The article is one block of HTML, so the copy buttons cannot be written into it as components.
+ * They are portalled into the slots the renderer left behind instead, which keeps the clipboard
+ * behaviour in one place rather than reimplemented against the DOM. The slots are empty in the
+ * prerendered page and fill in on hydration; the space they take is already reserved.
+ */
+function ArticleBody({ post }: { post: BlogPost }) {
+  // Stable across renders, and not only to save the parse: React compares this prop by object
+  // identity, so a fresh one re-runs `innerHTML =` and replaces the very slots the portals below
+  // are pointed at — leaving the buttons mounted in nodes no longer on the page.
+  const content = useMemo(() => ({ __html: renderPost(post) }), [post]);
+  const body = useRef<HTMLDivElement>(null);
+  const [blocks, setBlocks] = useState<CodeBlock[]>([]);
+
+  useEffect(() => {
+    const collected: CodeBlock[] = [];
+    for (const slot of body.current?.querySelectorAll('[data-copy-slot]') ?? []) {
+      collected.push({
+        key: `code-block-${collected.length}`,
+        slot,
+        code: slot.parentElement?.querySelector('code')?.textContent ?? '',
+      });
+    }
+    setBlocks(collected);
+  }, []);
+
+  return (
+    <>
+      {/* The source is a file in this repo, written by us and compiled at build time. */}
+      <div
+        ref={body}
+        className="prose border-border/60 border-t pt-10"
+        dangerouslySetInnerHTML={content}
+      />
+      {blocks.map(({ key, slot, code }) => createPortal(<CodeCopyButton code={code} />, slot, key))}
+    </>
+  );
+}
+
 function markdownPath(post: BlogPost): string {
   return `${SITE_URL}/blog/${post.slug}.md`;
 }
@@ -83,11 +127,7 @@ function RouteComponent() {
               View markdown
             </Button>
           </header>
-          {/* The source is a file in this repo, written by us and compiled at build time. */}
-          <div
-            className="prose border-border/60 border-t pt-10"
-            dangerouslySetInnerHTML={{ __html: renderPost(post) }}
-          />
+          <ArticleBody post={post} />
         </article>
       </main>
     </>

--- a/apps/www/src/routes/blog/$slug.tsx
+++ b/apps/www/src/routes/blog/$slug.tsx
@@ -1,0 +1,95 @@
+import { Button } from '@repo/ui/components/button';
+import { createFileRoute, Link, notFound } from '@tanstack/react-router';
+import { ArrowLeftIcon, FileTextIcon } from 'lucide-react';
+import { HomeLink } from '#components/home-link.tsx';
+import { PageBackdrop } from '#components/page-backdrop.tsx';
+import { SiteHeader } from '#components/site-header.tsx';
+import { type BlogPost, findPost, formatPostDate, renderPost } from '#lib/blog.ts';
+import { pageHead } from '#lib/page-head.ts';
+import { SITE_URL } from '#lib/site.ts';
+import '#styles/prose.css';
+
+export const Route = createFileRoute('/blog/$slug')({
+  // Returns nothing: the post is already in the bundle, and handing it back would serialize the
+  // whole article into the page a second time, beside the HTML it was rendered into.
+  loader: ({ params }) => {
+    if (findPost(params.slug) === undefined) {
+      throw notFound();
+    }
+  },
+  head: ({ params }) => {
+    const post = findPost(params.slug);
+    if (post === undefined) {
+      return {};
+    }
+    const head = pageHead({
+      path: `/blog/${post.slug}`,
+      title: `${post.title} — nibrun`,
+      description: post.description,
+      publishedAt: post.date,
+    });
+
+    return {
+      ...head,
+      links: [
+        ...head.links,
+        {
+          rel: 'alternate',
+          type: 'text/markdown',
+          href: markdownPath(post),
+          title: 'This post in Markdown',
+        },
+      ],
+    };
+  },
+  component: RouteComponent,
+});
+
+function markdownPath(post: BlogPost): string {
+  return `${SITE_URL}/blog/${post.slug}.md`;
+}
+
+function RouteComponent() {
+  const { slug } = Route.useParams();
+  const post = findPost(slug);
+  if (post === undefined) {
+    return null;
+  }
+
+  return (
+    <>
+      <PageBackdrop />
+      <main className="mx-auto flex w-full max-w-3xl flex-col px-6">
+        <SiteHeader left={<HomeLink />} />
+        <article className="flex flex-col py-12 sm:py-16">
+          <Button variant="ghost" size="sm" className="self-start" render={<Link to="/blog" />}>
+            <ArrowLeftIcon data-icon="inline-start" />
+            All posts
+          </Button>
+          <header className="flex flex-col gap-4 py-8">
+            <time dateTime={post.date} className="text-muted-foreground text-sm">
+              {formatPostDate(post.date)}
+            </time>
+            <h1 className="text-balance font-semibold text-4xl tracking-tight">{post.title}</h1>
+            <p className="text-balance text-lg text-muted-foreground">{post.description}</p>
+            {/* Not a router link: the target is a file the worker hands back, not a route. */}
+            <Button
+              variant="outline"
+              size="sm"
+              className="self-start"
+              render={<a href={`/blog/${post.slug}.md`} />}
+            >
+              <FileTextIcon data-icon="inline-start" />
+              View markdown
+            </Button>
+          </header>
+          {/* The source is a file in this repo, written by us and compiled at build time. */}
+          <div
+            className="prose border-border/60 border-t pt-10"
+            dangerouslySetInnerHTML={{ __html: renderPost(post) }}
+          />
+        </article>
+      </main>
+    </>
+  );
+}

--- a/apps/www/src/routes/blog/$slug.tsx
+++ b/apps/www/src/routes/blog/$slug.tsx
@@ -4,6 +4,7 @@ import { ArrowLeftIcon, FileTextIcon } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { CodeCopyButton } from '#components/code-copy-button.tsx';
+import { DeployCta } from '#components/deploy-cta.tsx';
 import { HomeLink } from '#components/home-link.tsx';
 import { PageBackdrop } from '#components/page-backdrop.tsx';
 import { SiteHeader } from '#components/site-header.tsx';
@@ -129,6 +130,7 @@ function RouteComponent() {
           </header>
           <ArticleBody post={post} />
         </article>
+        <DeployCta />
       </main>
     </>
   );

--- a/apps/www/src/routes/blog/index.tsx
+++ b/apps/www/src/routes/blog/index.tsx
@@ -6,8 +6,7 @@ import { formatPostDate, POSTS } from '#lib/blog.ts';
 import { pageHead } from '#lib/page-head.ts';
 
 const TITLE = 'Blog — nibrun';
-const DESCRIPTION =
-  'What running one binary on one machine is actually like, and how it compares to the alternatives.';
+const DESCRIPTION = "Notes on small apps, single binaries, and the infrastructure they don't need.";
 
 export const Route = createFileRoute('/blog/')({
   head: () => pageHead({ path: '/blog', title: TITLE, description: DESCRIPTION }),

--- a/apps/www/src/routes/blog/index.tsx
+++ b/apps/www/src/routes/blog/index.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { HomeLink } from '#components/home-link.tsx';
+import { PageBackdrop } from '#components/page-backdrop.tsx';
+import { SiteHeader } from '#components/site-header.tsx';
+import { formatPostDate, POSTS } from '#lib/blog.ts';
+import { pageHead } from '#lib/page-head.ts';
+
+const TITLE = 'Blog — nibrun';
+const DESCRIPTION =
+  'What running one binary on one machine is actually like, and how it compares to the alternatives.';
+
+export const Route = createFileRoute('/blog/')({
+  head: () => pageHead({ path: '/blog', title: TITLE, description: DESCRIPTION }),
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return (
+    <>
+      <PageBackdrop />
+      <main className="mx-auto flex w-full max-w-3xl flex-col px-6">
+        <SiteHeader left={<HomeLink />} />
+        <div className="flex flex-col gap-3 py-12 sm:py-16">
+          <h1 className="font-semibold text-4xl tracking-tight">Blog</h1>
+          <p className="text-balance text-lg text-muted-foreground">{DESCRIPTION}</p>
+        </div>
+        <ul className="flex flex-col border-border/60 border-t">
+          {POSTS.map((post) => (
+            <li key={post.slug}>
+              <Link
+                to="/blog/$slug"
+                params={{ slug: post.slug }}
+                className="group flex flex-col gap-2 border-border/60 border-b py-8 transition-colors hover:bg-muted/40"
+              >
+                <time dateTime={post.date} className="text-muted-foreground text-sm">
+                  {formatPostDate(post.date)}
+                </time>
+                <h2 className="text-pretty font-medium text-xl tracking-tight group-hover:text-primary">
+                  {post.title}
+                </h2>
+                <p className="text-pretty text-muted-foreground">{post.description}</p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </>
+  );
+}

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -1,26 +1,27 @@
 import { BrandMark } from '@repo/ui/custom/brand-mark';
 import { createFileRoute } from '@tanstack/react-router';
 import { BinaryDrop } from '#components/binary-drop.tsx';
-import { DashboardLink } from '#components/dashboard-link.tsx';
 import { DeployCta } from '#components/deploy-cta.tsx';
 import { GetStartedHint } from '#components/get-started-hint.tsx';
-import { GithubLink } from '#components/github-link.tsx';
 import { Hero } from '#components/hero.tsx';
 import { PageBackdrop } from '#components/page-backdrop.tsx';
+import { SiteHeader } from '#components/site-header.tsx';
 import { TryItOut } from '#components/try-it-out.tsx';
 import { WhatItActuallyNeeds } from '#components/what-it-actually-needs.tsx';
+import { pageHead } from '#lib/page-head.ts';
+import { SITE_DESCRIPTION, SITE_TITLE } from '#lib/site.ts';
 
-export const Route = createFileRoute('/')({ component: RouteComponent });
+export const Route = createFileRoute('/')({
+  head: () => pageHead({ path: '/', title: SITE_TITLE, description: SITE_DESCRIPTION }),
+  component: RouteComponent,
+});
 
 function RouteComponent() {
   return (
     <>
       <PageBackdrop />
       <main className="mx-auto flex w-full max-w-5xl flex-col items-center px-6">
-        <header className="flex w-full items-center justify-end gap-1 py-5">
-          <GithubLink />
-          <DashboardLink />
-        </header>
+        <SiteHeader />
         {/* Short of the viewport on purpose: the section below has to peek, or nobody scrolls. */}
         <section className="flex min-h-[78svh] w-full max-w-xl flex-col items-center justify-center gap-12 pb-16">
           <div className="flex flex-col items-center gap-6">

--- a/apps/www/src/server.ts
+++ b/apps/www/src/server.ts
@@ -1,9 +1,10 @@
 import { createStartHandler, defaultStreamHandler } from '@tanstack/react-start/server';
+import { markdownResponse } from '#lib/blog-markdown.ts';
 
 const startFetch = createStartHandler(defaultStreamHandler);
 
 export default {
   fetch(request) {
-    return startFetch(request);
+    return markdownResponse(request) ?? startFetch(request);
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/www/src/styles/prose.css
+++ b/apps/www/src/styles/prose.css
@@ -82,6 +82,17 @@
   font-size: 0.9em;
 }
 
+.prose .code-block {
+  position: relative;
+  margin-block: 1.25rem;
+}
+
+.prose .code-block pre {
+  margin-block: 0;
+  /* Room kept for the copy button, which sits over the block while the code scrolls under it. */
+  padding-inline-end: 3.5rem;
+}
+
 .prose pre {
   border: 1px solid var(--border);
   border-radius: calc(var(--radius) / 2);

--- a/apps/www/src/styles/prose.css
+++ b/apps/www/src/styles/prose.css
@@ -1,0 +1,140 @@
+/* Tailwind's reset strips every default the browser gives an article — heading sizes, list
+   markers, paragraph margins. Markdown emits exactly those bare tags, so without this a post
+   renders as one undifferentiated block of body text. Written against the shadcn variables
+   rather than utilities, because the HTML comes from `marked` and carries no classes. */
+
+.prose {
+  color: var(--foreground);
+  line-height: 1.75;
+  overflow-wrap: break-word;
+}
+
+.prose > :first-child {
+  margin-block-start: 0;
+}
+
+.prose > :last-child {
+  margin-block-end: 0;
+}
+
+.prose p,
+.prose ul,
+.prose ol,
+.prose pre,
+.prose blockquote,
+.prose table {
+  margin-block: 1.25rem;
+}
+
+.prose h2 {
+  margin-block: 3rem 1rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+}
+
+.prose h3 {
+  margin-block: 2rem 0.75rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.prose a {
+  color: var(--primary);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.prose a:hover {
+  text-decoration-thickness: 2px;
+}
+
+.prose ul,
+.prose ol {
+  padding-inline-start: 1.5rem;
+}
+
+.prose ul {
+  list-style: disc;
+}
+
+.prose ol {
+  list-style: decimal;
+}
+
+.prose li {
+  margin-block: 0.5rem;
+}
+
+.prose li::marker {
+  color: var(--muted-foreground);
+}
+
+.prose strong {
+  font-weight: 600;
+}
+
+.prose code {
+  border-radius: calc(var(--radius) / 6);
+  background: var(--muted);
+  padding: 0.125em 0.375em;
+  font-size: 0.9em;
+}
+
+.prose pre {
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) / 2);
+  background: var(--muted);
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  line-height: 1.6;
+}
+
+.prose pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.875rem;
+}
+
+.prose blockquote {
+  border-inline-start: 2px solid var(--border);
+  padding-inline-start: 1rem;
+  color: var(--muted-foreground);
+}
+
+.prose hr {
+  margin-block: 3rem;
+  border: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+/* A block, so a table too wide for the column scrolls itself. As a table it would stretch the
+   article instead, and the page would scroll sideways around the paragraphs too. */
+.prose table {
+  display: block;
+  border-collapse: collapse;
+  overflow-x: auto;
+  font-size: 0.9375rem;
+}
+
+.prose th,
+.prose td {
+  border-block-end: 1px solid var(--border);
+  padding: 0.625rem 0.75rem;
+  text-align: start;
+  vertical-align: top;
+}
+
+.prose th {
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.prose img {
+  border-radius: calc(var(--radius) / 2);
+  max-width: 100%;
+  height: auto;
+}

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -12,7 +12,16 @@ const config = defineConfig({
   plugins: [
     cloudflare({ viteEnvironment: { name: 'ssr' } }),
     tailwindcss(),
-    tanstackStart({ prerender: { enabled: true } }),
+    tanstackStart({
+      prerender: {
+        enabled: true,
+        // The crawler follows every root-relative `<a href>` it renders, which includes each
+        // post's "View markdown" link. Prerendered, those would become static assets typed by
+        // extension rather than by us — so they are left to the worker, which serves them as
+        // `text/markdown`.
+        filter: (page) => !page.path.endsWith('.md'),
+      },
+    }),
     viteReact(),
   ],
 });

--- a/apps/www/wrangler.jsonc
+++ b/apps/www/wrangler.jsonc
@@ -9,7 +9,11 @@
     "head_sampling_rate": 1
   },
   "assets": {
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    // Default is `auto-trailing-slash`, which answers /blog by redirecting to /blog/ — a URL
+    // that is not the one the page names as its canonical. Dropping it instead makes the two
+    // agree, so the address that gets shared is the address that gets served.
+    "html_handling": "drop-trailing-slash"
   },
   "env": {
     // Wrangler derives `nibrun-www-preview` from the environment name and would deploy a

--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
         "@tanstack/react-router": "catalog:",
         "@tanstack/react-start": "^1.168.46",
         "lucide-react": "catalog:",
+        "marked": "^18.0.11",
         "react": "catalog:",
         "react-dom": "catalog:",
         "tailwindcss": "catalog:",
@@ -141,7 +142,7 @@
     },
     "packages/cli": {
       "name": "@repo/cli",
-      "version": "2026.8.21-1",
+      "version": "2026.8.25-1",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
         "@parshjs/core": "^0.0.10",
@@ -1403,6 +1404,8 @@
     "lucide-react": ["lucide-react@1.28.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@18.0.11", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 


### PR DESCRIPTION
A `/blog` index and post pages in `apps/www`, with the first article on deploying PocketBase.

Posts are markdown files under `src/content/blog/`, edited in the repo. Each one also answers at its own URL with `.md` on the end — the worker serves that file verbatim, so a "View markdown" button on every post shows exactly what is in the tree.

Two supporting changes came out of it: the root route's canonical and `og:url` moved into the routes themselves, because the router renders every `link` a match contributes and two canonicals would both have shipped; and asset `html_handling` is now `drop-trailing-slash`, so the URL a page names as canonical is the one that gets served without a redirect.