### PR TITLE
feat(agent): a guest that asked for a public port is told where it is

### DIFF
--- a/apps/agent/src/lib/vm/instance-env.ts
+++ b/apps/agent/src/lib/vm/instance-env.ts
@@ -2,6 +2,7 @@ import { FileSystem, Path } from '@effect/platform';
 import type {
   AppHostname,
   Hostname,
+  HostPort,
   HttpPort,
   RestartPolicy,
   TenantArguments,
@@ -38,6 +39,26 @@ function platformHostname(hostnames: AppHostname[]): Hostname | undefined {
   return hostnames.find((each) => each.kind === 'platform')?.hostname;
 }
 
+/**
+ * Where a tenant's own port is reached, for an app that asked for one. The two together, because
+ * half of what a binary has to announce is not an announcement — and neither half is something a
+ * guest can find out for itself: the address belongs to the relay in front of the host, and the
+ * ruleset denies the metadata endpoint anyway.
+ */
+export type PublicAddress = {
+  readonly ipv4: string;
+  readonly port: HostPort;
+};
+
+type InstanceEnvContent = {
+  httpPort: HttpPort;
+  publicAddress?: PublicAddress | undefined;
+  hostnames: AppHostname[];
+  args: TenantArguments;
+  environment: TenantEnvironment;
+  restartPolicy: RestartPolicy;
+};
+
 export class UnrepresentableEnvironment extends Data.TaggedError('UnrepresentableEnvironment')<{
   readonly variableName: string;
 }> {
@@ -54,21 +75,22 @@ export class UnrepresentableEnvironment extends Data.TaggedError('Unrepresentabl
  */
 export function renderInstanceEnv({
   httpPort,
+  publicAddress,
   hostnames,
   args,
   environment,
   restartPolicy,
-}: {
-  httpPort: HttpPort;
-  hostnames: AppHostname[];
-  args: TenantArguments;
-  environment: TenantEnvironment;
-  restartPolicy: RestartPolicy;
-}): Either.Either<string, UnrepresentableEnvironment> {
+}: InstanceEnvContent): Either.Either<string, UnrepresentableEnvironment> {
   const hostname = platformHostname(hostnames);
   const lines = [
     `${RUNTIME_PREFIX}HTTP_PORT=${httpPort}`,
     ...(hostname === undefined ? [] : [`${RUNTIME_PREFIX}HOSTNAME=${hostname}`]),
+    ...(publicAddress === undefined
+      ? []
+      : [
+          `${RUNTIME_PREFIX}PUBLIC_IPV4=${publicAddress.ipv4}`,
+          `${RUNTIME_PREFIX}EXTRA_PUBLIC_PORT=${publicAddress.port}`,
+        ]),
     `${RUNTIME_PREFIX}MAX_RESTARTS=${restartPolicy.maxRestarts}`,
     `${RUNTIME_PREFIX}INITIAL_BACKOFF_MS=${restartPolicy.initialBackoffMs}`,
     `${RUNTIME_PREFIX}MAX_BACKOFF_MS=${restartPolicy.maxBackoffMs}`,
@@ -100,14 +122,7 @@ export function renderInstanceEnv({
 export const buildInstanceConfigImage = ({
   workingDir,
   ...content
-}: {
-  workingDir: string;
-  httpPort: HttpPort;
-  hostnames: AppHostname[];
-  args: TenantArguments;
-  environment: TenantEnvironment;
-  restartPolicy: RestartPolicy;
-}) =>
+}: InstanceEnvContent & { workingDir: string }) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -57,6 +57,9 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       const instanceConfigImagePath = yield* buildInstanceConfigImage({
         workingDir: directory,
         httpPort: desired.config.httpPort,
+        ...(desired.config.hasExtraPublicPort && {
+          publicAddress: { ipv4: config.portRelayPublicIpv4, port: slot.extraPublicPort },
+        }),
         hostnames: desired.hostnames,
         args: desired.config.args,
         environment: desired.config.environment,

--- a/apps/agent/tests/lib/vm/instance-env.test.ts
+++ b/apps/agent/tests/lib/vm/instance-env.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_HTTP_PORT,
   DEFAULT_RESTART_POLICY,
   HostnameSchema,
+  HostPortSchema,
   HttpPortSchema,
   Value,
 } from '@repo/protocol';
@@ -43,6 +44,14 @@ function refusedVariable(overrides: Overrides) {
   return Either.isLeft(result) ? result.left : undefined;
 }
 
+const RELAY_IPV4 = '203.0.113.7';
+const EXTRA_PUBLIC_PORT = 22_000;
+
+const REACHED_AT = {
+  ipv4: RELAY_IPV4,
+  port: Value.Parse(HostPortSchema, EXTRA_PUBLIC_PORT),
+};
+
 // apps/runtime/src/config.c accepts NIBRUN_ and ENV_ and rejects every other line, so these
 // assertions are the boot contract rather than a formatting preference.
 describe('what apps/runtime parses off the config drive', () => {
@@ -50,6 +59,29 @@ describe('what apps/runtime parses off the config drive', () => {
     expect(render().split('\n').filter(Boolean)).toEqual([
       `NIBRUN_HTTP_PORT=${DEFAULT_HTTP_PORT}`,
       `NIBRUN_HOSTNAME=${PLATFORM_HOSTNAME}`,
+      `NIBRUN_MAX_RESTARTS=${DEFAULT_RESTART_POLICY.maxRestarts}`,
+      `NIBRUN_INITIAL_BACKOFF_MS=${DEFAULT_RESTART_POLICY.initialBackoffMs}`,
+      `NIBRUN_MAX_BACKOFF_MS=${DEFAULT_RESTART_POLICY.maxBackoffMs}`,
+      `NIBRUN_BACKOFF_FACTOR=${DEFAULT_RESTART_POLICY.backoffFactor}`,
+      `NIBRUN_RESET_AFTER_MS=${DEFAULT_RESTART_POLICY.resetAfterMs}`,
+      'NIBRUN_DNS=1.1.1.1,1.0.0.1',
+    ]);
+  });
+
+  // The runtime reads both as optional and rejects a key it does not know, so an app that asked
+  // for no port has to be a file with neither line rather than one with an empty value.
+  test('an app that asked for no public port is sent neither half of one', () => {
+    const written = render();
+    expect(written).not.toContain('NIBRUN_PUBLIC_IPV4');
+    expect(written).not.toContain('NIBRUN_EXTRA_PUBLIC_PORT');
+  });
+
+  test('an app that asked is told the address and the port together', () => {
+    expect(render({ publicAddress: REACHED_AT }).split('\n').filter(Boolean)).toEqual([
+      `NIBRUN_HTTP_PORT=${DEFAULT_HTTP_PORT}`,
+      `NIBRUN_HOSTNAME=${PLATFORM_HOSTNAME}`,
+      `NIBRUN_PUBLIC_IPV4=${RELAY_IPV4}`,
+      `NIBRUN_EXTRA_PUBLIC_PORT=${EXTRA_PUBLIC_PORT}`,
       `NIBRUN_MAX_RESTARTS=${DEFAULT_RESTART_POLICY.maxRestarts}`,
       `NIBRUN_INITIAL_BACKOFF_MS=${DEFAULT_RESTART_POLICY.initialBackoffMs}`,
       `NIBRUN_MAX_BACKOFF_MS=${DEFAULT_RESTART_POLICY.maxBackoffMs}`,

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -19,6 +19,7 @@ Everything the binary can count on, and nothing else:
 | Persistent volume | `/app/data` — 8 GiB, survives every redeploy. `NIBRUN_DATA_DIR` names it |
 | Port | `NIBRUN_HTTP_PORT`, and `PORT` beside it; the app **must** listen on it, on `0.0.0.0` |
 | Own hostname | `NIBRUN_HOSTNAME` is set by the guest to the app's own `<slug>.nibrun.app` |
+| Second port | Only for an app that asked for one: `NIBRUN_EXTRA_PUBLIC_PORT` on `NIBRUN_PUBLIC_IPV4`, TCP and UDP, reached at that number and no other |
 | Ephemeral | `TMPDIR=/tmp` is a tmpfs and is lost on restart. So is everything outside `/app/data` |
 | Resources | 1 vCPU, 256 MiB RAM |
 | `HOME` | `/app` |
@@ -30,6 +31,11 @@ configuration to run here. The guest sets three names of its own — `NIBRUN_HTT
 which carries the same number as `NIBRUN_HTTP_PORT` under the name every other host uses. `HOME`
 and `TMPDIR` are defaults rather than owned, so one you set yourself is what the binary reads.
 
+An app needing a port HTTP cannot carry — WebRTC media, a game server, anything on UDP — asks for
+one, and is then set two more: `NIBRUN_PUBLIC_IPV4` and `NIBRUN_EXTRA_PUBLIC_PORT`. Bind that port
+and announce that pair; it is the same number end to end, which is what makes announcing it
+correct. Neither is discoverable from inside the guest.
+
 A binary that needs its own absolute URL — an OAuth redirect, a webhook it registers, a link in
 an email — builds it from `NIBRUN_HOSTNAME` rather than being told it, and falls back to whatever
 it uses when it is not on nibrun.
@@ -38,8 +44,13 @@ One that insists on a variable name of its own reaches the same values through i
 name a runtime one — `APP_BASE_URL=https://${NIBRUN_HOSTNAME}`,
 `DATABASE_URL=file:${NIBRUN_DATA_DIR}/app.db` — and the guest expands it before exec. Only that
 prefix expands, so a secret holding a `$` arrives untouched, and `NIBRUN_HTTP_PORT`,
-`NIBRUN_HOSTNAME` and `NIBRUN_DATA_DIR` are the whole of what may be named — `${PORT}` is not one
-of them — with anything else refused when you deploy it.
+`NIBRUN_HOSTNAME`, `NIBRUN_DATA_DIR`, `NIBRUN_PUBLIC_IPV4` and `NIBRUN_EXTRA_PUBLIC_PORT` are the
+whole of what may be named — `${PORT}` is not one of them — with anything else refused when you
+deploy it.
+
+The last two are set only for an app that asked for a second port, and naming one the app was not
+given fails the boot rather than expanding to nothing. Ask for the port in the same change that
+names it.
 
 ## Deploying
 


### PR DESCRIPTION
Closes the path: the relay forwards, the host DNATs 1:1, and the guest is now
told the pair to announce.

Both names or neither — the runtime fails the boot on a reference it was not
given, so half an address is worse than none.