### PR TITLE
fix: a suspended app is not offered a release that would never start

### DIFF
--- a/apps/dashboard/src/components/apps/app-environment-dialog-content.tsx
+++ b/apps/dashboard/src/components/apps/app-environment-dialog-content.tsx
@@ -14,6 +14,8 @@ import { PencilIcon } from 'lucide-react';
 import { useState } from 'react';
 import { DeployProgress } from '#components/apps/deploy-progress.tsx';
 import { EnvironmentTable } from '#components/apps/environment-table.tsx';
+import { greyedReason } from '#lib/app-actions.ts';
+import { useAppActions } from '#lib/hooks/use-app-actions.ts';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
 import { useEnvironmentForm } from '#lib/hooks/use-environment-form.ts';
 import type { AppSummary } from '#queries/apps.ts';
@@ -22,6 +24,8 @@ export function AppEnvironmentDialogContent({ app }: { app: AppSummary }) {
   const [open, setOpen] = useState(false);
   const run = useDeployRun();
   const form = useEnvironmentForm(app);
+  // Saving is a release, so it is offered exactly where the deploy button is.
+  const deploy = useAppActions(app.id).deploy;
   const releasing = run.phase === 'releasing' || run.phase === 'settling';
 
   function handleOpenChange(next: boolean): void {
@@ -43,7 +47,7 @@ export function AppEnvironmentDialogContent({ app }: { app: AppSummary }) {
           <DialogTitle>Environment variables</DialogTitle>
           <DialogDescription>
             {run.phase === 'idle'
-              ? `Saving releases ${app.slug} again on the binary it already runs. Its hostnames and everything on its volume stay as they are.`
+              ? describeSave({ slug: app.slug, withheld: greyedReason(deploy) })
               : 'The release is on its way. Closing this does not stop it.'}
           </DialogDescription>
         </DialogHeader>
@@ -60,7 +64,11 @@ export function AppEnvironmentDialogContent({ app }: { app: AppSummary }) {
                 <EnvironmentTable variables={form.variables} onChange={form.change} />
                 {form.error !== undefined && <FieldError>{form.error}</FieldError>}
               </Field>
-              <Button type="submit" size="lg" disabled={!form.submittable}>
+              <Button
+                type="submit"
+                size="lg"
+                disabled={!form.submittable || deploy.kind !== 'enabled'}
+              >
                 <span className="truncate">Save and redeploy {app.slug}</span>
               </Button>
             </form>
@@ -70,5 +78,12 @@ export function AppEnvironmentDialogContent({ app }: { app: AppSummary }) {
         </DialogBody>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function describeSave({ slug, withheld }: { slug: string; withheld: string | undefined }): string {
+  return (
+    withheld ??
+    `Saving releases ${slug} again on the binary it already runs. Its hostnames and everything on its volume stay as they are.`
   );
 }

--- a/apps/dashboard/src/components/apps/delete-app-dialog.tsx
+++ b/apps/dashboard/src/components/apps/delete-app-dialog.tsx
@@ -26,7 +26,7 @@ export function DeleteAppDialog({ availability }: { availability: AppActionAvail
   const deletion = useAppDeletion(appId);
   const [armed, setArmed] = useState(false);
 
-  if (availability === 'hidden') {
+  if (availability.kind === 'hidden') {
     return null;
   }
 
@@ -41,7 +41,7 @@ export function DeleteAppDialog({ availability }: { availability: AppActionAvail
       }}
     >
       <AlertDialogTrigger
-        render={<Button variant="destructive" disabled={availability === 'disabled'} />}
+        render={<Button variant="destructive" disabled={availability.kind === 'disabled'} />}
       >
         <Trash2Icon data-icon="inline-start" />
         {alreadyDeleting ? 'Deleting…' : 'Delete'}

--- a/apps/dashboard/src/components/apps/deploy-dialog.tsx
+++ b/apps/dashboard/src/components/apps/deploy-dialog.tsx
@@ -1,22 +1,26 @@
 import { DeployDialogContent } from '#components/apps/deploy-dialog-content.tsx';
-import type { AppActionAvailability } from '#lib/app-actions.ts';
+import { type AppActionAvailability, ENABLED, greyedReason } from '#lib/app-actions.ts';
 import { DeployRunProvider } from '#lib/providers/deploy-run-provider.tsx';
 
 export function DeployDialog({
   appId,
-  availability = 'enabled',
+  availability = ENABLED,
 }: {
   appId?: string;
   /** The apps page deploys with no app behind it, and so with no status to withhold it. */
   availability?: AppActionAvailability;
 }) {
-  if (availability === 'hidden') {
+  if (availability.kind === 'hidden') {
     return null;
   }
 
   return (
-    <DeployRunProvider>
-      <DeployDialogContent appId={appId} disabled={availability === 'disabled'} />
-    </DeployRunProvider>
+    // A greyed button takes no pointer events of its own, so the reason it is greyed is hung on
+    // what is around it.
+    <span className="inline-flex" title={greyedReason(availability)}>
+      <DeployRunProvider>
+        <DeployDialogContent appId={appId} disabled={availability.kind === 'disabled'} />
+      </DeployRunProvider>
+    </span>
   );
 }

--- a/apps/dashboard/src/components/apps/export-app-dialog.tsx
+++ b/apps/dashboard/src/components/apps/export-app-dialog.tsx
@@ -21,13 +21,15 @@ export function ExportAppDialog({ availability }: { availability: AppActionAvail
   const [open, setOpen] = useState(false);
   const run = useAppExport(appId);
 
-  if (availability === 'hidden') {
+  if (availability.kind === 'hidden') {
     return null;
   }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger render={<Button variant="outline" disabled={availability === 'disabled'} />}>
+      <DialogTrigger
+        render={<Button variant="outline" disabled={availability.kind === 'disabled'} />}
+      >
         <DownloadIcon data-icon="inline-start" />
         Export
       </DialogTrigger>

--- a/apps/dashboard/src/components/apps/suspend-app-button.tsx
+++ b/apps/dashboard/src/components/apps/suspend-app-button.tsx
@@ -30,14 +30,14 @@ export function SuspendAppButton({ availability }: { availability: AppActionAvai
   const suspension = useAppSuspension(appId);
   useFailureToast(suspension.error?.message);
 
-  if (availability === 'hidden') {
+  if (availability.kind === 'hidden') {
     return null;
   }
 
   const suspended = app.data?.state === 'suspended';
   const Icon = suspended ? PlayIcon : PauseIcon;
   const moving = status.status?.kind === 'transition' ? status.status.label : undefined;
-  const waiting = availability === 'disabled' || suspension.isPending;
+  const waiting = availability.kind === 'disabled' || suspension.isPending;
 
   return (
     <Button

--- a/apps/dashboard/src/lib/app-actions.test.ts
+++ b/apps/dashboard/src/lib/app-actions.test.ts
@@ -3,6 +3,10 @@ import { APP_STATES, type AppState, DEPLOYMENT_STATES, type DeploymentState } fr
 import { APP_ACTIONS, type AppActions, appActions } from '#lib/app-actions.ts';
 import { appStatus } from '#lib/app-status.ts';
 
+const ENABLED = { kind: 'enabled' } as const;
+const DISABLED = { kind: 'disabled' } as const;
+const HIDDEN = { kind: 'hidden' } as const;
+
 function actions({
   appState = 'active',
   deploymentState,
@@ -16,10 +20,10 @@ function actions({
 describe('an app is offered what its state can actually do', () => {
   test('one nobody has deployed has nothing to export and nothing to take offline', () => {
     expect(actions()).toEqual({
-      deploy: 'enabled',
-      export: 'hidden',
-      suspend: 'hidden',
-      delete: 'enabled',
+      deploy: ENABLED,
+      export: HIDDEN,
+      suspend: HIDDEN,
+      delete: ENABLED,
     });
   });
 
@@ -28,25 +32,25 @@ describe('an app is offered what its state can actually do', () => {
   for (const deploymentState of down) {
     test(`one whose release is ${deploymentState} is exportable and has nothing to suspend`, () => {
       expect(actions({ deploymentState })).toEqual({
-        deploy: 'enabled',
-        export: 'enabled',
-        suspend: 'hidden',
-        delete: 'enabled',
+        deploy: ENABLED,
+        export: ENABLED,
+        suspend: HIDDEN,
+        delete: ENABLED,
       });
     });
   }
 
   test('a serving one is offered every button', () => {
     expect(actions({ deploymentState: 'active' })).toEqual({
-      deploy: 'enabled',
-      export: 'enabled',
-      suspend: 'enabled',
-      delete: 'enabled',
+      deploy: ENABLED,
+      export: ENABLED,
+      suspend: ENABLED,
+      delete: ENABLED,
     });
   });
 
   test('a suspended one is offered the same, the suspend button being the way back', () => {
-    expect(actions({ appState: 'suspended', deploymentState: 'stopped' }).suspend).toBe('enabled');
+    expect(actions({ appState: 'suspended', deploymentState: 'stopped' }).suspend).toEqual(ENABLED);
   });
 });
 
@@ -56,39 +60,59 @@ describe('an app is offered what its state can actually do', () => {
  */
 describe('an app the host has not caught up with yet', () => {
   test('is not asked to suspend while it is suspending', () => {
-    expect(actions({ appState: 'suspended', deploymentState: 'active' }).suspend).toBe('disabled');
+    expect(actions({ appState: 'suspended', deploymentState: 'active' }).suspend).toEqual(DISABLED);
   });
 
   test('nor while it is coming back', () => {
-    expect(actions({ deploymentState: 'stopped' }).suspend).toBe('disabled');
+    expect(actions({ deploymentState: 'stopped' }).suspend).toEqual(DISABLED);
   });
 
   test('and one not read yet offers nothing to press', () => {
     expect(appActions(undefined)).toEqual({
-      deploy: 'disabled',
-      export: 'disabled',
-      suspend: 'disabled',
-      delete: 'disabled',
+      deploy: DISABLED,
+      export: DISABLED,
+      suspend: DISABLED,
+      delete: DISABLED,
     });
+  });
+});
+
+/**
+ * A release is only started for an app whose row asks to run, so one deployed here would sit
+ * pending until the app is resumed. The button is greyed with the sentence saying so, because
+ * unlike the two above it has no label of its own to say what it is waiting on.
+ */
+describe('a suspended app', () => {
+  for (const deploymentState of [...DEPLOYMENT_STATES, undefined]) {
+    test(`is not offered a deploy, and says why, with a ${deploymentState ?? 'missing'} release`, () => {
+      expect(actions({ appState: 'suspended', deploymentState }).deploy).toEqual({
+        kind: 'disabled',
+        reason: expect.any(String),
+      });
+    });
+  }
+
+  test('is offered one again the moment it is asked to run, before the host has started it', () => {
+    expect(actions({ deploymentState: 'stopped' }).deploy).toEqual(ENABLED);
   });
 });
 
 describe('an app on its way out', () => {
   test('has one button left, and it is the one saying so', () => {
     expect(actions({ appState: 'deleting' })).toEqual({
-      deploy: 'hidden',
-      export: 'hidden',
-      suspend: 'hidden',
-      delete: 'disabled',
+      deploy: HIDDEN,
+      export: HIDDEN,
+      suspend: HIDDEN,
+      delete: DISABLED,
     });
   });
 
   test('and once it is gone, none at all', () => {
     expect(actions({ appState: 'deleted' })).toEqual({
-      deploy: 'hidden',
-      export: 'hidden',
-      suspend: 'hidden',
-      delete: 'hidden',
+      deploy: HIDDEN,
+      export: HIDDEN,
+      suspend: HIDDEN,
+      delete: HIDDEN,
     });
   });
 });

--- a/apps/dashboard/src/lib/app-actions.ts
+++ b/apps/dashboard/src/lib/app-actions.ts
@@ -8,12 +8,32 @@ export type AppAction = (typeof APP_ACTIONS)[number];
 /**
  * `hidden` for an action this status has nothing to do with, `disabled` for one it is on its way
  * back to offering. The difference is what the owner is being told: a button that is gone means
- * the app cannot be asked this, and one that is greyed means it is already being asked something
- * — which is why every greyed button here says what it is waiting on.
+ * the app cannot be asked this, and one that is greyed means it will be asked again. Most greyed
+ * buttons say what they are waiting on in their own label; one that cannot carries the sentence
+ * saying so as `reason`.
  */
-export type AppActionAvailability = 'enabled' | 'disabled' | 'hidden';
+export type AppActionAvailability =
+  | { readonly kind: 'enabled' }
+  | { readonly kind: 'disabled'; readonly reason?: string }
+  | { readonly kind: 'hidden' };
 
 export type AppActions = Record<AppAction, AppActionAvailability>;
+
+/** Also what a deploy with no app behind it gets: no status is holding that one back. */
+export const ENABLED: AppActionAvailability = { kind: 'enabled' };
+
+const DISABLED: AppActionAvailability = { kind: 'disabled' };
+const HIDDEN: AppActionAvailability = { kind: 'hidden' };
+
+/**
+ * A host is only sent releases whose app is asking to run, so one deployed to a suspended app
+ * would sit pending until it is resumed rather than fail — an owner watching a spinner for a
+ * release nothing is going to start. The way out is the button beside it.
+ */
+const UNTIL_RESUMED: AppActionAvailability = {
+  kind: 'disabled',
+  reason: 'This app is suspended, so a new release would never start. Resume it first.',
+};
 
 /**
  * Every status against every button, written out rather than derived, because there is no rule
@@ -22,30 +42,36 @@ export type AppActions = Record<AppAction, AppActionAvailability>;
  * from here, which is a type error rather than a button someone finds behaving oddly weeks later.
  */
 const AVAILABILITY: Record<AppStatusKey, AppActions> = {
-  'never-deployed': { deploy: 'enabled', export: 'hidden', suspend: 'hidden', delete: 'enabled' },
-  pending: { deploy: 'enabled', export: 'enabled', suspend: 'enabled', delete: 'enabled' },
-  starting: { deploy: 'enabled', export: 'enabled', suspend: 'enabled', delete: 'enabled' },
-  active: { deploy: 'enabled', export: 'enabled', suspend: 'enabled', delete: 'enabled' },
+  'never-deployed': { deploy: ENABLED, export: HIDDEN, suspend: HIDDEN, delete: ENABLED },
+  pending: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
+  starting: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
+  active: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
   // Nothing is serving under either of these, so there is nothing to take offline — and a bundle
   // is cut from the volume rather than from a running microVM, so exporting still works.
-  failed: { deploy: 'enabled', export: 'enabled', suspend: 'hidden', delete: 'enabled' },
-  superseded: { deploy: 'enabled', export: 'enabled', suspend: 'hidden', delete: 'enabled' },
-  suspended: { deploy: 'enabled', export: 'enabled', suspend: 'enabled', delete: 'enabled' },
-  suspending: { deploy: 'enabled', export: 'enabled', suspend: 'disabled', delete: 'enabled' },
-  resuming: { deploy: 'enabled', export: 'enabled', suspend: 'disabled', delete: 'enabled' },
+  failed: { deploy: ENABLED, export: ENABLED, suspend: HIDDEN, delete: ENABLED },
+  superseded: { deploy: ENABLED, export: ENABLED, suspend: HIDDEN, delete: ENABLED },
+  suspended: { deploy: UNTIL_RESUMED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
+  suspending: { deploy: UNTIL_RESUMED, export: ENABLED, suspend: DISABLED, delete: ENABLED },
+  // Deploying is offered back the moment the app row asks to run again, which is what resuming is.
+  resuming: { deploy: ENABLED, export: ENABLED, suspend: DISABLED, delete: ENABLED },
   // An app on its way out has one thing left to say, and it is the button that says it.
-  deleting: { deploy: 'hidden', export: 'hidden', suspend: 'hidden', delete: 'disabled' },
-  deleted: { deploy: 'hidden', export: 'hidden', suspend: 'hidden', delete: 'hidden' },
+  deleting: { deploy: HIDDEN, export: HIDDEN, suspend: HIDDEN, delete: DISABLED },
+  deleted: { deploy: HIDDEN, export: HIDDEN, suspend: HIDDEN, delete: HIDDEN },
 };
 
 /** Nothing may be pressed on an app whose status has not been read yet. */
 const WHILE_UNREAD: AppActions = {
-  deploy: 'disabled',
-  export: 'disabled',
-  suspend: 'disabled',
-  delete: 'disabled',
+  deploy: DISABLED,
+  export: DISABLED,
+  suspend: DISABLED,
+  delete: DISABLED,
 };
 
 export function appActions(status: AppStatus | undefined): AppActions {
   return status === undefined ? WHILE_UNREAD : AVAILABILITY[statusKey(status)];
+}
+
+/** Why a button is greyed, where its own label does not already say. */
+export function greyedReason(availability: AppActionAvailability): string | undefined {
+  return availability.kind === 'disabled' ? availability.reason : undefined;
 }

--- a/packages/app-operations/src/apps.ts
+++ b/packages/app-operations/src/apps.ts
@@ -16,6 +16,23 @@ export async function appBySlug({ api, slug }: { api: PublicApiClient; slug: str
 }
 
 /**
+ * The app a release is being made onto.
+ *
+ * A host is only sent releases whose app is asking to run, so one made onto a suspended app would
+ * sit pending until it is resumed rather than fail — a wait with no end. Refused where the app is
+ * first read, which on a deploy is before the binary is uploaded.
+ */
+export async function releaseTarget({ api, slug }: { api: PublicApiClient; slug: string }) {
+  const app = await appBySlug({ api, slug });
+  if (app.state === 'suspended') {
+    throw new ApiError(
+      `App ${app.slug} is suspended, so a new release would never start. Resume it first.`,
+    );
+  }
+  return app;
+}
+
+/**
  * The release the app is on: the one a reader means by not naming one, and the only one that says
  * what the app is doing now. The api lists them newest first, so this is the head of the list
  * rather than a search through it.

--- a/packages/app-operations/src/deploy.ts
+++ b/packages/app-operations/src/deploy.ts
@@ -1,7 +1,7 @@
 import type { PublicApiClient } from '@repo/api-client/public';
 import { ApiError, unwrap } from '@repo/api-client/unwrap';
 import type { DeploymentState, Filename, TenantArguments } from '@repo/protocol';
-import { appBySlug } from '#apps.ts';
+import { releaseTarget } from '#apps.ts';
 import {
   type ConfigEdit,
   configPatch,
@@ -65,7 +65,7 @@ export async function deploy({
   upload = streamedUpload,
   ...edit
 }: DeployInput): Promise<Deployed> {
-  const target = slug === undefined ? null : await appBySlug({ api, slug });
+  const target = slug === undefined ? null : await releaseTarget({ api, slug });
   const config = configPatch(edit);
 
   const app =

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -6,6 +6,7 @@ export {
   appBySlug,
   currentArtifact,
   newestDeployment,
+  releaseTarget,
 } from '#apps.ts';
 export { deleteApp } from '#delete.ts';
 export {

--- a/packages/app-operations/src/redeploy.ts
+++ b/packages/app-operations/src/redeploy.ts
@@ -1,6 +1,6 @@
 import type { PublicApiClient } from '@repo/api-client/public';
 import { unwrap } from '@repo/api-client/unwrap';
-import { appBySlug, currentArtifact } from '#apps.ts';
+import { currentArtifact, releaseTarget } from '#apps.ts';
 import {
   type ConfigEdit,
   configPatch,
@@ -32,7 +32,7 @@ export async function redeploy({
   onStep,
   ...edit
 }: RedeployInput): Promise<Deployed> {
-  const target = await appBySlug({ api, slug });
+  const target = await releaseTarget({ api, slug });
   const artifact = await currentArtifact({ api, appId: target.id });
 
   const app = unwrap(await api.api.apps({ appId: target.id }).patch(configPatch(edit)));

--- a/packages/app-operations/tests/apps.test.ts
+++ b/packages/app-operations/tests/apps.test.ts
@@ -1,12 +1,18 @@
 import { expect, test } from 'bun:test';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { addressedDeployment, appBySlug, currentArtifact, newestDeployment } from '#apps.ts';
+import {
+  addressedDeployment,
+  appBySlug,
+  currentArtifact,
+  newestDeployment,
+  releaseTarget,
+} from '#apps.ts';
 
 function apiHolding({
   apps,
   deployments = [],
 }: {
-  apps: Array<{ id: string; slug: string }>;
+  apps: Array<{ id: string; slug: string; state?: string }>;
   deployments?: Array<{ id: string; artifactId?: string; state?: string }>;
 }): PublicApiClient {
   function underApp() {
@@ -39,6 +45,22 @@ test('a slug naming nothing is said to name nothing', async () => {
 
   await expect(appBySlug({ api, slug: 'loud-badger' })).rejects.toThrow(
     'No app with slug loud-badger.',
+  );
+});
+
+test('an app asking to run is one a release can be made onto', async () => {
+  const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter', state: 'active' }] });
+
+  expect(await releaseTarget({ api, slug: 'quiet-otter' })).toMatchObject({ id: 'app-1' });
+});
+
+// Nothing would refuse the deployment — it would sit pending for as long as the app stays down —
+// so the sentence has to come from here, before the binary that would have gone with it.
+test('a suspended one is refused, with the way to make it deployable', async () => {
+  const api = apiHolding({ apps: [{ id: 'app-1', slug: 'quiet-otter', state: 'suspended' }] });
+
+  await expect(releaseTarget({ api, slug: 'quiet-otter' })).rejects.toThrow(
+    'App quiet-otter is suspended, so a new release would never start. Resume it first.',
   );
 });
 

--- a/packages/app-operations/tests/deploy.test.ts
+++ b/packages/app-operations/tests/deploy.test.ts
@@ -31,7 +31,7 @@ function apiHolding({
   completed = { id: ARTIFACT_ID, digest: DIGEST },
   hostnames = [PENDING_CUSTOM, PLATFORM],
 }: {
-  apps: Array<{ id: string; slug: string }>;
+  apps: Array<{ id: string; slug: string; state?: string }>;
   sent: Sent[];
   completed?: { id: string; digest: string } | null;
   hostnames?: HostnameRow[];
@@ -128,6 +128,25 @@ test('a slug names the app the release lands on', async () => {
     deploymentId: 'deployment-1',
     url: `https://${SLUG}.nibrun.app`,
   });
+});
+
+// Nothing downstream would refuse the deployment — it would sit pending for as long as the app
+// stays down — and the upload is the half of this that costs, so the refusal comes before it.
+test('a suspended app is refused before its binary goes anywhere', async () => {
+  const sent: Sent[] = [];
+  storeAnswering({ sent });
+
+  const attempt = deploy({
+    api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG, state: 'suspended' }], sent }),
+    binary: binary(),
+    args: [],
+    app: SLUG,
+  });
+
+  await expect(attempt).rejects.toThrow(
+    'App quiet-otter is suspended, so a new release would never start. Resume it first.',
+  );
+  expect(sent).toEqual([]);
 });
 
 test('a domain the owner brought is the address handed back, once it is serving', async () => {

--- a/packages/app-operations/tests/redeploy.test.ts
+++ b/packages/app-operations/tests/redeploy.test.ts
@@ -20,10 +20,12 @@ function apiHolding({
   sent,
   deployments = [{ id: 'deployment-1', artifactId: ARTIFACT_ID }],
   hostnames = [PLATFORM],
+  state = 'active',
 }: {
   sent: Sent[];
   deployments?: Array<{ id: string; artifactId: string }>;
   hostnames?: HostnameRow[];
+  state?: string;
 }): PublicApiClient {
   function underApp({ appId }: { appId: string }) {
     function artifact({ artifactId }: { artifactId: string }) {
@@ -59,7 +61,8 @@ function apiHolding({
   return {
     api: {
       apps: Object.assign(underApp, {
-        get: () => Promise.resolve({ data: { apps: [{ id: APP_ID, slug: SLUG }] }, error: null }),
+        get: () =>
+          Promise.resolve({ data: { apps: [{ id: APP_ID, slug: SLUG, state }] }, error: null }),
       }),
     },
   } as unknown as PublicApiClient;
@@ -125,6 +128,23 @@ test('an app that has never been deployed is refused before its config moves', a
 
   await expect(attempt).rejects.toThrow('This app has never been deployed.');
   expect(sent.map((each) => each.what)).not.toContain('app patch');
+});
+
+// The config would be written for a release that then sits pending until the app comes back, so
+// what the app runs on would have changed without anything running it.
+test('a suspended app is refused before its config moves', async () => {
+  const sent: Sent[] = [];
+
+  const attempt = redeploy({
+    api: apiHolding({ sent, state: 'suspended' }),
+    app: SLUG,
+    args: ['serve'],
+  });
+
+  await expect(attempt).rejects.toThrow(
+    'App quiet-otter is suspended, so a new release would never start. Resume it first.',
+  );
+  expect(sent).toEqual([]);
 });
 
 test('a slug naming nothing is said to name nothing', async () => {

--- a/packages/cli/src/lib/plan.test.ts
+++ b/packages/cli/src/lib/plan.test.ts
@@ -107,6 +107,23 @@ test('what the binary will be run with is shown before anything is uploaded', as
   expect(notes.at(-1)).toContain('binary: /tmp/my-server');
 });
 
+// Both halves of the summary are wrong for a suspended app: nothing is running for the deploy to
+// replace, and nothing would start what it landed.
+test('a named app that cannot be deployed onto is refused before anything is asked', async () => {
+  const attempt = completeOptions({
+    api: apiListing([{ slug: 'demo-abc123', state: 'suspended' }]),
+    options: { app: 'demo-abc123' },
+    binaryPath: '/tmp/my-server',
+    args: [],
+  });
+
+  await expect(attempt).rejects.toThrow(
+    'App demo-abc123 is suspended, so a new release would never start. Resume it first.',
+  );
+  expect(asked).toEqual([]);
+  expect(notes).toEqual([]);
+});
+
 test('declining the confirmation cancels rather than deploying', async () => {
   confirmed = false;
 

--- a/packages/cli/src/lib/plan.ts
+++ b/packages/cli/src/lib/plan.ts
@@ -2,6 +2,7 @@ import { basename } from 'node:path';
 import { confirm, note, select, text } from '@clack/prompts';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { unwrap } from '@repo/api-client/unwrap';
+import { releaseTarget } from '@repo/app-operations';
 import { DEFAULT_GUEST_PORT, type TenantArguments } from '@repo/protocol';
 import { CancelledError } from '#lib/errors.ts';
 import { answered } from '#lib/prompts.ts';
@@ -42,7 +43,13 @@ async function fillGaps({
   options,
   binaryPath,
 }: Omit<Plan, 'args'> & { api: PublicApiClient }): Promise<RunOptions> {
-  const app = options.app ?? (await chooseApp({ api }));
+  if (options.app !== undefined) {
+    // A slug typed rather than chosen has been checked against nothing yet, and a summary saying
+    // what the deploy replaces is worse than useless in front of an app it cannot land on.
+    await releaseTarget({ api, slug: options.app });
+    return options;
+  }
+  const app = await chooseApp({ api });
   if (app !== undefined) {
     return { ...options, app };
   }


### PR DESCRIPTION
Deploying onto a suspended app was accepted everywhere and started nowhere: `listLive()` sets `desired_running` to `(a.state = 'active')`, so the release sat `pending` until the app came back — five minutes of spinner, then "was still starting after 300000ms".

The dashboard now greys the deploy button for a suspended app and says why (the button matrix gains a reason for cells whose own label cannot explain the wait); saving environment variables, which is a release, goes with it. The CLI refuses in `@repo/app-operations`, where the app is read before anything is sent — so `nib run` refuses before uploading the binary and `nib apps update` before moving the config.

The api still accepts such a deployment; this is a client-side refusal on both surfaces.