### PR TITLE
ci: open the guest image adoption PR from the build that published it

### DIFF
--- a/.github/actions/open-pr/action.yml
+++ b/.github/actions/open-pr/action.yml
@@ -1,0 +1,56 @@
+name: Open a pull request
+description: Commit the staged paths onto a branch and open a pull request for it.
+
+inputs:
+  branch:
+    description: Branch to push the commit to. Also the change's identity — if a pull request was ever opened for it, this one is not opened again.
+    required: true
+  title:
+    description: Pull request title, also the commit message.
+    required: true
+  body:
+    description: Pull request body, as Markdown.
+    required: true
+  paths:
+    description: Space-separated paths to commit.
+    required: true
+
+outputs:
+  url:
+    description: The pull request's URL, empty when one had already been opened.
+    value: ${{ steps.open.outputs.url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Open the pull request
+      id: open
+      shell: bash
+      env:
+        BRANCH: ${{ inputs.branch }}
+        TITLE: ${{ inputs.title }}
+        BODY: ${{ inputs.body }}
+        PATHS: ${{ inputs.paths }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "$(gh pr list --head "$BRANCH" --state all --json number --jq '.[].number')" ]; then
+          echo "Already proposed: a pull request for $BRANCH exists."
+          exit 0
+        fi
+
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+        git switch -c "$BRANCH"
+        # Unquoted on purpose: the input is a list, not one path.
+        # shellcheck disable=SC2086
+        git add -- $PATHS
+        git commit -m "$TITLE"
+        git push --set-upstream origin "$BRANCH"
+
+        printf '%s\n' "$BODY" > "${RUNNER_TEMP}/pr-body.md"
+        url=$(gh pr create --title "$TITLE" --body-file "${RUNNER_TEMP}/pr-body.md")
+        echo "url=$url" >> "$GITHUB_OUTPUT"
+        echo "Opened $url"

--- a/.github/actions/open-pr/action.yml
+++ b/.github/actions/open-pr/action.yml
@@ -14,6 +14,13 @@ inputs:
   paths:
     description: Space-separated paths to commit.
     required: true
+  token:
+    description: >-
+      Token to open the pull request with. GitHub fires no events for what
+      GITHUB_TOKEN does, so the default opens a pull request none of main's
+      required checks will ever run on. Pass a PAT or app token to get one that
+      can merge.
+    default: ${{ github.token }}
 
 outputs:
   url:
@@ -31,7 +38,7 @@ runs:
         TITLE: ${{ inputs.title }}
         BODY: ${{ inputs.body }}
         PATHS: ${{ inputs.paths }}
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.token }}
       run: |
         set -euo pipefail
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -250,6 +250,7 @@ jobs:
           branch: guest-image/${{ steps.publish.outputs.version }}
           title: "chore(infra): adopt guest image ${{ steps.publish.outputs.version }}"
           paths: infra/app-host/versions.json
+          token: ${{ secrets.OPEN_PR_TOKEN || github.token }}
           body: |
             Points the fleet at guest image `${{ steps.publish.outputs.version }}`, published by
             [this run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -213,6 +213,10 @@ jobs:
   build-guest-image:
     needs: terraform
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the adoption branch
+      pull-requests: write # open the adoption PR
+      id-token: write # OIDC token for the deploy role
     env:
       GUEST_IMAGES_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).guest_images_bucket }}
     steps:
@@ -229,5 +233,25 @@ jobs:
         run: bun run --filter @repo/runtime build
 
       - name: Publish the guest image
+        id: publish
         timeout-minutes: 45
         run: bun run --filter @repo/internal-scripts publish-guest-image
