### PR TITLE
fix(agent): a resumed app takes the next request, not the one after

### DIFF
--- a/apps/agent/src/services/app-activator.service.ts
+++ b/apps/agent/src/services/app-activator.service.ts
@@ -9,6 +9,12 @@ const HTTP_UNAVAILABLE = 503;
  * Plain and short, because a person reads it in a browser with no styling around it. It says the
  * app is down rather than unknown: the wildcard site's 404 is the answer for a hostname this host
  * serves nothing on, and a suspended app is not that.
+ *
+ * `connection: close` is what keeps a resume immediate. The proxy pools its upstream connections,
+ * and one opened while the microVM was down was accepted *here* rather than forwarded to a guest —
+ * so the forward rule appearing later cannot redirect it, and every request the proxy sends down
+ * that connection is answered by this until it retires it. Refusing to be reused is what bounds
+ * that to the one request already in flight.
  */
 function sayAppIsDown(): Response {
   return new Response('This app is not running.\n', {
@@ -16,6 +22,7 @@ function sayAppIsDown(): Response {
     headers: {
       'content-type': 'text/plain; charset=utf-8',
       'cache-control': 'no-store',
+      connection: 'close',
     },
   });
 }

--- a/apps/agent/tests/services/app-activator.test.ts
+++ b/apps/agent/tests/services/app-activator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import { connect } from 'node:net';
 import { AppIdSchema, type HostPort, HostPortSchema, Value } from '@repo/protocol';
-import { Effect, Either } from 'effect';
+import { Duration, Effect, Either } from 'effect';
 import { AppActivator } from '#services/app-activator.service.ts';
 import { APP_ID } from '#tests/support/fixtures.ts';
 import { provided } from '#tests/support/run.ts';
@@ -24,6 +25,28 @@ function unusedPort(): HostPort {
 
 function get(hostPort: HostPort) {
   return Effect.tryPromise(() => fetch(`http://${LOOPBACK}:${hostPort}/`));
+}
+
+const REUSE_TIMEOUT_SECONDS = 5;
+
+/**
+ * Whether the connection may be reused is hop-by-hop, so `fetch` never surfaces it and the socket
+ * has to be spoken to directly. Resolves with everything read, once the server hangs up.
+ */
+function untilServerHangsUp(hostPort: HostPort) {
+  return Effect.tryPromise(() => {
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    let received = '';
+    const socket = connect({ host: LOOPBACK, port: hostPort }, () => {
+      socket.write('GET / HTTP/1.1\r\nHost: activator\r\n\r\n');
+    });
+    socket.on('data', (chunk: Buffer) => {
+      received += chunk.toString();
+    });
+    socket.on('close', () => resolve(received));
+    socket.on('error', reject);
+    return promise;
+  });
 }
 
 describe('an app that is down answers for itself', () => {
@@ -63,6 +86,23 @@ describe('an app that is down answers for itself', () => {
         yield* activator.serve([{ appId: OTHER_APP_ID, hostPort: unusedPort() }]);
 
         expect(Either.isLeft(yield* Effect.either(get(hostPort)))).toBe(true);
+      }),
+    ));
+
+  test('the answer is not reusable, so the proxy cannot keep asking a microVM that is back', () =>
+    run(
+      Effect.gen(function* () {
+        const activator = yield* AppActivator;
+        const hostPort = unusedPort();
+        yield* activator.serve([{ appId: APP_ID, hostPort }]);
+
+        // The server hanging up is the assertion: this resolves on close, so a connection left
+        // open to be reused times out here instead.
+        const answer = yield* untilServerHangsUp(hostPort).pipe(
+          Effect.timeout(Duration.seconds(REUSE_TIMEOUT_SECONDS)),
+        );
+
+        expect(answer.toLowerCase()).toContain('connection: close');
       }),
     ));
 });


### PR DESCRIPTION
A resumed app kept answering `503` for as long as the proxy held a connection it had opened while the microVM was down. That connection terminates at the agent, so the forward rule appearing on resume cannot redirect it — measured against a live app, requests alternated between `200` and `503` from the same instant, and continuous traffic kept a stale connection alive for minutes.

The 503 now refuses reuse, which bounds it to the request already in flight.