### PR TITLE
feat(dashboard): the overview tab shows the machine an app runs on

### DIFF
--- a/apps/dashboard/src/components/apps/app-config-card.tsx
+++ b/apps/dashboard/src/components/apps/app-config-card.tsx
@@ -1,9 +1,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
+import { AppEnvironment } from '#components/apps/app-environment.tsx';
+import { AppRunCommand } from '#components/apps/app-run-command.tsx';
 import type { AppSummary } from '#queries/apps.ts';
 
 export function AppConfigCard({ app }: { app: AppSummary }) {
-  const { guestPort, args } = app.config;
-
   return (
     <Card>
       <CardHeader>
@@ -12,22 +12,10 @@ export function AppConfigCard({ app }: { app: AppSummary }) {
       <CardContent className="flex flex-col gap-4 text-sm">
         <div className="flex items-center justify-between gap-4">
           <span className="text-muted-foreground">Guest port</span>
-          <span className="font-mono tabular-nums">{guestPort}</span>
+          <span className="font-mono tabular-nums">{app.config.guestPort}</span>
         </div>
-        <div className="flex flex-col gap-2">
-          <span className="text-muted-foreground">Arguments</span>
-          {args.length === 0 ? (
-            <span className="text-muted-foreground">None — the binary runs bare.</span>
-          ) : (
-            <ol className="flex flex-wrap gap-1">
-              {[...args.entries()].map(([position, arg]) => (
-                <li key={position} className="rounded-md bg-muted px-2 py-0.5 font-mono">
-                  {arg}
-                </li>
-              ))}
-            </ol>
-          )}
-        </div>
+        <AppRunCommand app={app} />
+        <AppEnvironment app={app} />
       </CardContent>
     </Card>
   );

--- a/apps/dashboard/src/components/apps/app-config-card.tsx
+++ b/apps/dashboard/src/components/apps/app-config-card.tsx
@@ -1,9 +1,8 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
-import { formatBytes } from '#lib/format-bytes.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
 export function AppConfigCard({ app }: { app: AppSummary }) {
-  const { guestPort, args, volumeSizeBytes } = app.config;
+  const { guestPort, args } = app.config;
 
   return (
     <Card>
@@ -14,12 +13,6 @@ export function AppConfigCard({ app }: { app: AppSummary }) {
         <div className="flex items-center justify-between gap-4">
           <span className="text-muted-foreground">Guest port</span>
           <span className="font-mono tabular-nums">{guestPort}</span>
-        </div>
-        <div className="flex items-center justify-between gap-4">
-          <span className="text-muted-foreground">Volume size</span>
-          <span className="font-mono tabular-nums" title={`${volumeSizeBytes} bytes`}>
-            {formatBytes(volumeSizeBytes)}
-          </span>
         </div>
         <div className="flex flex-col gap-2">
           <span className="text-muted-foreground">Arguments</span>

--- a/apps/dashboard/src/components/apps/app-detail.tsx
+++ b/apps/dashboard/src/components/apps/app-detail.tsx
@@ -1,6 +1,7 @@
 import { Skeleton } from '@repo/ui/components/skeleton';
 import { AppConfigCard } from '#components/apps/app-config-card.tsx';
 import { AppOverviewCard } from '#components/apps/app-overview-card.tsx';
+import { AppResourcesCard } from '#components/apps/app-resources-card.tsx';
 import { DeploymentHistory } from '#components/apps/deployment-history.tsx';
 import { FailureEmpty } from '#components/failure-empty.tsx';
 import { useApp } from '#lib/hooks/use-app.ts';
@@ -19,9 +20,10 @@ export function AppDetail() {
 
   return (
     <div className="flex flex-col gap-4 md:gap-6">
-      <div className="grid @3xl/main:grid-cols-2 grid-cols-1 gap-4 md:gap-6">
+      <div className="grid @3xl/main:grid-cols-2 @5xl/main:grid-cols-3 grid-cols-1 gap-4 md:gap-6">
         <AppOverviewCard app={app.data} />
         <AppConfigCard app={app.data} />
+        <AppResourcesCard app={app.data} />
       </div>
       <DeploymentHistory />
     </div>

--- a/apps/dashboard/src/components/apps/app-environment-dialog-content.tsx
+++ b/apps/dashboard/src/components/apps/app-environment-dialog-content.tsx
@@ -1,0 +1,74 @@
+import { Button } from '@repo/ui/components/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@repo/ui/components/dialog';
+import { Field, FieldError } from '@repo/ui/components/field';
+import { DialogBody } from '@repo/ui/custom/dialog-body';
+import { PencilIcon } from 'lucide-react';
+import { useState } from 'react';
+import { DeployProgress } from '#components/apps/deploy-progress.tsx';
+import { EnvironmentTable } from '#components/apps/environment-table.tsx';
+import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
+import { useEnvironmentForm } from '#lib/hooks/use-environment-form.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+export function AppEnvironmentDialogContent({ app }: { app: AppSummary }) {
+  const [open, setOpen] = useState(false);
+  const run = useDeployRun();
+  const form = useEnvironmentForm(app);
+  const releasing = run.phase === 'releasing' || run.phase === 'settling';
+
+  function handleOpenChange(next: boolean): void {
+    if (next && !releasing) {
+      run.reset();
+      form.reset();
+    }
+    setOpen(next);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={<Button variant="outline" size="xs" />}>
+        <PencilIcon data-icon="inline-start" />
+        Edit
+      </DialogTrigger>
+      <DialogContent showCloseButton={!releasing} className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Environment</DialogTitle>
+          <DialogDescription>
+            {run.phase === 'idle'
+              ? `Saving releases ${app.slug} again on the binary it already runs. Its hostnames and everything on its volume stay as they are.`
+              : 'The release is on its way. Closing this does not stop it.'}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody>
+          {run.phase === 'idle' ? (
+            <form
+              className="flex min-w-0 flex-col gap-5"
+              onSubmit={(event) => {
+                event.preventDefault();
+                form.submit();
+              }}
+            >
+              <Field data-invalid={form.error !== undefined || undefined}>
+                <EnvironmentTable variables={form.variables} onChange={form.change} />
+                {form.error !== undefined && <FieldError>{form.error}</FieldError>}
+              </Field>
+              <Button type="submit" size="lg" disabled={!form.submittable}>
+                <span className="truncate">Save and redeploy {app.slug}</span>
+              </Button>
+            </form>
+          ) : (
+            <DeployProgress done={<DialogClose render={<Button />}>Done</DialogClose>} />
+          )}
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/components/apps/app-environment-dialog.tsx
+++ b/apps/dashboard/src/components/apps/app-environment-dialog.tsx
@@ -1,0 +1,11 @@
+import { AppEnvironmentDialogContent } from '#components/apps/app-environment-dialog-content.tsx';
+import { DeployRunProvider } from '#lib/providers/deploy-run-provider.tsx';
+import type { AppSummary } from '#queries/apps.ts';
+
+export function AppEnvironmentDialog({ app }: { app: AppSummary }) {
+  return (
+    <DeployRunProvider>
+      <AppEnvironmentDialogContent app={app} />
+    </DeployRunProvider>
+  );
+}

--- a/apps/dashboard/src/components/apps/app-environment.tsx
+++ b/apps/dashboard/src/components/apps/app-environment.tsx
@@ -1,0 +1,30 @@
+import { AppEnvironmentDialog } from '#components/apps/app-environment-dialog.tsx';
+import { storedNames } from '#lib/environment-variables.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+/** Which variables the app runs with. The values are sealed, so the names are the whole of it. */
+export function AppEnvironment({ app }: { app: AppSummary }) {
+  const names = storedNames(app);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground">Environment</span>
+        <AppEnvironmentDialog app={app} />
+      </div>
+      {names.length === 0 ? (
+        <span className="text-muted-foreground">
+          Nothing set — the binary runs with whatever the guest gives it.
+        </span>
+      ) : (
+        <ul className="flex flex-wrap gap-1">
+          {names.map((name) => (
+            <li key={name} className="rounded-md bg-muted px-2 py-0.5 font-mono">
+              {name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/apps/app-resources-card.tsx
+++ b/apps/dashboard/src/components/apps/app-resources-card.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
+import { CpuIcon, HardDriveIcon, type LucideIcon, MemoryStickIcon } from 'lucide-react';
+import { formatBytes } from '#lib/format-bytes.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+const BYTES_PER_MIB = 1_048_576;
+
+export function AppResourcesCard({ app }: { app: AppSummary }) {
+  const { resources, volumeSizeBytes } = app.config;
+
+  const allocated: { icon: LucideIcon; label: string; value: string }[] = [
+    { icon: CpuIcon, label: 'vCPU', value: String(resources.vcpuCount) },
+    {
+      icon: MemoryStickIcon,
+      label: 'Memory',
+      value: formatBytes(resources.memoryMib * BYTES_PER_MIB),
+    },
+    { icon: HardDriveIcon, label: 'Volume', value: formatBytes(volumeSizeBytes) },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Resources</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4 text-sm">
+        {allocated.map(({ icon: Icon, label, value }) => (
+          <div key={label} className="flex items-center justify-between gap-4">
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <Icon className="size-4 shrink-0" />
+              {label}
+            </span>
+            <span className="font-mono tabular-nums">{value}</span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/apps/app-run-command.tsx
+++ b/apps/dashboard/src/components/apps/app-run-command.tsx
@@ -1,0 +1,58 @@
+import { Skeleton } from '@repo/ui/components/skeleton';
+import { CopyButton } from '@repo/ui/custom/copy-button';
+import { useDeployedBinary } from '#lib/hooks/use-deployed-binary.ts';
+import { runCommand } from '#lib/run-command.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+/**
+ * How the app starts, as one line to copy. Without a binary to name there is no command to give,
+ * so the arguments stand on their own — which is all an app that has never been deployed has.
+ */
+export function AppRunCommand({ app }: { app: AppSummary }) {
+  const binary = useDeployedBinary(app.id);
+
+  if (binary.status === 'unknown') {
+    return (
+      <div className="flex flex-col gap-2">
+        <span className="text-muted-foreground">Arguments</span>
+        <AppArguments args={app.config.args} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-muted-foreground">Run command</span>
+      {binary.status === 'loading' ? (
+        <Skeleton className="h-8 w-full rounded-lg" />
+      ) : (
+        <RunCommandLine command={runCommand({ binaryName: binary.name, args: app.config.args })} />
+      )}
+    </div>
+  );
+}
+
+function RunCommandLine({ command }: { command: string }) {
+  return (
+    <div className="flex items-center gap-1 rounded-lg border bg-muted/40 py-1 pr-1 pl-3">
+      <code className="min-w-0 flex-1 select-all break-words font-mono text-xs">{command}</code>
+      <CopyButton value={command} />
+    </div>
+  );
+}
+
+function AppArguments({ args }: { args: readonly string[] }) {
+  if (args.length === 0) {
+    return <span className="text-muted-foreground">None — the binary runs bare.</span>;
+  }
+
+  return (
+    <ol className="flex flex-wrap gap-1">
+      {[...args.entries()].map(([position, arg]) => (
+        <li key={position} className="rounded-md bg-muted px-2 py-0.5 font-mono">
+          {arg}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/dashboard/src/lib/hooks/use-deployed-binary.ts
+++ b/apps/dashboard/src/lib/hooks/use-deployed-binary.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNewestDeployment } from '#lib/hooks/use-newest-deployment.ts';
+import { artifactQueryOptions } from '#queries/artifacts.ts';
+
+/**
+ * The binary an app is running, by the name it was uploaded under. `unknown` covers an app that
+ * has never been deployed as well as one whose artifact could not be read — neither leaves
+ * anything to name, and there is nothing an owner would do differently about which it was.
+ */
+export type DeployedBinary =
+  | { readonly status: 'loading' }
+  | { readonly status: 'unknown' }
+  | { readonly status: 'ready'; readonly name: string };
+
+const LOADING: DeployedBinary = { status: 'loading' };
+const UNKNOWN: DeployedBinary = { status: 'unknown' };
+
+export function useDeployedBinary(appId: string): DeployedBinary {
+  const newest = useNewestDeployment(appId);
+  const artifact = useQuery(artifactQueryOptions({ appId, artifactId: newest.data?.artifactId }));
+
+  if (newest.isError || artifact.isError) {
+    return UNKNOWN;
+  }
+  return artifact.data === undefined
+    ? LOADING
+    : { status: 'ready', name: artifact.data.originalFileName };
+}

--- a/apps/dashboard/src/lib/hooks/use-environment-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-environment-form.ts
@@ -1,0 +1,50 @@
+import { parseEnvironmentPatch } from '@repo/app-operations';
+import { useState } from 'react';
+import {
+  type EnvironmentVariable,
+  environmentEdits,
+  storedNames,
+  storedVariables,
+} from '#lib/environment-variables.ts';
+import { validateEnvironment } from '#lib/hooks/use-deploy-form.ts';
+import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+export type EnvironmentForm = {
+  variables: EnvironmentVariable[];
+  change: (variables: EnvironmentVariable[]) => void;
+  error: string | undefined;
+  submittable: boolean;
+  reset: () => void;
+  submit: () => void;
+};
+
+/**
+ * An app's environment on its own, as the release that changes it. A variable is only what the
+ * binary runs with once something runs with it, so saving is a deploy — of the artifact the app
+ * already has, with everything else about how it starts left exactly as it is.
+ */
+export function useEnvironmentForm(app: AppSummary): EnvironmentForm {
+  const { start } = useDeployRun();
+  // Untouched is `undefined` rather than the rows the app has, so the seed follows the app while
+  // the dialog sits open and a release settling behind it does not overwrite what is being typed.
+  const [edited, setEdited] = useState<EnvironmentVariable[] | undefined>(undefined);
+
+  const edits = environmentEdits({ variables: edited, stored: storedNames(app) });
+  const error = validateEnvironment({ value: edited });
+
+  return {
+    variables: edited ?? storedVariables(app),
+    change: setEdited,
+    error,
+    submittable: edits.length > 0 && error === undefined,
+    reset: () => setEdited(undefined),
+    submit: () =>
+      start({
+        app: app.slug,
+        args: app.config.args,
+        port: app.config.guestPort,
+        environment: parseEnvironmentPatch(edits),
+      }),
+  };
+}

--- a/apps/dashboard/src/lib/run-command.test.ts
+++ b/apps/dashboard/src/lib/run-command.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { runCommand } from '#lib/run-command.ts';
+
+describe('the command names the binary the owner uploaded', () => {
+  test('a binary with no arguments runs bare', () => {
+    expect(runCommand({ binaryName: 'server', args: [] })).toBe('./server');
+  });
+
+  test('arguments follow it in the order they are configured', () => {
+    expect(runCommand({ binaryName: 'server', args: ['serve', '--verbose'] })).toBe(
+      './server serve --verbose',
+    );
+  });
+});
+
+/**
+ * The whole point of the button is that what lands on the clipboard can be pasted, and an
+ * argument is arbitrary text: a value carrying a space is one argument, not two, and one carrying
+ * a `$` is text rather than something a shell should go and look up.
+ */
+describe('an argument reaches the clipboard as the one argument it is', () => {
+  test('a space is quoted rather than left to split the argument', () => {
+    expect(runCommand({ binaryName: 'server', args: ['--name', 'my app'] })).toBe(
+      "./server --name 'my app'",
+    );
+  });
+
+  test('a shell expansion is quoted rather than left to expand', () => {
+    expect(runCommand({ binaryName: 'server', args: ['--greet=$USER; rm -rf /'] })).toBe(
+      "./server '--greet=$USER; rm -rf /'",
+    );
+  });
+
+  test('a single quote closes the quoting, escapes, and opens it again', () => {
+    expect(runCommand({ binaryName: 'server', args: ["it's"] })).toBe("./server 'it'\\''s'");
+  });
+
+  test('a name with a space is quoted along with the path that runs it', () => {
+    expect(runCommand({ binaryName: 'my server', args: [] })).toBe("'./my server'");
+  });
+});

--- a/apps/dashboard/src/lib/run-command.ts
+++ b/apps/dashboard/src/lib/run-command.ts
@@ -1,0 +1,25 @@
+// What a POSIX shell reads as one word as it stands. Anything else is wrapped in single quotes,
+// inside which every character is literal — so an argument holding a space, a quote or a `$` is
+// copied out as the one argument it is rather than as whatever a shell would make of it.
+const BARE_WORD = /^[\w@%+=:,./-]+$/;
+
+function shellWord(word: string): string {
+  return BARE_WORD.test(word) ? word : `'${word.replaceAll("'", "'\\''")}'`;
+}
+
+/**
+ * How the app's binary would be started by hand: the name it was uploaded under, then the
+ * arguments it is configured with.
+ *
+ * The guest execs it from a path of nibrun's own choosing, so this is not the command line any
+ * host runs — it is the one an owner can paste beside the binary they still have.
+ */
+export function runCommand({
+  binaryName,
+  args,
+}: {
+  binaryName: string;
+  args: readonly string[];
+}): string {
+  return [`./${binaryName}`, ...args].map(shellWord).join(' ');
+}

--- a/apps/dashboard/src/queries/artifacts.ts
+++ b/apps/dashboard/src/queries/artifacts.ts
@@ -1,0 +1,22 @@
+import { unwrap } from '@repo/api-client/unwrap';
+import { queryOptions, skipToken } from '@tanstack/react-query';
+import { api } from '#lib/api.ts';
+
+async function fetchArtifact({ appId, artifactId }: { appId: string; artifactId: string }) {
+  return unwrap(await api.api.apps({ appId }).artifacts({ artifactId }).get());
+}
+
+export type ArtifactSummary = Awaited<ReturnType<typeof fetchArtifact>>;
+
+export function artifactQueryOptions({
+  appId,
+  artifactId,
+}: {
+  appId: string;
+  artifactId: string | undefined;
+}) {
+  return queryOptions({
+    queryKey: ['apps', appId, 'artifacts', artifactId],
+    queryFn: artifactId === undefined ? skipToken : () => fetchArtifact({ appId, artifactId }),
+  });
+}


### PR DESCRIPTION
An app's vCPUs and memory were already on its config and never shown. A Resources card puts them beside the volume size, which moves out of Configuration — that card is now only what an owner chooses.