### PR TITLE
fix(infra): guests reach the internet, and a denial fails fast

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -72,10 +72,12 @@ Owned by `infra/app-host/`, not fixable here.
   way to do this over the socket the agent already uses.
 - **`iproute2`, `nftables`, `nbd-client`, `e2fsprogs`, `squashfs-tools`.** Each is a subprocess the
   agent shells out to, and nothing installs any of them.
-- **`net.ipv4.ip_forward=1`**, and a base `FORWARD` policy of `ACCEPT`. The agent owns
-  `table ip nibrun` and expresses isolation as `drop` rules, which are final wherever they appear;
-  its `accept` rules only end its own chain, so it composes with a coexisting ruleset but cannot
-  open one that is closed.
+- **A base `FORWARD` policy of `ACCEPT`.** The agent owns `table ip nibrun` and expresses isolation
+  as `reject` rules, which are final wherever they appear; its `accept` rules only end its own
+  chain, so it composes with a coexisting ruleset but cannot open one that is closed. The other
+  half of a guest reaching the internet, `net.ipv4.ip_forward=1`, *is* provided — by
+  `infra/app-host/deploy/on_box_deploy.sh`, and without it the kernel discards a guest's packets
+  before any of these rules is consulted.
 - **A tracer.** The agent names its spans — every reconcile phase, subprocess and control-plane
   request — and nothing collects them, so they go nowhere. Where they are exported to is a
   deployment decision, not one the binary should hold.

--- a/apps/agent/src/lib/network/firewall.ts
+++ b/apps/agent/src/lib/network/firewall.ts
@@ -25,6 +25,16 @@ const PRIVATE_DESTINATIONS_V6 = ['::1/128', 'fe80::/10', 'fc00::/7'] as const;
 const CHAIN_INDENT = '  ';
 const RULE_INDENT = '    ';
 
+/**
+ * One verdict for every isolation rule, so none of them can silently be the odd one out.
+ *
+ * `reject` rather than `drop`: a dropped packet is indistinguishable from a slow one, so a tenant
+ * reaching a denied address waits out its own timeout with nothing logged — and on a one-vCPU
+ * guest one stuck call is enough to starve a runtime's IO threads. Staying silent hides only that
+ * a filter exists, which the addresses a guest cannot reach already tell it.
+ */
+const DENY = 'reject';
+
 export type ForwardedInstance = {
   readonly hostPort: HostPort;
   readonly guestPort: GuestPort;
@@ -80,13 +90,13 @@ function forwardChainV4({ controlPlaneCidrsV4 }: FirewallState): string[] {
     rules: [
       'type filter hook forward priority filter; policy accept;',
       'ct state established,related accept',
-      `iifname ${TAP_MATCH} ip daddr ${INSTANCE_METADATA_ADDRESS_V4} drop comment "instance metadata endpoint"`,
-      `iifname ${TAP_MATCH} oifname ${TAP_MATCH} drop comment "guest to guest"`,
-      `iifname ${TAP_MATCH} ip daddr ${GUEST_NETWORK_CIDR} drop comment "guest to guest"`,
+      `iifname ${TAP_MATCH} ip daddr ${INSTANCE_METADATA_ADDRESS_V4} ${DENY} comment "instance metadata endpoint"`,
+      `iifname ${TAP_MATCH} oifname ${TAP_MATCH} ${DENY} comment "guest to guest"`,
+      `iifname ${TAP_MATCH} ip daddr ${GUEST_NETWORK_CIDR} ${DENY} comment "guest to guest"`,
       ...controlPlaneCidrsV4.map(
-        (cidr) => `iifname ${TAP_MATCH} ip daddr ${cidr} drop comment "control plane"`,
+        (cidr) => `iifname ${TAP_MATCH} ip daddr ${cidr} ${DENY} comment "control plane"`,
       ),
-      `iifname ${TAP_MATCH} ip daddr ${set(PRIVATE_DESTINATIONS_V4)} drop comment "private destinations"`,
+      `iifname ${TAP_MATCH} ip daddr ${set(PRIVATE_DESTINATIONS_V4)} ${DENY} comment "private destinations"`,
     ],
   });
 }
@@ -98,7 +108,7 @@ function inputChainV4(): string[] {
     rules: [
       'type filter hook input priority filter; policy accept;',
       `iifname ${TAP_MATCH} ct state established,related accept`,
-      `iifname ${TAP_MATCH} drop comment "guest to host"`,
+      `iifname ${TAP_MATCH} ${DENY} comment "guest to host"`,
     ],
   });
 }
