### PR TITLE
refactor: the port a binary listens on is called its HTTP port

### DIFF
--- a/apps/dashboard/src/components/apps/app-config-card.tsx
+++ b/apps/dashboard/src/components/apps/app-config-card.tsx
@@ -11,7 +11,7 @@ export function AppConfigCard({ app }: { app: AppSummary }) {
       </CardHeader>
       <CardContent className="flex flex-col gap-4 text-sm">
         <div className="flex items-center justify-between gap-4">
-          <span className="text-muted-foreground">Guest port</span>
+          <span className="text-muted-foreground">HTTP port</span>
           <span className="font-mono tabular-nums">{app.config.guestPort}</span>
         </div>
         <AppRunCommand app={app} />

--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -53,7 +53,7 @@ export function DeployForm({
       <api.Field name="port" validators={{ onChange: validatePort }}>
         {(field) => (
           <Field data-invalid={field.state.meta.errors.length > 0 || undefined}>
-            <FieldLabel htmlFor="deploy-port">Guest port</FieldLabel>
+            <FieldLabel htmlFor="deploy-port">HTTP port</FieldLabel>
             <Input
               id="deploy-port"
               value={field.state.value ?? defaultPort}

--- a/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
+++ b/apps/www/src/content/blog/deploy-pocketbase-in-one-click.md
@@ -44,7 +44,7 @@ Drag and drop it onto [nibrun.com](https://nibrun.com).
 
 You land on the deploy screen with the binary already attached. Two fields to fill in:
 
-**Guest port**: `8090`
+**HTTP port**: `8090`
 
 **Arguments** (one per line):
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -30,7 +30,7 @@ export const SHARED_OPTIONS = {
     name: 'port',
     option: {
       schema: z.number().int().optional(),
-      description: 'Port the binary listens on inside the guest.',
+      description: 'HTTP port the binary listens on inside the guest.',
     },
   },
   env: {

--- a/packages/cli/src/lib/plan.test.ts
+++ b/packages/cli/src/lib/plan.test.ts
@@ -76,7 +76,7 @@ test('an owner with no apps is asked what to call one, not which to use', async 
   expect(resolved).toEqual({ name: 'my-server', port: 3000 });
   expect(asked).toEqual([
     'text:Name the app (my-server)',
-    'text:Which port does the binary listen on? (3000)',
+    'text:Which HTTP port does the binary listen on? (3000)',
     'confirm:Create my-server and deploy?',
   ]);
 });

--- a/packages/cli/src/lib/plan.ts
+++ b/packages/cli/src/lib/plan.ts
@@ -95,7 +95,7 @@ async function askName({ suggestion }: { suggestion: string }): Promise<string> 
 // Bounds are the api's to enforce; this only refuses what it could not send as a port at all.
 async function askPort(): Promise<number> {
   const answer = await text({
-    message: 'Which port does the binary listen on?',
+    message: 'Which HTTP port does the binary listen on?',
     initialValue: String(DEFAULT_GUEST_PORT),
     validate: (value) => (Number.isInteger(Number(value)) ? undefined : 'Ports are whole numbers.'),
   });

--- a/packages/protocol/src/lib/wire.ts
+++ b/packages/protocol/src/lib/wire.ts
@@ -126,7 +126,7 @@ export const StateMessageSchema = Type.String({
 export type GuestPort = Brand<number, 'GuestPort'>;
 
 export const GuestPortSchema = Type.Integer({
-  description: 'Port the tenant binary listens on inside the guest.',
+  description: 'HTTP port the tenant binary listens on inside the guest.',
   minimum: MIN_PORT,
   maximum: MAX_PORT,
 }) as BrandedSchema<TInteger, GuestPort>;

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -57,9 +57,9 @@ First deploy — creates the app:
 nib run ./my-server --name my-app --port 8080
 ```
 
-`--port` is what the binary listens on inside the guest — read it off the app rather than carrying
-a number over from an example. It is the port the guest then hands back as `PORT`, and it defaults
-to `3000`.
+`--port` is the HTTP port the binary listens on inside the guest — read it off the app rather
+than carrying a number over from an example. It is the port the guest then hands back as `PORT`,
+and it defaults to `3000`.
 
 **Every deploy after that must name the app**, or a non-interactive shell creates a second one:
 


### PR DESCRIPTION
"Guest port" is nibrun's word for it, not the owner's. Every surface that names the port now calls it the HTTP port — dashboard, CLI, the OpenAPI description, the PocketBase post and the deploy skill.

Copy only; the wire field is renamed in the PR stacked on top.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>