### PR TITLE
fix(dashboard): a stored variable claims nothing about who can read it

### DIFF
--- a/apps/dashboard/src/components/apps/deploy-environment-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-environment-field.tsx
@@ -50,5 +50,5 @@ function describeEnvironment(replacing: AppSummary | undefined): string {
   if (replacing === undefined) {
     return 'What the binary runs with.';
   }
-  return 'What the binary runs with. A value already set can be replaced but never read back, and a row removed here is a variable the app stops running with.';
+  return 'What the binary runs with. A value already set can be replaced, and a row removed here is a variable the app stops running with.';
 }

--- a/apps/dashboard/src/components/apps/environment-row.tsx
+++ b/apps/dashboard/src/components/apps/environment-row.tsx
@@ -9,9 +9,8 @@ import type { EnvironmentVariable } from '#lib/environment-variables.ts';
 const HIDDEN_VALUE = '••••••••••••';
 
 const SEALED = {
-  title: 'Sealed',
-  description:
-    'This value was encrypted when it was set, and nothing here can read it back — not this page, and not nibrun. Replacing it is the only way to change what the app runs with.',
+  title: 'Already set',
+  description: 'Replacing it is the only way to change what the app runs with.',
 };
 
 // A row is one line high, so a value with more than one in it can be carried and sent but never


### PR DESCRIPTION
The environment table told owners a stored value was encrypted and that nothing could read it back, "not this page, and not nibrun". The app host and the tenant decrypt it to run the app, so that was never true.

The copy now says only what an owner can do about the value, without explaining why it isn't shown. The CLI, www and docs make no such claim.