### PR TITLE
feat(api): platform hostnames follow the app domain to nibrun.app

### DIFF
--- a/apps/api/src/db/migrations/0028_app_hostnames_move_to_nibrun_app.sql
+++ b/apps/api/src/db/migrations/0028_app_hostnames_move_to_nibrun_app.sql
@@ -1,0 +1,13 @@
+-- A platform hostname is minted once when the app is created and never recomputed, so changing
+-- APP_HOST_DOMAIN leaves every existing row naming the domain it was minted under. The rendered
+-- proxy config is built from these rows, which is why the domain moves here rather than in config
+-- alone.
+--
+-- Both domains are named literally, so this matches nothing in development or CI, where the app
+-- domain has never been either of them. The `kind` guard is what keeps a brought domain out of a
+-- rewrite that has no business touching one.
+
+UPDATE nibrun.app_hostnames
+SET hostname = left(hostname, length(hostname) - length('.canister.site')) || '.nibrun.app'
+WHERE kind = 'platform'
+  AND hostname LIKE '%.canister.site';


### PR DESCRIPTION
The app domain moves from `canister.site` to `nibrun.app`. A platform hostname is minted once at create and never recomputed, so flipping `APP_DOMAIN` alone only changes what new apps get — the rendered proxy config is built from these rows, so the existing ones have to be rewritten for the fleet to answer on the new names.

Both domains are named literally, so the migration matches nothing in development or CI.