### PR TITLE
feat(www): page titles join on a pipe, from one place

### DIFF
--- a/apps/www/src/lib/site.ts
+++ b/apps/www/src/lib/site.ts
@@ -2,5 +2,10 @@ export const SITE_URL = 'https://nibrun.com';
 
 export const SITE_TITLE = 'nibrun — drop your binary, get a server';
 
+/** Every page but the landing one, which is named after the site rather than suffixed with it. */
+export function pageTitle(name: string): string {
+  return `${name} | nibrun`;
+}
+
 export const SITE_DESCRIPTION =
   "Small apps don't need to scale. Drop a compiled binary and get a microVM of its own, a filesystem that persists, and an HTTPS URL. Export the binary and the whole disk whenever you want.";

--- a/apps/www/src/routes/blog/$slug.tsx
+++ b/apps/www/src/routes/blog/$slug.tsx
@@ -10,7 +10,7 @@ import { PageBackdrop } from '#components/page-backdrop.tsx';
 import { SiteHeader } from '#components/site-header.tsx';
 import { type BlogPost, findPost, formatPostDate, renderPost } from '#lib/blog.ts';
 import { pageHead } from '#lib/page-head.ts';
-import { SITE_URL } from '#lib/site.ts';
+import { pageTitle, SITE_URL } from '#lib/site.ts';
 import '#styles/prose.css';
 
 export const Route = createFileRoute('/blog/$slug')({
@@ -28,7 +28,7 @@ export const Route = createFileRoute('/blog/$slug')({
     }
     const head = pageHead({
       path: `/blog/${post.slug}`,
-      title: `${post.title} — nibrun`,
+      title: pageTitle(post.title),
       description: post.description,
       publishedAt: post.date,
       image: post.image,

--- a/apps/www/src/routes/blog/index.tsx
+++ b/apps/www/src/routes/blog/index.tsx
@@ -4,8 +4,9 @@ import { PageBackdrop } from '#components/page-backdrop.tsx';
 import { SiteHeader } from '#components/site-header.tsx';
 import { formatPostDate, POSTS } from '#lib/blog.ts';
 import { pageHead } from '#lib/page-head.ts';
+import { pageTitle } from '#lib/site.ts';
 
-const TITLE = 'Blog — nibrun';
+const TITLE = pageTitle('Blog');
 const DESCRIPTION = "Notes on small apps, single binaries, and the infrastructure they don't need.";
 
 export const Route = createFileRoute('/blog/')({


### PR DESCRIPTION
Page titles now read `Blog | nibrun` rather than `Blog — nibrun`, and the separator lives in one helper instead of being written out at each call site.

The landing page is unchanged: its title names the site rather than being suffixed with it.