### PR TITLE
feat(app-operations): a failed app's files say so rather than asking a host

### DIFF
--- a/apps/dashboard/src/components/files/directory-browser.tsx
+++ b/apps/dashboard/src/components/files/directory-browser.tsx
@@ -1,21 +1,18 @@
 import { DirectoryListing } from '#components/files/directory-listing.tsx';
 import { SuspendedFilesystem } from '#components/files/suspended-filesystem.tsx';
-import { useApp } from '#lib/hooks/use-app.ts';
+import { UnreadableFilesystem } from '#components/files/unreadable-filesystem.tsx';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
+import { useFilesystemAvailability } from '#lib/hooks/use-filesystem-availability.ts';
 
-/**
- * A directory is read inside the microVM that has the volume mounted, so a suspended app has
- * nothing to answer with and a browse can only fail. Said here rather than waited for, because
- * what a host reports for this is deliberately vague — a directory that could not be read is the
- * same sentence whether the app is down or the device is broken.
- *
- * Read off the app row rather than the release: an app whose microVM has not stopped yet is one
- * that is about to, and offering a browse for the seconds it has left is worse than saying it is
- * suspended a moment early.
- */
 export function DirectoryBrowser() {
-  const appId = useAppId();
-  const app = useApp(appId);
+  const availability = useFilesystemAvailability(useAppId());
 
-  return app.data?.state === 'suspended' ? <SuspendedFilesystem /> : <DirectoryListing />;
+  switch (availability.kind) {
+    case 'suspended':
+      return <SuspendedFilesystem />;
+    case 'unreadable':
+      return <UnreadableFilesystem reason={availability.reason} />;
+    case 'browsable':
+      return <DirectoryListing />;
+  }
 }

