### PR TITLE
feat(agent): a host answers for an app whose microVM is down

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -6,6 +6,7 @@ import { AgentLogger } from '#lib/logger.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
+import { AppActivator } from '#services/app-activator.service.ts';
 import { ArtifactStore } from '#services/artifact-store.service.ts';
 import { CaddyProxy } from '#services/caddy-proxy.service.ts';
 import { CommandRunner } from '#services/command-runner.service.ts';
@@ -14,6 +15,7 @@ import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
 import { ExportManager } from '#services/export-manager.service.ts';
 import { ExportUploader } from '#services/export-uploader.service.ts';
 import { FilesystemReader } from '#services/filesystem-reader.service.ts';
+import { HostFirewall } from '#services/host-firewall.service.ts';
 import { LogStore } from '#services/log-store.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
@@ -41,6 +43,8 @@ const agent = Layer.mergeAll(
   ArtifactStore.Default,
   SlotAllocator.Default,
   ZerofsTopology.Default,
+  HostFirewall.Default,
+  AppActivator.Default,
   CaddyProxy.Default,
   TenantLogQueue.Default,
   TenantLogReceiver.Default,

--- a/apps/agent/src/lib/network/nftables.ts
+++ b/apps/agent/src/lib/network/nftables.ts
@@ -1,5 +1,0 @@
-import { type FirewallState, renderRuleset } from '#lib/network/firewall.ts';
-import { stdoutOf } from '#services/command-runner.service.ts';
-
-export const applyRuleset = (state: FirewallState) =>
-  stdoutOf({ command: ['nft', '-f', '-'], stdin: renderRuleset(state) });

--- a/apps/agent/src/lib/reconcile/network.ts
+++ b/apps/agent/src/lib/reconcile/network.ts
@@ -1,10 +1,11 @@
 import { Effect, Option } from 'effect';
 import type { ForwardedInstance } from '#lib/network/firewall.ts';
-import { applyRuleset } from '#lib/network/nftables.ts';
 import { renderableRoutes } from '#lib/report/routes.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
+import { AppActivator } from '#services/app-activator.service.ts';
 import { CaddyProxy } from '#services/caddy-proxy.service.ts';
+import { HostFirewall } from '#services/host-firewall.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 
 export const routes = Effect.map(AgentState.records, renderableRoutes);
@@ -16,11 +17,23 @@ export const applyRoutes = Effect.gen(function* () {
     .pipe(Effect.catchAll((error) => Effect.logError('proxy reload failed', error)));
 });
 
-const forwards = Effect.gen(function* () {
+/** A listener on every port this host holds a slot for, so one with no forward still answers. */
+export const applyActivators = Effect.gen(function* () {
+  const allocator = yield* SlotAllocator;
+  const activator = yield* AppActivator;
+  yield* activator.serve(yield* allocator.slots);
+});
+
+/**
+ * Only a tenant that has answered is forwarded: a booted-but-dead VM must never take traffic.
+ * The rule is the switch on the loopback port an app is reached by — with it the request is
+ * rewritten to the guest before local delivery, and without it the agent answers it instead.
+ */
+export const forwardedInstances = Effect.gen(function* () {
   const allocator = yield* SlotAllocator;
   const all = yield* AgentState.records;
   const forwarded: ForwardedInstance[] = [];
-  for (const record of all) {
+  for (const record of all.filter((one) => one.state === 'running')) {
     const slot = yield* allocator.lookup(record.appId);
     if (Option.isSome(slot)) {
       forwarded.push({
@@ -41,16 +54,19 @@ const forwards = Effect.gen(function* () {
  */
 export const applyNetwork = Effect.gen(function* () {
   const config = yield* AgentConfig;
-  yield* applyRuleset({
-    instances: yield* forwards,
-    controlPlaneCidrsV4: config.controlPlaneCidrsV4,
-    controlPlaneCidrsV6: config.controlPlaneCidrsV6,
-  }).pipe(
-    Effect.andThen(AgentState.modify((current) => ({ ...current, isolated: true }))),
-    Effect.catchAll((error) =>
-      AgentState.modify((current) => ({ ...current, isolated: false })).pipe(
-        Effect.andThen(Effect.logError('firewall apply failed', error)),
+  const firewall = yield* HostFirewall;
+  yield* firewall
+    .apply({
+      instances: yield* forwardedInstances,
+      controlPlaneCidrsV4: config.controlPlaneCidrsV4,
+      controlPlaneCidrsV6: config.controlPlaneCidrsV6,
+    })
+    .pipe(
+      Effect.andThen(AgentState.modify((current) => ({ ...current, isolated: true }))),
+      Effect.catchAll((error) =>
+        AgentState.modify((current) => ({ ...current, isolated: false })).pipe(
+          Effect.andThen(Effect.logError('firewall apply failed', error)),
+        ),
       ),
-    ),
-  );
+    );
 });

--- a/apps/agent/src/lib/report/routes.ts
+++ b/apps/agent/src/lib/report/routes.ts
@@ -7,10 +7,18 @@ export type RouteTarget = {
   readonly hostPort: HostPort;
 };
 
-/** Only a tenant that has answered is routable: a booted-but-dead VM must never take traffic. */
+/**
+ * Responsibility, not liveness: a host answers for every app it holds a slot for, up or down. The
+ * block is the same either way, so stopping and starting an app rewrites no config and reloads no
+ * proxy — and a hostname this host does own is answered rather than falling through to the
+ * wildcard's 404, which is the answer for one it does not.
+ *
+ * What the loopback port leads to is the forward rule's decision. With it the guest answers,
+ * without it the agent does.
+ */
 export function renderableRoutes(records: readonly InstanceRecord[]): RouteTarget[] {
   return records
-    .filter((record) => record.state === 'running' && record.hostnames.length > 0)
+    .filter((record) => record.hostnames.length > 0)
     .map((record) => ({
       appId: record.appId,
       hostnames: record.hostnames,

--- a/apps/agent/src/services/app-activator.service.ts
+++ b/apps/agent/src/services/app-activator.service.ts
@@ -1,0 +1,94 @@
+import type { AppId, HostPort } from '@repo/protocol';
+import { Effect, Ref } from 'effect';
+import type { AppSlot } from '#lib/network/slot.ts';
+
+const LOOPBACK = '127.0.0.1';
+const HTTP_UNAVAILABLE = 503;
+
+/**
+ * Plain and short, because a person reads it in a browser with no styling around it. It says the
+ * app is down rather than unknown: the wildcard site's 404 is the answer for a hostname this host
+ * serves nothing on, and a suspended app is not that.
+ */
+function sayAppIsDown(): Response {
+  return new Response('This app is not running.\n', {
+    status: HTTP_UNAVAILABLE,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'no-store',
+    },
+  });
+}
+
+type Listener = {
+  readonly hostPort: HostPort;
+  readonly server: ReturnType<typeof Bun.serve>;
+};
+
+/**
+ * The other end of an app's loopback port. The output-hook DNAT rewrites that port to the guest
+ * before local delivery, so while the microVM is up nothing here is reached — and while it is
+ * down this is what the proxy finds instead of a refused connection.
+ *
+ * Bound for the life of the slot rather than the life of the microVM: the rule is what switches
+ * between the two, so there is no bind to race the reconciler and no window the port is nobody's.
+ *
+ * The 503 is where a wake will go: a request for a sleeping microVM is the thing that has a
+ * reason to start one.
+ */
+export class AppActivator extends Effect.Service<AppActivator>()('AppActivator', {
+  scoped: Effect.gen(function* () {
+    const listeners = yield* Ref.make(new Map<AppId, Listener>());
+
+    const close = (appId: AppId) =>
+      Effect.gen(function* () {
+        const listener = (yield* Ref.get(listeners)).get(appId);
+        if (!listener) {
+          return;
+        }
+        yield* Ref.update(listeners, (current) => {
+          const remaining = new Map(current);
+          remaining.delete(appId);
+          return remaining;
+        });
+        // Not awaited: `stop` settles only once every handler has, and one holding a connection
+        // open would have the agent's own shutdown wait on a tenant's client.
+        yield* Effect.asVoid(Effect.sync(() => listener.server.stop(true)));
+      });
+
+    const listen = ({ appId, hostPort }: { appId: AppId; hostPort: HostPort }) =>
+      Effect.try(() => Bun.serve({ hostname: LOOPBACK, port: hostPort, fetch: sayAppIsDown })).pipe(
+        Effect.tap((server) =>
+          Ref.update(listeners, (current) => new Map(current).set(appId, { hostPort, server })),
+        ),
+        Effect.andThen(Effect.logInfo('app activator listening')),
+        Effect.catchAll((error) => Effect.logWarning('app activator bind failed', error)),
+        Effect.annotateLogs({ appId, hostPort }),
+      );
+
+    yield* Effect.addFinalizer(() =>
+      Effect.flatMap(Ref.get(listeners), (current) =>
+        Effect.forEach([...current.keys()], close, { discard: true }),
+      ),
+    );
+
+    return {
+      serve: Effect.fn('AppActivator.serve')(function* (
+        slots: readonly Pick<AppSlot, 'appId' | 'hostPort'>[],
+      ) {
+        const current = yield* Ref.get(listeners);
+        const wanted = new Map(slots.map((slot) => [slot.appId, slot.hostPort] as const));
+        for (const [appId, listener] of current) {
+          if (wanted.get(appId) !== listener.hostPort) {
+            yield* close(appId);
+          }
+        }
+        yield* Effect.forEach(
+          slots.filter((slot) => current.get(slot.appId)?.hostPort !== slot.hostPort),
+          listen,
+          { discard: true },
+        );
+      }),
+    };
+  }),
+}) {}

--- a/apps/agent/src/services/host-firewall.service.ts
+++ b/apps/agent/src/services/host-firewall.service.ts
@@ -1,0 +1,28 @@
+import { Effect, Option, Ref } from 'effect';
+import { type FirewallState, renderRuleset } from '#lib/network/firewall.ts';
+import { stdoutOf } from '#services/command-runner.service.ts';
+
+/**
+ * The kernel's copy of `renderRuleset`, and the memory of what was last put there. Which tenants
+ * are forwarded changes on the probe rather than on desired state, so this is applied on every
+ * status tick — and an unchanged ruleset has to cost nothing rather than a table replacement a
+ * second.
+ */
+export class HostFirewall extends Effect.Service<HostFirewall>()('HostFirewall', {
+  effect: Effect.gen(function* () {
+    // Never applied by this process yet, so the first apply always runs: what is in the kernel
+    // came from whichever agent ran before, and the host may have changed since.
+    const applied = yield* Ref.make(Option.none<string>());
+
+    return {
+      apply: Effect.fn('HostFirewall.apply')(function* (state: FirewallState) {
+        const ruleset = renderRuleset(state);
+        if (Option.getOrUndefined(yield* Ref.get(applied)) === ruleset) {
+          return;
+        }
+        yield* stdoutOf({ command: ['nft', '-f', '-'], stdin: ruleset });
+        yield* Ref.set(applied, Option.some(ruleset));
+      }),
+    };
+  }),
+}) {}

--- a/apps/agent/src/services/reconciler.service.ts
+++ b/apps/agent/src/services/reconciler.service.ts
@@ -10,7 +10,7 @@ import {
   startInstance,
   stopInstance,
 } from '#lib/reconcile/instances.ts';
-import { applyNetwork, applyRoutes } from '#lib/reconcile/network.ts';
+import { applyActivators, applyNetwork, applyRoutes } from '#lib/reconcile/network.ts';
 import { hasDeferredWork, type ObservedState, planReconcile } from '#lib/reconcile/plan.ts';
 import { applyTeardowns, applyVolumes, volumeOwners } from '#lib/reconcile/volumes.ts';
 import { readInstanceRecords } from '#lib/report/instance-record.ts';
@@ -58,6 +58,9 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
           exports: exports.length,
         }),
       );
+      // Before the first poll has even been answered: an app this host stopped before the agent
+      // restarted has no forward, so until something is listening its port refuses connections.
+      yield* applyActivators;
     }).pipe(Effect.withSpan('Reconciler.load'));
 
     /**
@@ -213,6 +216,9 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
         { concurrency: 'unbounded', discard: true },
       );
       yield* applyVolumes({ plan, observed, desired }).pipe(Effect.withSpan('reconcile.volumes'));
+      // Before the forwards below are withdrawn from a tenant that has just stopped, so the port
+      // it was reached on is answered rather than closed.
+      yield* applyActivators.pipe(Effect.withSpan('reconcile.activators'));
       // Before anything boots: nothing persists the ruleset across a reboot, so a host that
       // started its VMs first would serve tenants through a kernel with no `nibrun` table.
       yield* applyNetwork.pipe(Effect.withSpan('reconcile.network'));
@@ -237,9 +243,10 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       load,
       observe,
       reconcile,
-      // An instance becomes routable here rather than in reconcile: the probe is what tells a
-      // booted VM from one whose tenant has answered.
+      // An instance takes traffic here rather than in reconcile: the probe is what tells a booted
+      // VM from one whose tenant has answered, and the forward is what puts its port through.
       refresh: refreshStates.pipe(
+        Effect.andThen(applyNetwork),
         Effect.andThen(applyRoutes),
         Effect.andThen(persist),
         Effect.withSpan('Reconciler.refresh'),

--- a/apps/agent/tests/lib/reconcile/network.test.ts
+++ b/apps/agent/tests/lib/reconcile/network.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import { AppIdSchema, DEFAULT_GUEST_PORT, INSTANCE_STATES, Value } from '@repo/protocol';
+import { Effect, Layer, Option } from 'effect';
+import { forwardedInstances } from '#lib/reconcile/network.ts';
+import type { InstanceRecord } from '#lib/report/instance-record.ts';
+import { AgentState } from '#services/agent-state.service.ts';
+import { SlotAllocator } from '#services/slot-allocator.service.ts';
+import { agentConfig } from '#tests/support/config.ts';
+import { APP_ID, instanceRecord } from '#tests/support/fixtures.ts';
+import { platform, provided } from '#tests/support/run.ts';
+
+const OTHER_APP_ID = Value.Parse(AppIdSchema, 'app-2');
+
+/** Everything a record can say other than that the tenant has answered. */
+const DOWN_STATES = INSTANCE_STATES.filter((state) => state !== 'running');
+
+const run = provided(
+  Layer.mergeAll(
+    AgentState.Default,
+    SlotAllocator.DefaultWithoutDependencies.pipe(Layer.provide(agentConfig())),
+  ).pipe(Layer.provideMerge(platform)),
+);
+
+/** What a host looks like once every one of these apps has been placed on it. */
+function forwardsFor(records: readonly InstanceRecord[]) {
+  return Effect.gen(function* () {
+    const allocator = yield* SlotAllocator;
+    for (const record of records) {
+      yield* allocator.allocate(record.appId);
+      yield* AgentState.putRecord(record);
+    }
+    return yield* forwardedInstances;
+  });
+}
+
+describe('the forward is what decides whether a port reaches the guest', () => {
+  test.each(DOWN_STATES)('a %s instance is not forwarded', (state) =>
+    run(
+      Effect.gen(function* () {
+        expect(yield* forwardsFor([instanceRecord({ state })])).toEqual([]);
+      }),
+    ),
+  );
+
+  test('a running instance is forwarded onto the guest its slot describes', () =>
+    run(
+      Effect.gen(function* () {
+        const forwarded = yield* forwardsFor([instanceRecord()]);
+        const allocator = yield* SlotAllocator;
+        const slot = Option.getOrThrow(yield* allocator.lookup(APP_ID));
+
+        expect(forwarded).toEqual([
+          {
+            hostPort: slot.hostPort,
+            guestPort: DEFAULT_GUEST_PORT,
+            hostIpv4: slot.hostIpv4,
+            guestIpv4: slot.guestIpv4,
+          },
+        ]);
+      }),
+    ));
+
+  test('a host holding two apps and running one forwards only that one', () =>
+    run(
+      Effect.gen(function* () {
+        const forwarded = yield* forwardsFor([
+          instanceRecord({ state: 'stopped' }),
+          instanceRecord({ appId: OTHER_APP_ID }),
+        ]);
+
+        expect(forwarded).toHaveLength(1);
+      }),
+    ));
+});

--- a/apps/agent/tests/lib/report/build-report.test.ts
+++ b/apps/agent/tests/lib/report/build-report.test.ts
@@ -1,37 +1,27 @@
 import { describe, expect, test } from 'bun:test';
 import {
-  AppIdSchema,
   DEFAULT_GUEST_PORT,
-  DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   type GuestPort,
-  HostnameSchema,
   type HostPort,
   HostPortSchema,
   HostReportedStateSchema,
-  type InstanceState,
-  Ipv4AddressSchema,
   isValidMessage,
-  Sha256DigestSchema,
   Value,
 } from '@repo/protocol';
-import { initialTracker } from '#lib/health/state.ts';
 import { buildReportedState, toReportedInstance } from '#lib/report/build-report.ts';
 import { allocatableCapacity } from '#lib/report/capacity.ts';
-import type { InstanceRecord } from '#lib/report/instance-record.ts';
-import { renderableRoutes } from '#lib/report/routes.ts';
 import {
   APP_ID,
-  DEPLOYMENT_ID,
   EXPORT_ID,
   FIRST_HOST_PORT,
   HOST_ID,
+  instanceRecord,
   OBSERVED_AT,
   VOLUME_ID,
   VOLUME_SIZE_BYTES,
 } from '#tests/support/fixtures.ts';
 
-const DIGEST_HEX_LENGTH = 64;
 const BUNDLE_SIZE_BYTES = 1_782_579;
 const HOST_VCPUS = 4;
 const HOST_MEMORY_MIB = 8_192;
@@ -49,35 +39,13 @@ const DEFAULT_INSTANCE_RESOURCES_AS_CAPACITY = {
   cacheBytes: HOST_CACHE_BYTES,
 };
 
-function record(overrides: Partial<InstanceRecord> = {}): InstanceRecord {
-  return {
-    appId: APP_ID,
-    deploymentId: DEPLOYMENT_ID,
-    volumeId: VOLUME_ID,
-    hostnames: [{ hostname: Value.Parse(HostnameSchema, 'a.example.com'), kind: 'platform' }],
-    hostPort: FIRST_HOST_PORT,
-    guestPort: DEFAULT_GUEST_PORT,
-    guestIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.2'),
-    artifactDigest: Value.Parse(Sha256DigestSchema, 'a'.repeat(DIGEST_HEX_LENGTH)),
-    state: 'running' as InstanceState,
-    health: initialTracker(),
-    healthCheck: DEFAULT_HEALTH_CHECK,
-    resources: DEFAULT_INSTANCE_RESOURCES,
-    desiredRunning: true,
-    startAttempts: { attempts: 1 },
-    restartCount: 0,
-    stopRequested: false,
-    ...overrides,
-  };
-}
-
 describe('the report always names the host-side port', () => {
   test('routing is local, but the control plane cannot debug a host without it', () => {
-    expect(toReportedInstance(record()).hostPort).toBe(FIRST_HOST_PORT);
+    expect(toReportedInstance(instanceRecord()).hostPort).toBe(FIRST_HOST_PORT);
   });
 
   test('absent means unknown: no field is ever sent null', () => {
-    const reported = toReportedInstance(record());
+    const reported = toReportedInstance(instanceRecord());
     expect('startedAt' in reported).toBe(false);
     expect('lastHealthyAt' in reported).toBe(false);
     expect('lastExitCode' in reported).toBe(false);
@@ -85,7 +53,7 @@ describe('the report always names the host-side port', () => {
   });
 
   test('an exit code of zero is reported rather than dropped as falsy', () => {
-    expect(toReportedInstance(record({ lastExitCode: 0 })).lastExitCode).toBe(0);
+    expect(toReportedInstance(instanceRecord({ lastExitCode: 0 })).lastExitCode).toBe(0);
   });
 });
 
@@ -102,7 +70,7 @@ describe('the assembled report satisfies the protocol', () => {
         cacheBytes: FREE_CACHE_BYTES,
       },
       versions: { agent: 'sha', guestImage: '6.1', zerofs: '2.2.1', firecracker: '1.16.1' },
-      records: [record({ startedAt: OBSERVED_AT })],
+      records: [instanceRecord({ startedAt: OBSERVED_AT })],
       volumes: [
         { volumeId: VOLUME_ID, appId: APP_ID, state: 'ready', sizeBytes: VOLUME_SIZE_BYTES },
       ],
@@ -117,27 +85,6 @@ describe('the assembled report satisfies the protocol', () => {
       ],
     });
     expect(isValidMessage({ schema: HostReportedStateSchema, value: report })).toBe(true);
-  });
-});
-
-describe('the same records render the routing layer', () => {
-  test('only instances whose tenant answered are routable', () => {
-    const records = [
-      record(),
-      record({ appId: Value.Parse(AppIdSchema, 'inst-2'), state: 'starting' }),
-      record({ appId: Value.Parse(AppIdSchema, 'inst-3'), state: 'unhealthy' }),
-    ];
-    expect(renderableRoutes(records)).toEqual([
-      {
-        appId: APP_ID,
-        hostnames: records[0]?.hostnames ?? [],
-        hostPort: FIRST_HOST_PORT,
-      },
-    ]);
-  });
-
-  test('an app with no hostname yet is not routed', () => {
-    expect(renderableRoutes([record({ hostnames: [] })])).toEqual([]);
   });
 });
 

--- a/apps/agent/tests/lib/report/routes.test.ts
+++ b/apps/agent/tests/lib/report/routes.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { INSTANCE_STATES } from '@repo/protocol';
+import { renderAppSites } from '#lib/proxy/caddyfile.ts';
+import { renderableRoutes } from '#lib/report/routes.ts';
+import { APP_HOSTNAME, instanceRecord } from '#tests/support/fixtures.ts';
+
+/** Everything a record can say other than that the tenant has answered. */
+const DOWN_STATES = INSTANCE_STATES.filter((state) => state !== 'running');
+
+describe('a host answers for the apps it holds, not the ones that happen to be up', () => {
+  test.each(DOWN_STATES)('a %s app is still routed here', (state) => {
+    expect(renderableRoutes([instanceRecord({ state })])).toHaveLength(1);
+  });
+
+  test('an app with no hostname has nothing to answer on', () => {
+    expect(renderableRoutes([instanceRecord({ hostnames: [] })])).toEqual([]);
+  });
+
+  test('an app is reached on the same port whether or not its microVM is up', () => {
+    const [running] = renderableRoutes([instanceRecord()]);
+    const [stopped] = renderableRoutes([instanceRecord({ state: 'stopped' })]);
+
+    expect(running?.hostPort).toBe(stopped?.hostPort);
+  });
+});
+
+describe('stopping an app moves nothing the proxy would have to reload for', () => {
+  test('the rendered config is byte-identical whether the app is up or down', () => {
+    const up = renderAppSites(renderableRoutes([instanceRecord()]));
+    const down = renderAppSites(renderableRoutes([instanceRecord({ state: 'stopped' })]));
+
+    expect(up).toBe(down);
+    expect(up).toContain(`https://${APP_HOSTNAME.hostname} {`);
+  });
+});

--- a/apps/agent/tests/services/app-activator.test.ts
+++ b/apps/agent/tests/services/app-activator.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { AppIdSchema, type HostPort, HostPortSchema, Value } from '@repo/protocol';
+import { Effect, Either } from 'effect';
+import { AppActivator } from '#services/app-activator.service.ts';
+import { APP_ID } from '#tests/support/fixtures.ts';
+import { provided } from '#tests/support/run.ts';
+import { HTTP_UNAVAILABLE } from '#tests/support/server.ts';
+
+const OTHER_APP_ID = Value.Parse(AppIdSchema, 'app-2');
+const LOOPBACK = '127.0.0.1';
+
+const run = provided(AppActivator.Default);
+
+/**
+ * A port the kernel has just handed out and taken back, rather than the one an app's slot really
+ * carries: a test must not need 21000 to be free on whatever machine runs it.
+ */
+function unusedPort(): HostPort {
+  const probe = Bun.serve({ hostname: LOOPBACK, port: 0, fetch: () => new Response() });
+  const port = Value.Parse(HostPortSchema, Number(probe.port));
+  probe.stop(true);
+  return port;
+}
+
+function get(hostPort: HostPort) {
+  return Effect.tryPromise(() => fetch(`http://${LOOPBACK}:${hostPort}/`));
+}
+
+describe('an app that is down answers for itself', () => {
+  test('a request the microVM is not there to take is answered rather than refused', () =>
+    run(
+      Effect.gen(function* () {
+        const activator = yield* AppActivator;
+        const hostPort = unusedPort();
+        yield* activator.serve([{ appId: APP_ID, hostPort }]);
+
+        const response = yield* get(hostPort);
+
+        expect(response.status).toBe(HTTP_UNAVAILABLE);
+        expect(yield* Effect.promise(() => response.text())).toContain('not running');
+      }),
+    ));
+
+  test('the port survives a sync that changes nothing, so nothing goes out under it', () =>
+    run(
+      Effect.gen(function* () {
+        const activator = yield* AppActivator;
+        const hostPort = unusedPort();
+        const slots = [{ appId: APP_ID, hostPort }];
+        yield* activator.serve(slots);
+        yield* activator.serve(slots);
+
+        expect((yield* get(hostPort)).status).toBe(HTTP_UNAVAILABLE);
+      }),
+    ));
+
+  test('a slot the host no longer holds stops being answered for', () =>
+    run(
+      Effect.gen(function* () {
+        const activator = yield* AppActivator;
+        const hostPort = unusedPort();
+        yield* activator.serve([{ appId: APP_ID, hostPort }]);
+        yield* activator.serve([{ appId: OTHER_APP_ID, hostPort: unusedPort() }]);
+
+        expect(Either.isLeft(yield* Effect.either(get(hostPort)))).toBe(true);
+      }),
+    ));
+});

--- a/apps/agent/tests/support/fixtures.ts
+++ b/apps/agent/tests/support/fixtures.ts
@@ -1,4 +1,5 @@
 import {
+  type AppHostname,
   AppIdSchema,
   CheckpointIdSchema,
   DEFAULT_GUEST_PORT,
@@ -15,6 +16,7 @@ import {
   FilenameSchema,
   type HostDesiredState,
   HostIdSchema,
+  HostnameSchema,
   HostPortSchema,
   ObjectKeySchema,
   SecretStringSchema,
@@ -23,9 +25,11 @@ import {
   Value,
   VolumeIdSchema,
 } from '@repo/protocol';
+import { initialTracker } from '#lib/health/state.ts';
 import type { TenantLogEvent } from '#lib/logs/event.ts';
-import { HOST_PORT_BASE } from '#lib/network/slot.ts';
+import { describeSlot, FIRST_SLOT, HOST_PORT_BASE } from '#lib/network/slot.ts';
 import type { ObservedInstance, ObservedState, ObservedVolume } from '#lib/reconcile/plan.ts';
+import { type InstanceRecord, newInstanceRecord } from '#lib/report/instance-record.ts';
 import { ARTIFACT_BYTES, ARTIFACT_DIGEST } from '#tests/support/artifacts.ts';
 import { HOST_STORAGE_PREFIX } from '#tests/support/config.ts';
 
@@ -39,6 +43,11 @@ export const OBSERVED_AT = Value.Parse(TimestampSchema, '2026-08-03T10:00:00.000
 
 export const VOLUME_SIZE_BYTES = 4_096;
 export const FIRST_HOST_PORT = Value.Parse(HostPortSchema, HOST_PORT_BASE);
+
+export const APP_HOSTNAME: AppHostname = {
+  hostname: Value.Parse(HostnameSchema, 'app-1.apps.example.com'),
+  kind: 'platform',
+};
 
 /** A tenant's own variables, which are secrets wherever they are typed — including in a test. */
 export function tenantEnvironment(values: Record<string, string>): TenantEnvironment {
@@ -117,6 +126,27 @@ export function desiredState(overrides: Partial<HostDesiredState> = {}): HostDes
     instances: [],
     checkpoints: [],
     exports: [],
+    ...overrides,
+  };
+}
+
+export function instanceRecord(overrides: Partial<InstanceRecord> = {}): InstanceRecord {
+  return {
+    ...newInstanceRecord({
+      appId: APP_ID,
+      deploymentId: DEPLOYMENT_ID,
+      volumeId: VOLUME_ID,
+      hostnames: [APP_HOSTNAME],
+      hostPort: FIRST_HOST_PORT,
+      guestPort: DEFAULT_GUEST_PORT,
+      guestIpv4: describeSlot({ slot: FIRST_SLOT, appId: APP_ID }).guestIpv4,
+      artifactDigest: ARTIFACT_DIGEST,
+      state: 'running',
+      health: initialTracker(),
+      healthCheck: DEFAULT_HEALTH_CHECK,
+      resources: DEFAULT_INSTANCE_RESOURCES,
+      desiredRunning: true,
+    }),
     ...overrides,
   };
 }

--- a/infra/app-host/caddy/Caddyfile
+++ b/infra/app-host/caddy/Caddyfile
@@ -51,9 +51,11 @@ https://{$APP_HOST_DOMAIN}, https://fallback.{$APP_HOST_DOMAIN} {
 	redir https://{$WWW_HOSTNAME} permanent
 }
 
-# Everything else under the app domain: a hostname whose app is not running
-# here, or not running at all. Caddy orders site blocks most-specific first, so
-# the rendered ones above win and this is what is left.
+# Everything else under the app domain: a hostname no app on this host answers
+# for. Caddy orders site blocks most-specific first, so the rendered ones above
+# win and this is what is left. An app that lives here is never one of them —
+# its block is rendered whether or not its microVM is up, and while it is down
+# the agent answers the port with a 503 of its own.
 #
 # It exists so an unknown hostname is answered rather than handled by whatever
 # TLS policy Caddy falls back to — this way every connection the edge makes to


### PR DESCRIPTION
A suspended app is currently indistinguishable from one that does not exist: its site block disappears with its microVM and the hostname falls through to the wildcard 404.

Being responsible for a hostname and having the VM up are now separate things — the Caddy block follows the slot, the DNAT rule is the switch on the loopback port, and the agent answers 503 on every port it holds. The rendered Caddyfile is byte-identical up or down, so stopping an app no longer reloads the proxy. The listener is deliberately the skeleton of the activator that will one day wake a sleeping microVM instead.