### PR TITLE
refactor: a release is only ever running

### DIFF
--- a/apps/api/src/db/migrations/0029_deployments_forget_the_old_word.sql
+++ b/apps/api/src/db/migrations/0029_deployments_forget_the_old_word.sql
@@ -1,0 +1,11 @@
+-- The other half of 0028, now that every row has been moved off `active`. The CASE that read the
+-- old word as the new one goes with it.
+--
+-- Adding the constraint validates every row already in the table, so this is also what proves the
+-- move finished: one still holding `active` fails the migration and the api does not start, rather
+-- than starting on a vocabulary it no longer reads.
+
+ALTER TABLE nibrun.deployments
+  DROP CONSTRAINT deployments_state_check,
+  ADD CONSTRAINT deployments_state_check
+    CHECK (state IN ('pending', 'starting', 'running', 'stopped', 'superseded', 'failed'));

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -499,7 +499,7 @@ export interface ISelectDeploymentsByAppResult {
     id: IDeploymentsColumns["id"];
     app_id: IDeploymentsColumns["app_id"];
     artifact_id: IDeploymentsColumns["artifact_id"];
-    state: import("@repo/protocol").DeploymentState;
+    state: IDeploymentsColumns["state"];
     activated_at: IDeploymentsColumns["activated_at"];
     /** The deployment this one replays, when it was made to go back to one. */
     rollback_of_deployment_id: IDeploymentsColumns["rollback_of_deployment_id"];
@@ -534,7 +534,7 @@ export interface ISelectDeploymentByIdResult {
     id: IDeploymentsColumns["id"];
     app_id: IDeploymentsColumns["app_id"];
     artifact_id: IDeploymentsColumns["artifact_id"];
-    state: import("@repo/protocol").DeploymentState;
+    state: IDeploymentsColumns["state"];
     activated_at: IDeploymentsColumns["activated_at"];
     /** The deployment this one replays, when it was made to go back to one. */
     rollback_of_deployment_id: IDeploymentsColumns["rollback_of_deployment_id"];
@@ -567,7 +567,7 @@ export interface ISelectDeploymentByIdResult {
 /** Result of query `SelectLiveDeployments`. */
 export interface ISelectLiveDeploymentsResult {
     id: IDeploymentsColumns["id"];
-    state: import("@repo/protocol").DeploymentState;
+    state: IDeploymentsColumns["state"];
     /** Derived from the uuidv7 id; the moment the row was created. */
     created_at: Date;
     state_changed_at: IAppsColumns["updated_at"];

--- a/apps/api/src/repositories/deployments.repository.ts
+++ b/apps/api/src/repositories/deployments.repository.ts
@@ -156,11 +156,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
   listByApp({ appId, ownerId }: DeploymentsByAppInput): Promise<DeploymentRow[]> {
     return this.sql.SelectDeploymentsByApp`
       /* @notNull environment_names */
-      /* @notNull state */
-      -- TODO: remove with the migration dropping 'active' from deployments_state_check.
-      SELECT d.id, d.app_id, d.artifact_id,
-             CASE WHEN d.state = 'active' THEN 'running' ELSE d.state END AS state,
-             d.activated_at,
+      SELECT d.id, d.app_id, d.artifact_id, d.state, d.activated_at,
              d.rollback_of_deployment_id, d.created_at, d.message,
              d.started_at, d.last_healthy_at, d.restart_count,
                c.http_port, c.has_extra_public_port, c.args, c.vcpu_count, c.memory_mib,
@@ -184,11 +180,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
   }: DeploymentByIdInput): Promise<DeploymentRow | null> {
     const [row] = await this.sql.SelectDeploymentById`
       /* @notNull environment_names */
-      /* @notNull state */
-      -- TODO: remove with the migration dropping 'active' from deployments_state_check.
-      SELECT d.id, d.app_id, d.artifact_id,
-             CASE WHEN d.state = 'active' THEN 'running' ELSE d.state END AS state,
-             d.activated_at,
+      SELECT d.id, d.app_id, d.artifact_id, d.state, d.activated_at,
              d.rollback_of_deployment_id, d.created_at, d.message,
              d.started_at, d.last_healthy_at, d.restart_count,
                c.http_port, c.has_extra_public_port, c.args, c.vcpu_count, c.memory_mib,
@@ -213,13 +205,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
   listLive(): Promise<LiveDeploymentRow[]> {
     return this.sql.SelectLiveDeployments`
       /* @notNull desired_running */
-      /* @notNull state */
-      -- TODO: remove with the migration that drops 'active' from deployments_state_check, once
-      -- every row has been moved off it. Nothing else in the api knows the word, and a row still
-      -- holding it fails the whole report its host sent rather than only itself.
-      SELECT d.id,
-             CASE WHEN d.state = 'active' THEN 'running' ELSE d.state END AS state,
-             d.created_at, a.updated_at AS state_changed_at,
+      SELECT d.id, d.state, d.created_at, a.updated_at AS state_changed_at,
              (a.state = 'active') AS desired_running
       FROM nibrun.deployments d
       JOIN nibrun.apps a ON a.id = d.app_id

--- a/apps/api/tests/repositories/desired-hostnames.test.ts
+++ b/apps/api/tests/repositories/desired-hostnames.test.ts
@@ -101,7 +101,7 @@ async function seedDeployedApp(sql: SQL): Promise<void> {
   );
   await sql.unsafe(
     `INSERT INTO nibrun.deployments (app_id, artifact_id, config_id, state)
-     SELECT a.id, ar.id, c.id, 'active'
+     SELECT a.id, ar.id, c.id, 'running'
      FROM nibrun.apps a
      JOIN nibrun.artifacts ar ON ar.app_id = a.id
      JOIN nibrun.app_configs c ON c.app_id = a.id


### PR DESCRIPTION
The other half of #331, now that the rows have moved. The `CASE` that read `active` as `running` comes out of the three queries carrying it, and `deployments_state_check` stops accepting the old word.

## Before merging

Adding the constraint validates every row already in the table, so the migration is also the proof the move finished — but its failure mode is the api not starting, since migrations run at boot. Worth confirming there is nothing left first:

```sql
SELECT state, count(*) FROM nibrun.deployments GROUP BY state;
```

No `active` in the output and this is safe. Verified both directions against a real database: `0029` refuses with `23514` while a legacy row is present, and applies once it is moved.

## One thing the rename PR left behind

`desired-hostnames.test.ts` seeds its deployment with a raw-SQL `'active'`. Nothing typed could catch it, and it kept passing on main only because `0028` still permits the word — narrowing the constraint is what surfaced it.