### PR TITLE
feat(agent): a failed deployment reports what the guest said, not the VMM exit code

### DIFF
--- a/apps/agent/src/lib/health/state.ts
+++ b/apps/agent/src/lib/health/state.ts
@@ -99,19 +99,28 @@ export function nextProbeDelayMs(inputs: ProbeInputs): number {
  * There are two ways to reach it and one fact tells them apart: an instance either stopped when
  * nothing had asked it to, or was still up and never answered. Reading that off the unit is what
  * keeps this from being a second copy of the branches below, drifting out of step with them.
+ *
+ * A guest that stopped has usually said why on its console, and that account wins: the exit code
+ * beside it is the one *Firecracker* ended with, which is 0 whenever the guest powered itself off
+ * deliberately — so on the failure the owner is most likely to hit, it reads as success.
  */
 export function describeInstanceFailure({
   unit,
   tracker,
   healthCheck,
   guestPort,
+  guestVerdict,
 }: {
   unit: UnitStatus;
   tracker: HealthTracker;
   healthCheck: HealthCheck;
   guestPort: GuestPort;
+  guestVerdict?: string;
 }): string {
   if (!unit.active) {
+    if (guestVerdict !== undefined) {
+      return guestVerdict;
+    }
     return unit.exitCode === undefined
       ? 'the microVM stopped without being asked to'
       : `the microVM stopped without being asked to, exit code ${unit.exitCode}`;

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -237,7 +237,7 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
 });
 
 /** Only a failure has anything to say: every other state is its own account of itself. */
-function verdict({
+const verdict = Effect.fn('verdict')(function* ({
   state,
   status,
   health,
@@ -247,16 +247,24 @@ function verdict({
   status: UnitStatus;
   health: HealthTracker;
   record: InstanceRecord;
-}): string | undefined {
-  return state === 'failed'
-    ? describeInstanceFailure({
-        unit: status,
-        tracker: health,
-        healthCheck: record.healthCheck,
-        guestPort: record.guestPort,
-      })
-    : undefined;
-}
+}) {
+  if (state !== 'failed') {
+    return undefined;
+  }
+  // Only a VM that stopped has left a console to read, and only one this agent started has a run
+  // to bound that read to.
+  const guestVerdict =
+    status.active || record.startedAt === undefined
+      ? undefined
+      : yield* Systemd.guestVerdict({ appId: record.appId, sinceMs: Date.parse(record.startedAt) });
+  return describeInstanceFailure({
+    unit: status,
+    tracker: health,
+    healthCheck: record.healthCheck,
+    guestPort: record.guestPort,
+    ...(guestVerdict !== undefined ? { guestVerdict } : {}),
+  });
+});
 
 function probed({ record, nowMs }: { record: InstanceRecord; nowMs: number }) {
   return Effect.gen(function* () {
@@ -305,6 +313,7 @@ export const refreshStates = Effect.gen(function* () {
         });
 
         const changed = state !== record.state;
+        const message = changed ? yield* verdict({ state, status, health, record }) : undefined;
         yield* AgentState.putRecord({
           ...record,
           health,
@@ -314,7 +323,7 @@ export const refreshStates = Effect.gen(function* () {
             : {}),
           // Cleared as readily as it is written: a message outliving the state it explains is
           // read as an account of the state that replaced it.
-          ...(changed ? { message: verdict({ state, status, health, record }) } : {}),
+          ...(changed ? { message } : {}),
         });
         if (changed) {
           yield* Effect.logInfo('instance state changed').pipe(

--- a/apps/agent/src/lib/vm/systemd.ts
+++ b/apps/agent/src/lib/vm/systemd.ts
@@ -93,3 +93,62 @@ export const stop = Effect.fn('systemd.stop')((appId: AppId) =>
 export const forget = Effect.fn('systemd.forget')((appId: AppId) =>
   run({ command: [SYSTEMCTL, 'reset-failed', vmUnitName(appId)] }),
 );
+
+const JOURNALCTL = 'journalctl';
+
+/**
+ * The prefix `apps/runtime` writes its console diagnostics with, from `src/log.c`. Nothing
+ * compares the two, so renaming it there is also a change here.
+ */
+const GUEST_LOG_PREFIX = '[nibrun] ';
+
+/** Only the tail is ever wanted, and a guest that crash-looped can have written a great many. */
+const CONSOLE_TAIL_LINES = 200;
+const MS_PER_SECOND = 1000;
+
+/**
+ * The last thing the guest's own init said.
+ *
+ * `/init` ends every way it can stop with a line saying which one it took, so the last of them
+ * is its verdict — and reading only that keeps this from carrying a second copy of the runtime's
+ * vocabulary around.
+ */
+export function lastGuestLine(output: string): string | undefined {
+  const lines = output.split('\n');
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index]?.trim() ?? '';
+    if (line.startsWith(GUEST_LOG_PREFIX)) {
+      return line.slice(GUEST_LOG_PREFIX.length);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Why the guest powered itself off, off the console systemd captured for this microVM.
+ *
+ * Bounded to the run that began at `sinceMs`: a redeploy reuses the unit name, so this unit's
+ * journal still holds every earlier deployment's console and the newest line in it may belong to
+ * one of those. Answers `undefined` rather than failing — a verdict is an improvement on the exit
+ * code, not something the reconciler can be blocked on.
+ */
+export const guestVerdict = Effect.fn('systemd.guestVerdict')(
+  ({ appId, sinceMs }: { appId: AppId; sinceMs: number }) =>
+    run({
+      command: [
+        JOURNALCTL,
+        '--unit',
+        vmUnitName(appId),
+        '--since',
+        `@${Math.floor(sinceMs / MS_PER_SECOND)}`,
+        '--lines',
+        String(CONSOLE_TAIL_LINES),
+        '--output',
+        'cat',
+        '--no-pager',
+      ],
+    }).pipe(
+      Effect.map((result) => lastGuestLine(result.stdout)),
+      Effect.orElseSucceed(() => undefined),
+    ),
+);

--- a/apps/agent/tests/lib/health/state.test.ts
+++ b/apps/agent/tests/lib/health/state.test.ts
@@ -342,6 +342,36 @@ describe('a failure accounts for itself', () => {
     );
   });
 
+  // The exit code beside a stopped VM is Firecracker's, and a guest that powered itself off
+  // deliberately leaves it 0 — so an owner reading it is told the failure succeeded.
+  test('a guest that said why it stopped is quoted rather than the VMM exit code', () => {
+    expect(
+      describeInstanceFailure({
+        unit: exited,
+        tracker: initialTracker(),
+        healthCheck: check(),
+        guestPort: DEFAULT_GUEST_PORT,
+        guestVerdict: 'the tenant used its 5 restarts without staying up; shutting the guest down',
+      }),
+    ).toBe('the tenant used its 5 restarts without staying up; shutting the guest down');
+  });
+
+  // A VM still up never stopped, so there is no console verdict to prefer over the one branch
+  // that is about not being answered at all.
+  test('a verdict does not displace the account of a guest nothing could reach', () => {
+    expect(
+      describeInstanceFailure({
+        unit: active,
+        tracker: { ...initialTracker(), consecutiveFailures: UNHEALTHY_RUN },
+        healthCheck: check(),
+        guestPort: DEFAULT_GUEST_PORT,
+        guestVerdict: 'the tenant has stopped; shutting the guest down',
+      }),
+    ).toBe(
+      `nothing answered on port ${DEFAULT_GUEST_PORT} inside the guest: ${UNHEALTHY_RUN} health probes failed after the ${GRACE_MS}ms grace period`,
+    );
+  });
+
   test('a guest nobody could reach names the port and what was spent trying', () => {
     const tracker = { ...initialTracker(), consecutiveFailures: UNHEALTHY_RUN };
 

--- a/apps/agent/tests/lib/vm/systemd.test.ts
+++ b/apps/agent/tests/lib/vm/systemd.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { AppIdSchema, Value } from '@repo/protocol';
-import { appIdFromUnit, parseUnitNames, vmUnitName } from '#lib/vm/systemd.ts';
+import { appIdFromUnit, lastGuestLine, parseUnitNames, vmUnitName } from '#lib/vm/systemd.ts';
 import { parseProperties, parsePropertyBlocks, unitStatusFrom } from '#lib/vm/unit-status.ts';
 
 describe('unit naming round-trips', () => {
@@ -118,5 +118,35 @@ describe('unit status', () => {
 
   test('a missing exit code is absent rather than zero', () => {
     expect(unitStatusFrom({ LoadState: 'loaded', ActiveState: 'active' }).exitCode).toBeUndefined();
+  });
+});
+
+describe("the guest's own account of why it stopped", () => {
+  // Firecracker writes to the same console, and its lines come after the guest's — so the last
+  // line of the capture is routinely not the one that explains anything.
+  const CONSOLE = [
+    '[nibrun] starting the tenant as uid 65534 with data at /app/data',
+    '[nibrun] the tenant exited with status 126 after 0ms',
+    '[nibrun] restarting the tenant in 8000ms (restart 5 of 5)',
+    '[nibrun] the tenant used its 5 restarts without staying up; shutting the guest down',
+    '[   15.736786] reboot: Restarting system',
+    '2026-08-26T15:46:48.429 [anonymous-instance:main] Vmm is stopping.',
+    '',
+  ].join('\n');
+
+  test('the last line the guest wrote is the verdict, without its prefix', () => {
+    expect(lastGuestLine(CONSOLE)).toBe(
+      'the tenant used its 5 restarts without staying up; shutting the guest down',
+    );
+  });
+
+  test('a console holding nothing from the guest has no verdict to give', () => {
+    expect(
+      lastGuestLine('[    0.000000] Linux version 6.1.180\nVmm is stopping.\n'),
+    ).toBeUndefined();
+  });
+
+  test('an empty capture is not a verdict', () => {
+    expect(lastGuestLine('')).toBeUndefined();
   });
 });


### PR DESCRIPTION
The exit code on a stopped microVM is Firecracker's, and `/init` powers the guest off deliberately once the tenant exhausts its restarts — so every crash-looping binary reached its owner as "the microVM stopped without being asked to, exit code 0", which reads as success.

Read the last `[nibrun] ` line off the unit's console instead, bounded by `--since` to the run that produced it (a redeploy reuses the unit name, so its journal still holds earlier deployments'). Falls back to the old message when the guest said nothing, and never fails the reconciler.

For `dailychain-8esbq3` this turns that sentence into "the tenant used its 5 restarts without staying up; shutting the guest down".