### PR TITLE
fix(infra): a connection that never finishes its handshake is not held forever

### DIFF
--- a/infra/app-host/caddy/Caddyfile
+++ b/infra/app-host/caddy/Caddyfile
@@ -11,6 +11,23 @@
 	# next to this file. Hostnames are handed out per app, so there is no moment
 	# at which issuing a certificate would be a step in creating one.
 	auto_https off
+
+	# Authenticated Origin Pulls refuses a connection during the handshake, but
+	# nothing bounds how long a caller may take to reach that point: Go derives
+	# its TLS handshake deadline from the smallest read or write timeout set, and
+	# with none set there is no deadline at all. A connection opened and left
+	# mid-handshake is then held for as long as its opener likes, and the refusal
+	# that was the whole point never arrives.
+	#
+	# The header timeout alone, because it is the only one that bounds the
+	# handshake without also bounding the tenant: a write timeout would cut a
+	# streaming response and a body timeout a slow upload, and both are the
+	# tenant's to take as long over as their own users need.
+	servers {
+		timeouts {
+			read_header 10s
+		}
+	}
 }
 
 # Authenticated Origin Pulls. The origin IP is discoverable, so the edge has to

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -7,6 +7,22 @@
 	# every hostname below, so every site serves the same pair — which is why
 	# adding one here means reissuing that certificate.
 	auto_https off
+
+	# Authenticated Origin Pulls refuses a connection during the handshake, but
+	# nothing bounds how long a caller may take to reach that point: Go derives
+	# its TLS handshake deadline from the smallest read or write timeout set, and
+	# with none set there is no deadline at all. A connection opened and left
+	# mid-handshake is then held for as long as its opener likes, and the refusal
+	# that was the whole point never arrives. This listener is open to the world
+	# rather than to Cloudflare's ranges, so it is the one anyone can hold.
+	#
+	# The header timeout alone: a write timeout would cut the log stream, which
+	# is meant to stay open, and a body timeout an upload of a binary.
+	servers {
+		timeouts {
+			read_header 10s
+		}
+	}
 }
 
 # Authenticated Origin Pulls. The origin IP is discoverable, so the edge has to


### PR DESCRIPTION
Authenticated Origin Pulls refuses a caller during the handshake, which is what makes a discoverable origin IP acceptable — but nothing bounded how long a caller could take to get there. Go derives its TLS handshake deadline from the smallest read or write timeout set, and neither Caddyfile set any, so there was no deadline at all.

Only `read_header`: a write timeout would cut a tenant's streaming response and the api's log stream, and neither bounds the handshake.

Verified with `caddy adapt` on the pinned 2.11.4 — both files adapt cleanly and `read_header_timeout` lands on every listener (`:443`, and the control plane's `:8081`/`:8082`). `caddy fmt --diff` reports both already canonical.