### PR TITLE
refactor(dashboard): the additional address sits with the port it is not

### DIFF
--- a/apps/dashboard/src/components/apps/app-config-card.tsx
+++ b/apps/dashboard/src/components/apps/app-config-card.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
+import { CopyButton } from '@repo/ui/custom/copy-button';
 import { AppEnvironment } from '#components/apps/app-environment.tsx';
 import { AppRunCommand } from '#components/apps/app-run-command.tsx';
+import { useNewestDeployment } from '#lib/hooks/use-newest-deployment.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
 export function AppConfigCard({ app }: { app: AppSummary }) {
@@ -14,9 +16,49 @@ export function AppConfigCard({ app }: { app: AppSummary }) {
           <span className="text-muted-foreground">HTTP port</span>
           <span className="font-mono tabular-nums">{app.config.httpPort}</span>
         </div>
+        {app.config.hasExtraPublicPort && <ReachedOnItsOwnPort appId={app.id} />}
         <AppRunCommand app={app} />
         <AppEnvironment app={app} />
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * Where an app that asked for a port besides HTTP is reached, beside the HTTP port it was
+ * configured with — the two are the same question asked twice, and an owner looking for one is
+ * looking for the other.
+ *
+ * The address is not configuration and is not here because it is: only the host running the app
+ * knows it, so it arrives with the release and there is nothing to show until one is running.
+ */
+function ReachedOnItsOwnPort({ appId }: { appId: string }) {
+  const { publicIpv4, extraPublicPort } = useNewestDeployment(appId).data ?? {};
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Both protocols, always — nibrun never asks which a tenant means to carry over it — so it
+          is part of what the row is called rather than something beside the address. */}
+      <span className="text-muted-foreground">Additional TCP/UDP address</span>
+      {publicIpv4 && extraPublicPort ? (
+        // Nothing here links anywhere: it is not a URL, and what an owner does with it is paste it
+        // into whatever is dialling the app. Same line as the run command for that reason.
+        <ReachedAt address={`${publicIpv4}:${extraPublicPort}`} />
+      ) : (
+        // Asked for and not yet answered for: the host says where it is on its first report, so
+        // this is a release that has not started rather than an address that failed to arrive.
+        <span className="text-muted-foreground">assigned when it starts</span>
+      )}
+    </div>
+  );
+}
+
+function ReachedAt({ address }: { address: string }) {
+  return (
+    <div className="flex items-center gap-1 rounded-lg border bg-muted/40 py-1 pr-1 pl-3">
+      <code className="min-w-0 flex-1 select-all break-words font-mono text-xs tabular-nums">
+        {address}
+      </code>
+      <CopyButton value={address} />
+    </div>
   );
 }

--- a/apps/dashboard/src/components/apps/app-overview-card.tsx
+++ b/apps/dashboard/src/components/apps/app-overview-card.tsx
@@ -1,11 +1,9 @@
 import { Badge } from '@repo/ui/components/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
-import { CopyButton } from '@repo/ui/custom/copy-button';
 import { ExternalLinkIcon } from 'lucide-react';
 import { AppStatusBadge } from '#components/apps/app-status-badge.tsx';
 import { HostnameStateBadge } from '#components/apps/hostname-state-badge.tsx';
 import { dayAndMinute } from '#lib/format-timestamp.ts';
-import { useNewestDeployment } from '#lib/hooks/use-newest-deployment.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
 export function AppOverviewCard({ app }: { app: AppSummary }) {
@@ -23,9 +21,6 @@ export function AppOverviewCard({ app }: { app: AppSummary }) {
           <span className="text-muted-foreground">Last change</span>
           <span className="tabular-nums">{dayAndMinute(app.updatedAt)}</span>
         </div>
-        {/* Mounted only for an app that asked, because reading where it answers is a request of
-            its own and most apps have nothing to answer on. */}
-        {app.config.hasExtraPublicPort && <ReachedOnItsOwnPort appId={app.id} />}
         <div className="flex flex-col gap-2">
           <span className="text-muted-foreground">Hostnames</span>
           <ul className="flex flex-col gap-2">
@@ -54,41 +49,5 @@ export function AppOverviewCard({ app }: { app: AppSummary }) {
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-/**
- * The address and port an app that asked for one is reached at, which only the host running it
- * knows: it is reported with the release rather than configured, so there is nothing to show until
- * one is running and has said so.
- */
-function ReachedOnItsOwnPort({ appId }: { appId: string }) {
-  const { publicIpv4, extraPublicPort } = useNewestDeployment(appId).data ?? {};
-  return (
-    <div className="flex flex-col gap-2">
-      {/* Both protocols, always — nibrun never asks which a tenant means to carry over it — so it
-          is part of what the row is called rather than something beside the address. */}
-      <span className="text-muted-foreground">Additional TCP/UDP address</span>
-      {publicIpv4 && extraPublicPort ? (
-        // Nothing here links anywhere: it is not a URL, and what an owner does with it is paste it
-        // into whatever is dialling the app. Same line as the run command for that reason.
-        <ReachedAt address={`${publicIpv4}:${extraPublicPort}`} />
-      ) : (
-        // Asked for and not yet answered for: the host says where it is on its first report, so
-        // this is a release that has not started rather than an address that failed to arrive.
-        <span className="text-muted-foreground">assigned when it starts</span>
-      )}
-    </div>
-  );
-}
-
-function ReachedAt({ address }: { address: string }) {
-  return (
-    <div className="flex items-center gap-1 rounded-lg border bg-muted/40 py-1 pr-1 pl-3">
-      <code className="min-w-0 flex-1 select-all break-words font-mono text-xs tabular-nums">
-        {address}
-      </code>
-      <CopyButton value={address} />
-    </div>
   );
 }


### PR DESCRIPTION
#340 put it on the overview card because that is where the hostnames are — which
reads as an argument until you notice the run command is not there either.

Configuration is where an owner looks for what ports an app has, the deploy
form's section is called Additional ports, and reading it back beside HTTP port
is what matches.

It also stops a second card fetching what the first already had: `AppRunCommand`
lives in the config card and reads the newest deployment through
`useDeployedBinary`, so the query was there the whole time.