### PR TITLE
fix(agent): a freed slot waits its turn rather than going straight back out

### DIFF
--- a/apps/agent/src/lib/network/allocator.ts
+++ b/apps/agent/src/lib/network/allocator.ts
@@ -23,6 +23,15 @@ export function readSlotRecords(value: unknown): SlotRecords {
   );
 }
 
+/**
+ * Where the next scan starts. A hint and never an authority: the scan only ever returns a slot
+ * nothing holds, so a cursor that is stale, missing or nonsense costs a different free slot rather
+ * than a wrong one.
+ */
+export function readSlotCursor(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) ? value : FIRST_SLOT;
+}
+
 export function assignmentsFrom(records: SlotRecords): Assignments {
   const assignments = new Map<AppId, number>();
   const taken = new Set<number>();

--- a/apps/agent/src/services/agent-config.service.ts
+++ b/apps/agent/src/services/agent-config.service.ts
@@ -76,6 +76,10 @@ export class AgentConfig extends Effect.Service<AgentConfig>()('AgentConfig', {
       runtimeDir: yield* optional({ name: 'AGENT_RUNTIME_DIR', fallback: DEFAULT_RUNTIME_DIR }),
       hostIdFile: inStateDir('host-id'),
       slotsFile: inStateDir('slots.json'),
+      // Beside the slots rather than inside them: `slots.json` is a plain app-to-slot record that
+      // an agent either side of this reads the same way, and a key that is not an app in there
+      // would read back as one holding a slot.
+      slotCursorFile: inStateDir('slot-cursor.json'),
       instancesFile: inStateDir('instances.json'),
       exportsFile: inStateDir('exports.json'),
       deletedVolumesFile: inStateDir('deleted-volumes.json'),

--- a/apps/agent/src/services/slot-allocator.service.ts
+++ b/apps/agent/src/services/slot-allocator.service.ts
@@ -4,15 +4,32 @@ import { readJsonFile, writeJsonFile } from '#lib/json-store.ts';
 import {
   type Assignments,
   assignmentsFrom,
+  readSlotCursor,
   readSlotRecords,
   SlotExhausted,
 } from '#lib/network/allocator.ts';
 import { type AppSlot, describeSlot, FIRST_SLOT, SLOT_COUNT } from '#lib/network/slot.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 
-const firstFree = (assignments: Assignments) => {
+const SLOT_SPAN = SLOT_COUNT - FIRST_SLOT;
+
+/** Twice, because a cursor read off disk may be negative and `%` keeps the sign. */
+function wrapped(offset: number): number {
+  return FIRST_SLOT + (((offset % SLOT_SPAN) + SLOT_SPAN) % SLOT_SPAN);
+}
+
+type Allocation = Either.Either<{ slot: AppSlot; fresh: boolean }, SlotExhausted>;
+
+/**
+ * The next free slot at or after the cursor rather than the lowest free one, wrapping once so the
+ * scan still ends. A slot only comes back when its app's volume is torn down, and handing it
+ * straight to the next app makes an address a client may still be dialling somebody else's — so a
+ * freed slot waits for the cursor to come round to it, which is every other slot first.
+ */
+const nextFree = ({ assignments, from }: { assignments: Assignments; from: number }) => {
   const taken = new Set(assignments.values());
-  for (let slot = FIRST_SLOT; slot < SLOT_COUNT; slot += 1) {
+  for (let step = 0; step < SLOT_SPAN; step += 1) {
+    const slot = wrapped(from - FIRST_SLOT + step);
     if (!taken.has(slot)) {
       return slot;
     }
@@ -32,28 +49,37 @@ export class SlotAllocator extends Effect.Service<SlotAllocator>()('SlotAllocato
     const config = yield* AgentConfig;
     const stored = yield* readJsonFile(config.slotsFile);
     const ref = yield* Ref.make(assignmentsFrom(readSlotRecords(Option.getOrUndefined(stored))));
+    const storedCursor = yield* readJsonFile(config.slotCursorFile);
+    const cursorRef = yield* Ref.make(readSlotCursor(Option.getOrUndefined(storedCursor)));
 
     return {
       allocate: (appId: AppId) =>
-        Effect.flatten(
-          Ref.modify(
-            ref,
-            (assignments): readonly [Either.Either<AppSlot, SlotExhausted>, Assignments] => {
+        Effect.gen(function* () {
+          const from = yield* Ref.get(cursorRef);
+          const taken = yield* Effect.flatten(
+            Ref.modify(ref, (assignments): readonly [Allocation, Assignments] => {
               const existing = withSlot({ assignments, appId });
               if (Option.isSome(existing)) {
-                return [Either.right(existing.value), assignments];
+                return [Either.right({ slot: existing.value, fresh: false }), assignments];
               }
-              const slot = firstFree(assignments);
-              if (slot === undefined) {
+              const free = nextFree({ assignments, from });
+              if (free === undefined) {
                 return [Either.left(new SlotExhausted({ limit: SLOT_COUNT })), assignments];
               }
               return [
-                Either.right(describeSlot({ slot, appId })),
-                new Map(assignments).set(appId, slot),
+                Either.right({ slot: describeSlot({ slot: free, appId }), fresh: true }),
+                new Map(assignments).set(appId, free),
               ];
-            },
-          ),
-        ),
+            }),
+          );
+          // Only past a slot this just gave away. An app being handed the one it already holds is
+          // every redeploy, and moving the cursor there would leave it wherever the last redeploy
+          // happened to be — which is as likely to sit on a freed slot as anywhere else.
+          if (taken.fresh) {
+            yield* Ref.set(cursorRef, taken.slot.slot + 1);
+          }
+          return taken.slot;
+        }),
 
       lookup: (appId: AppId) =>
         Effect.map(Ref.get(ref), (assignments) => withSlot({ assignments, appId })),
@@ -69,9 +95,13 @@ export class SlotAllocator extends Effect.Service<SlotAllocator>()('SlotAllocato
         [...assignments].map(([appId, slot]) => describeSlot({ slot, appId })),
       ),
 
-      persist: Effect.flatMap(Ref.get(ref), (assignments) =>
-        writeJsonFile({ path: config.slotsFile, value: Object.fromEntries(assignments) }),
-      ),
+      persist: Effect.gen(function* () {
+        const assignments = yield* Ref.get(ref);
+        yield* writeJsonFile({ path: config.slotsFile, value: Object.fromEntries(assignments) });
+        // After the slots, and never in place of them: a cursor written without them would point
+        // past allocations the next boot has no record of.
+        yield* writeJsonFile({ path: config.slotCursorFile, value: yield* Ref.get(cursorRef) });
+      }),
     };
   }),
   dependencies: [AgentConfig.Default],

--- a/apps/agent/tests/lib/network/allocator.test.ts
+++ b/apps/agent/tests/lib/network/allocator.test.ts
@@ -1,10 +1,18 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
 import { type AppId, AppIdSchema, HostPortSchema, Ipv4AddressSchema, Value } from '@repo/protocol';
 import { Effect, Either, Layer, Option } from 'effect';
-import { assignmentsFrom, readSlotRecords, type SlotRecords } from '#lib/network/allocator.ts';
+import {
+  assignmentsFrom,
+  readSlotCursor,
+  readSlotRecords,
+  type SlotRecords,
+} from '#lib/network/allocator.ts';
 import {
   describeSlot,
   EXTRA_PUBLIC_PORT_BASE,
+  FIRST_SLOT,
   HOST_PORT_BASE,
   SLOT_COUNT,
 } from '#lib/network/slot.ts';
@@ -85,17 +93,56 @@ describe('allocation is stable for the lifetime of an app', () => {
     expect(new Set(ports).size).toBe(DISTINCT_APPS.length);
   });
 
+  // Asserted against a full host rather than an empty one: the freed slot is then the only one
+  // left, so this says the pool grew back without saying which order it is drawn from.
   test('a released slot becomes available again', async () => {
     const [released, reused] = await withAllocator((allocator) =>
       Effect.gen(function* () {
-        const first = yield* allocator.allocate(app(1));
-        yield* allocator.release(app(1));
-        const gone = yield* allocator.lookup(app(1));
-        const next = yield* allocator.allocate(app(2));
-        return [Option.isNone(gone) ? first.slot : -1, next.slot];
+        yield* Effect.forEach(everySlot, (index) => allocator.allocate(app(index)), {
+          discard: true,
+        });
+        const freed = yield* allocator.allocate(app(SOME_SLOT));
+        yield* allocator.release(app(SOME_SLOT));
+        const gone = yield* allocator.lookup(app(SOME_SLOT));
+        const next = yield* allocator.allocate(app(BEYOND_THE_LAST_SLOT));
+        return [Option.isNone(gone) ? freed.slot : -1, next.slot];
       }).pipe(Effect.orDie),
     );
     expect(reused).toBe(released as number);
+  });
+
+  /**
+   * The address a tenant hands its own users is this slot's, and a slot handed straight back out
+   * is that address pointing at somebody else. Every other slot goes first, which on a host with
+   * room is every allocation between now and the cursor coming round.
+   */
+  test('a released slot is not the next one handed out', async () => {
+    const [released, next] = await withAllocator((allocator) =>
+      Effect.gen(function* () {
+        const first = yield* allocator.allocate(app(1));
+        yield* allocator.release(app(1));
+        const second = yield* allocator.allocate(app(2));
+        return [first.slot, second.slot];
+      }).pipe(Effect.orDie),
+    );
+    expect(next).not.toBe(released);
+  });
+
+  // A redeploy asks for a slot the app already holds. Moving the cursor there would park it
+  // wherever the busiest app happens to sit, and a slot freed beside it would go straight back out.
+  test('being handed the slot an app already holds does not move the cursor', async () => {
+    const [released, next] = await withAllocator((allocator) =>
+      Effect.gen(function* () {
+        const first = yield* allocator.allocate(app(1));
+        yield* allocator.allocate(app(2));
+        yield* allocator.release(app(2));
+        // The redeploy: app 1 asking again for the slot it never gave up.
+        yield* allocator.allocate(app(1));
+        const third = yield* allocator.allocate(app(3));
+        return [first.slot + 1, third.slot];
+      }).pipe(Effect.orDie),
+    );
+    expect(next).not.toBe(released);
   });
 
   test('running out of slots is a typed failure, not a silent reuse', async () => {
@@ -109,6 +156,36 @@ describe('allocation is stable for the lifetime of an app', () => {
     );
     expect(Either.isLeft(exhausted) && exhausted.left._tag).toBe('SlotExhausted');
   });
+});
+
+/**
+ * The cursor is a hint and the scan is the authority: it decides where to start looking, never
+ * what may be handed out. Nothing a file holds can make this give away a slot another app has.
+ */
+describe('a cursor read off disk cannot hand out a slot somebody holds', () => {
+  test('anything that is not a whole number starts at the first slot', () => {
+    expect(readSlotCursor(undefined)).toBe(FIRST_SLOT);
+    expect(readSlotCursor(null)).toBe(FIRST_SLOT);
+    expect(readSlotCursor('7')).toBe(FIRST_SLOT);
+    expect(readSlotCursor(1.5)).toBe(FIRST_SLOT);
+    expect(readSlotCursor(SOME_SLOT)).toBe(SOME_SLOT);
+  });
+
+  test.each([BEYOND_THE_LAST_SLOT, -BEYOND_THE_LAST_SLOT])(
+    'a cursor of %s still lands on a slot this host has',
+    async (cursor) => {
+      const file = join(tmpdir(), `nibrun-cursor-${cursor}.json`);
+      await Bun.write(file, JSON.stringify(cursor));
+      const slot = await provided(
+        SlotAllocator.DefaultWithoutDependencies.pipe(
+          Layer.provide(Layer.merge(agentConfig({ slotCursorFile: file }), platform)),
+        ),
+      )(Effect.flatMap(SlotAllocator, (allocator) => allocator.allocate(app(1))).pipe(Effect.orDie));
+
+      expect(slot.slot).toBeGreaterThanOrEqual(FIRST_SLOT);
+      expect(slot.slot).toBeLessThan(SLOT_COUNT);
+    },
+  );
 });
 
 describe('allocation survives an agent restart', () => {

--- a/apps/agent/tests/lib/network/allocator.test.ts
+++ b/apps/agent/tests/lib/network/allocator.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, test } from 'bun:test';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, test } from 'bun:test';
 import { type AppId, AppIdSchema, HostPortSchema, Ipv4AddressSchema, Value } from '@repo/protocol';
 import { Effect, Either, Layer, Option } from 'effect';
 import {
@@ -25,6 +25,12 @@ const BOUNDARY_SLOT = 64;
 const SOME_SLOT = 3;
 const DISTINCT_APPS = ['alpha', 'beta', 'gamma'];
 const BEYOND_THE_LAST_SLOT = 1_000;
+const NOT_A_WHOLE_NUMBER = 1.5;
+
+/** Where the cursor would sit had the slot just handed out moved it. */
+function wouldBeNext(slot: number): number {
+  return slot + 1;
+}
 const everySlot = [...Array(SLOT_COUNT).keys()];
 
 const run = provided(
@@ -133,13 +139,13 @@ describe('allocation is stable for the lifetime of an app', () => {
   test('being handed the slot an app already holds does not move the cursor', async () => {
     const [released, next] = await withAllocator((allocator) =>
       Effect.gen(function* () {
-        const first = yield* allocator.allocate(app(1));
-        yield* allocator.allocate(app(2));
-        yield* allocator.release(app(2));
-        // The redeploy: app 1 asking again for the slot it never gave up.
-        yield* allocator.allocate(app(1));
-        const third = yield* allocator.allocate(app(3));
-        return [first.slot + 1, third.slot];
+        const staying = yield* allocator.allocate(app('staying'));
+        yield* allocator.allocate(app('leaving'));
+        yield* allocator.release(app('leaving'));
+        // The redeploy: an app asking again for the slot it never gave up.
+        yield* allocator.allocate(app('staying'));
+        const arriving = yield* allocator.allocate(app('arriving'));
+        return [wouldBeNext(staying.slot), arriving.slot];
       }).pipe(Effect.orDie),
     );
     expect(next).not.toBe(released);
@@ -167,7 +173,7 @@ describe('a cursor read off disk cannot hand out a slot somebody holds', () => {
     expect(readSlotCursor(undefined)).toBe(FIRST_SLOT);
     expect(readSlotCursor(null)).toBe(FIRST_SLOT);
     expect(readSlotCursor('7')).toBe(FIRST_SLOT);
-    expect(readSlotCursor(1.5)).toBe(FIRST_SLOT);
+    expect(readSlotCursor(NOT_A_WHOLE_NUMBER)).toBe(FIRST_SLOT);
     expect(readSlotCursor(SOME_SLOT)).toBe(SOME_SLOT);
   });
 
@@ -180,7 +186,9 @@ describe('a cursor read off disk cannot hand out a slot somebody holds', () => {
         SlotAllocator.DefaultWithoutDependencies.pipe(
           Layer.provide(Layer.merge(agentConfig({ slotCursorFile: file }), platform)),
         ),
-      )(Effect.flatMap(SlotAllocator, (allocator) => allocator.allocate(app(1))).pipe(Effect.orDie));
+      )(
+        Effect.flatMap(SlotAllocator, (allocator) => allocator.allocate(app(1))).pipe(Effect.orDie),
+      );
 
       expect(slot.slot).toBeGreaterThanOrEqual(FIRST_SLOT);
       expect(slot.slot).toBeLessThan(SLOT_COUNT);

--- a/apps/agent/tests/support/config.ts
+++ b/apps/agent/tests/support/config.ts
@@ -4,9 +4,10 @@ import { AgentConfig } from '#services/agent-config.service.ts';
 
 export const HOST_STORAGE_PREFIX = Value.Parse(ObjectKeySchema, 'filesystems/host-1');
 
-/** `slotsFile` names a directory nothing creates: what a test persists never reaches a host. */
+/** The slot files name a directory nothing creates: what a test persists never reaches a host. */
 export const AGENT_CONFIG = {
   slotsFile: '/nonexistent/nibrun-test/slots.json',
+  slotCursorFile: '/nonexistent/nibrun-test/slot-cursor.json',
   zerofsStoragePrefix: HOST_STORAGE_PREFIX,
   zerofsMount: '/mnt/zerofs',
   zerofsNbdSocket: '/run/zerofs/nbd.sock',


### PR DESCRIPTION
A slot is released when its app's volume is torn down, and `firstFree` then took
the lowest free one — so the app created after a deletion inherited the deleted
app's port, and an address a tenant handed its own users answered for someone
else. A hostname could never do that: those are unique platform-wide and never
reissued, where this is a bare number from a range of 63.

The scan starts at a cursor and wraps, so a freed slot goes last rather than
first.

**Nothing changes shape.** The cursor lives in its own file beside `slots.json`,
which keeps its exact app-to-slot format — an agent either side of this reads it
the same way, and a rollback is safe. A host upgrading has no cursor file yet, so
its first allocation behaves exactly as today.

**The cursor cannot cause a bad allocation.** It says where to start looking; the
scan still only returns a slot nothing holds. `readSlotCursor` rejects anything
that is not a whole number, and the walk wraps, so a negative or out-of-range
value costs a different free slot rather than a wrong one — tested both ways, and
the wrapping test was mutation-checked to confirm it is not vacuous.

One existing test asserted the old order (`a released slot becomes available
again` allocated, released, and expected the same slot straight back). It now
asserts the intent — release it on a full host, where the freed slot is the only
one left — so it proves the pool grows back without pinning the order.