### PR TITLE
feat(dashboard): one table decides which buttons an app's state offers

### DIFF
--- a/apps/dashboard/src/components/apps/app-actions.tsx
+++ b/apps/dashboard/src/components/apps/app-actions.tsx
@@ -2,17 +2,20 @@ import { DeleteAppDialog } from '#components/apps/delete-app-dialog.tsx';
 import { DeployDialog } from '#components/apps/deploy-dialog.tsx';
 import { ExportAppDialog } from '#components/apps/export-app-dialog.tsx';
 import { SuspendAppButton } from '#components/apps/suspend-app-button.tsx';
+import { useAppActions } from '#lib/hooks/use-app-actions.ts';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
 
+/** The one place the table is read: every button here is handed what the app's status allows it. */
 export function AppActions() {
   const appId = useAppId();
+  const actions = useAppActions(appId);
 
   return (
     <div className="flex shrink-0 items-center gap-2">
-      <DeployDialog appId={appId} />
-      <ExportAppDialog />
-      <SuspendAppButton />
-      <DeleteAppDialog />
+      <DeployDialog appId={appId} availability={actions.deploy} />
+      <ExportAppDialog availability={actions.export} />
+      <SuspendAppButton availability={actions.suspend} />
+      <DeleteAppDialog availability={actions.delete} />
     </div>
   );
 }

--- a/apps/dashboard/src/components/apps/app-status-badge.tsx
+++ b/apps/dashboard/src/components/apps/app-status-badge.tsx
@@ -9,16 +9,13 @@ import type { AppSummary } from '#queries/apps.ts';
  * What an app is doing, which is what its newest deployment is doing: an app row is `active`
  * from the moment it is created, so on its own it never says whether anything is serving.
  *
