### PR TITLE
fix(infra): adopt guest image 6.1.180-b74f07c126fa

### DIFF
--- a/infra/app-host/versions.json
+++ b/infra/app-host/versions.json
@@ -16,5 +16,5 @@
     "url": "https://github.com/caddyserver/caddy/releases/download/v2.11.4/caddy_2.11.4_linux_amd64.tar.gz",
     "sha256": "527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9"
   },
-  "guestImage": "6.1.180-3b420c82019c"
+  "guestImage": "6.1.180-b74f07c126fa"
 }


### PR DESCRIPTION
**The fleet cannot boot a microVM right now.**

#321 renamed the port key to `NIBRUN_HTTP_PORT` and moved the agent with it — correctly, and its own note said they had to ship together. But the guest image pin stayed on `3b420c82019c`, built the day before the rename.

So since that deploy landed (`cd` succeeded on `7d5bd89` at 08:30 today), the agent writes `NIBRUN_HTTP_PORT` into `instance.env`, and the running guest image's `config.c` does not know that key. `parse_runtime_key` falls through to *"which this runtime does not know"* and fails the parse, so `/init` dies before the tenant is exec'd. Already-running microVMs are unaffected until they restart; every new boot fails.

## Which image, verified rather than assumed

`/init` built from `origin/main` hashes to `e37c5bfe1124…`, which is exactly the `init_sha256` in `6.1.180-b74f07c126fa`'s manifest. The currently pinned image carries `7faa8ec28015…`, from before the rename.

| image | published | init_sha256 |
| --- | --- | --- |
| `3b420c82019c` (pinned) | 08-27 16:30 | `7faa8ec28015…` — pre-rename |
| `7999001b839e` | 08-28 09:23 | `ede2099c8ace…` |
| **`b74f07c126fa`** | 08-28 09:41 | **`e37c5bfe1124…` — matches main** |

## Worth a follow-up

Nothing compares the agent's keys against the pinned image, so this failure mode is silent until a boot. A CI check that the pinned image's `init_sha256` matches `/init` built from the same commit would have caught it at the PR.