### PR TITLE
refactor(runtime)!: the port a tenant is handed is spelled one way

### DIFF
--- a/apps/agent/src/lib/vm/instance-env.ts
+++ b/apps/agent/src/lib/vm/instance-env.ts
@@ -17,7 +17,7 @@ export const INSTANCE_CONFIG_IMAGE = 'config.squashfs';
 const PRIVATE_MODE = 0o600;
 const PRIVATE_DIR_MODE = 0o700;
 
-/** The two namespaces the runtime parses, so a tenant variable called NIBRUN_PORT stays the tenant's. */
+/** The two namespaces the runtime parses, so a tenant variable called NIBRUN_HTTP_PORT stays the tenant's. */
 const RUNTIME_PREFIX = 'NIBRUN_';
 const TENANT_PREFIX = 'ENV_';
 
@@ -67,7 +67,7 @@ export function renderInstanceEnv({
 }): Either.Either<string, UnrepresentableEnvironment> {
   const hostname = platformHostname(hostnames);
   const lines = [
-    `${RUNTIME_PREFIX}PORT=${httpPort}`,
+    `${RUNTIME_PREFIX}HTTP_PORT=${httpPort}`,
     ...(hostname === undefined ? [] : [`${RUNTIME_PREFIX}HOSTNAME=${hostname}`]),
     `${RUNTIME_PREFIX}MAX_RESTARTS=${restartPolicy.maxRestarts}`,
     `${RUNTIME_PREFIX}INITIAL_BACKOFF_MS=${restartPolicy.initialBackoffMs}`,

--- a/apps/agent/tests/lib/vm/instance-env.test.ts
+++ b/apps/agent/tests/lib/vm/instance-env.test.ts
@@ -48,7 +48,7 @@ function refusedVariable(overrides: Overrides) {
 describe('what apps/runtime parses off the config drive', () => {
   test('every key it writes is one the runtime knows', () => {
     expect(render().split('\n').filter(Boolean)).toEqual([
-      `NIBRUN_PORT=${DEFAULT_HTTP_PORT}`,
+      `NIBRUN_HTTP_PORT=${DEFAULT_HTTP_PORT}`,
       `NIBRUN_HOSTNAME=${PLATFORM_HOSTNAME}`,
       `NIBRUN_MAX_RESTARTS=${DEFAULT_RESTART_POLICY.maxRestarts}`,
       `NIBRUN_INITIAL_BACKOFF_MS=${DEFAULT_RESTART_POLICY.initialBackoffMs}`,
@@ -64,12 +64,12 @@ describe('what apps/runtime parses off the config drive', () => {
     expect(rendered).toContain('\nENV_ALPHA=2\nENV_ZED=1\n');
   });
 
-  // The prefix is what makes this impossible rather than merely handled: the runtime reads it
-  // as a tenant variable named NIBRUN_PORT, and its own PORT stays the one written above.
-  test('a tenant variable named after a runtime key stays the tenant’s', () => {
-    const rendered = render({ environment: tenantEnvironment({ NIBRUN_PORT: '9999' }) });
-    expect(rendered).toContain(`NIBRUN_PORT=${DEFAULT_HTTP_PORT}\n`);
-    expect(rendered).toContain('ENV_NIBRUN_PORT=9999\n');
+  // The prefix is what keeps the two apart on the drive: the runtime reads this as a tenant
+  // variable named NIBRUN_HTTP_PORT, and drops it there rather than here.
+  test('a tenant variable named after a runtime key is written under the tenant prefix', () => {
+    const rendered = render({ environment: tenantEnvironment({ NIBRUN_HTTP_PORT: '9999' }) });
+    expect(rendered).toContain(`NIBRUN_HTTP_PORT=${DEFAULT_HTTP_PORT}\n`);
+    expect(rendered).toContain('ENV_NIBRUN_HTTP_PORT=9999\n');
   });
 
   test('values are raw bytes, not quoted or escaped', () => {
@@ -101,7 +101,7 @@ describe('what apps/runtime parses off the config drive', () => {
 
   test('a non-default port is the one written', () => {
     expect(render({ httpPort: Value.Parse(HttpPortSchema, NON_DEFAULT_PORT) })).toContain(
-      `NIBRUN_PORT=${NON_DEFAULT_PORT}\n`,
+      `NIBRUN_HTTP_PORT=${NON_DEFAULT_PORT}\n`,
     );
   });
 });

--- a/apps/dashboard/src/components/apps/environment-table.tsx
+++ b/apps/dashboard/src/components/apps/environment-table.tsx
@@ -1,3 +1,4 @@
+import { RUNTIME_VALUE_NAMES, writtenRuntimeValue } from '@repo/protocol';
 import { Button } from '@repo/ui/components/button';
 import {
   Table,
@@ -8,9 +9,13 @@ import {
   TableRow,
 } from '@repo/ui/components/table';
 import { PlusIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { Fragment, type ReactNode } from 'react';
 import { EnvironmentRow } from '#components/apps/environment-row.tsx';
 import { blankVariable, type EnvironmentVariable } from '#lib/environment-variables.ts';
+
+function separatorBefore(index: number): string {
+  return index === RUNTIME_VALUE_NAMES.length - 1 ? ' or ' : ', ';
+}
 
 export function EnvironmentTable({
   variables,
@@ -72,13 +77,14 @@ export function EnvironmentTable({
         {children}
       </div>
       <p className="text-muted-foreground text-xs">
-        A value may name one the guest sets:{' '}
-        {/* biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated */}
-        <code className="font-mono">{'${NIBRUN_HTTP_PORT}'}</code>,{' '}
-        {/* biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated */}
-        <code className="font-mono">{'${NIBRUN_HOSTNAME}'}</code> or{' '}
-        {/* biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated */}
-        <code className="font-mono">{'${NIBRUN_DATA_DIR}'}</code>.
+        A value may name one the guest sets, and nothing else:{' '}
+        {[...RUNTIME_VALUE_NAMES.entries()].map(([index, name]) => (
+          <Fragment key={name}>
+            {index > 0 && separatorBefore(index)}
+            <code className="font-mono">{writtenRuntimeValue(name)}</code>
+          </Fragment>
+        ))}
+        .
       </p>
     </div>
   );

--- a/apps/dashboard/src/components/apps/environment-table.tsx
+++ b/apps/dashboard/src/components/apps/environment-table.tsx
@@ -74,7 +74,7 @@ export function EnvironmentTable({
       <p className="text-muted-foreground text-xs">
         A value may name one the guest sets:{' '}
         {/* biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated */}
-        <code className="font-mono">{'${NIBRUN_PORT}'}</code>,{' '}
+        <code className="font-mono">{'${NIBRUN_HTTP_PORT}'}</code>,{' '}
         {/* biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated */}
         <code className="font-mono">{'${NIBRUN_HOSTNAME}'}</code> or{' '}
         {/* biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated */}

--- a/apps/runtime/src/config.c
+++ b/apps/runtime/src/config.c
@@ -15,11 +15,17 @@
 #define RUNTIME_PREFIX "NIBRUN_"
 #define ARGUMENT_KEY_PREFIX "ARG_"
 #define TENANT_PREFIX "ENV_"
+#define HTTP_PORT_KEY "HTTP_PORT"
 #define HOSTNAME_KEY "HOSTNAME"
 #define DATA_DIR_KEY "DATA_DIR"
 /* The runtime keys the tenant is handed under their own names, each spelled once. */
+#define HTTP_PORT_VARIABLE RUNTIME_PREFIX HTTP_PORT_KEY
 #define HOSTNAME_VARIABLE RUNTIME_PREFIX HOSTNAME_KEY
 #define DATA_DIR_VARIABLE RUNTIME_PREFIX DATA_DIR_KEY
+
+/* The name every other host sets, carrying the same number, because a binary written
+ * against any of them reads this one and nothing of ours. */
+#define PORT_ALIAS "PORT"
 
 /* Only a sigil followed by RUNTIME_PREFIX opens a reference, which is what leaves a
  * secret's own '$' alone — see the format contract in config.h. */
@@ -34,9 +40,9 @@
 #define MIN_BACKOFF_FACTOR 1.0
 #define MAX_BACKOFF_FACTOR 1000.0
 
-/* PORT, NIBRUN_HOSTNAME, NIBRUN_DATA_DIR, HOME and TMPDIR, on top of whatever the
- * tenant configured. */
-#define BASE_VARIABLES 5
+/* NIBRUN_HTTP_PORT, PORT, NIBRUN_DATA_DIR, NIBRUN_HOSTNAME, HOME and TMPDIR, on top of
+ * whatever the tenant configured. */
+#define BASE_VARIABLES 6
 
 enum field_type {
   FIELD_UNSIGNED,
@@ -56,7 +62,8 @@ struct field {
 };
 
 static const struct field FIELDS[] = {
-    {"PORT", FIELD_UNSIGNED, offsetof(struct instance_config, port), MIN_PORT, MAX_PORT, true},
+    {HTTP_PORT_KEY, FIELD_UNSIGNED, offsetof(struct instance_config, port), MIN_PORT, MAX_PORT,
+     true},
     {"MAX_RESTARTS", FIELD_UNSIGNED, offsetof(struct instance_config, restart_policy.max_restarts), 0,
      MAX_RESTARTS_LIMIT, true},
     {"INITIAL_BACKOFF_MS", FIELD_UNSIGNED,
@@ -362,7 +369,7 @@ static bool names_key(const struct reference *reference, const char *key) {
  * something that never passed through it. */
 static bool reference_value(const struct instance_config *config, const struct reference *reference,
                             char *rendered, size_t rendered_size, const char **out) {
-  if (names_key(reference, "PORT")) {
+  if (names_key(reference, HTTP_PORT_KEY)) {
     snprintf(rendered, rendered_size, "%u", config->port);
     *out = rendered;
     return true;
@@ -541,6 +548,9 @@ static bool is_named(const char *entry, const char *name) {
  * issued too, and the prefix cannot keep the two apart here — both reach execve
  * under the one name. */
 static const char *platform_owned_name(const char *entry) {
+  if (is_named(entry, HTTP_PORT_VARIABLE)) {
+    return HTTP_PORT_VARIABLE;
+  }
   if (is_named(entry, HOSTNAME_VARIABLE)) {
     return HOSTNAME_VARIABLE;
   }
@@ -573,12 +583,16 @@ char *const *config_build_argv(const struct instance_config *config, const char 
 
 char *const *config_build_environment(const struct instance_config *config) {
   static char *environment[CONFIG_MAX_TENANT_VARIABLES + BASE_VARIABLES + 1];
-  static char port_variable[sizeof("PORT=65535")];
+  static char http_port_variable[sizeof(HTTP_PORT_VARIABLE "=65535")];
+  static char port_alias_variable[sizeof(PORT_ALIAS "=65535")];
   static char hostname_variable[sizeof(HOSTNAME_VARIABLE "=") + CONFIG_MAX_HOSTNAME];
 
-  snprintf(port_variable, sizeof(port_variable), "PORT=%u", config->port);
+  snprintf(http_port_variable, sizeof(http_port_variable), "%s=%u", HTTP_PORT_VARIABLE,
+           config->port);
+  snprintf(port_alias_variable, sizeof(port_alias_variable), "%s=%u", PORT_ALIAS, config->port);
   size_t count = 0;
-  environment[count++] = port_variable;
+  environment[count++] = http_port_variable;
+  environment[count++] = port_alias_variable;
   environment[count++] = DATA_DIR_VARIABLE "=" DATA_DIR;
   if (config->hostname != NULL) {
     snprintf(hostname_variable, sizeof(hostname_variable), "%s=%s", HOSTNAME_VARIABLE,
@@ -587,8 +601,9 @@ char *const *config_build_environment(const struct instance_config *config) {
   }
 
   for (size_t index = 0; index < config->tenant_variable_count; index++) {
-    if (is_named(config->tenant_environment[index], "PORT")) {
-      log_line("ignoring the tenant's own PORT; this instance is served on %u", config->port);
+    if (is_named(config->tenant_environment[index], PORT_ALIAS)) {
+      log_line("ignoring the tenant's own %s; this instance is served on %u", PORT_ALIAS,
+               config->port);
       continue;
     }
     /* The hostname is dropped whether or not one was written, so a tenant's own never

--- a/apps/runtime/src/config.h
+++ b/apps/runtime/src/config.h
@@ -12,10 +12,11 @@
  *   ENV_<NAME>=<value>     one of the tenant's own environment variables
  *
  * The prefixes exist so the two can never collide: a tenant variable actually
- * called NIBRUN_PORT arrives as ENV_NIBRUN_PORT and stays the tenant's.
+ * called NIBRUN_HTTP_PORT arrives as ENV_NIBRUN_HTTP_PORT and is read as the
+ * tenant's, which is what lets config_build_environment drop it on its own terms.
  *
- * A tenant value may name a runtime one it is handed: `$NIBRUN_PORT` and
- * `${NIBRUN_PORT}` both expand, and a name this runtime does not offer fails the
+ * A tenant value may name a runtime one it is handed: `$NIBRUN_HTTP_PORT` and
+ * `${NIBRUN_HTTP_PORT}` both expand, and a name this runtime does not offer fails the
  * boot rather than reaching the tenant as itself. Nothing else expands, so a secret
  * holding `$`, `$$` or `$HOME` arrives byte for byte — the prefix is what keeps the
  * substitution off values it was never meant for. The cost is that a value holding a
@@ -79,11 +80,16 @@ bool config_read_file(struct instance_config *config, const char *path, char *bu
 /* argv for execve: the binary, then the parsed arguments, then NULL. */
 char *const *config_build_argv(const struct instance_config *config, const char *executable);
 
-/* The environment the tenant is exec'd with: PORT, NIBRUN_HOSTNAME and NIBRUN_DATA_DIR,
- * which the platform owns because they are the port the agent probes, the name the edge
- * routes to and the path the volume is mounted at, then the tenant's own variables, then
- * defaults for anything they did not set. A tenant variable of any of those names is
- * dropped rather than exported: it would describe an instance that does not exist. */
+/* The environment the tenant is exec'd with: NIBRUN_HTTP_PORT, NIBRUN_HOSTNAME and
+ * NIBRUN_DATA_DIR, which the platform owns because they are the port the agent probes,
+ * the name the edge routes to and the path the volume is mounted at, then the tenant's
+ * own variables, then defaults for anything they did not set. A tenant variable of any
+ * of those names is dropped rather than exported: it would describe an instance that
+ * does not exist.
+ *
+ * PORT carries the same number as NIBRUN_HTTP_PORT under the name every other host uses,
+ * and is dropped from the tenant's own for the same reason. It is an alias and never a
+ * second choice: nothing reads it back, and a reference names the prefixed one. */
 char *const *config_build_environment(const struct instance_config *config);
 
 #endif

--- a/apps/runtime/test.sh
+++ b/apps/runtime/test.sh
@@ -76,7 +76,7 @@ for _ in $(seq 1 60); do
 done
 
 require 'the tenant runs unprivileged, in /app, on the port and under the name the config gave it' \
-  contains "$report" 'PORT=8080 NIBRUN_HOSTNAME=boot-test.nibrun.app NIBRUN_DATA_DIR=/app/data HOME=/app CWD=/app UID=65534 GID=65534'
+  contains "$report" 'NIBRUN_HTTP_PORT=8080 PORT=8080 NIBRUN_HOSTNAME=boot-test.nibrun.app NIBRUN_DATA_DIR=/app/data HOME=/app CWD=/app UID=65534 GID=65534'
 
 mounts=$(docker exec "$container" cat /proc/1/mounts)
 require 'the artifact is read-only and the data filesystem is not' \

--- a/apps/runtime/tests/boot.sh
+++ b/apps/runtime/tests/boot.sh
@@ -18,7 +18,7 @@ mkdir -p /images/artifact /images/config
 cp /fake-tenant /images/artifact/server
 
 cat >/images/config/instance.env <<'ENV'
-NIBRUN_PORT=8080
+NIBRUN_HTTP_PORT=8080
 NIBRUN_HOSTNAME=boot-test.nibrun.app
 NIBRUN_MAX_RESTARTS=5
 NIBRUN_INITIAL_BACKOFF_MS=100

--- a/apps/runtime/tests/fake-tenant.c
+++ b/apps/runtime/tests/fake-tenant.c
@@ -38,16 +38,18 @@ static void report(const char *record) {
   if (getcwd(directory, sizeof(directory)) == NULL) {
     _exit(UNWRITABLE_EXIT_CODE);
   }
-  const char *port = getenv("PORT");
+  const char *port = getenv("NIBRUN_HTTP_PORT");
+  const char *port_alias = getenv("PORT");
   const char *hostname = getenv("NIBRUN_HOSTNAME");
   const char *home = getenv("HOME");
   const char *data_dir = getenv("NIBRUN_DATA_DIR");
   char line[512];
   snprintf(line, sizeof(line),
-           "PORT=%s NIBRUN_HOSTNAME=%s NIBRUN_DATA_DIR=%s HOME=%s CWD=%s UID=%d GID=%d\n",
-           port == NULL ? "" : port, hostname == NULL ? "" : hostname,
-           data_dir == NULL ? "" : data_dir, home == NULL ? "" : home, directory, (int)getuid(),
-           (int)getgid());
+           "NIBRUN_HTTP_PORT=%s PORT=%s NIBRUN_HOSTNAME=%s NIBRUN_DATA_DIR=%s HOME=%s CWD=%s "
+           "UID=%d GID=%d\n",
+           port == NULL ? "" : port, port_alias == NULL ? "" : port_alias,
+           hostname == NULL ? "" : hostname, data_dir == NULL ? "" : data_dir,
+           home == NULL ? "" : home, directory, (int)getuid(), (int)getgid());
   append(record, line);
 }
 

--- a/apps/runtime/tests/test-config.c
+++ b/apps/runtime/tests/test-config.c
@@ -8,7 +8,7 @@
 #include "../src/config.h"
 #include "expect.h"
 
-#define PORT_KEY "NIBRUN_PORT=8080\n"
+#define PORT_KEY "NIBRUN_HTTP_PORT=8080\n"
 #define BACKOFF_FACTOR_KEY "NIBRUN_BACKOFF_FACTOR=2\n"
 #define OTHER_RESTART_KEYS          \
   "NIBRUN_MAX_RESTARTS=5\n"         \
@@ -74,7 +74,7 @@ static void accepts_a_file_without_a_trailing_newline(void) {
 
 static void accepts_a_fractional_backoff_factor(void) {
   struct instance_config config;
-  EXPECT(parse(&config, "NIBRUN_PORT=3000\n"
+  EXPECT(parse(&config, "NIBRUN_HTTP_PORT=3000\n"
                         "NIBRUN_MAX_RESTARTS=0\n"
                         "NIBRUN_INITIAL_BACKOFF_MS=0\n"
                         "NIBRUN_MAX_BACKOFF_MS=0\n"
@@ -112,7 +112,8 @@ static void drops_a_tenant_hostname(void) {
   while (environment[count] != NULL) {
     count++;
   }
-  EXPECT(count == 5); /* PORT, NIBRUN_DATA_DIR, NIBRUN_HOSTNAME, HOME, TMPDIR */
+  /* NIBRUN_HTTP_PORT, PORT, NIBRUN_DATA_DIR, NIBRUN_HOSTNAME, HOME, TMPDIR */
+  EXPECT(count == 6);
 }
 
 /* The only way a tenant value is not passed through byte for byte, and what a binary
@@ -120,12 +121,12 @@ static void drops_a_tenant_hostname(void) {
 static void expands_a_runtime_reference(void) {
   struct instance_config config;
   EXPECT(parse(&config, REQUIRED "NIBRUN_HOSTNAME=my-app.nibrun.app\n"
-                                 "ENV_BARE=$NIBRUN_PORT\n"
-                                 "ENV_BRACED=${NIBRUN_PORT}\n"
-                                 "ENV_WITHIN=http://$NIBRUN_HOSTNAME:${NIBRUN_PORT}/health\n"
+                                 "ENV_BARE=$NIBRUN_HTTP_PORT\n"
+                                 "ENV_BRACED=${NIBRUN_HTTP_PORT}\n"
+                                 "ENV_WITHIN=http://$NIBRUN_HOSTNAME:${NIBRUN_HTTP_PORT}/health\n"
                                  "ENV_UNDER_THE_VOLUME=${NIBRUN_DATA_DIR}/state.db\n"
-                                 "ENV_TWICE=$NIBRUN_PORT-$NIBRUN_PORT\n"
-                                 "ENV_ADJACENT=${NIBRUN_PORT}0\n"));
+                                 "ENV_TWICE=$NIBRUN_HTTP_PORT-$NIBRUN_HTTP_PORT\n"
+                                 "ENV_ADJACENT=${NIBRUN_HTTP_PORT}0\n"));
 
   char *const *environment = config_build_environment(&config);
   EXPECT(strcmp(value_of(environment, "BARE"), "8080") == 0);
@@ -157,8 +158,8 @@ static void leaves_every_other_dollar_alone(void) {
  * itself, where it would read as a value somebody meant to write. */
 static void rejects_a_reference_it_cannot_answer(void) {
   EXPECT(rejects(REQUIRED "ENV_A=$NIBRUN_NOTHING\n"));
-  EXPECT(rejects(REQUIRED "ENV_A=$NIBRUN_PORT0\n"));
-  EXPECT(rejects(REQUIRED "ENV_A=${NIBRUN_PORT\n"));
+  EXPECT(rejects(REQUIRED "ENV_A=$NIBRUN_HTTP_PORT0\n"));
+  EXPECT(rejects(REQUIRED "ENV_A=${NIBRUN_HTTP_PORT\n"));
   /* Offered, but this instance was issued no hostname. */
   EXPECT(rejects(REQUIRED "ENV_A=$NIBRUN_HOSTNAME\n"));
   /* The supervisor's own, and never handed to a tenant. */
@@ -190,7 +191,7 @@ static void accepts_an_ipv6_nameserver(void) {
 static void rejects_a_broken_file(void) {
   EXPECT(rejects("NIBRUN_MAX_RESTARTS=5\n")); /* missing everything else */
   EXPECT(rejects(REQUIRED "NIBRUN_SOMETHING_NEW=1\n"));
-  EXPECT(rejects(REQUIRED "NIBRUN_PORT=8081\n"));
+  EXPECT(rejects(REQUIRED "NIBRUN_HTTP_PORT=8081\n"));
   EXPECT(rejects(REQUIRED "PATH=/usr/bin\n"));
   EXPECT(rejects(REQUIRED "ENV_A=1\nENV_A=2\n"));
   EXPECT(rejects(REQUIRED "ENV_1LEADING_DIGIT=x\n"));
@@ -215,12 +216,12 @@ static void rejects_a_hostname_that_does_not_fit(void) {
 }
 
 static void rejects_a_value_that_is_not_a_number(void) {
-  EXPECT(rejects("NIBRUN_PORT=0\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
-  EXPECT(rejects("NIBRUN_PORT=65536\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
-  EXPECT(rejects("NIBRUN_PORT=80a\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
-  EXPECT(rejects("NIBRUN_PORT= 80\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
-  EXPECT(rejects("NIBRUN_PORT=-1\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
-  EXPECT(rejects("NIBRUN_PORT=\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
+  EXPECT(rejects("NIBRUN_HTTP_PORT=0\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
+  EXPECT(rejects("NIBRUN_HTTP_PORT=65536\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
+  EXPECT(rejects("NIBRUN_HTTP_PORT=80a\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
+  EXPECT(rejects("NIBRUN_HTTP_PORT= 80\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
+  EXPECT(rejects("NIBRUN_HTTP_PORT=-1\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
+  EXPECT(rejects("NIBRUN_HTTP_PORT=\n" BACKOFF_FACTOR_KEY OTHER_RESTART_KEYS));
   EXPECT(rejects(PORT_KEY "NIBRUN_BACKOFF_FACTOR=0.5\n" OTHER_RESTART_KEYS));
   EXPECT(rejects(PORT_KEY "NIBRUN_BACKOFF_FACTOR=nan\n" OTHER_RESTART_KEYS));
 }
@@ -255,6 +256,7 @@ static void builds_the_tenant_environment(void) {
   EXPECT(parse(&config, REQUIRED "ENV_HOME=/somewhere\nENV_PORT=9999\nENV_TOKEN=abc\n"));
 
   char *const *environment = config_build_environment(&config);
+  EXPECT(strcmp(value_of(environment, "NIBRUN_HTTP_PORT"), "8080") == 0);
   EXPECT(strcmp(value_of(environment, "PORT"), "8080") == 0);
   EXPECT(strcmp(value_of(environment, "HOME"), "/somewhere") == 0);
   EXPECT(strcmp(value_of(environment, "TOKEN"), "abc") == 0);
@@ -265,9 +267,32 @@ static void builds_the_tenant_environment(void) {
   while (environment[count] != NULL) {
     count++;
   }
-  /* PORT, NIBRUN_DATA_DIR, HOME, TOKEN, TMPDIR — the tenant's own PORT dropped, its
-   * HOME kept, because only the first of the two names an instance it is served on. */
-  EXPECT(count == 5);
+  /* NIBRUN_HTTP_PORT, PORT, NIBRUN_DATA_DIR, HOME, TOKEN, TMPDIR — the tenant's own PORT
+   * dropped, its HOME kept, because only the first of the two names an instance it is
+   * served on. */
+  EXPECT(count == 6);
+}
+
+/* One number under two names, so a value naming the prefixed one and a binary reading the
+ * conventional one can never disagree about the port this instance is served on. */
+static void carries_the_port_under_both_names(void) {
+  struct instance_config config;
+  EXPECT(parse(&config, REQUIRED));
+
+  char *const *environment = config_build_environment(&config);
+  EXPECT(strcmp(value_of(environment, "NIBRUN_HTTP_PORT"), "8080") == 0);
+  EXPECT(strcmp(value_of(environment, "PORT"), "8080") == 0);
+}
+
+/* The prefixed name is the platform's the way PORT already was: a tenant's own would
+ * disagree with what ${NIBRUN_HTTP_PORT} expands to in the value beside it. */
+static void drops_a_tenant_http_port(void) {
+  struct instance_config config;
+  EXPECT(parse(&config, REQUIRED "ENV_NIBRUN_HTTP_PORT=9999\nENV_PORT=7777\n"));
+
+  char *const *environment = config_build_environment(&config);
+  EXPECT(strcmp(value_of(environment, "NIBRUN_HTTP_PORT"), "8080") == 0);
+  EXPECT(strcmp(value_of(environment, "PORT"), "8080") == 0);
 }
 
 /* Where the volume is mounted is the platform's to say: a tenant's own would point the
@@ -350,6 +375,8 @@ int main(void) {
   rejects_a_nul_byte();
   rejects_too_many_tenant_variables();
   builds_the_tenant_environment();
+  carries_the_port_under_both_names();
+  drops_a_tenant_http_port();
   drops_a_tenant_data_dir();
   passes_arguments_through_in_order();
   accepts_arguments_in_any_order();

--- a/infra/guest-image/AGENTS.md
+++ b/infra/guest-image/AGENTS.md
@@ -111,8 +111,8 @@ privileged container, and the host kernel never parses a filesystem image.
 **Under Firecracker v1.16.1 on x86_64 with `/dev/kvm`, with the real `/init` and all four
 drives.** The whole contract above is measured, not assumed: `vda`…`vdd` enumerate in
 declaration order, the artifact mount is read-only from inside the guest, the tenant runs as
-uid 65534 with cwd `/app` and its data at `/app/data`, `PORT` and the tenant's own environment
-arrive from `vdc`, and the data disk survives a reboot. Boot to `Run /init` is 0.59–0.66 s.
+uid 65534 with cwd `/app` and its data at `/app/data`, the guest's own names and the tenant's
+environment arrive from `vdc`, and the data disk survives a reboot. Boot to `Run /init` is 0.59–0.66 s.
 
 The restart budget was exercised too: a tenant that exits immediately is restarted with
 200/400/800 ms backoff, three times as configured, after which the guest powers itself off —

--- a/packages/app-operations/src/environment.ts
+++ b/packages/app-operations/src/environment.ts
@@ -4,6 +4,7 @@ import {
   type TenantEnvironmentPatch,
   TenantEnvironmentPatchSchema,
   Value,
+  writtenRuntimeValue,
 } from '@repo/protocol';
 import { InvalidEnvironmentError } from '#errors.ts';
 
@@ -58,7 +59,7 @@ export function parseEnvironmentPatch(edits: readonly EnvironmentEdit[]): Tenant
     .map(({ name }) => name);
   if (naming.length > 0) {
     throw new InvalidEnvironmentError(
-      `A value may name a runtime value the guest sets — ${RUNTIME_VALUE_NAMES.map(written).join(', ')} — and nothing else: ${naming.join(', ')}`,
+      `A value may name a runtime value the guest sets — ${RUNTIME_VALUE_NAMES.map(writtenRuntimeValue).join(', ')} — and nothing else: ${naming.join(', ')}`,
     );
   }
 
@@ -66,11 +67,6 @@ export function parseEnvironmentPatch(edits: readonly EnvironmentEdit[]): Tenant
     TenantEnvironmentPatchSchema,
     Object.fromEntries(edits.map(({ name, value }) => [name, value])),
   );
-}
-
-/** A runtime value as it is named in a tenant value, which is the form worth showing back. */
-function written(name: string): string {
-  return `\${${name}}`;
 }
 
 function assigned(assignment: string): EnvironmentEdit {

--- a/packages/app-operations/tests/environment.test.ts
+++ b/packages/app-operations/tests/environment.test.ts
@@ -89,15 +89,15 @@ describe('a value naming a runtime value', () => {
 
   test('one the guest offers is carried through as it was written', () => {
     expect(parsed({ set: [`URL=https://${OFFERED}`] })).toEqual({ URL: `https://${OFFERED}` });
-    expect(parsed({ set: ['URL=http://$NIBRUN_HOSTNAME:$NIBRUN_PORT'] })).toEqual({
-      URL: 'http://$NIBRUN_HOSTNAME:$NIBRUN_PORT',
+    expect(parsed({ set: ['URL=http://$NIBRUN_HOSTNAME:$NIBRUN_HTTP_PORT'] })).toEqual({
+      URL: 'http://$NIBRUN_HOSTNAME:$NIBRUN_HTTP_PORT',
     });
   });
 
   test('one it does not is refused, and the variable holding it is named', () => {
     expect(() => parsed({ set: [`URL=https://${MISSPELLED}`] })).toThrow(
       new InvalidEnvironmentError(
-        `A value may name a runtime value the guest sets — \${NIBRUN_DATA_DIR}, ${OFFERED}, \${NIBRUN_PORT} — and nothing else: URL`,
+        `A value may name a runtime value the guest sets — \${NIBRUN_DATA_DIR}, ${OFFERED}, \${NIBRUN_HTTP_PORT} — and nothing else: URL`,
       ),
     );
   });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,5 @@
 import type { CommandOption } from '@parshjs/core';
+import { RUNTIME_VALUE_NAMES } from '@repo/protocol';
 import { z } from 'zod';
 import packageJson from '../package.json' with { type: 'json' };
 
@@ -37,9 +38,7 @@ export const SHARED_OPTIONS = {
     name: 'env',
     option: {
       schema: z.array(z.string()).optional(),
-      description:
-        // biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated
-        "Set an environment variable for the binary, as NAME=value. Repeatable. Anything the app already has and this does not name is left as it is. A value may name one the guest sets — NIBRUN_HTTP_PORT, NIBRUN_HOSTNAME or NIBRUN_DATA_DIR — quote it, as in 'URL=https://${NIBRUN_HOSTNAME}', or the shell expands it here instead.",
+      description: `Set an environment variable for the binary, as NAME=value. Repeatable. Anything the app already has and this does not name is left as it is. A value may name one the guest sets — ${RUNTIME_VALUE_NAMES.join(', ')} — quote it, as in 'URL=https://\${NIBRUN_HOSTNAME}', or the shell expands it here instead.`,
     },
   },
   unset: {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -39,7 +39,7 @@ export const SHARED_OPTIONS = {
       schema: z.array(z.string()).optional(),
       description:
         // biome-ignore lint/suspicious/noTemplateCurlyInString: the syntax being documented, shown to the reader rather than interpolated
-        "Set an environment variable for the binary, as NAME=value. Repeatable. Anything the app already has and this does not name is left as it is. A value may name one the guest sets — NIBRUN_PORT, NIBRUN_HOSTNAME or NIBRUN_DATA_DIR — quote it, as in 'URL=https://${NIBRUN_HOSTNAME}', or the shell expands it here instead.",
+        "Set an environment variable for the binary, as NAME=value. Repeatable. Anything the app already has and this does not name is left as it is. A value may name one the guest sets — NIBRUN_HTTP_PORT, NIBRUN_HOSTNAME or NIBRUN_DATA_DIR — quote it, as in 'URL=https://${NIBRUN_HOSTNAME}', or the shell expands it here instead.",
     },
   },
   unset: {

--- a/packages/protocol/src/domain/app.ts
+++ b/packages/protocol/src/domain/app.ts
@@ -25,11 +25,16 @@ const RUNTIME_VALUE_PREFIX = 'NIBRUN_';
  * The runtime values a tenant value may name, spelled as they are written. The guest is what
  * substitutes them, and it fails the boot over a name it does not offer — so a value naming
  * anything else is refused here instead, while whoever typed it is still listening.
+ *
+ * This is the list every other end reads rather than restates, so adding one is this array and
+ * whoever renders it. Two places cannot import it and have to be changed by hand:
+ * `reference_value` in `apps/runtime/src/config.c`, which is what actually substitutes them, and
+ * `skills/deploy-to-nibrun/SKILL.md`, which is what tells an agent they exist.
  */
 export const RUNTIME_VALUE_NAMES = [
   `${RUNTIME_VALUE_PREFIX}DATA_DIR`,
   `${RUNTIME_VALUE_PREFIX}HOSTNAME`,
-  `${RUNTIME_VALUE_PREFIX}PORT`,
+  `${RUNTIME_VALUE_PREFIX}HTTP_PORT`,
 ] as const;
 
 const OFFERED = RUNTIME_VALUE_NAMES.join('|');
@@ -56,6 +61,11 @@ const TENANT_VALUE = new RegExp(TENANT_VALUE_PATTERN);
  */
 export function namesOfferedRuntimeValues(value: string): boolean {
   return TENANT_VALUE.test(value);
+}
+
+/** A runtime value as it is named in a tenant value, which is the form worth showing back. */
+export function writtenRuntimeValue(name: string): string {
+  return `\${${name}}`;
 }
 
 // The pattern rather than a check of its own, so what the schema refuses and what a caller may

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -92,6 +92,7 @@ export {
   type TenantEnvironmentPatch,
   TenantEnvironmentPatchSchema,
   TenantEnvironmentSchema,
+  writtenRuntimeValue,
 } from '#domain/app.ts';
 export {
   type Artifact,

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -388,12 +388,12 @@ describe('a value naming a runtime value', () => {
 
   test('both forms the guest expands are accepted', () => {
     expect(accepts(`https://${OFFERED}/callback`)).toBe(true);
-    expect(accepts('$NIBRUN_PORT')).toBe(true);
+    expect(accepts('$NIBRUN_HTTP_PORT')).toBe(true);
   });
 
   test('a name the guest does not offer is refused', () => {
     expect(accepts(`https://${MISSPELLED}/callback`)).toBe(false);
-    expect(accepts('$NIBRUN_PORTS')).toBe(false);
+    expect(accepts('$NIBRUN_HTTP_PORTS')).toBe(false);
   });
 
   // The guest reads a name to its last name character, so this one is NIBRUN_HOSTNAME with no

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -17,7 +17,7 @@ Everything the binary can count on, and nothing else:
 | Platform | Linux **x86_64**, glibc (Debian rootfs) |
 | Working directory | `/app` |
 | Persistent volume | `/app/data` — 8 GiB, survives every redeploy. `NIBRUN_DATA_DIR` names it |
-| Port | `PORT` is set by the guest; the app **must** listen on it, on `0.0.0.0` |
+| Port | `NIBRUN_HTTP_PORT`, and `PORT` beside it; the app **must** listen on it, on `0.0.0.0` |
 | Own hostname | `NIBRUN_HOSTNAME` is set by the guest to the app's own `<slug>.nibrun.app` |
 | Ephemeral | `TMPDIR=/tmp` is a tmpfs and is lost on restart. So is everything outside `/app/data` |
 | Resources | 1 vCPU, 256 MiB RAM |
@@ -25,9 +25,10 @@ Everything the binary can count on, and nothing else:
 | URL | `https://<slug>.nibrun.app`, live as soon as it boots |
 
 An app that writes its SQLite file and its uploads under `./data` and reads `PORT` needs no
-configuration to run here. A `PORT`, `NIBRUN_HOSTNAME` or `NIBRUN_DATA_DIR` you set yourself is
-ignored — the guest owns all three. `HOME` and `TMPDIR` are defaults rather than owned, so one you
-set yourself is what the binary reads.
+configuration to run here. The guest sets three names of its own — `NIBRUN_HTTP_PORT`,
+`NIBRUN_HOSTNAME`, `NIBRUN_DATA_DIR` — and any of them you set yourself is ignored, as is `PORT`,
+which carries the same number as `NIBRUN_HTTP_PORT` under the name every other host uses. `HOME`
+and `TMPDIR` are defaults rather than owned, so one you set yourself is what the binary reads.
 
 A binary that needs its own absolute URL — an OAuth redirect, a webhook it registers, a link in
 an email — builds it from `NIBRUN_HOSTNAME` rather than being told it, and falls back to whatever
@@ -36,9 +37,9 @@ it uses when it is not on nibrun.
 One that insists on a variable name of its own reaches the same values through it: a value may
 name a runtime one — `APP_BASE_URL=https://${NIBRUN_HOSTNAME}`,
 `DATABASE_URL=file:${NIBRUN_DATA_DIR}/app.db` — and the guest expands it before exec. Only that
-prefix expands, so a secret holding a `$` arrives untouched, and `NIBRUN_PORT`, `NIBRUN_HOSTNAME`
-and `NIBRUN_DATA_DIR` are the whole of what may be named: anything else is refused when you deploy
-it.
+prefix expands, so a secret holding a `$` arrives untouched, and `NIBRUN_HTTP_PORT`,
+`NIBRUN_HOSTNAME` and `NIBRUN_DATA_DIR` are the whole of what may be named — `${PORT}` is not one
+of them — with anything else refused when you deploy it.
 
 ## Deploying
 
@@ -61,8 +62,8 @@ nib run ./my-server --name my-app --port 8080
 ```
 
 `--port` is the HTTP port the binary listens on inside the guest — read it off the app rather
-than carrying a number over from an example. It is the port the guest then hands back as `PORT`,
-and it defaults to `3000`.
+than carrying a number over from an example. It is the number the guest hands back as
+`NIBRUN_HTTP_PORT` and `PORT`, and it defaults to `3000`.
 
 **Every deploy after that must name the app**, or a non-interactive shell creates a second one:
 
@@ -115,7 +116,7 @@ Worth saying out loud before recommending it:
   container, no managed database next to it.
 - **256 MiB and 1 vCPU**, sized by nibrun rather than configured by you, and the OOM killer
   reaches for the tenant first.
-- **Health is a TCP connect** to `PORT`, and not something you configure. A process that accepts
+- **Health is a TCP connect** to that port, and not something you configure. A process that accepts
   connections while broken reads as healthy.
 - **A crash loop is fatal.** The guest restarts your process on a fixed budget you do not set;
   once it runs out the app is `failed` rather than restarted forever.


### PR DESCRIPTION
The port had two names: `NIBRUN_PORT` on the config drive, `PORT` in the tenant's
process. Nothing reserved `NIBRUN_PORT` in the tenant's own environment, so one set
there reached execve while `${NIBRUN_PORT}` beside it expanded to the real port —
one name, two meanings.

It is `NIBRUN_HTTP_PORT` now, the name `packages/protocol` has used since `HttpPort`
was branded apart from `HostPort`, and the guest owns it as it owns `NIBRUN_HOSTNAME`
and `NIBRUN_DATA_DIR`. `PORT` carries the same number under the name every other host
sets, so no binary has to change.

The guest now sets exactly three names of its own, spelled the same whether exported
or referenced, plus `PORT` as the alias. The CLI's `--env` help, the dashboard's
variable hint and the deploy skill all say that and agree.

**Rollout:** `NIBRUN_HTTP_PORT` is a required key, and an unknown `NIBRUN_` key fails
the boot — so an agent and a guest image on either side of this rename fail every
boot in both directions. They have to ship together.

Follow-up, as discussed: reserving the whole `NIBRUN_` prefix and rejecting it at the
API when the user's variables come in.