### PR TITLE
feat(dashboard): a deploy form puts arguments away beside the variables

### DIFF
--- a/apps/dashboard/src/components/apps/deploy-environment-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-environment-field.tsx
@@ -1,11 +1,9 @@
-import { Field, FieldDescription, FieldError, FieldTitle } from '@repo/ui/components/field';
+import { Field, FieldDescription, FieldError } from '@repo/ui/components/field';
 import { EnvFilePicker } from '#components/apps/env-file-picker.tsx';
 import { EnvironmentTable } from '#components/apps/environment-table.tsx';
 import { storedVariables, withEntries } from '#lib/environment-variables.ts';
 import { type DeployFormApi, validateEnvironment } from '#lib/hooks/use-deploy-form.ts';
 import type { AppSummary } from '#queries/apps.ts';
-
-const TITLE_ID = 'deploy-environment-title';
 
 export function DeployEnvironmentField({
   api,
@@ -22,11 +20,7 @@ export function DeployEnvironmentField({
         const variables = field.state.value ?? storedVariables(replacing);
 
         return (
-          <Field
-            aria-labelledby={TITLE_ID}
-            data-invalid={field.state.meta.errors.length > 0 || undefined}
-          >
-            <FieldTitle id={TITLE_ID}>Environment variables</FieldTitle>
+          <Field data-invalid={field.state.meta.errors.length > 0 || undefined}>
             <EnvironmentTable variables={variables} onChange={field.handleChange}>
               {replacing === undefined && (
                 <EnvFilePicker

--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -12,7 +12,15 @@ import { useStore } from '@tanstack/react-form';
 import { DeployBinaryField } from '#components/apps/deploy-binary-field.tsx';
 import { DeployEnvironmentField } from '#components/apps/deploy-environment-field.tsx';
 import { DeployNameField } from '#components/apps/deploy-name-field.tsx';
-import { type DeploySuggestion, useDeployForm, validatePort } from '#lib/hooks/use-deploy-form.ts';
+import { filledVariables, storedVariables } from '#lib/environment-variables.ts';
+import {
+  type DeploySuggestion,
+  tenantArguments,
+  useDeployForm,
+  validatePort,
+} from '#lib/hooks/use-deploy-form.ts';
+
+const ARGUMENTS = 'Arguments';
 
 export function DeployForm({
   appId,
@@ -63,30 +71,55 @@ export function DeployForm({
         )}
       </api.Field>
 
-      <api.Field name="args">
-        {(field) => (
-          <Field>
-            <FieldLabel htmlFor="deploy-args">Arguments</FieldLabel>
-            <Textarea
-              id="deploy-args"
-              value={field.state.value ?? defaultArgs}
-              onChange={(event) => field.handleChange(event.target.value)}
-              placeholder={'serve\n--verbose'}
-              className="font-mono"
-            />
-            <FieldDescription>
-              One per line. What is here is what the binary runs with — empty runs it bare.
-            </FieldDescription>
-          </Field>
-        )}
-      </api.Field>
-
-      <Accordion>
+      {/* Both sections are settings of the same release, not alternatives, so opening one
+          does not put the other away mid-edit. */}
+      <Accordion multiple>
         <AccordionItem>
           <AccordionTrigger>
-            Advanced settings
+            <span className="flex items-baseline gap-2">
+              {ARGUMENTS}
+              <api.Subscribe
+                selector={(state) => tenantArguments(state.values.args ?? defaultArgs).length}
+              >
+                {(count) => <CollapsedCount count={count} />}
+              </api.Subscribe>
+            </span>
+          </AccordionTrigger>
+          <AccordionContent>
+            <api.Field name="args">
+              {(field) => (
+                <Field>
+                  <Textarea
+                    aria-label={ARGUMENTS}
+                    value={field.state.value ?? defaultArgs}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                    placeholder={'serve\n--verbose'}
+                    className="font-mono"
+                  />
+                  <FieldDescription>
+                    One per line. What is here is what the binary runs with — empty runs it bare.
+                  </FieldDescription>
+                </Field>
+              )}
+            </api.Field>
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem>
+          <AccordionTrigger>
+            <span className="flex items-baseline gap-2">
+              Environment variables
+              <api.Subscribe
+                selector={(state) =>
+                  filledVariables(state.values.environment ?? storedVariables(replacing)).length
+                }
+              >
+                {(count) => <CollapsedCount count={count} />}
+              </api.Subscribe>
+            </span>
             {/* Collapsed, a refused variable would disable the button with nothing on screen
-                saying why, so the section that holds it says so itself. */}
+                saying why, so the section that holds it says so itself — which is why its
+                panel stays mounted, and its variables keep being validated, while it is shut. */}
             <api.Subscribe selector={(state) => state.fieldMeta.environment?.errors.length ?? 0}>
               {(refused) =>
                 refused > 0 ? (
@@ -95,7 +128,7 @@ export function DeployForm({
               }
             </api.Subscribe>
           </AccordionTrigger>
-          <AccordionContent>
+          <AccordionContent keepMounted>
             <DeployEnvironmentField api={api} replacing={replacing} />
           </AccordionContent>
         </AccordionItem>
@@ -119,6 +152,15 @@ export function DeployForm({
         )}
       </api.Subscribe>
     </form>
+  );
+}
+
+/** What the section holds, for as long as it is closed over it. */
+function CollapsedCount({ count }: { count: number }) {
+  return (
+    <span className="font-normal text-muted-foreground text-xs group-aria-expanded/accordion-trigger:hidden">
+      {count === 0 ? 'none' : count}
+    </span>
   );
 }
 

--- a/apps/dashboard/src/lib/hooks/use-deploy-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy-form.ts
@@ -200,7 +200,8 @@ function uploadableFrom(file: File): UploadableBinary | undefined {
   return Value.Check(FilenameSchema, file.name) ? { name: file.name, body: file } : undefined;
 }
 
-function tenantArguments(onePerLine: string): string[] {
+/** The lines that are arguments: what a blank one is not, and what the trailing newline is not. */
+export function tenantArguments(onePerLine: string): string[] {
   return onePerLine
     .split('\n')
     .map((line) => line.trim())


### PR DESCRIPTION
The advanced-settings accordion becomes "Environment variables", and arguments get a section of their own beside it. Both say what they hold — a count, or "none" — while they are shut, and both can be open at once.

The environment panel stays mounted while collapsed, so a refused variable keeps being refused and "needs a look" keeps saying so.