--- a/apps/dashboard/src/components/files/unreadable-filesystem.tsx
+++ b/apps/dashboard/src/components/files/unreadable-filesystem.tsx
@@ -1,0 +1,31 @@
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@repo/ui/components/empty';
+import { TriangleAlertIcon } from 'lucide-react';
+
+/**
+ * The release's own account of why it never came up is repeated verbatim: it names the port
+ * nothing answered on and how long it was given, which is the whole of what turns "no files here"
+ * into something an owner can fix.
+ */
+export function UnreadableFilesystem({ reason }: { reason: string }) {
+  return (
+    <Empty className="border">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <TriangleAlertIcon />
+        </EmptyMedia>
+        <EmptyTitle>This app is not running</EmptyTitle>
+        <EmptyDescription>
+          Its files are read from inside the microVM that has them mounted, and a release that
+          failed never got one. Nothing has left the volume — deploy again to browse it.
+        </EmptyDescription>
+        <EmptyDescription className="font-mono text-xs">{reason}</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}

--- a/apps/dashboard/src/lib/hooks/use-deployment-logs.ts
+++ b/apps/dashboard/src/lib/hooks/use-deployment-logs.ts
@@ -1,7 +1,7 @@
 import type { TenantLogRecord } from '@repo/protocol';
 import { useQuery } from '@tanstack/react-query';
-import { useLatestDeployment } from '#lib/hooks/use-latest-deployment.ts';
 import { useLogTimerange } from '#lib/hooks/use-log-timerange.ts';
+import { useNewestDeployment } from '#lib/hooks/use-newest-deployment.ts';
 import { deploymentLogsQueryOptions } from '#queries/logs.ts';
 
 export type DeploymentLogsView = {
@@ -12,14 +12,14 @@ export type DeploymentLogsView = {
 };
 
 export function useDeploymentLogs(appId: string): DeploymentLogsView {
-  const latest = useLatestDeployment(appId);
-  const deploymentId = latest.data;
+  const newest = useNewestDeployment(appId);
+  const deploymentId = newest.data?.id;
   const timerange = useLogTimerange();
   const logs = useQuery(deploymentLogsQueryOptions({ appId, deploymentId, timerange }));
   const records = logs.data ?? [];
 
-  if (latest.isError) {
-    return { status: 'failed', records, deploymentId: undefined, reason: latest.error.message };
+  if (newest.isError) {
+    return { status: 'failed', records, deploymentId: undefined, reason: newest.error.message };
   }
   if (logs.isError) {
     return { status: 'failed', records, deploymentId, reason: logs.error.message };

--- a/apps/dashboard/src/lib/hooks/use-directory-listing.ts
+++ b/apps/dashboard/src/lib/hooks/use-directory-listing.ts
@@ -1,7 +1,7 @@
 import { guestPath } from '@repo/app-operations';
 import type { DirectoryListing, GuestPath } from '@repo/protocol';
 import { useQuery } from '@tanstack/react-query';
-import { useLatestDeployment } from '#lib/hooks/use-latest-deployment.ts';
+import { useNewestDeployment } from '#lib/hooks/use-newest-deployment.ts';
 import { directoryQueryOptions } from '#queries/filesystem.ts';
 
 export type DirectoryListingView = {
@@ -20,10 +20,10 @@ export function useDirectoryListing({
   appId,
   typedPath,
 }: DirectoryListingInput): DirectoryListingView {
-  const latest = useLatestDeployment(appId);
+  const newest = useNewestDeployment(appId);
   const parsed = parsePath(typedPath);
   const listing = useQuery(
-    directoryQueryOptions({ appId, deploymentId: latest.data, path: parsed.path }),
+    directoryQueryOptions({ appId, deploymentId: newest.data?.id, path: parsed.path }),
   );
 
   if (parsed.reason !== undefined) {
@@ -34,19 +34,19 @@ export function useDirectoryListing({
       reason: parsed.reason,
     };
   }
-  if (latest.isError) {
+  if (newest.isError) {
     return {
       status: 'failed',
       listing: undefined,
       deploymentId: undefined,
-      reason: latest.error.message,
+      reason: newest.error.message,
     };
   }
   if (listing.isError) {
     return {
       status: 'failed',
       listing: undefined,
-      deploymentId: latest.data,
+      deploymentId: newest.data?.id,
       reason: listing.error.message,
     };
   }
@@ -54,14 +54,14 @@ export function useDirectoryListing({
     return {
       status: 'loading',
       listing: undefined,
-      deploymentId: latest.data,
+      deploymentId: newest.data?.id,
       reason: undefined,
     };
   }
   return {
     status: 'ready',
     listing: listing.data,
-    deploymentId: latest.data,
+    deploymentId: newest.data?.id,
     reason: undefined,
   };
 }

--- a/apps/dashboard/src/lib/hooks/use-directory-refresh.ts
+++ b/apps/dashboard/src/lib/hooks/use-directory-refresh.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
-import { latestDeploymentQueryOptions } from '#queries/deployments.ts';
+import { newestDeploymentQueryOptions } from '#queries/deployments.ts';
 import { filesystemQueryKey } from '#queries/filesystem.ts';
 
 export type DirectoryRefresh = {
@@ -18,7 +18,7 @@ export function useDirectoryRefresh(): DirectoryRefresh {
   const refreshing = useMutation({
     mutationFn: async () => {
       await queryClient.invalidateQueries({
-        queryKey: latestDeploymentQueryOptions(appId).queryKey,
+        queryKey: newestDeploymentQueryOptions(appId).queryKey,
       });
       await queryClient.invalidateQueries({ queryKey: filesystemQueryKey(appId) });
     },

--- a/apps/dashboard/src/lib/hooks/use-filesystem-availability.ts
+++ b/apps/dashboard/src/lib/hooks/use-filesystem-availability.ts
@@ -1,0 +1,39 @@
+import { describeUnreadableFilesystem } from '@repo/app-operations';
+import { useApp } from '#lib/hooks/use-app.ts';
+import { useNewestDeployment } from '#lib/hooks/use-newest-deployment.ts';
+
+/**
+ * Whether an app's files can be browsed at all, and what stands in their place when they cannot.
+ *
+ * `browsable` is also what a page waiting on either answer gets: neither reason is known until the
+ * app and its release have been read, and a browse that has not started yet says so for itself.
+ */
+export type FilesystemAvailability =
+  | { readonly kind: 'browsable' }
+  | { readonly kind: 'suspended' }
+  | { readonly kind: 'unreadable'; readonly reason: string };
+
+const BROWSABLE: FilesystemAvailability = { kind: 'browsable' };
+const SUSPENDED: FilesystemAvailability = { kind: 'suspended' };
+
+/**
+ * A directory is read inside the microVM that has the volume mounted, so an app running none has
+ * nothing to answer a browse with. Decided here rather than waited for, because what a host
+ * reports for this is deliberately vague — a directory that could not be read is the same sentence
+ * whether the app is down or the device is broken — while the release that never came up kept the
+ * reason it didn't.
+ *
+ * Suspension is read off the app row rather than the release: an app whose microVM has not stopped
+ * yet is one that is about to, and offering a browse for the seconds it has left is worse than
+ * saying it is suspended a moment early.
+ */
+export function useFilesystemAvailability(appId: string): FilesystemAvailability {
+  const app = useApp(appId);
+  const newest = useNewestDeployment(appId);
+
+  if (app.data?.state === 'suspended') {
+    return SUSPENDED;
+  }
+  const reason = newest.data === undefined ? undefined : describeUnreadableFilesystem(newest.data);
+  return reason === undefined ? BROWSABLE : { kind: 'unreadable', reason };
+}

--- a/apps/dashboard/src/lib/hooks/use-latest-deployment.ts
+++ b/apps/dashboard/src/lib/hooks/use-latest-deployment.ts
@@ -1,6 +1,0 @@
-import { type UseQueryResult, useQuery } from '@tanstack/react-query';
-import { latestDeploymentQueryOptions } from '#queries/deployments.ts';
-
-export function useLatestDeployment(appId: string): UseQueryResult<string, Error> {
-  return useQuery(latestDeploymentQueryOptions(appId));
-}

--- a/apps/dashboard/src/lib/hooks/use-newest-deployment.ts
+++ b/apps/dashboard/src/lib/hooks/use-newest-deployment.ts
@@ -1,0 +1,6 @@
+import { type UseQueryResult, useQuery } from '@tanstack/react-query';
+import { type DeploymentSummary, newestDeploymentQueryOptions } from '#queries/deployments.ts';
+
+export function useNewestDeployment(appId: string): UseQueryResult<DeploymentSummary, Error> {
+  return useQuery(newestDeploymentQueryOptions(appId));
+}

--- a/apps/dashboard/src/queries/deployments.ts
+++ b/apps/dashboard/src/queries/deployments.ts
@@ -1,5 +1,5 @@
 import { unwrap } from '@repo/api-client/unwrap';
-import { latestDeployment } from '@repo/app-operations';
+import { newestDeployment } from '@repo/app-operations';
 import { queryOptions, skipToken } from '@tanstack/react-query';
 import { api } from '#lib/api.ts';
 
@@ -16,9 +16,9 @@ export function deploymentsQueryOptions(appId: string | undefined) {
   });
 }
 
-export function latestDeploymentQueryOptions(appId: string) {
+export function newestDeploymentQueryOptions(appId: string) {
   return queryOptions({
-    queryKey: ['deployments', appId, 'latest'],
-    queryFn: () => latestDeployment({ api, appId }),
+    queryKey: ['deployments', appId, 'newest'],
+    queryFn: () => newestDeployment({ api, appId }),
   });
 }

--- a/packages/app-operations/src/apps.ts
+++ b/packages/app-operations/src/apps.ts
@@ -1,5 +1,6 @@
 import type { PublicApiClient } from '@repo/api-client/public';
 import { ApiError, unwrap } from '@repo/api-client/unwrap';
+import type { SettledDeployment } from '#deploy.ts';
 
 const NO_DEPLOYMENTS = 'This app has never been deployed.';
 
@@ -15,17 +16,17 @@ export async function appBySlug({ api, slug }: { api: PublicApiClient; slug: str
 }
 
 /**
- * The deployment a reader means by not naming one. The api lists them newest first, so this is
- * the head of the list rather than a search through it.
+ * The release the app is on: the one a reader means by not naming one, and the only one that says
+ * what the app is doing now. The api lists them newest first, so this is the head of the list
+ * rather than a search through it.
  */
-export async function latestDeployment({
-  api,
-  appId,
-}: {
-  api: PublicApiClient;
-  appId: string;
-}): Promise<string> {
-  return (await newestDeployment({ api, appId })).id;
+export async function newestDeployment({ api, appId }: { api: PublicApiClient; appId: string }) {
+  const { deployments } = unwrap(await api.api.apps({ appId }).deployments.get());
+  const newest = deployments[0];
+  if (!newest) {
+    throw new ApiError(NO_DEPLOYMENTS);
+  }
+  return newest;
 }
 
 /**
@@ -39,20 +40,24 @@ export async function currentArtifact({ api, appId }: { api: PublicApiClient; ap
   return unwrap(await api.api.apps({ appId }).artifacts({ artifactId }).get());
 }
 
-async function newestDeployment({ api, appId }: { api: PublicApiClient; appId: string }) {
-  const { deployments } = unwrap(await api.api.apps({ appId }).deployments.get());
-  const newest = deployments[0];
-  if (!newest) {
-    throw new ApiError(NO_DEPLOYMENTS);
-  }
-  return newest;
-}
+export type AddressedDeployment = {
+  appId: string;
+  deploymentId: string;
+  slug: string;
+  /**
+   * The release the app is on, which is a different question from the one addressed: naming an
+   * older deployment addresses a release that has been replaced, not the one running now.
+   */
+  newest: SettledDeployment;
+};
 
 /**
- * The deployment a command was pointed at.
+ * The deployment a command was pointed at, and the release the app is actually on.
  *
- * The app is looked up either way — a deployment is addressed under the app that owns it — so
- * what naming one skips is only the question of which deployment is current.
+ * The app is looked up either way — a deployment is addressed under the app that owns it — and so
+ * is the newest release, even when naming one made it unnecessary to ask which that is: whether
+ * anything is running is a question about the app rather than about the deployment addressed, and
+ * it is the answer to that one that decides whether a command can do anything at all.
  */
 export async function addressedDeployment({
   api,
@@ -62,8 +67,13 @@ export async function addressedDeployment({
   api: PublicApiClient;
   slug: string;
   deploymentId: string | undefined;
-}): Promise<{ appId: string; deploymentId: string; slug: string }> {
+}): Promise<AddressedDeployment> {
   const app = await appBySlug({ api, slug });
-  const addressed = deploymentId ?? (await latestDeployment({ api, appId: app.id }));
-  return { appId: app.id, deploymentId: addressed, slug: app.slug };
+  const newest = await newestDeployment({ api, appId: app.id });
+  return {
+    appId: app.id,
+    deploymentId: deploymentId ?? newest.id,
+    slug: app.slug,
+    newest,
+  };
 }

--- a/packages/app-operations/src/filesystem.ts
+++ b/packages/app-operations/src/filesystem.ts
@@ -1,6 +1,7 @@
 import type { PublicApiClient } from '@repo/api-client/public';
 import { unwrap } from '@repo/api-client/unwrap';
 import { type DirectoryListing, type GuestPath, GuestPathSchema, Value } from '@repo/protocol';
+import { describeUnservedDeployment, type SettledDeployment } from '#deploy.ts';
 import { InvalidPathError } from '#errors.ts';
 
 /**
@@ -36,4 +37,23 @@ export async function readDirectory({
   return unwrap(
     await api.api.apps({ appId }).deployments({ deploymentId }).filesystem.get({ query: { path } }),
   );
+}
+
+/**
+ * Why this app's filesystem cannot be read, when it cannot.
+ *
+ * A directory is read inside the microVM that has the volume mounted, so an app running none has
+ * nothing to answer a read with. Asking anyway costs a wait on a host to be told the same thing in
+ * worse words: what comes back names no release and no reason, because a host cannot tell a
+ * directory that is not there from a device it could not reach.
+ *
+ * The newest release decides it rather than the one a caller addressed. The volume outlives every
+ * release of it, so a superseded deployment is a perfectly good handle on a filesystem something
+ * newer is still mounting — what matters is whether anything is mounting it now.
+ *
+ * Only a failed release is answered here. One still coming up is worth the wait, and a stopped one
+ * belongs to a suspended app, which is an owner's own doing and reads as such where they did it.
+ */
+export function describeUnreadableFilesystem(newest: SettledDeployment): string | undefined {
+  return newest.state === 'failed' ? describeUnservedDeployment(newest) : undefined;
 }

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -1,6 +1,12 @@
 /** biome-ignore-all lint/performance/noBarrelFile: index is the only allowed file where we can export other files */
 
-export { addressedDeployment, appBySlug, currentArtifact, latestDeployment } from '#apps.ts';
+export {
+  type AddressedDeployment,
+  addressedDeployment,
+  appBySlug,
+  currentArtifact,
+  newestDeployment,
+} from '#apps.ts';
 export { deleteApp } from '#delete.ts';
 export {
   awaitDeploymentSettled,
@@ -16,7 +22,7 @@ export { type EnvironmentAssignment, parseEnvFile } from '#env-file.ts';
 export { type EnvironmentEdit, parseEnvironment, parseEnvironmentPatch } from '#environment.ts';
 export { InvalidEnvironmentError, InvalidPathError } from '#errors.ts';
 export { awaitExportBundle, type ExportBundle, requestExport } from '#exports.ts';
-export { guestPath, readDirectory } from '#filesystem.ts';
+export { describeUnreadableFilesystem, guestPath, readDirectory } from '#filesystem.ts';
 export { type FollowInput, followLogs } from '#logs.ts';
 export { type RedeployInput, redeploy } from '#redeploy.ts';
 export type { ConfigEdit, Deployed, DeployStep } from '#release.ts';

--- a/packages/app-operations/tests/apps.test.ts
+++ b/packages/app-operations/tests/apps.test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from 'bun:test';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { addressedDeployment, appBySlug, currentArtifact, latestDeployment } from '#apps.ts';
+import { addressedDeployment, appBySlug, currentArtifact, newestDeployment } from '#apps.ts';
 
 function apiHolding({
   apps,
   deployments = [],
 }: {
   apps: Array<{ id: string; slug: string }>;
-  deployments?: Array<{ id: string; artifactId?: string }>;
+  deployments?: Array<{ id: string; artifactId?: string; state?: string }>;
 }): PublicApiClient {
   function underApp() {
     return {
@@ -49,13 +49,13 @@ test('the deployment nobody named is the newest one', async () => {
     deployments: [{ id: 'deployment-2' }, { id: 'deployment-1' }],
   });
 
-  expect(await latestDeployment({ api, appId: 'app-1' })).toBe('deployment-2');
+  expect(await newestDeployment({ api, appId: 'app-1' })).toMatchObject({ id: 'deployment-2' });
 });
 
 test('an app that has never been deployed has no newest deployment', async () => {
   const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter' }] });
 
-  await expect(latestDeployment({ api, appId: 'app-1' })).rejects.toThrow(
+  await expect(newestDeployment({ api, appId: 'app-1' })).rejects.toThrow(
     'This app has never been deployed.',
   );
 });
@@ -85,21 +85,42 @@ test('an app that has never been deployed is running no binary', async () => {
 test('addressing without a deployment id resolves to the newest one', async () => {
   const api = apiHolding({
     apps: [{ id: 'app-1', slug: 'quiet-otter' }],
-    deployments: [{ id: 'deployment-2' }],
+    deployments: [{ id: 'deployment-2', state: 'active' }],
   });
 
   expect(await addressedDeployment({ api, slug: 'quiet-otter', deploymentId: undefined })).toEqual({
     appId: 'app-1',
     deploymentId: 'deployment-2',
     slug: 'quiet-otter',
+    newest: { id: 'deployment-2', state: 'active' },
   });
 });
 
 // The app is looked up either way, because a deployment is addressed under the app that owns it.
 test('a deployment named outright still comes back under its app', async () => {
-  const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter' }] });
+  const api = apiHolding({
+    apps: [{ id: 'app-1', slug: 'quiet-otter' }],
+    deployments: [{ id: 'deployment-2', state: 'active' }],
+  });
 
   expect(
     await addressedDeployment({ api, slug: 'quiet-otter', deploymentId: 'deployment-9' }),
-  ).toEqual({ appId: 'app-1', deploymentId: 'deployment-9', slug: 'quiet-otter' });
+  ).toMatchObject({ appId: 'app-1', deploymentId: 'deployment-9', slug: 'quiet-otter' });
+});
+
+// Which release the app is on is a different question from which one was addressed, and the one
+// that says whether anything is running: naming an older deployment does not skip asking it.
+test('the release the app is on comes back alongside the one addressed', async () => {
+  const api = apiHolding({
+    apps: [{ id: 'app-1', slug: 'quiet-otter' }],
+    deployments: [{ id: 'deployment-2', state: 'failed' }, { id: 'deployment-1' }],
+  });
+
+  const addressed = await addressedDeployment({
+    api,
+    slug: 'quiet-otter',
+    deploymentId: 'deployment-1',
+  });
+
+  expect(addressed.newest).toMatchObject({ id: 'deployment-2', state: 'failed' });
 });

--- a/packages/app-operations/tests/filesystem.test.ts
+++ b/packages/app-operations/tests/filesystem.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { guestPath } from '#filesystem.ts';
+import { describeUnreadableFilesystem, guestPath } from '#filesystem.ts';
 
 function spelled(typed: string): string {
   return guestPath(typed);
@@ -33,5 +33,28 @@ describe('what is refused rather than repaired', () => {
 
   test('a quote the reader tooling would tokenise is refused', () => {
     expect(() => guestPath("/it's")).toThrow("/it's is not a path inside an app filesystem.");
+  });
+});
+
+describe('a filesystem nothing is mounting is said to be, rather than asked after', () => {
+  test("a failed release accounts for itself in the host's own words", () => {
+    expect(
+      describeUnreadableFilesystem({
+        id: 'dep-1',
+        state: 'failed',
+        message: 'nothing answered on port 4991 inside the guest.',
+      }),
+    ).toBe('Deployment dep-1 is failed. nothing answered on port 4991 inside the guest.');
+  });
+
+  test('a release that is serving is nothing to say', () => {
+    expect(describeUnreadableFilesystem({ id: 'dep-1', state: 'active' })).toBeUndefined();
+  });
+
+  // The wait is worth it while a release is still coming up, and a stopped one belongs to a
+  // suspended app, which is an owner's own doing and reads as such where they did it.
+  test('nor is one still on its way up, or one an owner stopped', () => {
+    expect(describeUnreadableFilesystem({ id: 'dep-1', state: 'starting' })).toBeUndefined();
+    expect(describeUnreadableFilesystem({ id: 'dep-1', state: 'stopped' })).toBeUndefined();
   });
 });

--- a/packages/cli/src/lib/apps.test.ts
+++ b/packages/cli/src/lib/apps.test.ts
@@ -139,6 +139,10 @@ test('which deployment a command settled on is said before it is read from', asy
     print: { dim: (line: string) => dimmed.push(line) } as unknown as Print,
   });
 
-  expect(addressed).toEqual({ appId: 'app-1', deploymentId: 'deployment-2', slug: 'quiet-otter' });
+  expect(addressed).toMatchObject({
+    appId: 'app-1',
+    deploymentId: 'deployment-2',
+    slug: 'quiet-otter',
+  });
   expect(dimmed).toEqual(['quiet-otter · deployment deployment-2']);
 });

--- a/packages/cli/src/lib/apps.ts
+++ b/packages/cli/src/lib/apps.ts
@@ -2,7 +2,7 @@ import { select } from '@clack/prompts';
 import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { unwrap } from '@repo/api-client/unwrap';
-import { addressedDeployment } from '@repo/app-operations';
+import { type AddressedDeployment, addressedDeployment } from '@repo/app-operations';
 import { SHARED_OPTIONS } from '#config.ts';
 import { UsageError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
@@ -63,9 +63,9 @@ async function chooseApp({ api }: { api: PublicApiClient }): Promise<string> {
 /**
  * The deployment a command was pointed at, and a line saying which one it turned out to be.
  *
- * What naming one skips is only the question of which deployment is current. Which makes the line
- * worth printing: the answer to that question is the difference between reading the release
- * someone just made and reading the one before it.
+ * The line is worth printing because naming no deployment is a question rather than a default, and
+ * its answer is the difference between reading the release someone just made and reading the one
+ * before it.
  */
 export async function announcedDeployment({
   api,
@@ -77,7 +77,7 @@ export async function announcedDeployment({
   slug: string;
   deploymentId: string | undefined;
   print: Print;
-}): Promise<{ appId: string; deploymentId: string; slug: string }> {
+}): Promise<AddressedDeployment> {
   const addressed = await addressedDeployment({ api, slug, deploymentId });
   print.dim(`${addressed.slug} · deployment ${addressed.deploymentId}`);
   return addressed;

--- a/packages/cli/src/lib/filesystem.ts
+++ b/packages/cli/src/lib/filesystem.ts
@@ -1,6 +1,12 @@
 import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { guestPath, InvalidPathError, readDirectory } from '@repo/app-operations';
+import { ApiError } from '@repo/api-client/unwrap';
+import {
+  describeUnreadableFilesystem,
+  guestPath,
+  InvalidPathError,
+  readDirectory,
+} from '@repo/app-operations';
 import {
   DIRECTORY_ENTRY_LIMIT,
   FILESYSTEM_ENTRY_KINDS,
@@ -36,7 +42,9 @@ export type ListInput = {
  * Print one directory of an app's filesystem.
  *
  * The request is held open by the api until a host next polls, so this is a wait rather than a
- * read — hence the deployment being named before it starts rather than alongside the answer.
+ * read — hence the deployment being named before it starts rather than alongside the answer, and
+ * hence a release that failed being answered from here: the wait is the expensive part, and what
+ * it buys in that case is a refusal that names neither the release nor why it never came up.
  */
 export async function listDirectory({
   api,
@@ -46,6 +54,12 @@ export async function listDirectory({
   print,
 }: ListInput): Promise<void> {
   const addressed = await announcedDeployment({ api, slug, deploymentId, print });
+
+  const unreadable = describeUnreadableFilesystem(addressed.newest);
+  if (unreadable !== undefined) {
+    throw new ApiError(unreadable);
+  }
+
   const listing = await readDirectory({
     api,
     appId: addressed.appId,


### PR DESCRIPTION
Browsing the files of an app whose release failed asked a host for a directory and got a refusal back, which Cloudflare had already replaced with its own 502 page. The dashboard and `nib apps files ls` now read the release first and say which one failed and why, in the words the host left.

The rule is shared so both surfaces answer the same way, and it keys on the newest release rather than the one addressed: the volume outlives every release of it, so a superseded deployment is still a good handle on a filesystem something newer is mounting.

Only `failed` is answered this way — a release still coming up is worth the wait, and a stopped one belongs to a suspended app, which already reads as such.

```
$ nib apps files ls --app sharkord-ar3k8t
sharkord-ar3k8t · deployment 01a03dec-2892-7fc8-9fe5-ae1055577a51
nib: Deployment 01a03dec-2892-7fc8-9fe5-ae1055577a51 is failed. nothing answered on port 4991 inside the guest: 108 health probes failed after the 30000ms grace period
```