+
+      - name: Pin the published image
+        id: pin
+        env:
+          GUEST_IMAGE_VERSION: ${{ steps.publish.outputs.version }}
+        run: bun run --filter @repo/internal-scripts adopt-guest-image
+
+      - name: Open the adoption pull request
+        if: steps.pin.outputs.changed == 'true'
+        uses: ./.github/actions/open-pr
+        with:
+          branch: guest-image/${{ steps.publish.outputs.version }}
+          title: "chore(infra): adopt guest image ${{ steps.publish.outputs.version }}"
+          paths: infra/app-host/versions.json
+          body: |
+            Points the fleet at guest image `${{ steps.publish.outputs.version }}`, published by
+            [this run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            Merging is the adoption: from then on every app host deploy boots this kernel.

--- a/.github/workflows/prepare-cli-release.yml
+++ b/.github/workflows/prepare-cli-release.yml
@@ -24,36 +24,19 @@ jobs:
         id: release
         run: bun run --filter @repo/internal-scripts prepare-cli-release
 
-      - name: Configure git user
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+      - name: Open the release pull request
+        uses: ./.github/actions/open-pr
+        with:
+          branch: release/${{ steps.release.outputs.tag }}
+          title: "chore(release): ${{ steps.release.outputs.tag }}"
+          paths: packages/cli/package.json packages/cli/CHANGELOG.md
+          body: |
+            Bumps `@repo/cli` to **${{ steps.release.outputs.version }}** and regenerates its changelog.
 
-      - name: Commit and push to the release branch
-        env:
-          TAG: ${{ steps.release.outputs.tag }}
-          RELEASE_BRANCH: release/${{ steps.release.outputs.tag }}
-        run: |
-          git switch -c "$RELEASE_BRANCH"
-          git add packages/cli/package.json packages/cli/CHANGELOG.md
-          git commit -m "chore(release): ${TAG}"
-          git push --set-upstream origin "$RELEASE_BRANCH"
+            Merging this releases nothing. Tagging the commit it lands as is what does:
 
-      - name: Create the release PR
-        env:
-          TAG: ${{ steps.release.outputs.tag }}
-          VERSION: ${{ steps.release.outputs.version }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          cat > "${RUNNER_TEMP}/pr-body.md" <<EOF
-          Bumps \`@repo/cli\` to **${VERSION}** and regenerates its changelog.
-
-          Merging this releases nothing. Tagging the commit it lands as is what does:
-
-          \`\`\`sh
-          git switch main && git pull
-          git tag ${TAG}
-          git push origin ${TAG}
-          \`\`\`
-          EOF
-          gh pr create --title "chore(release): ${TAG}" --body-file "${RUNNER_TEMP}/pr-body.md"
+            ```sh
+            git switch main && git pull
+            git tag ${{ steps.release.outputs.tag }}
+            git push origin ${{ steps.release.outputs.tag }}
+            ```

--- a/.github/workflows/prepare-cli-release.yml
+++ b/.github/workflows/prepare-cli-release.yml
@@ -30,6 +30,7 @@ jobs:
           branch: release/${{ steps.release.outputs.tag }}
           title: "chore(release): ${{ steps.release.outputs.tag }}"
           paths: packages/cli/package.json packages/cli/CHANGELOG.md
+          token: ${{ secrets.OPEN_PR_TOKEN || github.token }}
           body: |
             Bumps `@repo/cli` to **${{ steps.release.outputs.version }}** and regenerates its changelog.
 

--- a/packages/internal-scripts/package.json
+++ b/packages/internal-scripts/package.json
@@ -6,6 +6,7 @@
     "#*": "./src/*"
   },
   "scripts": {
+    "adopt-guest-image": "bun run src/adopt-guest-image.ts",
     "build-and-push-image": "bun run src/build-and-push-image.ts",
     "cli-release-notes": "bun run src/cli-release-notes.ts",
     "prepare-cli-release": "bun run src/prepare-cli-release.ts",

--- a/packages/internal-scripts/src/adopt-guest-image.ts
+++ b/packages/internal-scripts/src/adopt-guest-image.ts
@@ -1,0 +1,21 @@
+import * as core from '@actions/core';
+import { readAppHostVersions, versionsPath } from '#shared/app-host-versions.ts';
+import { requiredEnv } from '#shared/env.ts';
+
+// Only edits the file. The commit it lands in is a pull request, so the kernel
+// every host boots still changes on a merge someone approved.
+
+const version = requiredEnv('GUEST_IMAGE_VERSION');
+const versions = await readAppHostVersions();
+const changed = versions.guestImage !== version;
+
+core.setOutput('changed', String(changed));
+
+if (!changed) {
+  core.info(`Already pinned to ${version}.`);
+  process.exit(0);
+}
+
+await Bun.write(versionsPath, `${JSON.stringify({ ...versions, guestImage: version }, null, 2)}\n`);
+
+core.info(`${versions.guestImage} → ${version}`);

--- a/packages/internal-scripts/src/publish-guest-image.ts
+++ b/packages/internal-scripts/src/publish-guest-image.ts
@@ -7,9 +7,10 @@ import { requiredEnv } from '#shared/env.ts';
 import { repoRoot } from '#shared/paths.ts';
 
 // Publishing is not adopting. This uploads an image under its own version and
-// stops; a host only runs it once a separate, reviewable commit edits `guestImage`
-// in infra/app-host/versions.json. That split is what keeps the fleet's kernel a
-// deliberate input rather than whatever the last build produced.
+// stops; a host only runs it once `guestImage` in infra/app-host/versions.json
+// points at it. CI proposes that edit as a pull request, so the fleet's kernel
+// still changes on a merge someone approved rather than on whatever the last
+// build produced.
 
 type Manifest = {
   version: string;
@@ -73,16 +74,13 @@ await aws(['s3', 'cp', '--recursive', distDir, `s3://${bucket}/${version}/`]);
 
 core.info(`Published s3://${bucket}/${version}/`);
 
-// Publishing is not adopting, and adopting is a human editing a pin. That person
-// should not have to dig the version out of a build log to find what to paste.
 await writeSummary(
   [
     '## Guest image published',
     '',
     `\`${version}\``,
     '',
-    'No host runs it yet. To adopt it, set `guestImage` to that value in',
-    '`infra/app-host/versions.json` and open a pull request — that commit is the',
-    'reviewable record of the fleet changing kernel.',
+    'No host runs it yet. The pull request pinning it in',
+    '`infra/app-host/versions.json` is what puts it on the fleet.',
   ].join('\n'),
 );


### PR DESCRIPTION
The guest image build already tells you the version to pin — it just relied on someone reading the
job summary and remembering. Now the build opens that pin bump as a pull request itself.

Publishing still is not adopting: the PR is the proposal, merging it is the decision.

`prepare-cli-release`'s push-a-branch-and-open-a-PR half moves into `.github/actions/open-pr`,
which both workflows now call. It skips when a PR was ever opened for that branch, so `cd` running
on every push to main does not re-propose an image already waiting for review.

### Needs a secret to be mergeable

`main` requires four status checks, and GitHub fires no events for what `GITHUB_TOKEN` does — so a
PR opened with the default token gets none of them and cannot merge. The action takes a `token`
input for that, wired to `secrets.OPEN_PR_TOKEN` with a fallback, so it works either way. Add a PAT
or GitHub App token as `OPEN_PR_TOKEN` (contents + pull-requests write) and the PRs merge normally.
`prepare-cli-release` has the same latent issue today — it has never been run.
