### PR TITLE
feat(dashboard): the logs stream says live only while something is running

### DIFF
--- a/apps/dashboard/src/components/logs/log-stream-status.tsx
+++ b/apps/dashboard/src/components/logs/log-stream-status.tsx
@@ -15,6 +15,11 @@ const PRESENTATION: Record<
     dotClassName: 'bg-emerald-500',
     haloClassName: 'bg-emerald-500 motion-safe:animate-live-halo',
   },
+  'not-running': {
+    label: 'Not running',
+    dotClassName: 'bg-muted-foreground',
+    haloClassName: 'hidden',
+  },
   failed: {
     label: 'Stream disconnected',
     dotClassName: 'bg-destructive',

--- a/apps/dashboard/src/lib/app-status.test.ts
+++ b/apps/dashboard/src/lib/app-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { AppState, DeploymentState } from '@repo/protocol';
-import { type AppStatus, appStatus, isSettling } from '#lib/app-status.ts';
+import { type AppStatus, appStatus, isRunning, isSettling } from '#lib/app-status.ts';
 
 function status({
   appState = 'active',
@@ -111,6 +111,38 @@ describe('what is worth asking about again', () => {
   for (const [name, status] of settled) {
     test(`${name} is not`, () => {
       expect(isSettling(status)).toBe(false);
+    });
+  }
+});
+
+describe('what has something running to write output', () => {
+  const writing: [string, AppStatus][] = [
+    ['a serving release', status({ deploymentState: 'active' })],
+    ['a booting one', status({ deploymentState: 'starting' })],
+    ['an app still winding down', status({ appState: 'suspended', deploymentState: 'active' })],
+    ['one on its way back', status({ deploymentState: 'stopped' })],
+  ];
+
+  for (const [name, each] of writing) {
+    test(`${name} has`, () => {
+      expect(isRunning(each)).toBe(true);
+    });
+  }
+
+  // A release being staged is the one that looks like it is coming up and has nothing up yet: no
+  // host has made a microVM for it, so there is nothing tailing it can carry.
+  const silent: [string, AppStatus][] = [
+    ['a release still being staged', status({ deploymentState: 'pending' })],
+    ['a failed one', status({ deploymentState: 'failed' })],
+    ['a superseded one', status({ deploymentState: 'superseded' })],
+    ['a suspended app', status({ appState: 'suspended', deploymentState: 'stopped' })],
+    ['one nobody has deployed', status()],
+    ['one being deleted', status({ appState: 'deleting' })],
+  ];
+
+  for (const [name, each] of silent) {
+    test(`${name} has not`, () => {
+      expect(isRunning(each)).toBe(false);
     });
   }
 });

--- a/apps/dashboard/src/lib/app-status.ts
+++ b/apps/dashboard/src/lib/app-status.ts
@@ -75,6 +75,31 @@ export function appStatus({
   return deploymentState === 'stopped' ? RESUMING : { kind: 'deployment', state: deploymentState };
 }
 
+/**
+ * Whether a microVM is up to write anything. A stream tailing an app in any other state is
+ * connected to something that will never say a word, which is not what live means.
+ */
+const RUNNING: Record<AppStatusKey, boolean> = {
+  'never-deployed': false,
+  // Staged rather than started: there is no microVM until a host has made one.
+  pending: false,
+  starting: true,
+  active: true,
+  failed: false,
+  superseded: false,
+  suspended: false,
+  // One is still up until the host says otherwise and the other is on its way back, so both are
+  // states output can still arrive in.
+  suspending: true,
+  resuming: true,
+  deleting: false,
+  deleted: false,
+};
+
+export function isRunning(status: AppStatus): boolean {
+  return RUNNING[statusKey(status)];
+}
+
 /** Whether this is a state something else is still moving out of, and so worth asking again. */
 export function isSettling(status: AppStatus): boolean {
   if (status.kind === 'transition') {

--- a/apps/dashboard/src/lib/hooks/use-deployment-logs.ts
+++ b/apps/dashboard/src/lib/hooks/use-deployment-logs.ts
@@ -1,17 +1,27 @@
 import type { TenantLogRecord } from '@repo/protocol';
 import { useQuery } from '@tanstack/react-query';
+import { isRunning } from '#lib/app-status.ts';
+import { useApp } from '#lib/hooks/use-app.ts';
+import { useAppStatus } from '#lib/hooks/use-app-status.ts';
 import { useLogTimerange } from '#lib/hooks/use-log-timerange.ts';
 import { useNewestDeployment } from '#lib/hooks/use-newest-deployment.ts';
 import { deploymentLogsQueryOptions } from '#queries/logs.ts';
 
+/**
+ * `not-running` is a stream that is open and will stay silent: the records under it are the app's
+ * history and nothing is left to add to them. Saying that rather than nothing, because a page with
+ * no word for it is one where the owner is left waiting on output that is never coming.
+ */
 export type DeploymentLogsView = {
-  status: 'connecting' | 'following' | 'failed';
+  status: 'connecting' | 'following' | 'not-running' | 'failed';
   records: readonly TenantLogRecord[];
   deploymentId: string | undefined;
   reason: string | undefined;
 };
 
 export function useDeploymentLogs(appId: string): DeploymentLogsView {
+  const app = useApp(appId);
+  const status = useAppStatus(app.data).status;
   const newest = useNewestDeployment(appId);
   const deploymentId = newest.data?.id;
   const timerange = useLogTimerange();
@@ -24,8 +34,14 @@ export function useDeploymentLogs(appId: string): DeploymentLogsView {
   if (logs.isError) {
     return { status: 'failed', records, deploymentId, reason: logs.error.message };
   }
-  if (deploymentId === undefined) {
-    return { status: 'connecting', records, deploymentId: undefined, reason: undefined };
+  // An app still being read is one nothing is known about yet, which is what connecting says.
+  if (deploymentId === undefined || status === undefined) {
+    return { status: 'connecting', records, deploymentId, reason: undefined };
   }
-  return { status: 'following', records, deploymentId, reason: undefined };
+  return {
+    status: isRunning(status) ? 'following' : 'not-running',
+    records,
+    deploymentId,
+    reason: undefined,
+  };
 }


### PR DESCRIPTION
A log stream open on a suspended, failed or never-started app is one nothing will ever write to, so "Live" left the owner watching for output that was not coming. The indicator now reads the app's status: **Live** while a microVM is up, **Not running** while one isn't. The records under it stay — they are the app's history, which is the reason to keep the stream rather than hide the line.

The per-state answer sits in `app-status.ts` beside the button table from #297, keyed the same way, so a state added later has to answer this one too.