### PR TITLE
fix(dashboard): a deploy that landed leaves for the app it landed on

### DIFF
--- a/apps/dashboard/src/components/apps/app-environment-dialog-content.tsx
+++ b/apps/dashboard/src/components/apps/app-environment-dialog-content.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@repo/ui/components/button';
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
   DialogHeader,
@@ -12,6 +11,7 @@ import { Field, FieldError } from '@repo/ui/components/field';
 import { DialogBody } from '@repo/ui/custom/dialog-body';
 import { PencilIcon } from 'lucide-react';
 import { useState } from 'react';
+import { DeployDoneButton } from '#components/apps/deploy-done-button.tsx';
 import { DeployProgress } from '#components/apps/deploy-progress.tsx';
 import { EnvironmentTable } from '#components/apps/environment-table.tsx';
 import { greyedReason } from '#lib/app-actions.ts';
@@ -73,7 +73,7 @@ export function AppEnvironmentDialogContent({ app }: { app: AppSummary }) {
               </Button>
             </form>
           ) : (
-            <DeployProgress done={<DialogClose render={<Button />}>Done</DialogClose>} />
+            <DeployProgress done={<DeployDoneButton />} />
           )}
         </DialogBody>
       </DialogContent>

--- a/apps/dashboard/src/components/apps/deploy-dialog-content.tsx
+++ b/apps/dashboard/src/components/apps/deploy-dialog-content.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@repo/ui/components/button';
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
   DialogHeader,
@@ -11,6 +10,7 @@ import {
 import { DialogBody } from '@repo/ui/custom/dialog-body';
 import { RocketIcon } from 'lucide-react';
 import { useState } from 'react';
+import { DeployDoneButton } from '#components/apps/deploy-done-button.tsx';
 import { DeployForm } from '#components/apps/deploy-form.tsx';
 import { DeployProgress } from '#components/apps/deploy-progress.tsx';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
@@ -50,7 +50,7 @@ export function DeployDialogContent({ appId, disabled }: { appId?: string; disab
           {run.phase === 'idle' ? (
             <DeployForm appId={appId} binary={undefined} />
           ) : (
-            <DeployProgress done={<DialogClose render={<Button />}>Done</DialogClose>} />
+            <DeployProgress done={<DeployDoneButton />} />
           )}
         </DialogBody>
       </DialogContent>

--- a/apps/dashboard/src/components/apps/deploy-done-button.tsx
+++ b/apps/dashboard/src/components/apps/deploy-done-button.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@repo/ui/components/button';
+import { DialogClose } from '@repo/ui/components/dialog';
+import { Link } from '@tanstack/react-router';
+import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
+import { Route as AppRoute } from '#routes/(dashboard)/apps/$appId/index.tsx';
+
+// A run that landed has somewhere to go: the app it landed on, which the page behind the dialog
+// is not necessarily showing. A run that failed produced no app to leave for.
+export function DeployDoneButton() {
+  const { deployed } = useDeployRun();
+
+  if (deployed === undefined) {
+    return <DialogClose render={<Button />}>Done</DialogClose>;
+  }
+
+  return (
+    <DialogClose
+      render={<Button render={<Link to={AppRoute.to} params={{ appId: deployed.appId }} />} />}
+    >
+      Done
+    </DialogClose>
+  );
+}

--- a/apps/dashboard/src/components/apps/deploy-progress.tsx
+++ b/apps/dashboard/src/components/apps/deploy-progress.tsx
@@ -58,9 +58,11 @@ export function DeployProgress({ done }: { done: ReactNode }) {
 
       {waiting === undefined && (
         <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-          <Button variant="outline" onClick={run.reset}>
-            Deploy another
-          </Button>
+          {run.phase === 'failed' && (
+            <Button variant="outline" onClick={run.reset}>
+              Deploy another
+            </Button>
+          )}
           {done}
         </div>
       )}


### PR DESCRIPTION
A finished deploy no longer offers "Deploy another" — that is now the retry a failed run keeps — and Done takes you to the app the deploy produced instead of only closing the dialog.

The handoff page is untouched: it still leaves for the dashboard index on its own.