### PR TITLE
refactor(dashboard): each deploy section is an accordion of its own

### DIFF
--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -83,7 +83,7 @@ export function DeployForm({
               </api.Subscribe>
             </span>
           </AccordionTrigger>
-          <AccordionContent>
+          <AccordionContent keepMounted>
             <api.Field name="args">
               {(field) => (
                 <Field>
@@ -118,8 +118,8 @@ export function DeployForm({
               </api.Subscribe>
             </span>
             {/* Collapsed, a refused variable would disable the button with nothing on screen
-                saying why, so the section that holds it says so itself — which is why its
-                panel stays mounted, and its variables keep being validated, while it is shut. */}
+                saying why, so the section that holds it says so itself. A shut panel keeps its
+                variables validated, which is what leaves anything to say. */}
             <api.Subscribe selector={(state) => state.fieldMeta.environment?.errors.length ?? 0}>
               {(refused) =>
                 refused > 0 ? (

--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -71,9 +71,7 @@ export function DeployForm({
         )}
       </api.Field>
 
-      {/* Both sections are settings of the same release, not alternatives, so opening one
-          does not put the other away mid-edit. */}
-      <Accordion multiple>
+      <Accordion>
         <AccordionItem>
           <AccordionTrigger>
             <span className="flex items-baseline gap-2">
@@ -104,7 +102,9 @@ export function DeployForm({
             </api.Field>
           </AccordionContent>
         </AccordionItem>
+      </Accordion>
 
+      <Accordion>
         <AccordionItem>
           <AccordionTrigger>
             <span className="flex items-baseline gap-2">


### PR DESCRIPTION
Arguments and environment variables get a card each rather than two rows of one group. Follow-up to #313.