### PR TITLE
docs: the readme shows which bun version the project pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1>nibrun</h1>
   <p><em>Drop a binary. Get a server.</em></p>
 
-[![runtime](https://img.shields.io/github/package-json/packageManager/ilbertt/nibrun?label=runtime&logo=bun&logoColor=black&color=fbf0df)](https://bun.com)
+[![runtime](https://img.shields.io/github/package-json/packageManager/ilbertt/nibrun?label=runtime&logo=bun&logoColor=fbf0df&color=fbf0df)](https://bun.com)
 [![skills.sh](https://skills.sh/b/ilbertt/nibrun)](https://skills.sh/ilbertt/nibrun)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <h1>nibrun</h1>
   <p><em>Drop a binary. Get a server.</em></p>
 
+[![runtime](https://img.shields.io/github/package-json/packageManager/ilbertt/nibrun?label=runtime&logo=bun&logoColor=black&color=fbf0df)](https://bun.com)
 [![skills.sh](https://skills.sh/b/ilbertt/nibrun)](https://skills.sh/ilbertt/nibrun)
 
 </div>


### PR DESCRIPTION
A badge for the Bun version, read from `packageManager` so it tracks the pin instead of going stale.