- * An app on its way out is the one case the row answers alone, and it answers before anything is
- * read — every other answer needs the release, including the two that say the host has not caught
- * up with what the owner asked for yet.
+ * An app on its way out is the one case the row answers alone; every other answer needs the
+ * release, including the two that say the host has not caught up with what the owner asked for
+ * yet.
  */
 export function AppStatusBadge({ app }: { app: AppSummary }) {
   const status = useAppStatus(app);
 
-  if (app.state === 'deleting' || app.state === 'deleted') {
-    return <AppStateBadge state={app.state} />;
-  }
   if (status.isPending) {
     return <Skeleton className="h-5 w-20 rounded-2xl" />;
   }

--- a/apps/dashboard/src/components/apps/delete-app-dialog.tsx
+++ b/apps/dashboard/src/components/apps/delete-app-dialog.tsx
@@ -15,15 +15,20 @@ import { Field, FieldError } from '@repo/ui/components/field';
 import { SlideToDelete } from '@repo/ui/custom/slide-to-delete';
 import { Trash2Icon, TriangleAlertIcon } from 'lucide-react';
 import { useState } from 'react';
+import type { AppActionAvailability } from '#lib/app-actions.ts';
 import { useApp } from '#lib/hooks/use-app.ts';
 import { useAppDeletion } from '#lib/hooks/use-app-deletion.ts';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
 
-export function DeleteAppDialog() {
+export function DeleteAppDialog({ availability }: { availability: AppActionAvailability }) {
   const appId = useAppId();
   const app = useApp(appId);
   const deletion = useAppDeletion(appId);
   const [armed, setArmed] = useState(false);
+
+  if (availability === 'hidden') {
+    return null;
+  }
 
   const slug = app.data?.slug;
   const alreadyDeleting = app.data?.state === 'deleting';
@@ -36,7 +41,7 @@ export function DeleteAppDialog() {
       }}
     >
       <AlertDialogTrigger
-        render={<Button variant="destructive" disabled={slug === undefined || alreadyDeleting} />}
+        render={<Button variant="destructive" disabled={availability === 'disabled'} />}
       >
         <Trash2Icon data-icon="inline-start" />
         {alreadyDeleting ? 'Deleting…' : 'Delete'}

--- a/apps/dashboard/src/components/apps/deploy-dialog-content.tsx
+++ b/apps/dashboard/src/components/apps/deploy-dialog-content.tsx
@@ -15,7 +15,7 @@ import { DeployForm } from '#components/apps/deploy-form.tsx';
 import { DeployProgress } from '#components/apps/deploy-progress.tsx';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
 
-export function DeployDialogContent({ appId }: { appId?: string }) {
+export function DeployDialogContent({ appId, disabled }: { appId?: string; disabled: boolean }) {
   const [open, setOpen] = useState(false);
   const run = useDeployRun();
   const running = run.phase === 'uploading' || run.phase === 'settling';
@@ -29,7 +29,11 @@ export function DeployDialogContent({ appId }: { appId?: string }) {
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger render={<Button variant={appId === undefined ? 'default' : 'outline'} />}>
+      <DialogTrigger
+        render={
+          <Button variant={appId === undefined ? 'default' : 'outline'} disabled={disabled} />
+        }
+      >
         <RocketIcon data-icon="inline-start" />
         Deploy
       </DialogTrigger>

--- a/apps/dashboard/src/components/apps/deploy-dialog.tsx
+++ b/apps/dashboard/src/components/apps/deploy-dialog.tsx
@@ -1,10 +1,22 @@
 import { DeployDialogContent } from '#components/apps/deploy-dialog-content.tsx';
+import type { AppActionAvailability } from '#lib/app-actions.ts';
 import { DeployRunProvider } from '#lib/providers/deploy-run-provider.tsx';
 
-export function DeployDialog({ appId }: { appId?: string }) {
+export function DeployDialog({
+  appId,
+  availability = 'enabled',
+}: {
+  appId?: string;
+  /** The apps page deploys with no app behind it, and so with no status to withhold it. */
+  availability?: AppActionAvailability;
+}) {
+  if (availability === 'hidden') {
+    return null;
+  }
+
   return (
     <DeployRunProvider>
-      <DeployDialogContent appId={appId} />
+      <DeployDialogContent appId={appId} disabled={availability === 'disabled'} />
     </DeployRunProvider>
   );
 }

--- a/apps/dashboard/src/components/apps/export-app-dialog.tsx
+++ b/apps/dashboard/src/components/apps/export-app-dialog.tsx
@@ -11,18 +11,23 @@ import {
 import { Spinner } from '@repo/ui/components/spinner';
 import { DownloadIcon, TriangleAlertIcon } from 'lucide-react';
 import { useState } from 'react';
+import type { AppActionAvailability } from '#lib/app-actions.ts';
 import { formatBytes } from '#lib/format-bytes.ts';
 import { useAppExport } from '#lib/hooks/use-app-export.ts';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
 
-export function ExportAppDialog() {
+export function ExportAppDialog({ availability }: { availability: AppActionAvailability }) {
   const appId = useAppId();
   const [open, setOpen] = useState(false);
   const run = useAppExport(appId);
 
+  if (availability === 'hidden') {
+    return null;
+  }
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger render={<Button variant="outline" />}>
+      <DialogTrigger render={<Button variant="outline" disabled={availability === 'disabled'} />}>
         <DownloadIcon data-icon="inline-start" />
         Export
       </DialogTrigger>

--- a/apps/dashboard/src/components/apps/suspend-app-button.tsx
+++ b/apps/dashboard/src/components/apps/suspend-app-button.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@repo/ui/components/button';
 import { Spinner } from '@repo/ui/components/spinner';
 import { PauseIcon, PlayIcon } from 'lucide-react';
+import type { AppActionAvailability } from '#lib/app-actions.ts';
 import type { AppTransition } from '#lib/app-status.ts';
 import { useApp } from '#lib/hooks/use-app.ts';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
@@ -22,25 +23,26 @@ const WHILE_MOVING: Record<AppTransition, string> = {
  * It stays down until the microVM has actually stopped or come back, because until then the app
  * row it would read to decide what to do next says something the host has not done yet.
  */
-export function SuspendAppButton() {
+export function SuspendAppButton({ availability }: { availability: AppActionAvailability }) {
   const appId = useAppId();
   const app = useApp(appId);
   const status = useAppStatus(app.data);
   const suspension = useAppSuspension(appId);
   useFailureToast(suspension.error?.message);
 
-  const state = app.data?.state;
-  const suspended = state === 'suspended';
+  if (availability === 'hidden') {
+    return null;
+  }
+
+  const suspended = app.data?.state === 'suspended';
   const Icon = suspended ? PlayIcon : PauseIcon;
-  // An app on its way out is not one to take offline, and the api refuses it either way.
-  const going = state === 'deleting' || state === 'deleted';
   const moving = status.status?.kind === 'transition' ? status.status.label : undefined;
-  const waiting = suspension.isPending || moving !== undefined;
+  const waiting = availability === 'disabled' || suspension.isPending;
 
   return (
     <Button
       variant="outline"
-      disabled={state === undefined || going || waiting}
+      disabled={waiting}
       onClick={() => suspension.mutate(suspended ? 'active' : 'suspended')}
     >
       {waiting ? <Spinner data-icon="inline-start" /> : <Icon data-icon="inline-start" />}

--- a/apps/dashboard/src/lib/app-actions.test.ts
+++ b/apps/dashboard/src/lib/app-actions.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test';
+import { APP_STATES, type AppState, DEPLOYMENT_STATES, type DeploymentState } from '@repo/protocol';
+import { APP_ACTIONS, type AppActions, appActions } from '#lib/app-actions.ts';
+import { appStatus } from '#lib/app-status.ts';
+
+function actions({
+  appState = 'active',
+  deploymentState,
+}: {
+  appState?: AppState;
+  deploymentState?: DeploymentState;
+} = {}): AppActions {
+  return appActions(appStatus({ appState, deploymentState }));
+}
+
+describe('an app is offered what its state can actually do', () => {
+  test('one nobody has deployed has nothing to export and nothing to take offline', () => {
+    expect(actions()).toEqual({
+      deploy: 'enabled',
+      export: 'hidden',
+      suspend: 'hidden',
+      delete: 'enabled',
+    });
+  });
+
+  const down: DeploymentState[] = ['failed', 'superseded'];
+
+  for (const deploymentState of down) {
+    test(`one whose release is ${deploymentState} is exportable and has nothing to suspend`, () => {
+      expect(actions({ deploymentState })).toEqual({
+        deploy: 'enabled',
+        export: 'enabled',
+        suspend: 'hidden',
+        delete: 'enabled',
+      });
+    });
+  }
+
+  test('a serving one is offered every button', () => {
+    expect(actions({ deploymentState: 'active' })).toEqual({
+      deploy: 'enabled',
+      export: 'enabled',
+      suspend: 'enabled',
+      delete: 'enabled',
+    });
+  });
+
+  test('a suspended one is offered the same, the suspend button being the way back', () => {
+    expect(actions({ appState: 'suspended', deploymentState: 'stopped' }).suspend).toBe('enabled');
+  });
+});
+
+/**
+ * The two the owner has already asked for. A button that comes back on its own is greyed rather
+ * than gone, because taking it away would say the app cannot be asked this at all.
+ */
+describe('an app the host has not caught up with yet', () => {
+  test('is not asked to suspend while it is suspending', () => {
+    expect(actions({ appState: 'suspended', deploymentState: 'active' }).suspend).toBe('disabled');
+  });
+
+  test('nor while it is coming back', () => {
+    expect(actions({ deploymentState: 'stopped' }).suspend).toBe('disabled');
+  });
+
+  test('and one not read yet offers nothing to press', () => {
+    expect(appActions(undefined)).toEqual({
+      deploy: 'disabled',
+      export: 'disabled',
+      suspend: 'disabled',
+      delete: 'disabled',
+    });
+  });
+});
+
+describe('an app on its way out', () => {
+  test('has one button left, and it is the one saying so', () => {
+    expect(actions({ appState: 'deleting' })).toEqual({
+      deploy: 'hidden',
+      export: 'hidden',
+      suspend: 'hidden',
+      delete: 'disabled',
+    });
+  });
+
+  test('and once it is gone, none at all', () => {
+    expect(actions({ appState: 'deleted' })).toEqual({
+      deploy: 'hidden',
+      export: 'hidden',
+      suspend: 'hidden',
+      delete: 'hidden',
+    });
+  });
+});
+
+// What the table is for: a state nothing was decided about is a hole here rather than a button
+// someone finds behaving oddly in front of a customer.
+test('every app and release the api can report is answered for, button by button', () => {
+  const releases: (DeploymentState | undefined)[] = [...DEPLOYMENT_STATES, undefined];
+
+  for (const appState of APP_STATES) {
+    for (const deploymentState of releases) {
+      for (const action of APP_ACTIONS) {
+        expect(actions({ appState, deploymentState })[action]).toBeDefined();
+      }
+    }
+  }
+});

--- a/apps/dashboard/src/lib/app-actions.ts
+++ b/apps/dashboard/src/lib/app-actions.ts
@@ -1,0 +1,51 @@
+import { type AppStatus, type AppStatusKey, statusKey } from '#lib/app-status.ts';
+
+/** Every button on an app's action bar, and so every column of the table below. */
+export const APP_ACTIONS = ['deploy', 'export', 'suspend', 'delete'] as const;
+
+export type AppAction = (typeof APP_ACTIONS)[number];
+
+/**
+ * `hidden` for an action this status has nothing to do with, `disabled` for one it is on its way
+ * back to offering. The difference is what the owner is being told: a button that is gone means
+ * the app cannot be asked this, and one that is greyed means it is already being asked something
+ * — which is why every greyed button here says what it is waiting on.
+ */
+export type AppActionAvailability = 'enabled' | 'disabled' | 'hidden';
+
+export type AppActions = Record<AppAction, AppActionAvailability>;
+
+/**
+ * Every status against every button, written out rather than derived, because there is no rule
+ * underneath: export needs a release to have ever existed, suspend needs one that is running,
+ * delete needs the app to not already be going. A status added to `AppStatusKey` is a row missing
+ * from here, which is a type error rather than a button someone finds behaving oddly weeks later.
+ */
+const AVAILABILITY: Record<AppStatusKey, AppActions> = {
+  'never-deployed': { deploy: 'enabled', export: 'hidden', suspend: 'hidden', delete: 'enabled' },
+  pending: { deploy: 'enabled', export: 'enabled', suspend: 'enabled', delete: 'enabled' },
+  starting: { deploy: 'enabled', export: 'enabled', suspend: 'enabled', delete: 'enabled' },
+  active: { deploy: 'enabled', export: 'enabled', suspend: 'enabled', delete: 'enabled' },
+  // Nothing is serving under either of these, so there is nothing to take offline — and a bundle
+  // is cut from the volume rather than from a running microVM, so exporting still works.
+  failed: { deploy: 'enabled', export: 'enabled', suspend: 'hidden', delete: 'enabled' },
+  superseded: { deploy: 'enabled', export: 'enabled', suspend: 'hidden', delete: 'enabled' },
+  suspended: { deploy: 'enabled', export: 'enabled', suspend: 'enabled', delete: 'enabled' },
+  suspending: { deploy: 'enabled', export: 'enabled', suspend: 'disabled', delete: 'enabled' },
+  resuming: { deploy: 'enabled', export: 'enabled', suspend: 'disabled', delete: 'enabled' },
+  // An app on its way out has one thing left to say, and it is the button that says it.
+  deleting: { deploy: 'hidden', export: 'hidden', suspend: 'hidden', delete: 'disabled' },
+  deleted: { deploy: 'hidden', export: 'hidden', suspend: 'hidden', delete: 'hidden' },
+};
+
+/** Nothing may be pressed on an app whose status has not been read yet. */
+const WHILE_UNREAD: AppActions = {
+  deploy: 'disabled',
+  export: 'disabled',
+  suspend: 'disabled',
+  delete: 'disabled',
+};
+
+export function appActions(status: AppStatus | undefined): AppActions {
+  return status === undefined ? WHILE_UNREAD : AVAILABILITY[statusKey(status)];
+}

--- a/apps/dashboard/src/lib/app-status.test.ts
+++ b/apps/dashboard/src/lib/app-status.test.ts
@@ -13,7 +13,7 @@ function status({
 }
 
 describe('an app on its way out answers for itself', () => {
-  const going: AppState[] = ['deleting', 'deleted'];
+  const going = ['deleting', 'deleted'] as const satisfies readonly AppState[];
 
   for (const appState of going) {
     test(`a ${appState} app says so whatever its release says`, () => {
@@ -66,7 +66,13 @@ describe('resuming is not running until the host has started it', () => {
     });
   });
 
-  const followed: DeploymentState[] = ['pending', 'starting', 'active', 'failed', 'superseded'];
+  const followed = [
+    'pending',
+    'starting',
+    'active',
+    'failed',
+    'superseded',
+  ] as const satisfies readonly DeploymentState[];
 
   for (const deploymentState of followed) {
     test(`and a ${deploymentState} release is what the app is doing`, () => {
@@ -93,11 +99,10 @@ describe('what is worth asking about again', () => {
     });
   }
 
-  // A stopped release is the one that looks transitional and is not: the host has done what it
-  // was asked, and asking again every two seconds forever is what this stops.
+  // A suspended app is the one that looks transitional and is not: the host has done what it was
+  // asked, and asking again every two seconds forever is what this stops.
   const settled: [string, AppStatus][] = [
     ['a serving release', { kind: 'deployment', state: 'active' }],
-    ['a stopped release', { kind: 'deployment', state: 'stopped' }],
     ['a failed release', { kind: 'deployment', state: 'failed' }],
     ['a suspended app', { kind: 'app', state: 'suspended' }],
     ['an app never deployed', { kind: 'never-deployed' }],

--- a/apps/dashboard/src/lib/app-status.ts
+++ b/apps/dashboard/src/lib/app-status.ts
@@ -13,10 +13,35 @@ import type { AppState, DeploymentState } from '@repo/protocol';
 export type AppTransition = 'suspending' | 'resuming';
 
 export type AppStatus =
-  | { readonly kind: 'app'; readonly state: AppState }
-  | { readonly kind: 'deployment'; readonly state: DeploymentState }
+  // Never `active`: an app row is active from the moment it is created, so on its own it says
+  // nothing about what is serving, and the release answers instead.
+  | { readonly kind: 'app'; readonly state: Exclude<AppState, 'active'> }
+  // Never `stopped`: a release is only ever stopped because its app was suspended, which is the
+  // suspended app above or one of the two transitions below.
+  | { readonly kind: 'deployment'; readonly state: Exclude<DeploymentState, 'stopped'> }
   | { readonly kind: 'transition'; readonly label: AppTransition }
   | { readonly kind: 'never-deployed' };
+
+type Named<Status extends AppStatus> = Status extends { readonly label: AppTransition }
+  ? Status['label']
+  : Status extends { readonly state: string }
+    ? Status['state']
+    : Status['kind'];
+
+/** The one word a status goes by, and so what a table of every status is keyed by. */
+export type AppStatusKey = Named<AppStatus>;
+
+export function statusKey(status: AppStatus): AppStatusKey {
+  switch (status.kind) {
+    case 'app':
+    case 'deployment':
+      return status.state;
+    case 'transition':
+      return status.label;
+    case 'never-deployed':
+      return status.kind;
+  }
+}
 
 const SUSPENDED: AppStatus = { kind: 'app', state: 'suspended' };
 const SUSPENDING: AppStatus = { kind: 'transition', label: 'suspending' };

--- a/apps/dashboard/src/lib/hooks/use-app-actions.ts
+++ b/apps/dashboard/src/lib/hooks/use-app-actions.ts
@@ -1,0 +1,9 @@
+import { type AppActions, appActions } from '#lib/app-actions.ts';
+import { useApp } from '#lib/hooks/use-app.ts';
+import { useAppStatus } from '#lib/hooks/use-app-status.ts';
+
+/** What the action bar may offer for this app, which is what the app is doing read off the table. */
+export function useAppActions(appId: string): AppActions {
+  const app = useApp(appId);
+  return appActions(useAppStatus(app.data).status);
+}

--- a/apps/dashboard/src/lib/hooks/use-app-status.ts
+++ b/apps/dashboard/src/lib/hooks/use-app-status.ts
@@ -48,6 +48,12 @@ export function useAppStatus(app: AppSummary | undefined): AppStatusResult {
         : false,
   });
 
+  // The skipped query never succeeds, so an app that answers alone is answered for here rather
+  // than left waiting on a release nobody asked for.
+  if (app && !readsDeployments(app)) {
+    return { isPending: false, isError: false, status: statusOf({ app, deployments: undefined }) };
+  }
+
   return {
     isPending: deployments.isPending,
     isError: deployments.isError,


### PR DESCRIPTION
Suspend and Export each decided for themselves which app states they applied to, so every state was a hole found in front of a customer: an app nobody had deployed offered both, a failed one offered Suspend.

`apps/dashboard/src/lib/app-actions.ts` holds every status against every button — `hidden` for an action the state has nothing to do with, `disabled` for one the app is mid-move out of, and every greyed button says what it is waiting on. It is keyed by a status type the table has to cover, so a state added later is a type error rather than the next hole.