@@ -110,12 +120,12 @@ function forwardChainV6({ controlPlaneCidrsV6 }: FirewallState): string[] {
     rules: [
       'type filter hook forward priority filter; policy accept;',
       'ct state established,related accept',
-      `iifname ${TAP_MATCH} ip6 daddr ${INSTANCE_METADATA_ADDRESS_V6} drop comment "instance metadata endpoint"`,
-      `iifname ${TAP_MATCH} oifname ${TAP_MATCH} drop comment "guest to guest"`,
+      `iifname ${TAP_MATCH} ip6 daddr ${INSTANCE_METADATA_ADDRESS_V6} ${DENY} comment "instance metadata endpoint"`,
+      `iifname ${TAP_MATCH} oifname ${TAP_MATCH} ${DENY} comment "guest to guest"`,
       ...controlPlaneCidrsV6.map(
-        (cidr) => `iifname ${TAP_MATCH} ip6 daddr ${cidr} drop comment "control plane"`,
+        (cidr) => `iifname ${TAP_MATCH} ip6 daddr ${cidr} ${DENY} comment "control plane"`,
       ),
-      `iifname ${TAP_MATCH} ip6 daddr ${set(PRIVATE_DESTINATIONS_V6)} drop comment "private destinations"`,
+      `iifname ${TAP_MATCH} ip6 daddr ${set(PRIVATE_DESTINATIONS_V6)} ${DENY} comment "private destinations"`,
     ],
   });
 }
@@ -126,7 +136,7 @@ function inputChainV6(): string[] {
     rules: [
       'type filter hook input priority filter; policy accept;',
       `iifname ${TAP_MATCH} ct state established,related accept`,
-      `iifname ${TAP_MATCH} drop comment "guest to host"`,
+      `iifname ${TAP_MATCH} ${DENY} comment "guest to host"`,
     ],
   });
 }

--- a/apps/agent/tests/lib/network/firewall.test.ts
+++ b/apps/agent/tests/lib/network/firewall.test.ts
@@ -30,28 +30,28 @@ function state(overrides: Partial<FirewallState> = {}): FirewallState {
   };
 }
 
