### PR TITLE
feat(runtime): the guest names the directory its volume is mounted at

### DIFF
--- a/apps/dashboard/src/components/apps/environment-table.tsx
+++ b/apps/dashboard/src/components/apps/environment-table.tsx
@@ -72,9 +72,13 @@ export function EnvironmentTable({
         {children}
       </div>
       <p className="text-muted-foreground text-xs">
-        A value may name one the guest sets, like{' '}
+        A value may name one the guest sets:{' '}
         {/* biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated */}
-        <code className="font-mono">{'${NIBRUN_HOSTNAME}'}</code>.
+        <code className="font-mono">{'${NIBRUN_PORT}'}</code>,{' '}
+        {/* biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated */}
+        <code className="font-mono">{'${NIBRUN_HOSTNAME}'}</code> or{' '}
+        {/* biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated */}
+        <code className="font-mono">{'${NIBRUN_DATA_DIR}'}</code>.
       </p>
     </div>
   );

--- a/apps/runtime/src/config.c
+++ b/apps/runtime/src/config.c
@@ -16,8 +16,10 @@
 #define ARGUMENT_KEY_PREFIX "ARG_"
 #define TENANT_PREFIX "ENV_"
 #define HOSTNAME_KEY "HOSTNAME"
-/* The one runtime key the tenant is handed under its own name, so it is spelled once. */
+#define DATA_DIR_KEY "DATA_DIR"
+/* The runtime keys the tenant is handed under their own names, each spelled once. */
 #define HOSTNAME_VARIABLE RUNTIME_PREFIX HOSTNAME_KEY
+#define DATA_DIR_VARIABLE RUNTIME_PREFIX DATA_DIR_KEY
 
 /* Only a sigil followed by RUNTIME_PREFIX opens a reference, which is what leaves a
  * secret's own '$' alone — see the format contract in config.h. */
@@ -32,8 +34,9 @@
 #define MIN_BACKOFF_FACTOR 1.0
 #define MAX_BACKOFF_FACTOR 1000.0
 
-/* PORT, NIBRUN_HOSTNAME, HOME and TMPDIR, on top of whatever the tenant configured. */
-#define BASE_VARIABLES 4
+/* PORT, NIBRUN_HOSTNAME, NIBRUN_DATA_DIR, HOME and TMPDIR, on top of whatever the
+ * tenant configured. */
+#define BASE_VARIABLES 5
 
 enum field_type {
   FIELD_UNSIGNED,
@@ -364,6 +367,10 @@ static bool reference_value(const struct instance_config *config, const struct r
     *out = config->hostname;
     return true;
   }
+  if (names_key(reference, DATA_DIR_KEY)) {
+    *out = DATA_DIR;
+    return true;
+  }
   return false;
 }
 
@@ -526,6 +533,19 @@ static bool is_named(const char *entry, const char *name) {
   return strncmp(entry, name, length) == 0 && entry[length] == '=';
 }
 
+/* The names the platform issues: a tenant value under one of them would read as
+ * issued too, and the prefix cannot keep the two apart here — both reach execve
+ * under the one name. */
+static const char *platform_owned_name(const char *entry) {
+  if (is_named(entry, HOSTNAME_VARIABLE)) {
+    return HOSTNAME_VARIABLE;
+  }
+  if (is_named(entry, DATA_DIR_VARIABLE)) {
+    return DATA_DIR_VARIABLE;
+  }
+  return NULL;
+}
+
 static bool defines(char *const *entries, size_t count, const char *name) {
   for (size_t index = 0; index < count; index++) {
     if (is_named(entries[index], name)) {
@@ -555,6 +575,7 @@ char *const *config_build_environment(const struct instance_config *config) {
   snprintf(port_variable, sizeof(port_variable), "PORT=%u", config->port);
   size_t count = 0;
   environment[count++] = port_variable;
+  environment[count++] = DATA_DIR_VARIABLE "=" DATA_DIR;
   if (config->hostname != NULL) {
     snprintf(hostname_variable, sizeof(hostname_variable), "%s=%s", HOSTNAME_VARIABLE,
              config->hostname);
@@ -566,10 +587,11 @@ char *const *config_build_environment(const struct instance_config *config) {
       log_line("ignoring the tenant's own PORT; this instance is served on %u", config->port);
       continue;
     }
-    /* Dropped whether or not one was written: the name belongs to the platform, so a
-     * value the tenant set would read as issued by it. */
-    if (is_named(config->tenant_environment[index], HOSTNAME_VARIABLE)) {
-      log_line("ignoring the tenant's own %s; the platform owns that name", HOSTNAME_VARIABLE);
+    /* The hostname is dropped whether or not one was written, so a tenant's own never
+     * stands in for an instance that was issued none. */
+    const char *owned = platform_owned_name(config->tenant_environment[index]);
+    if (owned != NULL) {
+      log_line("ignoring the tenant's own %s; the platform owns that name", owned);
       continue;
     }
     environment[count++] = config->tenant_environment[index];

--- a/apps/runtime/src/config.h
+++ b/apps/runtime/src/config.h
@@ -79,11 +79,11 @@ bool config_read_file(struct instance_config *config, const char *path, char *bu
 /* argv for execve: the binary, then the parsed arguments, then NULL. */
 char *const *config_build_argv(const struct instance_config *config, const char *executable);
 
-/* The environment the tenant is exec'd with: PORT and NIBRUN_HOSTNAME, which the
- * platform owns because they are the port the agent probes and the name the edge
- * routes to, then the tenant's own variables, then defaults for anything they did
- * not set. A tenant variable of either name is dropped rather than exported: it
- * would describe an instance that does not exist. */
+/* The environment the tenant is exec'd with: PORT, NIBRUN_HOSTNAME and NIBRUN_DATA_DIR,
+ * which the platform owns because they are the port the agent probes, the name the edge
+ * routes to and the path the volume is mounted at, then the tenant's own variables, then
+ * defaults for anything they did not set. A tenant variable of any of those names is
+ * dropped rather than exported: it would describe an instance that does not exist. */
 char *const *config_build_environment(const struct instance_config *config);
 
 #endif

--- a/apps/runtime/test.sh
+++ b/apps/runtime/test.sh
@@ -76,7 +76,7 @@ for _ in $(seq 1 60); do
 done
 
 require 'the tenant runs unprivileged, in /app, on the port and under the name the config gave it' \
-  contains "$report" 'PORT=8080 NIBRUN_HOSTNAME=boot-test.nibrun.app HOME=/app CWD=/app UID=65534 GID=65534'
+  contains "$report" 'PORT=8080 NIBRUN_HOSTNAME=boot-test.nibrun.app NIBRUN_DATA_DIR=/app/data HOME=/app CWD=/app UID=65534 GID=65534'
 
 mounts=$(docker exec "$container" cat /proc/1/mounts)
 require 'the artifact is read-only and the data filesystem is not' \

--- a/apps/runtime/tests/fake-tenant.c
+++ b/apps/runtime/tests/fake-tenant.c
@@ -41,10 +41,13 @@ static void report(const char *record) {
   const char *port = getenv("PORT");
   const char *hostname = getenv("NIBRUN_HOSTNAME");
   const char *home = getenv("HOME");
+  const char *data_dir = getenv("NIBRUN_DATA_DIR");
   char line[512];
-  snprintf(line, sizeof(line), "PORT=%s NIBRUN_HOSTNAME=%s HOME=%s CWD=%s UID=%d GID=%d\n",
-           port == NULL ? "" : port, hostname == NULL ? "" : hostname, home == NULL ? "" : home,
-           directory, (int)getuid(), (int)getgid());
+  snprintf(line, sizeof(line),
+           "PORT=%s NIBRUN_HOSTNAME=%s NIBRUN_DATA_DIR=%s HOME=%s CWD=%s UID=%d GID=%d\n",
+           port == NULL ? "" : port, hostname == NULL ? "" : hostname,
+           data_dir == NULL ? "" : data_dir, home == NULL ? "" : home, directory, (int)getuid(),
+           (int)getgid());
   append(record, line);
 }
 

--- a/apps/runtime/tests/test-config.c
+++ b/apps/runtime/tests/test-config.c
@@ -112,7 +112,7 @@ static void drops_a_tenant_hostname(void) {
   while (environment[count] != NULL) {
     count++;
   }
-  EXPECT(count == 4); /* PORT, NIBRUN_HOSTNAME, HOME, TMPDIR */
+  EXPECT(count == 5); /* PORT, NIBRUN_DATA_DIR, NIBRUN_HOSTNAME, HOME, TMPDIR */
 }
 
 /* The only way a tenant value is not passed through byte for byte, and what a binary
@@ -123,6 +123,7 @@ static void expands_a_runtime_reference(void) {
                                  "ENV_BARE=$NIBRUN_PORT\n"
                                  "ENV_BRACED=${NIBRUN_PORT}\n"
                                  "ENV_WITHIN=http://$NIBRUN_HOSTNAME:${NIBRUN_PORT}/health\n"
+                                 "ENV_UNDER_THE_VOLUME=${NIBRUN_DATA_DIR}/state.db\n"
                                  "ENV_TWICE=$NIBRUN_PORT-$NIBRUN_PORT\n"
                                  "ENV_ADJACENT=${NIBRUN_PORT}0\n"));
 
@@ -130,6 +131,7 @@ static void expands_a_runtime_reference(void) {
   EXPECT(strcmp(value_of(environment, "BARE"), "8080") == 0);
   EXPECT(strcmp(value_of(environment, "BRACED"), "8080") == 0);
   EXPECT(strcmp(value_of(environment, "WITHIN"), "http://my-app.nibrun.app:8080/health") == 0);
+  EXPECT(strcmp(value_of(environment, "UNDER_THE_VOLUME"), "/app/data/state.db") == 0);
   EXPECT(strcmp(value_of(environment, "TWICE"), "8080-8080") == 0);
   /* Braces are the whole reason there are two forms: without them this names PORT0. */
   EXPECT(strcmp(value_of(environment, "ADJACENT"), "80800") == 0);
@@ -257,12 +259,25 @@ static void builds_the_tenant_environment(void) {
   EXPECT(strcmp(value_of(environment, "HOME"), "/somewhere") == 0);
   EXPECT(strcmp(value_of(environment, "TOKEN"), "abc") == 0);
   EXPECT(strcmp(value_of(environment, "TMPDIR"), "/tmp") == 0);
+  EXPECT(strcmp(value_of(environment, "NIBRUN_DATA_DIR"), "/app/data") == 0);
 
   size_t count = 0;
   while (environment[count] != NULL) {
     count++;
   }
-  EXPECT(count == 4); /* PORT, HOME, TOKEN, TMPDIR — the tenant's own PORT dropped */
+  /* PORT, NIBRUN_DATA_DIR, HOME, TOKEN, TMPDIR — the tenant's own PORT dropped, its
+   * HOME kept, because only the first of the two names an instance it is served on. */
+  EXPECT(count == 5);
+}
+
+/* Where the volume is mounted is the platform's to say: a tenant's own would point the
+ * binary at a path that is not the one thing surviving its next boot. */
+static void drops_a_tenant_data_dir(void) {
+  struct instance_config config;
+  EXPECT(parse(&config, REQUIRED "ENV_NIBRUN_DATA_DIR=/somewhere-else\n"));
+
+  char *const *environment = config_build_environment(&config);
+  EXPECT(strcmp(value_of(environment, "NIBRUN_DATA_DIR"), "/app/data") == 0);
 }
 
 /* A binary that needs a subcommand cannot be started without these, and an argv
@@ -335,6 +350,7 @@ int main(void) {
   rejects_a_nul_byte();
   rejects_too_many_tenant_variables();
   builds_the_tenant_environment();
+  drops_a_tenant_data_dir();
   passes_arguments_through_in_order();
   accepts_arguments_in_any_order();
   a_binary_with_no_arguments_is_exec_d_bare();

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -39,7 +39,7 @@ export const SHARED_OPTIONS = {
       schema: z.array(z.string()).optional(),
       description:
         // biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated
-        "Set an environment variable for the binary, as NAME=value. Repeatable. Anything the app already has and this does not name is left as it is. A value may name one the guest sets — quote it, as in 'URL=https://${NIBRUN_HOSTNAME}', or the shell expands it here instead.",
+        "Set an environment variable for the binary, as NAME=value. Repeatable. Anything the app already has and this does not name is left as it is. A value may name one the guest sets — NIBRUN_PORT, NIBRUN_HOSTNAME or NIBRUN_DATA_DIR — quote it, as in 'URL=https://${NIBRUN_HOSTNAME}', or the shell expands it here instead.",
     },
   },
   unset: {

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -16,7 +16,7 @@ Everything the binary can count on, and nothing else:
 | --- | --- |
 | Platform | Linux **x86_64**, glibc (Debian rootfs) |
 | Working directory | `/app` |
-| Persistent volume | `/app/data` — 8 GiB, survives every redeploy |
+| Persistent volume | `/app/data` — 8 GiB, survives every redeploy. `NIBRUN_DATA_DIR` names it |
 | Port | `PORT` is set by the guest; the app **must** listen on it, on `0.0.0.0` |
 | Own hostname | `NIBRUN_HOSTNAME` is set by the guest to the app's own `<slug>.nibrun.app` |
 | Ephemeral | `TMPDIR=/tmp` is a tmpfs and is lost on restart. So is everything outside `/app/data` |
@@ -25,17 +25,19 @@ Everything the binary can count on, and nothing else:
 | URL | `https://<slug>.nibrun.app`, live as soon as it boots |
 
 An app that writes its SQLite file and its uploads under `./data` and reads `PORT` needs no
-configuration to run here. A `PORT` or `NIBRUN_HOSTNAME` you set yourself is ignored — the guest
-owns both.
+configuration to run here. A `PORT`, `NIBRUN_HOSTNAME` or `NIBRUN_DATA_DIR` you set yourself is
+ignored — the guest owns all three. `HOME` and `TMPDIR` are defaults rather than owned, so one you
+set yourself is what the binary reads.
 
 A binary that needs its own absolute URL — an OAuth redirect, a webhook it registers, a link in
 an email — builds it from `NIBRUN_HOSTNAME` rather than being told it, and falls back to whatever
 it uses when it is not on nibrun.
 
 One that insists on a variable name of its own reaches the same values through it: a value may
-name a runtime one — `APP_BASE_URL=https://${NIBRUN_HOSTNAME}` — and the guest expands it before
-exec. Only that prefix expands, so a secret holding a `$` arrives untouched, and a name the guest
-does not offer fails the boot rather than reaching the process as itself.
+name a runtime one — `APP_BASE_URL=https://${NIBRUN_HOSTNAME}`,
+`DATABASE_URL=file:${NIBRUN_DATA_DIR}/app.db` — and the guest expands it before exec. Only that
+prefix expands, so a secret holding a `$` arrives untouched, and a name the guest does not offer
+fails the boot rather than reaching the process as itself.
 
 ## Deploying
 


### PR DESCRIPTION
A user found only `PORT`, `NIBRUN_HOSTNAME`, `HOME` and `TMPDIR` in their process
environment: nothing said where the persistent volume was, so a binary had to infer
`data/` from its working directory.

`NIBRUN_DATA_DIR` says it, alongside the two names the platform already owns — a
tenant's own is dropped rather than defaulted, since it would point the binary at a
path its next boot does not keep. It expands in tenant values too, so an app
configured by a variable of its own reaches it as `${NIBRUN_DATA_DIR}`.

Ships with the guest image, so instances see it once that rolls out.