### PR TITLE
fix(ci): the manifest is the last thing a guest image publish writes

### DIFF
--- a/packages/internal-scripts/src/publish-guest-image.ts
+++ b/packages/internal-scripts/src/publish-guest-image.ts
@@ -70,9 +70,16 @@ const checksums = manifest.artifacts
   .join('\n');
 await Bun.write(join(distDir, 'SHA256SUMS'), `${checksums}\n`);
 
-await aws(['s3', 'cp', '--recursive', distDir, `s3://${bucket}/${version}/`]);
+const prefix = `s3://${bucket}/${version}/`;
 
-core.info(`Published s3://${bucket}/${version}/`);
+// manifest.json is what the check above reads to decide the version is already
+// published, so it is written last and on its own. Uploaded inside the recursive
+// copy it can land before the artifacts do, and a job that dies in between
+// leaves a prefix every later run skips as done and every host fails to verify.
+await aws(['s3', 'cp', '--recursive', '--exclude', 'manifest.json', distDir, prefix]);
+await aws(['s3', 'cp', join(distDir, 'manifest.json'), `${prefix}manifest.json`]);
+
+core.info(`Published ${prefix}`);
 
 await writeSummary(
   [


### PR DESCRIPTION
`manifest.json` is the marker `publish-guest-image` reads to decide a version is already published, and it was uploaded in the same recursive copy as the artifacts — which transfers in parallel, so it could land first. A job dying in between left a prefix every later run skipped as done and every host failed `sha256sum -c` on.

It is now written last, on its own.