-function dropsFrom(ruleset: string) {
+function refusalsFrom(ruleset: string) {
   return ruleset
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line.endsWith('drop') || line.includes('drop comment'));
+    .filter((line) => line.includes(' reject'));
 }
 
 describe('the three isolation rules are never optional', () => {
   test('guests cannot reach the instance metadata endpoint, with no instances configured', () => {
-    const drops = dropsFrom(renderRuleset(state()));
-    expect(drops.some((line) => line.includes(INSTANCE_METADATA_ADDRESS_V4))).toBe(true);
+    const refusals = refusalsFrom(renderRuleset(state()));
+    expect(refusals.some((line) => line.includes(INSTANCE_METADATA_ADDRESS_V4))).toBe(true);
   });
 
   test('guests cannot reach each other', () => {
-    const drops = dropsFrom(renderRuleset(state({ instances: [instance] })));
-    expect(drops.some((line) => line.includes('guest to guest'))).toBe(true);
-    expect(drops.some((line) => line.includes('10.201.0.0/16'))).toBe(true);
+    const refusals = refusalsFrom(renderRuleset(state({ instances: [instance] })));
+    expect(refusals.some((line) => line.includes('guest to guest'))).toBe(true);
+    expect(refusals.some((line) => line.includes('10.201.0.0/16'))).toBe(true);
   });
 
   test('guests cannot reach the control plane', () => {
     const ruleset = renderRuleset(state({ controlPlaneCidrsV4: ['203.0.113.10/32'] }));
-    expect(dropsFrom(ruleset).some((line) => line.includes('203.0.113.10/32'))).toBe(true);
+    expect(refusalsFrom(ruleset).some((line) => line.includes('203.0.113.10/32'))).toBe(true);
   });
 
   // The api's internal routes are reachable from this host and from nowhere else, so a tenant
@@ -60,7 +60,7 @@ describe('the three isolation rules are never optional', () => {
   test('a guest cannot reach the control plane before it is allowed out', () => {
     const vpc = '10.43.0.0/16';
     const lines = renderRuleset(state({ controlPlaneCidrsV4: [vpc] })).split('\n');
-    const denied = lines.findIndex((line) => line.includes(vpc) && line.includes('drop'));
+    const denied = lines.findIndex((line) => line.includes(vpc) && line.includes('reject'));
     const allowedOut = lines.findIndex((line) => line.includes('masquerade'));
 
     expect(denied).toBeGreaterThan(-1);
@@ -68,16 +68,31 @@ describe('the three isolation rules are never optional', () => {
   });
 
   test('every private destination is denied, not only the ones enumerated', () => {
-    const drops = dropsFrom(renderRuleset(state())).join('\n');
+    const refusals = refusalsFrom(renderRuleset(state())).join('\n');
     for (const cidr of ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', '169.254.0.0/16']) {
-      expect(drops).toContain(cidr);
+      expect(refusals).toContain(cidr);
     }
   });
 
   test('guests cannot reach services on the host itself', () => {
-    expect(dropsFrom(renderRuleset(state())).some((line) => line.includes('guest to host'))).toBe(
-      true,
+    expect(
+      refusalsFrom(renderRuleset(state())).some((line) => line.includes('guest to host')),
+    ).toBe(true);
+  });
+
+  // A tenant hitting a denied address gets an error its socket reports at once, rather than a
+  // silence it spends its own timeout on and logs nothing about. One `drop` anywhere in either
+  // table is one denial that reaches an app as an unexplained stall.
+  test('nothing is denied silently, in either family', () => {
+    const ruleset = renderRuleset(
+      state({
+        instances: [instance],
+        controlPlaneCidrsV4: ['10.43.0.0/16'],
+        controlPlaneCidrsV6: ['2600:1f18:abcd::/56'],
+      }),
     );
+
+    expect(ruleset).not.toContain('drop');
   });
 });
 
@@ -111,7 +126,7 @@ describe('the same isolation holds over ipv6', () => {
   });
 
   // AWS allocates a VPC's IPv6 from global unicast, so `fc00::/7` does not contain it. Where the
-  // v4 control-plane rule is belt-and-braces over the blanket private drop, this one is the only
+  // v4 control-plane rule is belt-and-braces over the blanket private refusal, this one is the only
   // thing denying the control plane — a v6 ruleset without it reads it as ordinary internet.
   test('the vpc v6 range is denied by name, since no blanket rule contains it', () => {
     const vpcV6 = '2600:1f18:abcd::/56';
@@ -119,7 +134,7 @@ describe('the same isolation holds over ipv6', () => {
       `table ip6 ${NFTABLES_TABLE} {`,
     )[1];
 
-    expect(v6).toContain(`ip6 daddr ${vpcV6} drop`);
+    expect(v6).toContain(`ip6 daddr ${vpcV6} reject`);
     // Named, rather than swept up by a private-range rule that does not cover it.
     expect(PRIVATE_DESTINATIONS_V6_SAMPLE.some((range) => vpcV6.startsWith(range))).toBe(false);
   });

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -232,6 +232,25 @@ changed_file() {
   return 0
 }
 
+# A guest reaches the internet through this host: its default route is the tap,
+# and the agent's ruleset masquerades what leaves. Without forwarding the kernel
+# discards those packets before a single rule is consulted, and discards them
+# silently — so a tenant's outbound call hangs to its own timeout rather than
+# failing, with nothing anywhere saying why.
+#
+# Not in user_data, which only runs on a host being created: this has to reach
+# the fleet already running as well. Numbered so it wins over anything AL2023
+# ships under a lower prefix.
+cat > /etc/sysctl.d/99-nibrun.conf.new <<'EOF'
+net.ipv4.ip_forward = 1
+EOF
+chmod 0644 /etc/sysctl.d/99-nibrun.conf.new
+changed_file /etc/sysctl.d/99-nibrun.conf && log "Guest egress forwarding enabled" || true
+# Applied every deploy rather than only when the file moved: what forwards a
+# packet is the running kernel, and the file only decides what the next boot
+# starts from. Setting a value the kernel already holds does nothing.
+sysctl -q -p /etc/sysctl.d/99-nibrun.conf
+
 cat > /etc/zerofs/zerofs.env.new <<EOF
 NIBRUN_FILESYSTEMS_URL=${NIBRUN_FILESYSTEMS_URL}
 NIBRUN_FILESYSTEMS_PASSWORD=$(secret filesystems_encryption_password)


### PR DESCRIPTION
Closes #282.

Nothing on an app host set `net.ipv4.ip_forward`, so the kernel discarded a guest's packets before the forward hook ran — the ruleset was never the problem. It goes in `on_box_deploy.sh` rather than `user_data`, which only runs on a host being created: this has to reach the fleet already running, without replacing it.

The second half of the issue: every isolation rule now refuses rather than drops, so the destinations that stay denied by design reach an app as an error rather than as a hang.

Verified by loading the rendered ruleset into the AMI's `nft` (1.0.4) in a privileged `amazonlinux:2023` container, with a veth pair named `nbr0` standing in for a tap:

```
=== ip_forward=0 ===                       === ip_forward=1 ===
  public tcp 1.1.1.1:443    8063ms           public tcp 1.1.1.1:443     103ms  connected
  denied 192.168.1.1:443    8069ms           denied 192.168.1.1:443    1151ms  Connection refused
  denied 169.254.169.254    8071ms           denied 169.254.169.254    1104ms  Connection refused
```

The ICMP unreachable is on the wire in 0.7ms; the ~1.1s is the guest's TCP stack ignoring the first one on a `SYN_SENT` socket and waiting for a SYN retransmit. UDP has no such guard.

Not covered: the container's kernel is not an EC2 AL2023 host, so this proves the rules and the sysctl but not the Firecracker tap path. IPv6 egress is unchanged — the guest's `ip=` cmdline is v4-only, so it has no global v6 address and there is nothing to forward.