### PR TITLE
fix(dashboard): a handed-off binary lands on the app it became

### DIFF
--- a/apps/dashboard/src/components/handoff/handoff-deploy.tsx
+++ b/apps/dashboard/src/components/handoff/handoff-deploy.tsx
@@ -35,8 +35,8 @@ export function HandoffDeploy({
         {run.phase === 'idle' ? (
           <DeployForm appId={undefined} binary={binary} suggested={suggested} />
         ) : (
-          // Only ever seen when the deploy failed: a run that lands leaves for the dashboard
-          // on its own, so there is nothing here to click.
+          // Only ever seen when the deploy failed: a run that lands leaves for the app it made
+          // on its own, and a failed one made none to offer.
           <DeployProgress
             done={<Button render={<Link to={IndexRoute.to} />}>Go to the dashboard</Button>}
           />

--- a/apps/dashboard/src/lib/hooks/use-deploy.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy.ts
@@ -43,7 +43,7 @@ export function useDeploy({
 }: {
   onStep: (step: DeployStep) => void;
   onProgress: (progress: UploadProgress) => void;
-  onDeployed: (() => void) | undefined;
+  onDeployed: ((deployed: Deployed) => void) | undefined;
 }): DeployMutation {
   const queryClient = useQueryClient();
 

--- a/apps/dashboard/src/lib/hooks/use-finish-handoff.ts
+++ b/apps/dashboard/src/lib/hooks/use-finish-handoff.ts
@@ -1,19 +1,22 @@
+import type { Deployed } from '@repo/app-operations';
 import { useNavigate } from '@tanstack/react-router';
 import { forgetHandedOffBinary } from '#lib/handoff-store.ts';
-import { Route as IndexRoute } from '#routes/(dashboard)/index.tsx';
+import { Route as AppRoute } from '#routes/(dashboard)/apps/$appId/index.tsx';
 
 /**
- * What to do once a handed-off binary has been deployed. It is the only deploy with nowhere to
- * return to: it runs on a page outside the dashboard, opened by a drop on another origin, and
- * the binary that page exists for is spent the moment it lands.
+ * What to do once a handed-off binary has been deployed. The page it ran on is outside the
+ * dashboard, opened by a drop on another origin, and the binary it exists for is spent the moment
+ * it lands — so what is left of it is thrown away and the app it became is where this goes.
  *
  * Leaving is not conditional on the forgetting: a browser that refuses the delete is no reason
  * to strand someone on a page whose work is done.
  */
-export function useFinishHandoff(): () => void {
+export function useFinishHandoff(): (deployed: Deployed) => void {
   const navigate = useNavigate();
 
-  return function finish(): void {
-    void forgetHandedOffBinary().finally(() => navigate({ to: IndexRoute.to }));
+  return function finish(deployed: Deployed): void {
+    void forgetHandedOffBinary().finally(() =>
+      navigate({ to: AppRoute.to, params: { appId: deployed.appId } }),
+    );
   };
 }

--- a/apps/dashboard/src/lib/hooks/use-run-app.ts
+++ b/apps/dashboard/src/lib/hooks/use-run-app.ts
@@ -14,7 +14,11 @@ export type DeployRun = {
   reset: () => void;
 };
 
-export function useRunApp({ onDeployed }: { onDeployed: (() => void) | undefined }): DeployRun {
+export function useRunApp({
+  onDeployed,
+}: {
+  onDeployed: ((deployed: Deployed) => void) | undefined;
+}): DeployRun {
   const [steps, setSteps] = useState<readonly DeployStep[]>([]);
   const [progress, setProgress] = useState<UploadProgress | undefined>(undefined);
   // What the run was asked for, because the steps cannot say it: a release that reuses the stored

--- a/apps/dashboard/src/lib/providers/deploy-run-provider.tsx
+++ b/apps/dashboard/src/lib/providers/deploy-run-provider.tsx
@@ -1,3 +1,4 @@
+import type { Deployed } from '@repo/app-operations';
 import type { ReactNode } from 'react';
 import { DeployRunContext } from '#lib/contexts/deploy-run-context.ts';
 import { useRunApp } from '#lib/hooks/use-run-app.ts';
@@ -7,7 +8,7 @@ export function DeployRunProvider({
   onDeployed,
 }: {
   children: ReactNode;
-  onDeployed?: () => void;
+  onDeployed?: (deployed: Deployed) => void;
 }) {
   const run = useRunApp({ onDeployed });
 


### PR DESCRIPTION
Follow-up to #304. The /deploy page dropped you on the apps list once the binary landed; it now goes to the app it just made.

`onDeployed` carries the `Deployed` it already had, so the handoff has the app id to leave for.