### PR TITLE
feat(api,dashboard): the health badge names which part of the system is down

### DIFF
--- a/apps/api/src/lib/victorialogs/client.ts
+++ b/apps/api/src/lib/victorialogs/client.ts
@@ -1,6 +1,7 @@
 import { type LogRow, lines, toRow } from '#lib/victorialogs/parse.ts';
 
 const QUERY_PATH = '/select/logsql/query';
+const HEALTH_PATH = '/health';
 
 /** The store's own name for a query submitted in a body, which is where a filter this long belongs. */
 const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded';
@@ -28,12 +29,8 @@ abstract class VictoriaLogsEndpoint {
     this.url = new URL(path, baseUrl).toString();
   }
 
-  protected async post({ params }: { params: Record<string, string> }): Promise<Response> {
-    const response = await fetch(this.url, {
-      method: 'POST',
-      headers: { 'content-type': FORM_CONTENT_TYPE },
-      body: new URLSearchParams(params),
-    });
+  protected async send(init: RequestInit): Promise<Response> {
+    const response = await fetch(this.url, init);
     if (!response.ok) {
       throw new VictoriaLogsError({
         status: response.status,
@@ -41,6 +38,18 @@ abstract class VictoriaLogsEndpoint {
       });
     }
     return response;
+  }
+
+  protected post({ params }: { params: Record<string, string> }): Promise<Response> {
+    return this.send({
+      method: 'POST',
+      headers: { 'content-type': FORM_CONTENT_TYPE },
+      body: new URLSearchParams(params),
+    });
+  }
+
+  protected get(): Promise<Response> {
+    return this.send({ method: 'GET' });
   }
 }
 
@@ -81,6 +90,20 @@ export class VictoriaLogsQuery extends VictoriaLogsEndpoint {
 }
 
 /**
+ * Whether the store is answering at all, which is a different question from whether a query
+ * returns rows: an app that has written nothing has no rows either way.
+ */
+export class VictoriaLogsHealth extends VictoriaLogsEndpoint {
+  constructor(baseUrl: URL) {
+    super({ baseUrl, path: HEALTH_PATH });
+  }
+
+  async check(): Promise<void> {
+    await this.get();
+  }
+}
+
+/**
  * Reads the store, and only reads it.
  *
  * Records arrive from the fleet over an ingest listener that admits app hosts and nothing else,
@@ -89,8 +112,10 @@ export class VictoriaLogsQuery extends VictoriaLogsEndpoint {
  */
 export class VictoriaLogsClient {
   readonly query: VictoriaLogsQuery;
+  readonly health: VictoriaLogsHealth;
 
   constructor(baseUrl: URL) {
     this.query = new VictoriaLogsQuery(baseUrl);
+    this.health = new VictoriaLogsHealth(baseUrl);
   }
 }

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -1,5 +1,12 @@
 import type { TypedSQL } from '@ilbertt/bun-sqlgen';
-import type { HostDesiredState, HostId, SecretString } from '@repo/protocol';
+import type {
+  HostDesiredState,
+  HostId,
+  HostReportedState,
+  HostState,
+  SecretString,
+  Timestamp,
+} from '@repo/protocol';
 import type { Queries } from '#db/queries.gen.ts';
 import {
   environmentByDeployment,
@@ -11,15 +18,29 @@ import { environmentByExport, toDesiredExport } from '#lib/exports/desired-state
 import type { TenantSecretsKey } from '#lib/tenant-secrets.ts';
 import { Repository } from '#repositories/repository.ts';
 
+/**
+ * The last thing a host said about itself, which is the whole of what this end knows about one
+ * between two reports. Kept rather than the report itself: nothing here is a substitute for the
+ * tables the report's contents land in, and holding those twice is how they come apart.
+ */
+export type HostObservation = {
+  hostId: HostId;
+  reportedAt: Timestamp;
+  state: HostState;
+};
+
 export abstract class AgentRepositoryContract {
   abstract saveSession(input: { sessionToken: SecretString; hostId: HostId }): Promise<void>;
   abstract hostForSession(input: { sessionToken: string }): Promise<HostId | undefined>;
   abstract desiredState(input: { hostId: HostId }): Promise<HostDesiredState>;
+  abstract observeReport(input: { reported: HostReportedState }): Promise<void>;
+  abstract lastObservation(): Promise<HostObservation | undefined>;
 }
 
 export class AgentRepository extends Repository implements AgentRepositoryContract {
   readonly #hostBySession = new Map<string, HostId>();
   readonly #secretsKey: TenantSecretsKey;
+  #lastObservation: HostObservation | undefined;
 
   constructor({ sql, secretsKey }: { sql: TypedSQL<Queries>; secretsKey: TenantSecretsKey }) {
     super(sql);
@@ -39,6 +60,26 @@ export class AgentRepository extends Repository implements AgentRepositoryContra
 
   hostForSession({ sessionToken }: { sessionToken: string }): Promise<HostId | undefined> {
     return Promise.resolve(this.#hostBySession.get(sessionToken));
+  }
+
+  /**
+   * In memory and only in memory. A restarted api has heard from no host yet, which is the truth
+   * — the last report was made to a process that is gone, and the next one is a poll away.
+   *
+   * One host, like `desiredState`: the newest report wins, and a second host would need this to
+   * become a map keyed on the id it already carries.
+   */
+  observeReport({ reported }: { reported: HostReportedState }): Promise<void> {
+    this.#lastObservation = {
+      hostId: reported.hostId,
+      reportedAt: reported.reportedAt,
+      state: reported.state,
+    };
+    return Promise.resolve();
+  }
+
+  lastObservation(): Promise<HostObservation | undefined> {
+    return Promise.resolve(this.#lastObservation);
   }
 
   /**

--- a/apps/api/src/repositories/health.repository.ts
+++ b/apps/api/src/repositories/health.repository.ts
@@ -1,8 +1,55 @@
-import type { ISelectHealthPingResult } from '#db/queries.gen.ts';
+import type { TypedSQL } from '@ilbertt/bun-sqlgen';
+import type { Queries } from '#db/queries.gen.ts';
+import type { VictoriaLogsHealth } from '#lib/victorialogs/client.ts';
 import { Repository } from '#repositories/repository.ts';
 
-export class HealthRepository extends Repository {
-  async ping(): Promise<ISelectHealthPingResult[]> {
-    return await this.sql.SelectHealthPing`SELECT 1 AS ok`;
+/** Listing is what proves the bucket is there and these credentials reach it; the keys are not read. */
+const PROBE_KEY_LIMIT = 1;
+
+export type LogStoreProbe = Pick<VictoriaLogsHealth, 'check'>;
+export type ObjectStoreProbe = Pick<Bun.S3Client, 'list'>;
+
+export abstract class HealthRepositoryContract {
+  abstract pingDatabase(): Promise<void>;
+  abstract pingLogStore(): Promise<void>;
+  abstract pingObjectStore(): Promise<void>;
+}
+
+/**
+ * Whether each thing the api depends on answers. One repository rather than a probe bolted onto
+ * each dependency's own: reachability is not what those repositories are for, and asking it of
+ * them would put a method on every contract that only this reads.
+ *
+ * Each probe returns nothing and throws when the dependency is unreachable — there is no degree
+ * of reachable, and a caller that has to read a boolean to find out is one that can forget to.
+ */
+export class HealthRepository extends Repository implements HealthRepositoryContract {
+  readonly #logStore: LogStoreProbe;
+  readonly #objectStore: ObjectStoreProbe;
+
+  constructor({
+    sql,
+    logStore,
+    objectStore,
+  }: {
+    sql: TypedSQL<Queries>;
+    logStore: LogStoreProbe;
+    objectStore: ObjectStoreProbe;
+  }) {
+    super(sql);
+    this.#logStore = logStore;
+    this.#objectStore = objectStore;
+  }
+
+  async pingDatabase(): Promise<void> {
+    await this.sql.SelectHealthPing`SELECT 1 AS ok`;
+  }
+
+  async pingLogStore(): Promise<void> {
+    await this.#logStore.check();
+  }
+
+  async pingObjectStore(): Promise<void> {
+    await this.#objectStore.list({ maxKeys: PROBE_KEY_LIMIT });
   }
 }

--- a/apps/api/src/routes/api/health/controller.ts
+++ b/apps/api/src/routes/api/health/controller.ts
@@ -2,6 +2,15 @@ import { Elysia, StatusMap } from 'elysia';
 import { GetHealthResponseSchema } from '#routes/api/health/model.ts';
 import { HealthServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
+/**
+ * Always OK while this process is answering, whatever it reports below itself. The container's
+ * own healthcheck calls this route and the deploy gates on that healthcheck, so a status carrying
+ * the fleet's verdict would fail a release for a log store nobody deployed — and would fail every
+ * release outright, since a freshly started api has heard from no host yet.
+ *
+ * A refusal would not reach a reader anyway: the edge replaces an origin 5xx with a page of its
+ * own, so the breakdown is only ever readable in a body that came back 200.
+ */
 export const HealthController = new Elysia()
   .use(loggerPlugin('healthController'))
   .use(HealthServicePlugin)

--- a/apps/api/src/routes/api/health/model.ts
+++ b/apps/api/src/routes/api/health/model.ts
@@ -1,6 +1,25 @@
 import { t } from 'elysia';
 
+const MAX_DETAIL_LENGTH = 128;
+
+const ComponentSchema = t.Object({
+  status: t.Union([t.Literal('up'), t.Literal('down'), t.Literal('unknown')]),
+  detail: t.Optional(t.String({ maxLength: MAX_DETAIL_LENGTH })),
+});
+
+/**
+ * Named keys rather than a list: a reader renders one row per component and has to know which
+ * row it is drawing, so the set being fixed is what lets it label them without a lookup that
+ * can miss.
+ */
 export const GetHealthResponseSchema = t.Object({
-  status: t.Literal('ok'),
+  status: t.Union([t.Literal('healthy'), t.Literal('degraded')]),
   uptime: t.Number(),
+  components: t.Object({
+    database: ComponentSchema,
+    logStore: ComponentSchema,
+    objectStore: ComponentSchema,
+    agent: ComponentSchema,
+    appHost: ComponentSchema,
+  }),
 });

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -113,9 +113,10 @@ export class AgentService extends Service {
    * Read by the things that own what it talks about: the releases running on the host, the apps
    * whose filesystems it is holding or has just let go of, and the bundles it was told to write.
    *
-   * The rest is dropped. Capacity, versions and the host's own state have no table to land in
-   * while hosts are not modelled, and holding them in this process would be a second source of
-   * truth to unpick once they do.
+   * The rest is dropped. Capacity and versions have no table to land in while hosts are not
+   * modelled, and holding them in this process would be a second source of truth to unpick once
+   * they do. The host's own state is kept, but only as the passing observation liveness reads —
+   * see `observeReport`.
    */
   async acceptReport({ reported }: { reported: HostReportedState }): Promise<void> {
     this.logger.info('host reported', {
@@ -124,6 +125,10 @@ export class AgentService extends Service {
       instances: reported.instances.length,
       volumes: reported.volumes.length,
     });
+    // First, and unconditionally: what a report says about the host itself is the only thing
+    // this end learns from one that nothing below records, and a report that goes on to fail
+    // still arrived — which is the whole of what liveness asks.
+    await this.agentRepo.observeReport({ reported });
     await this.deploymentsService.applyHostReport({ reported });
     await this.appsService.completeDeletions({ volumes: reported.volumes });
     await this.exportsService.applyHostReport({ reported });

--- a/apps/api/src/services/health.service.ts
+++ b/apps/api/src/services/health.service.ts
@@ -1,16 +1,169 @@
-import type { HealthRepository } from '#repositories/health.repository.ts';
+import { DEFAULT_AGENT_POLL_SETTINGS, type HostState } from '@repo/protocol';
+import type { AgentRepositoryContract, HostObservation } from '#repositories/agent.repository.ts';
+import type { HealthRepositoryContract } from '#repositories/health.repository.ts';
 import { Service } from '#services/service.ts';
 
-export class HealthService extends Service {
-  private readonly healthRepo: HealthRepository;
+/**
+ * How long a probe has to answer in. The dashboard asks on a timer, so a dependency that hangs
+ * rather than refusing has to become an answer here — otherwise it becomes a request that never
+ * completes, and a reader is told the api is unreachable when it is the one thing that is not.
+ */
+const PROBE_TIMEOUT_MS = 2_000;
 
-  constructor(healthRepo: HealthRepository) {
+/**
+ * Reports arrive on a fixed cadence, so silence is only meaningful in multiples of it. Three
+ * gives a host a missed report and a slow one before it is called gone.
+ */
+const REPORTS_BEFORE_SILENT = 3;
+const SILENT_AFTER_MS = DEFAULT_AGENT_POLL_SETTINGS.reportIntervalMs * REPORTS_BEFORE_SILENT;
+
+const MS_PER_SECOND = 1_000;
+
+/**
+ * `unknown` is not a softer `down`: it is this end having no way to see. Only the host is ever
+ * that, because the agent is the only window onto it — an agent that has stopped reporting takes
+ * the host's status with it rather than proving anything about it.
+ */
+export type ComponentStatus = 'up' | 'down' | 'unknown';
+
+export type Component = {
+  status: ComponentStatus;
+  /** Why, when the status alone does not say it. Never a dependency's own words — see `probe`. */
+  detail?: string;
+};
+
+const HOST_STATE_STATUS: Record<HostState, ComponentStatus> = {
+  registering: 'unknown',
+  ready: 'up',
+  draining: 'unknown',
+  unreachable: 'down',
+};
+
+export type SystemHealth = {
+  status: 'healthy' | 'degraded';
+  uptime: number;
+  components: {
+    database: Component;
+    logStore: Component;
+    objectStore: Component;
+    agent: Component;
+    appHost: Component;
+  };
+};
+
+export class HealthService extends Service {
+  private readonly healthRepo: HealthRepositoryContract;
+  private readonly agentRepo: HostObserver;
+
+  constructor({
+    healthRepo,
+    agentRepo,
+  }: { healthRepo: HealthRepositoryContract; agentRepo: HostObserver }) {
     super();
     this.healthRepo = healthRepo;
+    this.agentRepo = agentRepo;
   }
 
-  async check(): Promise<{ status: 'ok'; uptime: number }> {
-    await this.healthRepo.ping();
-    return { status: 'ok', uptime: process.uptime() };
+  /**
+   * Together rather than in turn: nothing here reads what another returns, so a reader waits on
+   * the slowest dependency instead of on the sum of them.
+   */
+  async check(): Promise<SystemHealth> {
+    const [database, logStore, objectStore, observation] = await Promise.all([
+      this.probe({ component: 'database', run: () => this.healthRepo.pingDatabase() }),
+      this.probe({ component: 'logStore', run: () => this.healthRepo.pingLogStore() }),
+      this.probe({ component: 'objectStore', run: () => this.healthRepo.pingObjectStore() }),
+      this.agentRepo.lastObservation(),
+    ]);
+
+    const silence = silenceSince(observation);
+    const components = {
+      database,
+      logStore,
+      objectStore,
+      agent: agentComponent(silence),
+      appHost: appHostComponent({ observation, silence }),
+    };
+
+    return {
+      status: Object.values(components).every((component) => component.status === 'up')
+        ? 'healthy'
+        : 'degraded',
+      uptime: process.uptime(),
+      components,
+    };
   }
+
+  /**
+   * What a dependency said when it refused is logged, not returned. This route answers
+   * unauthenticated — it is what the container's own probe calls — and a driver's error text
+   * carries the host, port and user it was dialling.
+   */
+  private async probe({
+    component,
+    run,
+  }: {
+    component: keyof SystemHealth['components'];
+    run: () => Promise<void>;
+  }): Promise<Component> {
+    try {
+      await withTimeout(run());
+      return { status: 'up' };
+    } catch (failure) {
+      this.logger.warn('health probe failed', { component, failure });
+      return { status: 'down' };
+    }
+  }
+}
+
+/** The whole of what health asks of the agent: what the last report said, if there was one. */
+export type HostObserver = Pick<AgentRepositoryContract, 'lastObservation'>;
+
+class ProbeTimeout extends Error {
+  constructor() {
+    super(`no answer within ${PROBE_TIMEOUT_MS}ms`);
+    this.name = 'ProbeTimeout';
+  }
+}
+
+/**
+ * The timer is cleared either way: a probe answering in a millisecond must not then hold the
+ * event loop open for the rest of the budget, which is what a bare `setTimeout` race does — and
+ * this runs three of them on every poll of every open dashboard.
+ */
+function withTimeout(work: Promise<void>): Promise<void> {
+  const expiry = Promise.withResolvers<never>();
+  const timer = setTimeout(() => expiry.reject(new ProbeTimeout()), PROBE_TIMEOUT_MS);
+  return Promise.race([work, expiry.promise]).finally(() => clearTimeout(timer));
+}
+
+/** How long since the host last said anything, or nothing at all if it never has. */
+function silenceSince(observation: HostObservation | undefined): number | undefined {
+  return observation === undefined ? undefined : Date.now() - Date.parse(observation.reportedAt);
+}
+
+function agentComponent(silence: number | undefined): Component {
+  if (silence === undefined) {
+    return { status: 'down', detail: 'no host has reported to this api yet' };
+  }
+  return silence > SILENT_AFTER_MS
+    ? { status: 'down', detail: `no report in the last ${SILENT_AFTER_MS / MS_PER_SECOND}s` }
+    : { status: 'up' };
+}
+
+function appHostComponent({
+  observation,
+  silence,
+}: {
+  observation: HostObservation | undefined;
+  silence: number | undefined;
+}): Component {
+  if (observation === undefined || silence === undefined) {
+    return { status: 'unknown', detail: 'nothing has reported a host' };
+  }
+  if (silence > SILENT_AFTER_MS) {
+    return { status: 'unknown', detail: 'the agent has stopped reporting it' };
+  }
+  const status = HOST_STATE_STATUS[observation.state];
+  return status === 'up' ? { status } : { status, detail: `reported as ${observation.state}` };
 }

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -41,9 +41,15 @@ const cloudflareClient =
       })
     : undefined;
 
+const victoriaLogsClient = new VictoriaLogsClient(env.VICTORIALOGS_ENDPOINT);
+
 const agentRepository = new AgentRepository({ sql, secretsKey });
 const assetsRepository = new AssetsRepository(sql);
-const healthRepository = new HealthRepository(sql);
+const healthRepository = new HealthRepository({
+  sql,
+  logStore: victoriaLogsClient.health,
+  objectStore: artifactsS3,
+});
 const appsRepository = new AppsRepository(sql);
 const appHostnamesRepository = new AppHostnamesRepository(sql);
 const artifactsRepository = new ArtifactsRepository(sql);
@@ -56,7 +62,7 @@ const artifactStorageRepository = new ArtifactStorageRepository({
 const exportsRepository = new ExportsRepository(sql);
 const exportStorageRepository = new ExportStorageRepository(exportsS3);
 const customHostnamesRepository = new CustomHostnamesRepository(cloudflareClient);
-const logsRepository = new LogsRepository(new VictoriaLogsClient(env.VICTORIALOGS_ENDPOINT));
+const logsRepository = new LogsRepository(victoriaLogsClient);
 
 const deploymentsService = new DeploymentsService({ deploymentsRepo: deploymentsRepository });
 const appsService = new AppsService({
@@ -82,7 +88,10 @@ const exportsService = new ExportsService({
 });
 
 const assetsService = new AssetsService(assetsRepository);
-const healthService = new HealthService(healthRepository);
+const healthService = new HealthService({
+  healthRepo: healthRepository,
+  agentRepo: agentRepository,
+});
 const filesystemService = new FilesystemService({ deploymentsRepo: deploymentsRepository });
 const artifactsService = new ArtifactsService({
   artifactsRepo: artifactsRepository,

--- a/apps/api/tests/controllers/health.test.ts
+++ b/apps/api/tests/controllers/health.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { parseMessage } from '@repo/protocol';
+import { StatusMap } from 'elysia';
+import { GetHealthResponseSchema } from '#routes/api/health/model.ts';
+import { ORIGIN, send } from '#tests/controllers/support/api.ts';
+
+const URL = `${ORIGIN}/api/health`;
+
+/** Through the schema the route declares, so a body that drifts from it fails here. */
+async function health() {
+  const response = await send({ url: URL });
+  return {
+    status: response.status,
+    body: parseMessage({ schema: GetHealthResponseSchema, value: await response.json() }),
+  };
+}
+
+/**
+ * Every dependency this app was built with points at a closed port, which is the whole point:
+ * the interesting answer is the one given when nothing below the api is reachable.
+ */
+describe('GET /api/health', () => {
+  test('answers even when nothing it depends on does', async () => {
+    expect((await health()).status).toBe(StatusMap.OK);
+  });
+
+  test('says which of them refused rather than only that something did', async () => {
+    const { body } = await health();
+
+    expect(body.status).toBe('degraded');
+    expect(body.components.database.status).toBe('down');
+    expect(body.components.logStore.status).toBe('down');
+    expect(body.components.objectStore.status).toBe('down');
+  });
+
+  test('has heard from no host, so it can say nothing about one', async () => {
+    const { body } = await health();
+
+    expect(body.components.agent.status).toBe('down');
+    expect(body.components.appHost.status).toBe('unknown');
+  });
+});

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -10,7 +10,7 @@ import {
   Value,
 } from '@repo/protocol';
 import { UnauthorizedError } from '#lib/errors.ts';
-import type { AgentRepositoryContract } from '#repositories/agent.repository.ts';
+import type { AgentRepositoryContract, HostObservation } from '#repositories/agent.repository.ts';
 import { AgentService, type HostnameReconcile, type UploadSweep } from '#services/agent.service.ts';
 import type { AppsService } from '#services/apps.service.ts';
 import type { DeploymentsService } from '#services/deployments.service.ts';
@@ -23,6 +23,7 @@ const SESSION_REQUEST = {
 
 class FakeAgentRepository implements AgentRepositoryContract {
   readonly #hostBySession = new Map<string, HostId>();
+  observed: HostObservation | undefined;
 
   saveSession({
     sessionToken,
@@ -47,6 +48,19 @@ class FakeAgentRepository implements AgentRepositoryContract {
       checkpoints: [],
       exports: [],
     });
+  }
+
+  observeReport({ reported }: { reported: HostReportedState }): Promise<void> {
+    this.observed = {
+      hostId: reported.hostId,
+      reportedAt: reported.reportedAt,
+      state: reported.state,
+    };
+    return Promise.resolve();
+  }
+
+  lastObservation(): Promise<HostObservation | undefined> {
+    return Promise.resolve(this.observed);
   }
 }
 

--- a/apps/api/tests/services/health.test.ts
+++ b/apps/api/tests/services/health.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_AGENT_POLL_SETTINGS,
+  HostIdSchema,
+  type HostState,
+  type Timestamp,
+  TimestampSchema,
+  Value,
+} from '@repo/protocol';
+import type { HostObservation } from '#repositories/agent.repository.ts';
+import type { HealthRepositoryContract } from '#repositories/health.repository.ts';
+import { HealthService, type SystemHealth } from '#services/health.service.ts';
+
+const HOST_ID = Value.Parse(HostIdSchema, 'host-1');
+
+const REPORTS_BEFORE_SILENT = 3;
+const ONE_MS = 1;
+
+/** Past the three reports' silence the service allows, and not a moment more than it has to be. */
+const SILENT_MS = DEFAULT_AGENT_POLL_SETTINGS.reportIntervalMs * REPORTS_BEFORE_SILENT + ONE_MS;
+
+function agoAsTimestamp(ms: number): Timestamp {
+  return Value.Parse(TimestampSchema, new Date(Date.now() - ms).toISOString());
+}
+
+function observation({
+  state = 'ready',
+  silentFor = 0,
+}: {
+  state?: HostState;
+  silentFor?: number;
+} = {}): HostObservation {
+  return { hostId: HOST_ID, reportedAt: agoAsTimestamp(silentFor), state };
+}
+
+type Reachability = { database?: boolean; logStore?: boolean; objectStore?: boolean };
+
+class FakeHealthRepository implements HealthRepositoryContract {
+  readonly #reachable: Required<Reachability>;
+
+  constructor({ database = true, logStore = true, objectStore = true }: Reachability = {}) {
+    this.#reachable = { database, logStore, objectStore };
+  }
+
+  pingDatabase(): Promise<void> {
+    return this.#answer('database');
+  }
+
+  pingLogStore(): Promise<void> {
+    return this.#answer('logStore');
+  }
+
+  pingObjectStore(): Promise<void> {
+    return this.#answer('objectStore');
+  }
+
+  #answer(name: keyof Reachability): Promise<void> {
+    return this.#reachable[name]
+      ? Promise.resolve()
+      : Promise.reject(new Error(`${name} is unreachable`));
+  }
+}
+
+function check({
+  reachability,
+  observed,
+}: {
+  reachability?: Reachability;
+  observed?: HostObservation;
+} = {}): Promise<SystemHealth> {
+  return new HealthService({
+    healthRepo: new FakeHealthRepository(reachability),
+    agentRepo: { lastObservation: () => Promise.resolve(observed) },
+  }).check();
+}
+
+describe('HealthService', () => {
+  test('is healthy when every dependency answers and a host is reporting', async () => {
+    const health = await check({ observed: observation() });
+
+    expect(health.status).toBe('healthy');
+    expect(health.components).toEqual({
+      database: { status: 'up' },
+      logStore: { status: 'up' },
+      objectStore: { status: 'up' },
+      agent: { status: 'up' },
+      appHost: { status: 'up' },
+    });
+  });
+
+  test('reports uptime alongside the components', async () => {
+    const health = await check({ observed: observation() });
+
+    expect(health.uptime).toBeGreaterThan(0);
+  });
+
+  test.each([
+    { name: 'database', reachability: { database: false } },
+    { name: 'logStore', reachability: { logStore: false } },
+    { name: 'objectStore', reachability: { objectStore: false } },
+  ] as const)('an unreachable $name degrades the whole system', async ({ name, reachability }) => {
+    const health = await check({ reachability, observed: observation() });
+
+    expect(health.status).toBe('degraded');
+    expect(health.components[name]).toEqual({ status: 'down' });
+  });
+
+  test('a refusal does not carry the dependency’s own words out to an open route', async () => {
+    const health = await check({ reachability: { database: false }, observed: observation() });
+
+    expect(health.components.database.detail).toBeUndefined();
+  });
+
+  test('the other components still answer when one dependency is unreachable', async () => {
+    const health = await check({ reachability: { logStore: false }, observed: observation() });
+
+    expect(health.components.database.status).toBe('up');
+    expect(health.components.objectStore.status).toBe('up');
+  });
+
+  describe('the agent', () => {
+    test('is down before any host has reported', async () => {
+      const health = await check();
+
+      expect(health.status).toBe('degraded');
+      expect(health.components.agent.status).toBe('down');
+      expect(health.components.agent.detail).toBeDefined();
+    });
+
+    test('is up while reports keep arriving', async () => {
+      const health = await check({ observed: observation({ silentFor: 0 }) });
+
+      expect(health.components.agent).toEqual({ status: 'up' });
+    });
+
+    test('is down once it has gone quiet for longer than three reports', async () => {
+      const health = await check({ observed: observation({ silentFor: SILENT_MS }) });
+
+      expect(health.status).toBe('degraded');
+      expect(health.components.agent.status).toBe('down');
+    });
+  });
+
+  describe('the app host', () => {
+    test('is unknown rather than down when nothing has reported one', async () => {
+      const health = await check();
+
+      expect(health.components.appHost.status).toBe('unknown');
+    });
+
+    test('is unknown when the agent that reports it has gone quiet', async () => {
+      const health = await check({ observed: observation({ silentFor: SILENT_MS }) });
+
+      expect(health.components.appHost.status).toBe('unknown');
+    });
+
+    test.each([
+      { state: 'ready', status: 'up' },
+      { state: 'registering', status: 'unknown' },
+      { state: 'draining', status: 'unknown' },
+      { state: 'unreachable', status: 'down' },
+    ] as const)('reported as $state reads as $status', async ({ state, status }) => {
+      const health = await check({ observed: observation({ state }) });
+
+      expect(health.components.appHost.status).toBe(status);
+    });
+
+    test('says which state it was reported in when that is not ready', async () => {
+      const health = await check({ observed: observation({ state: 'draining' }) });
+
+      expect(health.components.appHost.detail).toContain('draining');
+    });
+  });
+});

--- a/apps/dashboard/src/components/system-status-badge.tsx
+++ b/apps/dashboard/src/components/system-status-badge.tsx
@@ -1,21 +1,85 @@
 import { Badge } from '@repo/ui/components/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@repo/ui/components/popover';
 import { cn } from '@repo/ui/lib/utils';
 import { type ApiHealth, useApiHealth } from '#lib/hooks/use-api-health.ts';
+import type { ComponentName, SystemComponents } from '#queries/health.ts';
 
-const PRESENTATION: Record<ApiHealth['status'], { label: string; dotClassName: string }> = {
+const BADGE: Record<ApiHealth['state'], { label: string; dotClassName: string }> = {
   checking: { label: 'Checking', dotClassName: 'bg-muted-foreground animate-pulse' },
-  reachable: { label: 'System healthy', dotClassName: 'bg-emerald-500' },
-  unreachable: { label: 'System degraded', dotClassName: 'bg-destructive' },
+  healthy: { label: 'System healthy', dotClassName: 'bg-emerald-500' },
+  degraded: { label: 'System degraded', dotClassName: 'bg-amber-500' },
+  unreachable: { label: 'System unreachable', dotClassName: 'bg-destructive' },
 };
 
+const DOT: Record<SystemComponents[ComponentName]['status'], string> = {
+  up: 'bg-emerald-500',
+  down: 'bg-destructive',
+  unknown: 'bg-amber-500',
+};
+
+/** Also the order they are read in: the fleet first, then what this process itself talks to. */
+const LABEL: Record<ComponentName, string> = {
+  appHost: 'App host',
+  agent: 'Host agent',
+  database: 'Database',
+  logStore: 'Log store',
+  objectStore: 'Object store',
+};
+
+const NAMES = Object.keys(LABEL) as ComponentName[];
+
+const WITHOUT_COMPONENTS: Record<'checking' | 'unreachable', string> = {
+  checking: 'Asking the api how it is.',
+  unreachable: 'The api did not answer, so nothing below it can be reported on either.',
+};
+
+/**
+ * The badge is the trigger because the badge is the summary: one word for a system of five parts,
+ * and the only question it leaves is which part it was said for.
+ */
 export function SystemStatusBadge() {
-  const { status } = useApiHealth();
-  const { label, dotClassName } = PRESENTATION[status];
+  const health = useApiHealth();
+  const { label, dotClassName } = BADGE[health.state];
 
   return (
-    <Badge variant="outline" className="gap-1.5">
-      <span className={cn('size-1.5 rounded-full', dotClassName)} />
-      {label}
-    </Badge>
+    <Popover>
+      <PopoverTrigger openOnHover className="cursor-default">
+        <Badge variant="outline" className="gap-1.5">
+          <span className={cn('size-1.5 rounded-full', dotClassName)} />
+          {label}
+        </Badge>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80">
+        {health.components === undefined ? (
+          <p className="text-muted-foreground text-xs">{WITHOUT_COMPONENTS[health.state]}</p>
+        ) : (
+          <ComponentBreakdown components={health.components} />
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ComponentBreakdown({ components }: { components: SystemComponents }) {
+  return (
+    <dl className="grid grid-cols-[1fr_auto] gap-x-6 gap-y-2 text-xs">
+      {NAMES.map((name) => (
+        <div className="contents" key={name}>
+          <dt>
+            {LABEL[name]}
+            {components[name].detail === undefined ? null : (
+              <p className="text-muted-foreground">{components[name].detail}</p>
+            )}
+          </dt>
+          <dd className="flex items-center gap-1.5 self-start">
+            <span
+              className={cn('size-1.5 rounded-full', DOT[components[name].status])}
+              aria-hidden="true"
+            />
+            {components[name].status}
+          </dd>
+        </div>
+      ))}
+    </dl>
   );
 }

--- a/apps/dashboard/src/lib/hooks/use-api-health.ts
+++ b/apps/dashboard/src/lib/hooks/use-api-health.ts
@@ -1,18 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
-import { healthQueryOptions } from '#queries/health.ts';
+import { healthQueryOptions, type SystemComponents, type SystemHealth } from '#queries/health.ts';
 
+/**
+ * The api's own two verdicts, plus the two states only this end can be in: it has not asked yet,
+ * or it asked and got nothing. An api that does not answer reports no components, which is why
+ * they arrive together with the state that has them rather than beside it.
+ */
 export type ApiHealth =
-  | { status: 'checking' | 'unreachable'; uptimeSeconds?: undefined }
-  | { status: 'reachable'; uptimeSeconds: number };
+  | { state: 'checking' | 'unreachable'; components?: undefined }
+  | { state: SystemHealth['status']; components: SystemComponents };
 
 export function useApiHealth(): ApiHealth {
   const { data, isError } = useQuery(healthQueryOptions);
 
   if (isError) {
-    return { status: 'unreachable' };
+    return { state: 'unreachable' };
   }
   if (!data) {
-    return { status: 'checking' };
+    return { state: 'checking' };
   }
-  return { status: 'reachable', uptimeSeconds: data.uptime };
+  return { state: data.status, components: data.components };
 }

--- a/apps/dashboard/src/queries/health.ts
+++ b/apps/dashboard/src/queries/health.ts
@@ -1,16 +1,19 @@
+import { unwrap } from '@repo/api-client/unwrap';
 import { queryOptions } from '@tanstack/react-query';
 import { api } from '#lib/api.ts';
 
 const REFETCH_INTERVAL_MS = 5_000;
 
+async function fetchHealth() {
+  return unwrap(await api.api.health.get());
+}
+
+export type SystemHealth = Awaited<ReturnType<typeof fetchHealth>>;
+export type SystemComponents = SystemHealth['components'];
+export type ComponentName = keyof SystemComponents;
+
 export const healthQueryOptions = queryOptions({
   queryKey: ['health'],
-  queryFn: async () => {
-    const { data, error } = await api.api.health.get();
-    if (error) {
-      throw error;
-    }
-    return data;
-  },
+  queryFn: fetchHealth,
   refetchInterval: REFETCH_INTERVAL_MS,
 });


### PR DESCRIPTION
`/api/health` now reports the database, log store, object store, agent and app host separately, and the badge shows a breakdown on hover instead of one word for five things.

The agent and app host come from in-memory state stamped on every host report — `AgentRepository` already keeps session state that way, so nothing new reaches the database. The other three are live probes, run together with a 2s budget each.

Two decisions worth a look:

- **The route always answers 200.** It used to 500 when the database ping threw. The container healthcheck calls this route and `on_box_deploy.sh` gates the deploy on it, so a status carrying the fleet's verdict would fail every release — a freshly started api has heard from no host yet. An unreachable database still fails a deploy: `runMigrations()` throws at boot and the container never comes up.
- **A probe's failure is logged, not returned.** The route is unauthenticated and a Postgres error names the host, port and user it was dialling.