### PR TITLE
feat(api): a binary naming a loader the guest lacks is refused at upload

### DIFF
--- a/apps/api/src/lib/artifact-digest.ts
+++ b/apps/api/src/lib/artifact-digest.ts
@@ -5,10 +5,20 @@ import {
   Sha256DigestSchema,
   Value,
 } from '@repo/protocol';
-import { ELF_MAGIC_LENGTH, isElfExecutable } from '#lib/elf.ts';
+import { ELF_MAGIC_LENGTH, interpreterOf, isElfExecutable, isGuestInterpreter } from '#lib/elf.ts';
 
 const DIGEST_ALGORITHM = 'sha256';
 const HEX_ENCODING = 'hex';
+
+/**
+ * How much of the object is held to read the program headers out of.
+ *
+ * The interpreter is named by a segment the linker puts near the front — a kibibyte or two in,
+ * across every toolchain seen here — and one that sat past this would be read as a binary that
+ * names none, which is the lenient verdict. Generous rather than exact because the cost is one
+ * buffer per upload and the cost of being wrong is a rejected deploy.
+ */
+const HEADER_BYTES = 65_536;
 
 export type ArtifactIdentity = {
   digest: Sha256Digest;
@@ -19,7 +29,16 @@ export type ArtifactIdentity = {
 export type ArtifactInspection =
   | ({ outcome: 'stored' } & ArtifactIdentity)
   | { outcome: 'not-executable' }
+  | { outcome: 'unsupported-interpreter'; interpreter: string }
   | { outcome: 'too-large' };
+
+/** Only ever a verdict on a loader path actually read; see `interpreterOf`. */
+function refuseInterpreter(bytes: Uint8Array): ArtifactInspection | undefined {
+  const interpreter = interpreterOf(bytes);
+  return interpreter !== undefined && !isGuestInterpreter(interpreter)
+    ? { outcome: 'unsupported-interpreter', interpreter }
+    : undefined;
+}
 
 /**
  * The digest a host will verify, taken from the bytes the store now holds.
@@ -28,9 +47,9 @@ export type ArtifactInspection =
  * that never converges rather than a rejected upload — so the bytes are read back and hashed
  * here even though the api never had them in hand.
  *
- * Executability and size are settled in the same pass because the pass is the expensive part:
- * the object is a whole binary, and reading it three times to answer three questions about it
- * would cost three times the bandwidth to reach the same verdict.
+ * Executability, the loader it asks for, and size are settled in the same pass because the pass
+ * is the expensive part: the object is a whole binary, and reading it four times to answer four
+ * questions about it would cost four times the bandwidth to reach the same verdict.
  */
 export async function inspectArtifact({
   stream,
@@ -40,15 +59,29 @@ export async function inspectArtifact({
   maxSizeBytes: number;
 }): Promise<ArtifactInspection> {
   const hasher = new Bun.CryptoHasher(DIGEST_ALGORITHM);
-  const magic: number[] = [];
+  const header = new Uint8Array(HEADER_BYTES);
+  let headerLength = 0;
   let sizeBytes = 0;
 
   for await (const chunk of stream) {
-    magic.push(...chunk.slice(0, ELF_MAGIC_LENGTH - magic.length));
+    const wasComplete = headerLength === HEADER_BYTES;
+    if (!wasComplete) {
+      const taken = Math.min(chunk.byteLength, HEADER_BYTES - headerLength);
+      header.set(chunk.subarray(0, taken), headerLength);
+      headerLength += taken;
+    }
     // Leaving the loop cancels the read, so something that was never a binary costs one chunk
     // rather than the whole object.
-    if (magic.length >= ELF_MAGIC_LENGTH && !isElfExecutable(Uint8Array.from(magic))) {
+    if (headerLength >= ELF_MAGIC_LENGTH && !isElfExecutable(header)) {
       return { outcome: 'not-executable' };
+    }
+    // On the one chunk that completes the header, so a binary the guest could never exec is
+    // refused without pulling the rest of it either.
+    if (!wasComplete && headerLength === HEADER_BYTES) {
+      const refusal = refuseInterpreter(header);
+      if (refusal) {
+        return refusal;
+      }
     }
 
     sizeBytes += chunk.byteLength;
@@ -59,9 +92,16 @@ export async function inspectArtifact({
     hasher.update(chunk);
   }
 
+  const read = header.subarray(0, headerLength);
   // Shorter than the magic itself, so the loop above never reached a verdict.
-  if (!isElfExecutable(Uint8Array.from(magic))) {
+  if (!isElfExecutable(read)) {
     return { outcome: 'not-executable' };
+  }
+  if (headerLength < HEADER_BYTES) {
+    const refusal = refuseInterpreter(read);
+    if (refusal) {
+      return refusal;
+    }
   }
 
   const digest = Value.Parse(Sha256DigestSchema, hasher.digest(HEX_ENCODING));

--- a/apps/api/src/lib/elf.ts
+++ b/apps/api/src/lib/elf.ts
@@ -18,3 +18,85 @@ export function isElfExecutable(bytes: Uint8Array): boolean {
   }
   return true;
 }
+
+const ELF_CLASS_AT = 4;
+const ELF_CLASS_64 = 2;
+const ELF_ENDIANNESS_AT = 5;
+const ELF_LITTLE_ENDIAN = 1;
+const ELF_HEADER_BYTES = 0x40;
+const SEGMENT_TABLE_START_AT = 0x20;
+const SEGMENT_ENTRY_BYTES_AT = 0x36;
+const SEGMENT_COUNT_AT = 0x38;
+/** A 64-bit program header, which is the shortest entry the reads below stay inside. */
+const SEGMENT_ENTRY_MIN_BYTES = 56;
+const SEGMENT_TYPE_INTERPRETER = 3;
+const SEGMENT_START_AT = 8;
+const SEGMENT_BYTES_AT = 32;
+const LITTLE_ENDIAN = true;
+
+const NUL = '\0';
+
+/**
+ * The dynamic loader this binary names, if the prefix given holds it.
+ *
+ * `undefined` is "this prefix does not say" and never "there is none": a static binary, an ELF
+ * this cannot parse, and an interpreter sitting past the prefix are all indistinguishable here,
+ * so the caller may only ever reject on a path it actually read.
+ */
+export function interpreterOf(bytes: Uint8Array): string | undefined {
+  if (
+    bytes.length < ELF_HEADER_BYTES ||
+    bytes[ELF_CLASS_AT] !== ELF_CLASS_64 ||
+    bytes[ELF_ENDIANNESS_AT] !== ELF_LITTLE_ENDIAN
+  ) {
+    return undefined;
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const tableStart = Number(view.getBigUint64(SEGMENT_TABLE_START_AT, LITTLE_ENDIAN));
+  const entryBytes = view.getUint16(SEGMENT_ENTRY_BYTES_AT, LITTLE_ENDIAN);
+  const entryCount = view.getUint16(SEGMENT_COUNT_AT, LITTLE_ENDIAN);
+  if (entryBytes < SEGMENT_ENTRY_MIN_BYTES) {
+    return undefined;
+  }
+  for (let index = 0; index < entryCount; index++) {
+    const entry = tableStart + index * entryBytes;
+    if (entry + entryBytes > bytes.length) {
+      return undefined;
+    }
+    if (view.getUint32(entry, LITTLE_ENDIAN) !== SEGMENT_TYPE_INTERPRETER) {
+      continue;
+    }
+    const start = Number(view.getBigUint64(entry + SEGMENT_START_AT, LITTLE_ENDIAN));
+    const length = Number(view.getBigUint64(entry + SEGMENT_BYTES_AT, LITTLE_ENDIAN));
+    if (start + length > bytes.length) {
+      return undefined;
+    }
+    const [path] = new TextDecoder().decode(bytes.subarray(start, start + length)).split(NUL);
+    return path;
+  }
+  return undefined;
+}
+
+/**
+ * The paths the guest rootfs actually resolves, from `infra/guest-image/rootfs/build-rootfs.sh`
+ * — which installs glibc's loader and symlinks `/lib` and `/lib64` at it. Nothing compares the
+ * two, so a change to that image's layout is also a change here.
+ */
+const GUEST_INTERPRETERS = [
+  '/lib64/ld-linux-x86-64.so.2',
+  '/usr/lib64/ld-linux-x86-64.so.2',
+  '/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2',
+  '/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2',
+];
+
+/**
+ * Whether the guest could open this loader.
+ *
+ * A binary built against a store-addressed toolchain (Nix) or a different libc (musl) names a
+ * path nothing in the image provides, and `execve` reports that as `ENOENT` against the binary
+ * rather than against the loader — so a deploy that reaches a host fails saying the file it did
+ * find is not there.
+ */
+export function isGuestInterpreter(interpreter: string): boolean {
+  return GUEST_INTERPRETERS.includes(interpreter);
+}

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -8,7 +8,7 @@ import {
   type OwnerId,
   Value,
 } from '@repo/protocol';
-import { inspectArtifact } from '#lib/artifact-digest.ts';
+import { type ArtifactInspection, inspectArtifact } from '#lib/artifact-digest.ts';
 import { BadRequestError, NotFoundError } from '#lib/errors.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
 import type { AppsRepositoryContract } from '#repositories/apps.repository.ts';
@@ -41,6 +41,22 @@ const MAX_ARTIFACT_MEBIBYTES = 256;
  */
 export const MAX_ARTIFACT_SIZE_BYTES = MAX_ARTIFACT_MEBIBYTES * BYTES_PER_MEBIBYTE;
 const TOO_LARGE = `A binary may be at most ${MAX_ARTIFACT_MEBIBYTES} MB.`;
+
+function unsupportedInterpreter(interpreter: string): string {
+  return `The artifact needs the dynamic loader at ${interpreter}, which the guest does not have. Link it against /lib64/ld-linux-x86-64.so.2, or compile it static.`;
+}
+
+/** Why the bytes were refused, in the uploader's terms rather than the inspection's. */
+function refusalMessage(inspection: Exclude<ArtifactInspection, { outcome: 'stored' }>): string {
+  switch (inspection.outcome) {
+    case 'too-large':
+      return TOO_LARGE;
+    case 'unsupported-interpreter':
+      return unsupportedInterpreter(inspection.interpreter);
+    case 'not-executable':
+      return NOT_AN_EXECUTABLE;
+  }
+}
 
 /**
  * Long enough that no upload is still on its way to a row this old — the signed policy expires
@@ -178,7 +194,7 @@ export class ArtifactsService extends Service {
     });
     if (inspection.outcome !== 'stored') {
       await this.abandon({ appId, artifactId, ownerId });
-      throw new BadRequestError(inspection.outcome === 'too-large' ? TOO_LARGE : NOT_AN_EXECUTABLE);
+      throw new BadRequestError(refusalMessage(inspection));
     }
 
     const { digest, sizeBytes, objectKey } = inspection;

--- a/apps/api/tests/lib/artifact-digest.test.ts
+++ b/apps/api/tests/lib/artifact-digest.test.ts
@@ -147,3 +147,116 @@ describe('a size the store accepted is still a size this api will not', () => {
     expect(delivered).toEqual([chunks[0] as Uint8Array]);
   });
 });
+
+const ELF_HEADER_BYTES = 0x40;
+const ELF_CLASS_AT = 4;
+const ELF_CLASS_64 = 2;
+const ELF_ENDIANNESS_AT = 5;
+const ELF_LITTLE_ENDIAN = 1;
+const SEGMENT_TABLE_START_AT = 0x20;
+const SEGMENT_ENTRY_BYTES_AT = 0x36;
+const SEGMENT_COUNT_AT = 0x38;
+const SEGMENT_START_AT = 8;
+const SEGMENT_BYTES_AT = 32;
+const SEGMENT_ENTRY_BYTES = 56;
+const SEGMENT_TYPE_INTERPRETER = 3;
+const ONE_SEGMENT = 1;
+const NO_SEGMENTS = 0;
+const LITTLE_ENDIAN = true;
+
+const GUEST_LOADER = '/lib64/ld-linux-x86-64.so.2';
+const NIX_LOADER =
+  '/nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/ld-linux-x86-64.so.2';
+const MUSL_LOADER = '/lib/ld-musl-x86_64.so.1';
+
+/** Comfortably past the prefix the inspection holds, whatever that prefix is set to. */
+const PAST_THE_HEADER_BYTES = 131_072;
+
+/**
+ * A 64-bit ELF whose only segment names a loader — or, given none, one that names no loader at
+ * all, which is what a static binary looks like here.
+ *
+ * The layout is spelled out rather than taken from `#lib/elf.ts`, so that a test asserting how
+ * an ELF is read cannot be satisfied by the reader agreeing with itself.
+ */
+function elfNaming(interpreter?: string): Uint8Array {
+  const path = interpreter === undefined ? new Uint8Array() : bytesOf(`${interpreter}\0`);
+  const pathStart = ELF_HEADER_BYTES + SEGMENT_ENTRY_BYTES;
+  const bytes = new Uint8Array(pathStart + path.length);
+  const view = new DataView(bytes.buffer);
+
+  bytes.set(bytesOf('\x7fELF'));
+  bytes[ELF_CLASS_AT] = ELF_CLASS_64;
+  bytes[ELF_ENDIANNESS_AT] = ELF_LITTLE_ENDIAN;
+  view.setBigUint64(SEGMENT_TABLE_START_AT, BigInt(ELF_HEADER_BYTES), LITTLE_ENDIAN);
+  view.setUint16(SEGMENT_ENTRY_BYTES_AT, SEGMENT_ENTRY_BYTES, LITTLE_ENDIAN);
+  view.setUint16(
+    SEGMENT_COUNT_AT,
+    interpreter === undefined ? NO_SEGMENTS : ONE_SEGMENT,
+    LITTLE_ENDIAN,
+  );
+  view.setUint32(ELF_HEADER_BYTES, SEGMENT_TYPE_INTERPRETER, LITTLE_ENDIAN);
+  view.setBigUint64(ELF_HEADER_BYTES + SEGMENT_START_AT, BigInt(pathStart), LITTLE_ENDIAN);
+  view.setBigUint64(ELF_HEADER_BYTES + SEGMENT_BYTES_AT, BigInt(path.length), LITTLE_ENDIAN);
+  bytes.set(path, pathStart);
+
+  return bytes;
+}
+
+function inspectBytes(chunks: Uint8Array[]): Promise<ArtifactInspection> {
+  return inspectArtifact({ stream: streamOf(chunks).stream, maxSizeBytes: PAST_THE_HEADER_BYTES });
+}
+
+describe('a loader the guest does not have is refused before a host ever sees it', () => {
+  test('a binary built against a Nix toolchain is refused, naming the loader it asked for', async () => {
+    expect(await inspectBytes([elfNaming(NIX_LOADER)])).toEqual({
+      outcome: 'unsupported-interpreter',
+      interpreter: NIX_LOADER,
+    });
+  });
+
+  test('a binary built against musl is refused the same way', async () => {
+    expect(await inspectBytes([elfNaming(MUSL_LOADER)])).toEqual({
+      outcome: 'unsupported-interpreter',
+      interpreter: MUSL_LOADER,
+    });
+  });
+
+  test('the loader the image actually ships is stored', async () => {
+    expect((await inspectBytes([elfNaming(GUEST_LOADER)])).outcome).toBe('stored');
+  });
+
+  // The guest execs it directly, so naming no loader is the one case that needs nothing from
+  // the image at all.
+  test('a static binary names no loader and is stored', async () => {
+    expect((await inspectBytes([elfNaming()])).outcome).toBe('stored');
+  });
+
+  // Refusing on a path that was never read would reject binaries that are fine, so anything
+  // this cannot parse has to pass.
+  test('an ELF whose headers this cannot read is stored rather than guessed at', async () => {
+    expect((await inspect({ text: BINARY })).outcome).toBe('stored');
+  });
+
+  test('where the chunks fall makes no difference to the verdict', async () => {
+    const split = [...elfNaming(NIX_LOADER)].map((byte) => Uint8Array.of(byte));
+
+    expect(await inspectBytes(split)).toEqual({
+      outcome: 'unsupported-interpreter',
+      interpreter: NIX_LOADER,
+    });
+  });
+
+  // Longer than the prefix, so the verdict is reached partway through the first chunk rather
+  // than at the end of an object that may be hundreds of megabytes.
+  test('the rest of it is never pulled', async () => {
+    const head = new Uint8Array(PAST_THE_HEADER_BYTES);
+    head.set(elfNaming(NIX_LOADER));
+    const chunks = [head, bytesOf('and a great deal more')];
+    const { stream, delivered } = streamOf(chunks);
+
+    await inspectArtifact({ stream, maxSizeBytes: PAST_THE_HEADER_BYTES });
+
+    expect(delivered).toEqual([chunks[0] as Uint8Array]);
+  });
+});


### PR DESCRIPTION
`execve` reports a missing ELF interpreter as `ENOENT` against the binary, so a Nix- or musl-built upload reached a host and spent its whole restart budget failing with a message about the file it *did* find. Read `PT_INTERP` in the pass that already hashes the object, and refuse it there.

Only ever rejects a loader path actually read — a static binary, an unparseable ELF, and an interpreter past the buffered prefix all pass.

Verified against the real artifact from `dailychain-8esbq3` (rejected, naming its `/nix/store/…` loader) and official Node 24 LTS (accepted).