### PR TITLE
fix(infra): the relay refuses a fleet its port scheme cannot reach

### DIFF
--- a/infra/terraform/port_relay.tf
+++ b/infra/terraform/port_relay.tf
@@ -43,9 +43,15 @@ resource "aws_instance" "port_relay" {
   lifecycle {
     ignore_changes = [ami]
 
+    # One, not "at least one": the range is forwarded to a single host, and a tenant's port is
+    # 22000 + its slot, which every host numbers from 0 — so two hosts both hold 22005 and the
+    # port carries nothing to tell them apart. A second host would take no tenant traffic at all
+    # and nothing would say so, which is why this refuses the plan rather than a comment saying
+    # not to. Widening the fleet means giving the ports a number unique across it first, and
+    # editing this in the same change.
     precondition {
-      condition     = var.app_host_count > 0
-      error_message = "The port relay forwards to an app host, and app_host_count is 0."
+      condition     = var.app_host_count == 1
+      error_message = "The port relay forwards the whole tenant port range to app_host[0], and a slot's port is host-local, so a second app host would hold ports nothing routes to. Give tenant ports a fleet-wide number before raising app_host_count."
     }
   }
 


### PR DESCRIPTION
A tenant's port is `22000 + slot` and every host numbers slots from 0, so two app
hosts both hold 22005 — and the relay forwards the whole range to `app_host[0]`
regardless. `app_host_count = 2` plans and applies cleanly today; the second
host's tenant ports just never answer, and nothing says so.

Tightened from `> 0` to `== 1`, so scaling fails the plan with the reason.

**Tradeoff worth a look:** this blocks scaling the fleet *at all*, including for
capacity when no app uses an extra port. That is deliberate — the relay is
pinned to `app_host[0]` either way, so a second host is already outside what this
design covers — but it does mean the day you scale is a day you edit terraform.

Verified against a stand-in resource: `app_host_count = 1` plans, `= 2` fails
with the message.