### PR TITLE
feat(api): a binary may be fetched from a url instead of uploaded

### DIFF
--- a/apps/api/src/db/migrations/0031_artifacts_remember_where_they_came_from.sql
+++ b/apps/api/src/db/migrations/0031_artifacts_remember_where_they_came_from.sql
@@ -1,0 +1,10 @@
+-- An artifact the api fetched rather than took delivery of. The bytes are addressed by their
+-- digest and named by the file at the end of the url, so neither of those says where they came
+-- from — and where they came from is the only part of such a deploy that could be repeated.
+--
+-- Null for every upload: nothing sent from a browser or a terminal has a url anyone else could
+-- follow. Never sent anywhere: a host is told a digest and a key, and this is the control plane's
+-- own record of where it found the bytes.
+
+ALTER TABLE nibrun.artifacts
+  ADD COLUMN original_file_url text;

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -398,6 +398,7 @@ export interface IInsertPendingArtifactResult {
     app_id: IArtifactsColumns["app_id"];
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: IArtifactsColumns["original_file_name"];
+    original_file_url: IArtifactsColumns["original_file_url"];
     /** Derived from the uuidv7 id; the moment the row was created. */
     created_at: Date;
 }
@@ -414,6 +415,7 @@ export interface ICompleteArtifactResult {
     object_key: NonNullable<IArtifactsColumns["object_key"]>;
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: IArtifactsColumns["original_file_name"];
+    original_file_url: IArtifactsColumns["original_file_url"];
     /** Derived from the uuidv7 id; the moment the row was created. */
     created_at: Date;
 }
@@ -428,6 +430,7 @@ export interface ISelectPendingArtifactResult {
     app_id: IArtifactsColumns["app_id"];
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: IArtifactsColumns["original_file_name"];
+    original_file_url: IArtifactsColumns["original_file_url"];
     /** Derived from the uuidv7 id; the moment the row was created. */
     created_at: Date;
 }
@@ -454,6 +457,7 @@ export interface ISelectArtifactsByAppResult {
     object_key: NonNullable<IArtifactsColumns["object_key"]>;
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: IArtifactsColumns["original_file_name"];
+    original_file_url: IArtifactsColumns["original_file_url"];
     /** Derived from the uuidv7 id; the moment the row was created. */
     created_at: Date;
 }
@@ -470,6 +474,7 @@ export interface ISelectArtifactByIdResult {
     object_key: NonNullable<IArtifactsColumns["object_key"]>;
     /** The name the binary was uploaded under; a content-addressed key carries none. */
     original_file_name: IArtifactsColumns["original_file_name"];
+    original_file_url: IArtifactsColumns["original_file_url"];
     /** Derived from the uuidv7 id; the moment the row was created. */
     created_at: Date;
 }
@@ -1021,6 +1026,7 @@ export interface IArtifactsColumns {
     /** Derived from the uuidv7 id; the moment the row was created. */
     created_at: Date;
     updated_at: Date;
+    original_file_url: string | null;
 }
 
 /** Schema of `artifacts`. */
@@ -1531,7 +1537,8 @@ export const schema = {
             object_key: { _columnName: "object_key", _foreignKeys: {} },
             original_file_name: { _columnName: "original_file_name", _foreignKeys: {} },
             created_at: { _columnName: "created_at", _foreignKeys: {} },
-            updated_at: { _columnName: "updated_at", _foreignKeys: {} }
+            updated_at: { _columnName: "updated_at", _foreignKeys: {} },
+            original_file_url: { _columnName: "original_file_url", _foreignKeys: {} }
         },
         _indexes: {
             artifacts_app_id_idx: { _indexName: "artifacts_app_id_idx" },

--- a/apps/api/src/lib/artifact-digest.ts
+++ b/apps/api/src/lib/artifact-digest.ts
@@ -20,6 +20,34 @@ const HEX_ENCODING = 'hex';
  */
 const HEADER_BYTES = 65_536;
 
+/** Raised into a stream rather than returned, because the reader is what has to stop. */
+export class ArtifactTooLargeError extends Error {}
+
+/**
+ * The stream, up to the point where what is left of it could not be stored anyway.
+ *
+ * It errors rather than ends: a truncated binary is not the binary that was asked for, and a
+ * reader that took it for one would store something nobody chose to deploy.
+ */
+export function cappedTo({
+  maxSizeBytes,
+}: {
+  maxSizeBytes: number;
+}): TransformStream<Uint8Array, Uint8Array> {
+  let sizeBytes = 0;
+  return new TransformStream<Uint8Array, Uint8Array>({
+    // biome-ignore lint/complexity/useMaxParams: a transform is handed what to pass it on to
+    transform(chunk, controller) {
+      sizeBytes += chunk.byteLength;
+      if (sizeBytes > maxSizeBytes) {
+        controller.error(new ArtifactTooLargeError());
+        return;
+      }
+      controller.enqueue(chunk);
+    },
+  });
+}
+
 export type ArtifactIdentity = {
   digest: Sha256Digest;
   sizeBytes: number;

--- a/apps/api/src/lib/artifact-digest.ts
+++ b/apps/api/src/lib/artifact-digest.ts
@@ -20,34 +20,6 @@ const HEX_ENCODING = 'hex';
  */
 const HEADER_BYTES = 65_536;
 
-/** Raised into a stream rather than returned, because the reader is what has to stop. */
-export class ArtifactTooLargeError extends Error {}
-
-/**
- * The stream, up to the point where what is left of it could not be stored anyway.
- *
- * It errors rather than ends: a truncated binary is not the binary that was asked for, and a
- * reader that took it for one would store something nobody chose to deploy.
- */
-export function cappedTo({
-  maxSizeBytes,
-}: {
-  maxSizeBytes: number;
-}): TransformStream<Uint8Array, Uint8Array> {
-  let sizeBytes = 0;
-  return new TransformStream<Uint8Array, Uint8Array>({
-    // biome-ignore lint/complexity/useMaxParams: a transform is handed what to pass it on to
-    transform(chunk, controller) {
-      sizeBytes += chunk.byteLength;
-      if (sizeBytes > maxSizeBytes) {
-        controller.error(new ArtifactTooLargeError());
-        return;
-      }
-      controller.enqueue(chunk);
-    },
-  });
-}
-
 export type ArtifactIdentity = {
   digest: Sha256Digest;
   sizeBytes: number;
@@ -95,6 +67,71 @@ function refuseChunk({
 }
 
 /**
+ * The inspection as it is made, a chunk at a time.
+ *
+ * Held apart from where the bytes come from because they come two ways: read back out of the store
+ * after an upload, or on their way into it from a url. Both reach the same verdict from the same
+ * pass; only who is pulling the chunks differs.
+ */
+function reading({ maxSizeBytes }: { maxSizeBytes: number }) {
+  const hasher = new Bun.CryptoHasher(DIGEST_ALGORITHM);
+  const header = new Uint8Array(HEADER_BYTES);
+  let headerLength = 0;
+  let sizeBytes = 0;
+
+  return {
+    /** Whatever this chunk already settles; `undefined` while the rest could still change it. */
+    take(chunk: Uint8Array): ArtifactInspection | undefined {
+      const wasComplete = headerLength === HEADER_BYTES;
+      if (!wasComplete) {
+        const taken = Math.min(chunk.byteLength, HEADER_BYTES - headerLength);
+        header.set(chunk.subarray(0, taken), headerLength);
+        headerLength += taken;
+      }
+      sizeBytes += chunk.byteLength;
+
+      const refusal = refuseChunk({
+        header,
+        headerLength,
+        headerJustFilled: !wasComplete && headerLength === HEADER_BYTES,
+        sizeBytes,
+        maxSizeBytes,
+      });
+      if (refusal) {
+        return refusal;
+      }
+
+      hasher.update(chunk);
+      return undefined;
+    },
+
+    /** What the bytes came to, once there are no more of them. */
+    verdict(): ArtifactInspection {
+      const read = header.subarray(0, headerLength);
+      // Shorter than the magic itself, so no chunk ever reached a verdict.
+      if (!isElfExecutable(read)) {
+        return { outcome: 'not-executable' };
+      }
+      if (headerLength < HEADER_BYTES) {
+        const refusal = refuseInterpreter(read);
+        if (refusal) {
+          return refusal;
+        }
+      }
+
+      const digest = Value.Parse(Sha256DigestSchema, hasher.digest(HEX_ENCODING));
+
+      return {
+        outcome: 'stored',
+        digest,
+        sizeBytes,
+        objectKey: Value.Parse(ObjectKeySchema, digest),
+      };
+    },
+  };
+}
+
+/**
  * The digest a host will verify, taken from the bytes the store now holds.
  *
  * An uploader-supplied digest could only ever fail out on the host, where it becomes a deploy
@@ -112,54 +149,63 @@ export async function inspectArtifact({
   stream: ReadableStream<Uint8Array>;
   maxSizeBytes: number;
 }): Promise<ArtifactInspection> {
-  const hasher = new Bun.CryptoHasher(DIGEST_ALGORITHM);
-  const header = new Uint8Array(HEADER_BYTES);
-  let headerLength = 0;
-  let sizeBytes = 0;
+  const read = reading({ maxSizeBytes });
 
   for await (const chunk of stream) {
-    const wasComplete = headerLength === HEADER_BYTES;
-    if (!wasComplete) {
-      const taken = Math.min(chunk.byteLength, HEADER_BYTES - headerLength);
-      header.set(chunk.subarray(0, taken), headerLength);
-      headerLength += taken;
-    }
-    sizeBytes += chunk.byteLength;
-
     // Leaving the loop cancels the read, so an object that can already be refused costs one
     // chunk rather than the whole of itself.
-    const refusal = refuseChunk({
-      header,
-      headerLength,
-      headerJustFilled: !wasComplete && headerLength === HEADER_BYTES,
-      sizeBytes,
-      maxSizeBytes,
-    });
-    if (refusal) {
-      return refusal;
-    }
-
-    hasher.update(chunk);
-  }
-
-  const read = header.subarray(0, headerLength);
-  // Shorter than the magic itself, so the loop above never reached a verdict.
-  if (!isElfExecutable(read)) {
-    return { outcome: 'not-executable' };
-  }
-  if (headerLength < HEADER_BYTES) {
-    const refusal = refuseInterpreter(read);
+    const refusal = read.take(chunk);
     if (refusal) {
       return refusal;
     }
   }
 
-  const digest = Value.Parse(Sha256DigestSchema, hasher.digest(HEX_ENCODING));
+  return read.verdict();
+}
 
-  return {
-    outcome: 'stored',
-    digest,
-    sizeBytes,
-    objectKey: Value.Parse(ObjectKeySchema, digest),
-  };
+/** What a refusal is raised as, so that whoever was writing the bytes stops and says why. */
+export class RefusedArtifactError extends Error {
+  readonly inspection: ArtifactInspection;
+
+  constructor(inspection: ArtifactInspection) {
+    super(`The bytes were refused: ${inspection.outcome}`);
+    this.inspection = inspection;
+  }
+}
+
+/**
+ * The same inspection, made of bytes on their way somewhere else.
+ *
+ * A pass-through rather than a second reader: the bytes are hashed as they are handed on, so one
+ * chunk is in hand at a time. Teeing the stream instead would have made the two readers race — the
+ * hash runs at memory speed and an upload does not — and everything the slower one had not reached
+ * would sit in a queue, which for a binary is the whole binary.
+ *
+ * A refusal errors the stream rather than ending it: whoever is writing has to stop where they
+ * are, and a half-written object is not something to mistake for what was asked for.
+ */
+export function inspectingPassThrough({ maxSizeBytes }: { maxSizeBytes: number }): {
+  through: TransformStream<Uint8Array, Uint8Array>;
+  inspection: Promise<ArtifactInspection>;
+} {
+  const read = reading({ maxSizeBytes });
+  const { promise, resolve } = Promise.withResolvers<ArtifactInspection>();
+
+  const through = new TransformStream<Uint8Array, Uint8Array>({
+    // biome-ignore lint/complexity/useMaxParams: a transform is handed what to pass it on to
+    transform(chunk, controller) {
+      const refusal = read.take(chunk);
+      if (refusal) {
+        resolve(refusal);
+        controller.error(new RefusedArtifactError(refusal));
+        return;
+      }
+      controller.enqueue(chunk);
+    },
+    flush() {
+      resolve(read.verdict());
+    },
+  });
+
+  return { through, inspection: promise };
 }

--- a/apps/api/src/lib/binary-url.ts
+++ b/apps/api/src/lib/binary-url.ts
@@ -1,0 +1,32 @@
+import { type Filename, FilenameSchema, Value } from '@repo/protocol';
+
+// Where a binary may be fetched from rather than uploaded. `https` alone: the api is what follows
+// this, and a plaintext hop is one where what the guest ends up running was chosen by whoever sat
+// between.
+//
+// The api's own, not the protocol's: a host is told a digest and a key, never where the bytes were
+// found, so this reaches nothing below the control plane.
+export const BINARY_URL_PATTERN = '^https://[^\\s]+$';
+export const MAX_BINARY_URL_LENGTH = 2048;
+
+/**
+ * What to call a binary nobody named: the last segment of the url's path, which is where a release
+ * host puts the file's own name. Undefined where that is not a name an export could carry — a url
+ * ending in a slash, or in something `FilenameSchema` refuses.
+ */
+export function filenameFromUrl(url: string): Filename | undefined {
+  const path = pathOf(url);
+  if (path === undefined) {
+    return undefined;
+  }
+  const segment = decodeURIComponent(path.split('/').at(-1) ?? '');
+  return Value.Check(FilenameSchema, segment) ? segment : undefined;
+}
+
+function pathOf(url: string): string | undefined {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/api/src/lib/binary-url.ts
+++ b/apps/api/src/lib/binary-url.ts
@@ -9,23 +9,60 @@ import { type Filename, FilenameSchema, Value } from '@repo/protocol';
 export const BINARY_URL_PATTERN = '^https://[^\\s]+$';
 export const MAX_BINARY_URL_LENGTH = 2048;
 
+const BINARY_URL = new RegExp(BINARY_URL_PATTERN);
+
+/**
+ * The rule the request body is held to, as something every later hop is held to as well: what the
+ * caller typed is only the first address fetched, and a redirect to a plaintext one is exactly the
+ * hop the rule exists to refuse.
+ */
+export function isBinaryUrl(url: string): boolean {
+  return url.length <= MAX_BINARY_URL_LENGTH && BINARY_URL.test(url);
+}
+
 /**
  * What to call a binary nobody named: the last segment of the url's path, which is where a release
  * host puts the file's own name. Undefined where that is not a name an export could carry — a url
  * ending in a slash, or in something `FilenameSchema` refuses.
  */
 export function filenameFromUrl(url: string): Filename | undefined {
-  const path = pathOf(url);
-  if (path === undefined) {
-    return undefined;
-  }
-  const segment = decodeURIComponent(path.split('/').at(-1) ?? '');
-  return Value.Check(FilenameSchema, segment) ? segment : undefined;
+  const segment = lastPathSegment(url);
+  return segment !== undefined && Value.Check(FilenameSchema, segment) ? segment : undefined;
 }
 
-function pathOf(url: string): string | undefined {
+/**
+ * The url with whatever a caller authenticated by taken out of it. This is the form that is written
+ * down and read back in errors, and a password kept forever in a row — or answered to a browser —
+ * is one nobody chose to store.
+ */
+export function withoutCredentials(url: string): string {
+  const parsed = parse(url);
+  if (parsed === undefined) {
+    return url;
+  }
+  parsed.username = '';
+  parsed.password = '';
+  return parsed.toString();
+}
+
+// Decoded because that is how a name with a space in it reaches the path. A malformed escape is a
+// url that names no file rather than one that throws: it arrived as a request body, and every
+// other shape of unusable url here is answered rather than raised.
+function lastPathSegment(url: string): string | undefined {
+  const parsed = parse(url);
+  if (parsed === undefined) {
+    return undefined;
+  }
   try {
-    return new URL(url).pathname;
+    return decodeURIComponent(parsed.pathname.split('/').at(-1) ?? '');
+  } catch {
+    return undefined;
+  }
+}
+
+function parse(url: string): URL | undefined {
+  try {
+    return new URL(url);
   } catch {
     return undefined;
   }

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -51,6 +51,14 @@ export class ConflictError extends AppError {
   }
 }
 
+/** The api is already carrying as much of this kind of work as it will at once. */
+export class TooManyRequestsError extends AppError {
+  constructor(message = 'Too Many Requests') {
+    super(StatusMap['Too Many Requests'], message);
+    this.name = 'TooManyRequestsError';
+  }
+}
+
 /** A host was asked something and said it could not answer it. */
 export class BadGatewayError extends AppError {
   constructor(message = 'Bad Gateway') {

--- a/apps/api/src/repositories/artifact-storage.repository.ts
+++ b/apps/api/src/repositories/artifact-storage.repository.ts
@@ -20,6 +20,7 @@ const UPLOAD_URL_TTL_SECONDS = 900;
 
 export abstract class ArtifactStorageRepositoryContract {
   abstract signUpload(input: { objectKey: ObjectKey; sizeBytes: number }): Promise<string>;
+  abstract write(input: { objectKey: ObjectKey; body: ReadableStream<Uint8Array> }): Promise<void>;
   abstract read(input: { objectKey: ObjectKey }): ReadableStream<Uint8Array>;
   abstract copy(input: { from: ObjectKey; to: ObjectKey }): Promise<void>;
   abstract exists(input: { objectKey: ObjectKey }): Promise<boolean>;
@@ -75,6 +76,33 @@ export class ArtifactStorageRepository implements ArtifactStorageRepositoryContr
       }),
       { expiresIn: UPLOAD_URL_TTL_SECONDS, signableHeaders: new Set(['content-length']) },
     );
+  }
+
+  /**
+   * The only way bytes reach a staging key without a signed url: the api fetched them itself, so
+   * it is the api that has to put them somewhere. Streamed for the same reason `copy` is — a
+   * binary held whole is memory this process is not sized for.
+   */
+  async write({
+    objectKey,
+    body,
+  }: {
+    objectKey: ObjectKey;
+    body: ReadableStream<Uint8Array>;
+  }): Promise<void> {
+    const writer = this.client.file(objectKey).writer({
+      type: ARTIFACT_CONTENT_TYPE,
+      retry: UPLOAD_RETRIES,
+    });
+    try {
+      for await (const chunk of body) {
+        await writer.write(chunk);
+      }
+      await writer.end();
+    } catch (failure) {
+      await abandon({ writer, failure });
+      throw failure;
+    }
   }
 
   read({ objectKey }: { objectKey: ObjectKey }): ReadableStream<Uint8Array> {

--- a/apps/api/src/repositories/artifact-storage.repository.ts
+++ b/apps/api/src/repositories/artifact-storage.repository.ts
@@ -79,9 +79,11 @@ export class ArtifactStorageRepository implements ArtifactStorageRepositoryContr
   }
 
   /**
-   * The only way bytes reach a staging key without a signed url: the api fetched them itself, so
-   * it is the api that has to put them somewhere. Streamed for the same reason `copy` is — a
-   * binary held whole is memory this process is not sized for.
+   * The only way bytes reach a key without a signed url: the api fetched them itself, or is moving
+   * what it already holds, so it is the api that has to put them somewhere.
+   *
+   * Streamed rather than buffered: this runs on an object as large as a whole binary, and holding
+   * one in memory is the cost that signing the upload away was meant to avoid.
    */
   async write({
     objectKey,
@@ -110,27 +112,12 @@ export class ArtifactStorageRepository implements ArtifactStorageRepositoryContr
   }
 
   /**
-   * Streamed rather than buffered: this runs on an object as large as a whole binary, and holding
-   * one in memory is the cost that signing the upload away was meant to avoid.
-   *
    * Nothing else writes the content-addressed namespace. That is what lets a key found there be
    * trusted without reading it again — the bytes under it were hashed by this process, on their
    * way to it.
    */
   async copy({ from, to }: { from: ObjectKey; to: ObjectKey }): Promise<void> {
-    const writer = this.client.file(to).writer({
-      type: ARTIFACT_CONTENT_TYPE,
-      retry: UPLOAD_RETRIES,
-    });
-    try {
-      for await (const chunk of this.client.file(from).stream()) {
-        await writer.write(chunk);
-      }
-      await writer.end();
-    } catch (failure) {
-      await abandon({ writer, failure });
-      throw failure;
-    }
+    await this.write({ objectKey: to, body: this.read({ objectKey: from }) });
   }
 
   exists({ objectKey }: { objectKey: ObjectKey }): Promise<boolean> {

--- a/apps/api/src/repositories/artifacts.repository.ts
+++ b/apps/api/src/repositories/artifacts.repository.ts
@@ -6,6 +6,15 @@ export type ArtifactRow = Queries['SelectArtifactById'];
 export type PendingArtifactRow = Queries['SelectPendingArtifact'];
 export type AbandonedArtifactRow = Queries['SelectAbandonedArtifacts'];
 
+export type InsertPendingArtifactInput = {
+  appId: AppId;
+  ownerId: OwnerId;
+  originalFileName: Filename;
+  // Only an artifact the api fetched has one, so the column it lands in is nullable and this is
+  // how a caller says the bytes were sent instead.
+  originalFileUrl: string | null;
+};
+
 export type CompleteArtifactInput = {
   appId: AppId;
   artifactId: ArtifactId;
@@ -16,11 +25,7 @@ export type CompleteArtifactInput = {
 };
 
 export abstract class ArtifactsRepositoryContract {
-  abstract insertPending(input: {
-    appId: AppId;
-    ownerId: OwnerId;
-    originalFileName: Filename;
-  }): Promise<PendingArtifactRow | null>;
+  abstract insertPending(input: InsertPendingArtifactInput): Promise<PendingArtifactRow | null>;
   abstract complete(input: CompleteArtifactInput): Promise<ArtifactRow | null>;
   abstract remove(input: { appId: AppId; artifactId: ArtifactId; ownerId: OwnerId }): Promise<void>;
   abstract findPending(input: {
@@ -47,17 +52,14 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
     appId,
     ownerId,
     originalFileName,
-  }: {
-    appId: AppId;
-    ownerId: OwnerId;
-    originalFileName: Filename;
-  }): Promise<PendingArtifactRow | null> {
+    originalFileUrl,
+  }: InsertPendingArtifactInput): Promise<PendingArtifactRow | null> {
     const [row] = await this.sql.InsertPendingArtifact`
-      INSERT INTO nibrun.artifacts (app_id, original_file_name)
-      SELECT a.id, ${originalFileName}
+      INSERT INTO nibrun.artifacts (app_id, original_file_name, original_file_url)
+      SELECT a.id, ${originalFileName}, ${originalFileUrl}
       FROM nibrun.live_apps a
       WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
-      RETURNING id, app_id, original_file_name, created_at
+      RETURNING id, app_id, original_file_name, original_file_url, created_at
     `;
     return row ?? null;
   }
@@ -84,7 +86,7 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
       WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.id = ar.app_id
         AND a.owner_id = ${ownerId} AND ar.digest IS NULL
       RETURNING ar.id, ar.app_id, ar.digest, ar.size_bytes, ar.object_key, ar.original_file_name,
-                ar.created_at
+                ar.original_file_url, ar.created_at
     `;
     return row ?? null;
   }
@@ -116,7 +118,7 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
     ownerId: OwnerId;
   }): Promise<PendingArtifactRow | null> {
     const [row] = await this.sql.SelectPendingArtifact`
-      SELECT ar.id, ar.app_id, ar.original_file_name, ar.created_at
+      SELECT ar.id, ar.app_id, ar.original_file_name, ar.original_file_url, ar.created_at
       FROM nibrun.artifacts ar
       JOIN nibrun.live_apps a ON a.id = ar.app_id
       WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.owner_id = ${ownerId}
@@ -160,7 +162,7 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
       /* @notNull size_bytes */
       /* @notNull object_key */
       SELECT ar.id, ar.app_id, ar.digest, ar.size_bytes, ar.object_key, ar.original_file_name,
-             ar.created_at
+             ar.original_file_url, ar.created_at
       FROM nibrun.artifacts ar
       JOIN nibrun.live_apps a ON a.id = ar.app_id
       WHERE ar.app_id = ${appId} AND a.owner_id = ${ownerId} AND ar.digest IS NOT NULL
@@ -182,7 +184,7 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
       /* @notNull size_bytes */
       /* @notNull object_key */
       SELECT ar.id, ar.app_id, ar.digest, ar.size_bytes, ar.object_key, ar.original_file_name,
-             ar.created_at
+             ar.original_file_url, ar.created_at
       FROM nibrun.artifacts ar
       JOIN nibrun.live_apps a ON a.id = ar.app_id
       WHERE ar.id = ${artifactId} AND ar.app_id = ${appId} AND a.owner_id = ${ownerId}

--- a/apps/api/src/repositories/binary-source.repository.ts
+++ b/apps/api/src/repositories/binary-source.repository.ts
@@ -1,3 +1,22 @@
+import { isBinaryUrl } from '#lib/binary-url.ts';
+
+/**
+ * The whole fetch rather than the connect alone: the signal stays with the body, so this is also
+ * what bounds a source that answers at once and then trickles. Long enough for the largest binary
+ * that may be stored coming over an ordinary link, and short enough that a source which stopped
+ * saying anything is a request that failed rather than one still being held.
+ */
+const FETCH_DEADLINE_MS = 300_000;
+
+/**
+ * A chain no longer than the ones release hosts actually serve — an address to a store, and the
+ * store to a region. Bounded because a chain that never ends is a fetch that never does.
+ */
+const MAX_REDIRECTS = 10;
+
+const FIRST_REDIRECT_STATUS = 300;
+const FIRST_ERROR_STATUS = 400;
+
 /**
  * A url the api was asked to fetch a binary from, opened but not read. The body is handed over as
  * a stream because a binary is the one thing here too large to hold: whoever asked for it decides
@@ -11,7 +30,21 @@ export type BinarySource =
   | { outcome: 'open'; body: ReadableStream<Uint8Array>; declaredSizeBytes: number | undefined }
   | { outcome: 'unreachable' }
   | { outcome: 'refused'; status: number }
-  | { outcome: 'empty' };
+  | { outcome: 'empty' }
+  | { outcome: 'insecure-redirect'; to: string }
+  | { outcome: 'too-many-redirects' };
+
+/**
+ * What a source failing part way through is raised as. Everything downstream of the fetch is this
+ * process and its own store, so a read that fails is the one failure in the chain that belongs to
+ * the url — and it is answered as the url's rather than as a fault of the api.
+ */
+export class InterruptedSourceError extends Error {
+  constructor(cause: unknown) {
+    super('The url stopped sending before the binary was whole.', { cause });
+    this.name = 'InterruptedSourceError';
+  }
+}
 
 export abstract class BinarySourceRepositoryContract {
   abstract open(input: { url: string }): Promise<BinarySource>;
@@ -19,42 +52,138 @@ export abstract class BinarySourceRepositoryContract {
 
 export class BinarySourceRepository implements BinarySourceRepositoryContract {
   /**
-   * Redirects are followed, which is what makes an ordinary release link work: every store that
-   * hosts one answers the address people share with a redirect to where the bytes actually are.
+   * Redirects are followed a hop at a time rather than by `fetch` itself, which is what makes the
+   * https rule mean anything: every store that hosts a release answers the address people share
+   * with a redirect, and a rule applied to the first address alone is one a `302` to plaintext
+   * walks straight around.
    */
   async open({ url }: { url: string }): Promise<BinarySource> {
-    const response = await this.get(url);
-    if (response === undefined) {
-      return { outcome: 'unreachable' };
-    }
-    if (!response.ok) {
-      return { outcome: 'refused', status: response.status };
-    }
-    if (response.body === null) {
-      return { outcome: 'empty' };
-    }
-    return {
-      outcome: 'open',
-      body: response.body,
-      declaredSizeBytes: declaredLength(response.headers),
-    };
-  }
+    const deadline = AbortSignal.timeout(FETCH_DEADLINE_MS);
+    let target = url;
 
-  /**
-   * A url that answers nothing is the ordinary failure here rather than a fault of this api: it
-   * was typed by whoever wrote the link, and only they can fix it. Undefined rather than the
-   * error, because what went wrong at the socket is not something to read back to them.
-   */
-  private async get(url: string): Promise<Response | undefined> {
-    try {
-      return await fetch(url, { redirect: 'follow' });
-    } catch {
-      return undefined;
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      const response = await get({ url: target, deadline });
+      if (response === undefined) {
+        return { outcome: 'unreachable' };
+      }
+      const location = redirectTarget({ response, from: target });
+      if (location === undefined) {
+        return await answered(response);
+      }
+      await discard(response);
+      if (!isBinaryUrl(location)) {
+        return { outcome: 'insecure-redirect', to: location };
+      }
+      target = location;
     }
+
+    return { outcome: 'too-many-redirects' };
   }
 }
 
+/**
+ * A url that answers nothing is the ordinary failure here rather than a fault of this api: it was
+ * typed by whoever wrote the link, and only they can fix it. Undefined rather than the error,
+ * because what went wrong at the socket is not something to read back to them.
+ */
+async function get({
+  url,
+  deadline,
+}: {
+  url: string;
+  deadline: AbortSignal;
+}): Promise<Response | undefined> {
+  try {
+    return await fetch(url, { redirect: 'manual', signal: deadline });
+  } catch {
+    return undefined;
+  }
+}
+
+async function answered(response: Response): Promise<BinarySource> {
+  if (!response.ok) {
+    await discard(response);
+    return { outcome: 'refused', status: response.status };
+  }
+  if (response.body === null) {
+    return { outcome: 'empty' };
+  }
+  return {
+    outcome: 'open',
+    body: saidAsTheSource(response.body),
+    declaredSizeBytes: declaredLength(response.headers),
+  };
+}
+
+/**
+ * Where a redirect points, resolved against the address that answered with it. Any 3xx carrying a
+ * `location` counts: what makes one a hop worth following is that a host named somewhere else to
+ * look, not which of the five statuses it chose to say so with.
+ */
+function redirectTarget({
+  response,
+  from,
+}: {
+  response: Response;
+  from: string;
+}): string | undefined {
+  const location = response.headers.get('location');
+  if (location === null || !isRedirect(response.status)) {
+    return undefined;
+  }
+  try {
+    return new URL(location, from).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function isRedirect(status: number): boolean {
+  return status >= FIRST_REDIRECT_STATUS && status < FIRST_ERROR_STATUS;
+}
+
+/** A body nobody is going to read holds its connection open until it is let go of. */
+async function discard(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    return;
+  }
+}
+
+/**
+ * The body as a stream that says whose failure a failure was. What reads it is the same code that
+ * reads an object back out of the store, and a socket that dropped part way through is the one
+ * thing in that chain nibrun is not the one to answer for.
+ */
+function saidAsTheSource(body: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  const reader = body.getReader();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (failure) {
+        controller.error(new InterruptedSourceError(failure));
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+// A header that is absent is not a length of zero, and `Number(null)` is — so the header is read
+// before it is coerced.
 function declaredLength(headers: Headers): number | undefined {
-  const declared = Number(headers.get('content-length'));
-  return Number.isInteger(declared) && declared >= 0 ? declared : undefined;
+  const declared = headers.get('content-length');
+  if (declared === null || declared.trim() === '') {
+    return undefined;
+  }
+  const length = Number(declared);
+  return Number.isInteger(length) && length >= 0 ? length : undefined;
 }

--- a/apps/api/src/repositories/binary-source.repository.ts
+++ b/apps/api/src/repositories/binary-source.repository.ts
@@ -1,0 +1,60 @@
+/**
+ * A url the api was asked to fetch a binary from, opened but not read. The body is handed over as
+ * a stream because a binary is the one thing here too large to hold: whoever asked for it decides
+ * where the bytes go, and they go there as they arrive.
+ *
+ * `declaredSizeBytes` is the source's word about its own length, absent where it gave none — a
+ * chunked response, or a host that does not say. It is worth having anyway: it is what lets an
+ * object too large to store be refused before a byte of it is fetched.
+ */
+export type BinarySource =
+  | { outcome: 'open'; body: ReadableStream<Uint8Array>; declaredSizeBytes: number | undefined }
+  | { outcome: 'unreachable' }
+  | { outcome: 'refused'; status: number }
+  | { outcome: 'empty' };
+
+export abstract class BinarySourceRepositoryContract {
+  abstract open(input: { url: string }): Promise<BinarySource>;
+}
+
+export class BinarySourceRepository implements BinarySourceRepositoryContract {
+  /**
+   * Redirects are followed, which is what makes an ordinary release link work: every store that
+   * hosts one answers the address people share with a redirect to where the bytes actually are.
+   */
+  async open({ url }: { url: string }): Promise<BinarySource> {
+    const response = await this.get(url);
+    if (response === undefined) {
+      return { outcome: 'unreachable' };
+    }
+    if (!response.ok) {
+      return { outcome: 'refused', status: response.status };
+    }
+    if (response.body === null) {
+      return { outcome: 'empty' };
+    }
+    return {
+      outcome: 'open',
+      body: response.body,
+      declaredSizeBytes: declaredLength(response.headers),
+    };
+  }
+
+  /**
+   * A url that answers nothing is the ordinary failure here rather than a fault of this api: it
+   * was typed by whoever wrote the link, and only they can fix it. Undefined rather than the
+   * error, because what went wrong at the socket is not something to read back to them.
+   */
+  private async get(url: string): Promise<Response | undefined> {
+    try {
+      return await fetch(url, { redirect: 'follow' });
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+function declaredLength(headers: Headers): number | undefined {
+  const declared = Number(headers.get('content-length'));
+  return Number.isInteger(declared) && declared >= 0 ? declared : undefined;
+}

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
@@ -26,18 +26,24 @@ export const AppsAppIdArtifactsController = new Elysia()
       response: { [StatusMap.OK]: ListArtifactsResponseSchema },
     },
   )
-  // Created rather than OK: the artifact exists from here on, and the upload it is waiting for is
-  // what the response says where to send.
+  // Created rather than OK: the artifact exists from here on. What is left to do with it is what
+  // differs — an upload is told where to send the bytes, while a url has already been followed by
+  // the time this answers, and the request the caller is waiting on is the one that fetched it.
   .post(
     '/apps/:appId/artifacts',
     async ({ artifactsService, params, body, user, status }) => {
-      const upload = await artifactsService.create({
-        appId: Value.Parse(AppIdSchema, params.appId),
-        ownerId: Value.Parse(OwnerIdSchema, user.id),
-        filename: body.filename,
-        sizeBytes: body.sizeBytes,
-      });
-      return status(StatusMap.Created, upload);
+      const appId = Value.Parse(AppIdSchema, params.appId);
+      const ownerId = Value.Parse(OwnerIdSchema, user.id);
+      const created =
+        'url' in body
+          ? await artifactsService.createFromUrl({ appId, ownerId, url: body.url })
+          : await artifactsService.create({
+              appId,
+              ownerId,
+              filename: body.filename,
+              sizeBytes: body.sizeBytes,
+            });
+      return status(StatusMap.Created, created);
     },
     {
       body: CreateArtifactBodySchema,

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
@@ -1,21 +1,40 @@
 import { ArtifactIdSchema, ArtifactSchema, ByteSizeSchema, FilenameSchema } from '@repo/protocol';
 import { t } from 'elysia';
+import { BINARY_URL_PATTERN, MAX_BINARY_URL_LENGTH } from '#lib/binary-url.ts';
 
-// The name is the caller's, not the store's: a content-addressed key carries none, and this is
-// what a host writes into an export archive. Refused here as a shape rather than sanitised into
-// a different name — see FilenameSchema.
+// The bytes the caller holds. The name is theirs, not the store's: a content-addressed key carries
+// none, and this is what a host writes into an export archive. Refused here as a shape rather than
+// sanitised into a different name — see FilenameSchema.
 //
 // The size is answered before anything is signed, and then signed into the url: the store holds
 // the upload to exactly it.
-export const CreateArtifactBodySchema = t.Object({
+const UploadedBinarySchema = t.Object({
   filename: FilenameSchema,
   sizeBytes: ByteSizeSchema,
 });
 
-export const CreateArtifactResponseSchema = t.Object({
+// Bytes the caller does not hold: no name and no size, because the api is the one fetching and so
+// the one that finds out how large the binary is and what the file at the end of the url is called.
+const FetchedBinarySchema = t.Object({
+  url: t.String({
+    description: 'Public https url the api fetches the binary from.',
+    pattern: BINARY_URL_PATTERN,
+    maxLength: MAX_BINARY_URL_LENGTH,
+  }),
+});
+
+// Where the binary is, however that is answered. One request either way: what differs is who ends
+// up moving the bytes, which is not a different thing to have asked for.
+export const CreateArtifactBodySchema = t.Union([UploadedBinarySchema, FetchedBinarySchema]);
+
+const StagedUploadSchema = t.Object({
   artifactId: ArtifactIdSchema,
   url: t.String({ description: 'Where to PUT the binary, as the whole request body.' }),
 });
+
+// Somewhere to send bytes, or the artifact those bytes already made. A caller knows which it is
+// owed by what it asked for, and `digest` is what tells them apart in the hand.
+export const CreateArtifactResponseSchema = t.Union([StagedUploadSchema, ArtifactSchema]);
 
 // Said by the only end that knows: the upload happened between the caller and the store, so the
 // api learns how it went by being told.

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -8,7 +8,13 @@ import {
   type OwnerId,
   Value,
 } from '@repo/protocol';
-import { type ArtifactInspection, inspectArtifact } from '#lib/artifact-digest.ts';
+import {
+  type ArtifactInspection,
+  ArtifactTooLargeError,
+  cappedTo,
+  inspectArtifact,
+} from '#lib/artifact-digest.ts';
+import { filenameFromUrl } from '#lib/binary-url.ts';
 import { BadRequestError, NotFoundError } from '#lib/errors.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
 import type { AppsRepositoryContract } from '#repositories/apps.repository.ts';
@@ -17,6 +23,10 @@ import type {
   ArtifactRow,
   ArtifactsRepositoryContract,
 } from '#repositories/artifacts.repository.ts';
+import type {
+  BinarySource,
+  BinarySourceRepositoryContract,
+} from '#repositories/binary-source.repository.ts';
 import { Service } from '#services/service.ts';
 
 // An app the caller does not own has to be indistinguishable from one that does not exist: a
@@ -25,6 +35,9 @@ const NO_SUCH_APP = 'App not found.';
 const NO_SUCH_ARTIFACT = 'Artifact not found.';
 const NO_SUCH_UPLOAD = 'No upload is awaiting that artifact.';
 const NOTHING_UPLOADED = 'Nothing was uploaded against that artifact.';
+const UNNAMED_BINARY =
+  "The url has to end in the binary's own name, as a release download does: .../my-server";
+const NOTHING_FETCHED = 'The url answered with no body.';
 const NOT_AN_EXECUTABLE = 'The artifact is not a Linux executable.';
 
 const BYTES_PER_MEBIBYTE = 1_048_576;
@@ -41,6 +54,19 @@ const MAX_ARTIFACT_MEBIBYTES = 256;
  */
 export const MAX_ARTIFACT_SIZE_BYTES = MAX_ARTIFACT_MEBIBYTES * BYTES_PER_MEBIBYTE;
 const TOO_LARGE = `A binary may be at most ${MAX_ARTIFACT_MEBIBYTES} MB.`;
+
+/**
+ * A url that answers nothing, said with the url in it. The api reaches it from where the api runs
+ * rather than from where the link was followed, so a host only the caller's own network can see is
+ * a url that works everywhere they tried it and nowhere this runs.
+ */
+function unreachable(url: string): string {
+  return `The url could not be reached from nibrun: ${url}`;
+}
+
+function refusedBy({ url, status }: { url: string; status: number }): string {
+  return `The url answered ${status}, so there was nothing to deploy: ${url}`;
+}
 
 function unsupportedInterpreter(interpreter: string): string {
   return `The artifact needs the dynamic loader at ${interpreter}, which the guest does not have. Link it against /lib64/ld-linux-x86-64.so.2, or compile it static.`;
@@ -92,20 +118,24 @@ function toArtifact(row: ArtifactRow): Artifact {
 export class ArtifactsService extends Service {
   private readonly artifactsRepo: ArtifactsRepositoryContract;
   private readonly storageRepo: ArtifactStorageRepositoryContract;
+  private readonly sourceRepo: BinarySourceRepositoryContract;
   private readonly appsRepo: AppOwnership;
 
   constructor({
     artifactsRepo,
     storageRepo,
+    sourceRepo,
     appsRepo,
   }: {
     artifactsRepo: ArtifactsRepositoryContract;
     storageRepo: ArtifactStorageRepositoryContract;
+    sourceRepo: BinarySourceRepositoryContract;
     appsRepo: AppOwnership;
   }) {
     super();
     this.artifactsRepo = artifactsRepo;
     this.storageRepo = storageRepo;
+    this.sourceRepo = sourceRepo;
     this.appsRepo = appsRepo;
   }
 
@@ -142,6 +172,7 @@ export class ArtifactsService extends Service {
       appId,
       ownerId,
       originalFileName: filename,
+      originalFileUrl: null,
     });
     if (!pending) {
       throw new NotFoundError(NO_SUCH_APP);
@@ -192,6 +223,118 @@ export class ArtifactsService extends Service {
       stream: this.storageRepo.read({ objectKey: staged }),
       maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES,
     });
+
+    return await this.promote({ appId, artifactId, ownerId, staged, inspection });
+  }
+
+  /**
+   * The bytes fetched instead of sent, which is the only way some of them can arrive at all: a
+   * release asset is served by a store that answers no cross-origin request, so a browser cannot
+   * read one to upload it. It is also the shorter path — the api holds the bytes once, on their
+   * way past, rather than reading back what a caller already sent.
+   *
+   * Hashed on that same pass. The stream is teed, so what is written to the staging key and what
+   * decides whether it is an artifact at all are one read of the source.
+   */
+  async createFromUrl({
+    appId,
+    ownerId,
+    url,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    url: string;
+  }): Promise<Artifact> {
+    if (!(await this.appsRepo.isOwnedBy({ appId, ownerId }))) {
+      throw new NotFoundError(NO_SUCH_APP);
+    }
+
+    // The name a host writes into an export comes from the url, because nobody else is here to
+    // give one. A url that ends in no name at all is refused before it is fetched.
+    const filename = filenameFromUrl(url);
+    if (filename === undefined) {
+      throw new BadRequestError(UNNAMED_BINARY);
+    }
+
+    const source = await this.sourceRepo.open({ url });
+    if (source.outcome !== 'open') {
+      throw new BadRequestError(sourceRefusal({ url, source }));
+    }
+    if (
+      source.declaredSizeBytes !== undefined &&
+      source.declaredSizeBytes > MAX_ARTIFACT_SIZE_BYTES
+    ) {
+      throw new BadRequestError(TOO_LARGE);
+    }
+
+    const pending = await this.artifactsRepo.insertPending({
+      appId,
+      ownerId,
+      originalFileName: filename,
+      originalFileUrl: url,
+    });
+    if (!pending) {
+      throw new NotFoundError(NO_SUCH_APP);
+    }
+
+    const staged = stagingKey({ appId, artifactId: pending.id });
+    const inspection = await this.stage({ staged, body: source.body });
+
+    return await this.promote({ appId, artifactId: pending.id, ownerId, staged, inspection });
+  }
+
+  /**
+   * The source read once, into the staging key and into the inspection at the same time.
+   *
+   * Capped before it is teed rather than by the inspection alone: a refusal only stops the branch
+   * that reached it, and the branch still writing would otherwise spend a bucket on however much
+   * a url that lied about its length cares to send.
+   */
+  private async stage({
+    staged,
+    body,
+  }: {
+    staged: ObjectKey;
+    body: ReadableStream<Uint8Array>;
+  }): Promise<ArtifactInspection> {
+    const [stored, inspected] = body
+      .pipeThrough(cappedTo({ maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES }))
+      .tee();
+    try {
+      const [, inspection] = await Promise.all([
+        this.storageRepo.write({ objectKey: staged, body: stored }),
+        inspectArtifact({ stream: inspected, maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES }),
+      ]);
+      return inspection;
+    } catch (failure) {
+      // One branch failing leaves the other reading a source nothing will consume, so both are
+      // let go of before the failure is anybody else's.
+      await Promise.allSettled([stored.cancel(), inspected.cancel()]);
+      if (failure instanceof ArtifactTooLargeError) {
+        return { outcome: 'too-large' };
+      }
+      throw failure;
+    }
+  }
+
+  /**
+   * The staged bytes as the artifact they turned out to be, which is the same last step whether
+   * they were uploaded or fetched: what the inspection settled is written down, the bytes are put
+   * where their digest says, and the slot they came through is given up.
+   */
+  private async promote({
+    appId,
+    artifactId,
+    ownerId,
+    staged,
+    inspection,
+  }: {
+    appId: AppId;
+    artifactId: ArtifactId;
+    ownerId: OwnerId;
+    staged: ObjectKey;
+    inspection: ArtifactInspection;
+  }): Promise<Artifact> {
     if (inspection.outcome !== 'stored') {
       await this.abandon({ appId, artifactId, ownerId });
       throw new BadRequestError(refusalMessage(inspection));
@@ -302,6 +445,24 @@ export class ArtifactsService extends Service {
     } catch (error) {
       this.logger.warn('a staged upload could not be removed', { objectKey, error });
     }
+  }
+}
+
+/** Why the url gave nothing to store, in the terms of whoever wrote the link. */
+function sourceRefusal({
+  url,
+  source,
+}: {
+  url: string;
+  source: Exclude<BinarySource, { outcome: 'open' }>;
+}): string {
+  switch (source.outcome) {
+    case 'unreachable':
+      return unreachable(url);
+    case 'refused':
+      return refusedBy({ url, status: source.status });
+    case 'empty':
+      return NOTHING_FETCHED;
   }
 }
 

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -10,9 +10,9 @@ import {
 } from '@repo/protocol';
 import {
   type ArtifactInspection,
-  ArtifactTooLargeError,
-  cappedTo,
   inspectArtifact,
+  inspectingPassThrough,
+  RefusedArtifactError,
 } from '#lib/artifact-digest.ts';
 import { filenameFromUrl } from '#lib/binary-url.ts';
 import { BadRequestError, NotFoundError } from '#lib/errors.ts';
@@ -284,11 +284,11 @@ export class ArtifactsService extends Service {
   }
 
   /**
-   * The source read once, into the staging key and into the inspection at the same time.
+   * The source written to the staging key and inspected on the way through, which is one read of
+   * it and one chunk in hand at a time. The upload the store is making is what holds the rest.
    *
-   * Capped before it is teed rather than by the inspection alone: a refusal only stops the branch
-   * that reached it, and the branch still writing would otherwise spend a bucket on however much
-   * a url that lied about its length cares to send.
+   * A refusal reaches this as the write failing, because that is what it did: the inspection
+   * errored the stream under it rather than letting a binary nobody will deploy finish arriving.
    */
   private async stage({
     staged,
@@ -297,24 +297,22 @@ export class ArtifactsService extends Service {
     staged: ObjectKey;
     body: ReadableStream<Uint8Array>;
   }): Promise<ArtifactInspection> {
-    const [stored, inspected] = body
-      .pipeThrough(cappedTo({ maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES }))
-      .tee();
+    const { through, inspection } = inspectingPassThrough({
+      maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES,
+    });
+
     try {
-      const [, inspection] = await Promise.all([
-        this.storageRepo.write({ objectKey: staged, body: stored }),
-        inspectArtifact({ stream: inspected, maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES }),
-      ]);
-      return inspection;
+      await this.storageRepo.write({ objectKey: staged, body: body.pipeThrough(through) });
     } catch (failure) {
-      // One branch failing leaves the other reading a source nothing will consume, so both are
-      // let go of before the failure is anybody else's.
-      await Promise.allSettled([stored.cancel(), inspected.cancel()]);
-      if (failure instanceof ArtifactTooLargeError) {
-        return { outcome: 'too-large' };
+      if (failure instanceof RefusedArtifactError) {
+        return failure.inspection;
       }
+      // The source stopped or the store did, and neither is a verdict on the binary — so the
+      // inspection is never awaited here: nothing ended the stream, and nothing will settle it.
       throw failure;
     }
+
+    return await inspection;
   }
 
   /**

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -14,8 +14,8 @@ import {
   inspectingPassThrough,
   RefusedArtifactError,
 } from '#lib/artifact-digest.ts';
-import { filenameFromUrl } from '#lib/binary-url.ts';
-import { BadRequestError, NotFoundError } from '#lib/errors.ts';
+import { filenameFromUrl, withoutCredentials } from '#lib/binary-url.ts';
+import { BadRequestError, NotFoundError, TooManyRequestsError } from '#lib/errors.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
 import type { AppsRepositoryContract } from '#repositories/apps.repository.ts';
 import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
@@ -23,9 +23,10 @@ import type {
   ArtifactRow,
   ArtifactsRepositoryContract,
 } from '#repositories/artifacts.repository.ts';
-import type {
-  BinarySource,
-  BinarySourceRepositoryContract,
+import {
+  type BinarySource,
+  type BinarySourceRepositoryContract,
+  InterruptedSourceError,
 } from '#repositories/binary-source.repository.ts';
 import { Service } from '#services/service.ts';
 
@@ -38,7 +39,18 @@ const NOTHING_UPLOADED = 'Nothing was uploaded against that artifact.';
 const UNNAMED_BINARY =
   "The url has to end in the binary's own name, as a release download does: .../my-server";
 const NOTHING_FETCHED = 'The url answered with no body.';
+const TOO_MANY_REDIRECTS = 'The url redirected more times than nibrun will follow.';
 const NOT_AN_EXECUTABLE = 'The artifact is not a Linux executable.';
+
+/**
+ * A binary being fetched passes through this process, which is the cost signing an upload away was
+ * meant to avoid paying — so how many may be in flight at once is a number rather than whatever a
+ * caller starts. Refused rather than queued: a caller told to come back has a request that ended,
+ * while one held in a queue is one more transfer this end is carrying while it waits.
+ */
+export const MAX_CONCURRENT_FETCHES = 8;
+const TOO_MANY_FETCHES =
+  'nibrun is fetching as many binaries as it will at once. Try again in a moment.';
 
 const BYTES_PER_MEBIBYTE = 1_048_576;
 const MAX_ARTIFACT_MEBIBYTES = 256;
@@ -66,6 +78,19 @@ function unreachable(url: string): string {
 
 function refusedBy({ url, status }: { url: string; status: number }): string {
   return `The url answered ${status}, so there was nothing to deploy: ${url}`;
+}
+
+/**
+ * The hop that was refused rather than the address that was typed: a redirect out of https is one
+ * the caller never saw, and naming it is the difference between a link they can fix and a fetch
+ * that failed for no reason they can see.
+ */
+function insecureRedirect(to: string): string {
+  return `The url redirected to ${withoutCredentials(to)}, which is not an https address nibrun will follow.`;
+}
+
+function interruptedSource(url: string): string {
+  return `The url stopped sending before the binary was whole: ${url}`;
 }
 
 function unsupportedInterpreter(interpreter: string): string {
@@ -120,6 +145,7 @@ export class ArtifactsService extends Service {
   private readonly storageRepo: ArtifactStorageRepositoryContract;
   private readonly sourceRepo: BinarySourceRepositoryContract;
   private readonly appsRepo: AppOwnership;
+  private fetchesInFlight = 0;
 
   constructor({
     artifactsRepo,
@@ -233,8 +259,8 @@ export class ArtifactsService extends Service {
    * read one to upload it. It is also the shorter path — the api holds the bytes once, on their
    * way past, rather than reading back what a caller already sent.
    *
-   * Hashed on that same pass. The stream is teed, so what is written to the staging key and what
-   * decides whether it is an artifact at all are one read of the source.
+   * Hashed on that same pass: the bytes are inspected as they are handed to the store, so what is
+   * written to the staging key and what decides whether it is an artifact at all are one read.
    */
   async createFromUrl({
     appId,
@@ -255,15 +281,47 @@ export class ArtifactsService extends Service {
     if (filename === undefined) {
       throw new BadRequestError(UNNAMED_BINARY);
     }
+    if (this.fetchesInFlight >= MAX_CONCURRENT_FETCHES) {
+      throw new TooManyRequestsError(TOO_MANY_FETCHES);
+    }
+
+    this.fetchesInFlight += 1;
+    try {
+      return await this.fetchInto({ appId, ownerId, url, filename });
+    } finally {
+      this.fetchesInFlight -= 1;
+    }
+  }
+
+  /**
+   * The url opened and made an artifact of, with the slot it is counted against already taken.
+   *
+   * What is written down and said back is the url without whatever a caller authenticated by: the
+   * bytes are fetched with the address as it was given, and a token in it belongs to that fetch
+   * rather than to a row that outlives it.
+   */
+  private async fetchInto({
+    appId,
+    ownerId,
+    url,
+    filename,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    url: string;
+    filename: Filename;
+  }): Promise<Artifact> {
+    const said = withoutCredentials(url);
 
     const source = await this.sourceRepo.open({ url });
     if (source.outcome !== 'open') {
-      throw new BadRequestError(sourceRefusal({ url, source }));
+      throw new BadRequestError(sourceRefusal({ url: said, source }));
     }
     if (
       source.declaredSizeBytes !== undefined &&
       source.declaredSizeBytes > MAX_ARTIFACT_SIZE_BYTES
     ) {
+      await release(source.body);
       throw new BadRequestError(TOO_LARGE);
     }
 
@@ -271,16 +329,57 @@ export class ArtifactsService extends Service {
       appId,
       ownerId,
       originalFileName: filename,
-      originalFileUrl: url,
+      originalFileUrl: said,
     });
     if (!pending) {
+      await release(source.body);
       throw new NotFoundError(NO_SUCH_APP);
     }
 
     const staged = stagingKey({ appId, artifactId: pending.id });
-    const inspection = await this.stage({ staged, body: source.body });
+    const inspection = await this.stageOrGiveUp({
+      appId,
+      artifactId: pending.id,
+      ownerId,
+      staged,
+      body: source.body,
+      url: said,
+    });
 
     return await this.promote({ appId, artifactId: pending.id, ownerId, staged, inspection });
+  }
+
+  /**
+   * The staging write, with the row taken back whichever way it fails: somebody who is going to
+   * follow the same link again should not have to find what the last attempt left behind.
+   *
+   * A source that stopped part way is the caller's link rather than this api, and is answered as
+   * such — every other way this url could be unusable already is.
+   */
+  private async stageOrGiveUp({
+    appId,
+    artifactId,
+    ownerId,
+    staged,
+    body,
+    url,
+  }: {
+    appId: AppId;
+    artifactId: ArtifactId;
+    ownerId: OwnerId;
+    staged: ObjectKey;
+    body: ReadableStream<Uint8Array>;
+    url: string;
+  }): Promise<ArtifactInspection> {
+    try {
+      return await this.stage({ staged, body });
+    } catch (failure) {
+      await this.abandon({ appId, artifactId, ownerId });
+      if (failure instanceof InterruptedSourceError) {
+        throw new BadRequestError(interruptedSource(url));
+      }
+      throw failure;
+    }
   }
 
   /**
@@ -461,6 +560,19 @@ function sourceRefusal({
       return refusedBy({ url, status: source.status });
     case 'empty':
       return NOTHING_FETCHED;
+    case 'insecure-redirect':
+      return insecureRedirect(source.to);
+    case 'too-many-redirects':
+      return TOO_MANY_REDIRECTS;
+  }
+}
+
+/** A body nobody is going to read holds its connection open until it is let go of. */
+async function release(body: ReadableStream<Uint8Array>): Promise<void> {
+  try {
+    await body.cancel();
+  } catch {
+    return;
   }
 }
 

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -12,6 +12,7 @@ import { AppsRepository } from '#repositories/apps.repository.ts';
 import { ArtifactStorageRepository } from '#repositories/artifact-storage.repository.ts';
 import { ArtifactsRepository } from '#repositories/artifacts.repository.ts';
 import { AssetsRepository } from '#repositories/assets.repository.ts';
+import { BinarySourceRepository } from '#repositories/binary-source.repository.ts';
 import { CustomHostnamesRepository } from '#repositories/custom-hostnames.repository.ts';
 import { DeploymentsRepository } from '#repositories/deployments.repository.ts';
 import { ExportStorageRepository } from '#repositories/export-storage.repository.ts';
@@ -59,6 +60,7 @@ const artifactStorageRepository = new ArtifactStorageRepository({
   signer: artifactsSigner,
   bucket: env.ARTIFACTS_BUCKET,
 });
+const binarySourceRepository = new BinarySourceRepository();
 const exportsRepository = new ExportsRepository(sql);
 const exportStorageRepository = new ExportStorageRepository(exportsS3);
 const customHostnamesRepository = new CustomHostnamesRepository(cloudflareClient);
@@ -96,6 +98,7 @@ const filesystemService = new FilesystemService({ deploymentsRepo: deploymentsRe
 const artifactsService = new ArtifactsService({
   artifactsRepo: artifactsRepository,
   storageRepo: artifactStorageRepository,
+  sourceRepo: binarySourceRepository,
   appsRepo: appsRepository,
 });
 const agentService = new AgentService({

--- a/apps/api/tests/controllers/artifacts.test.ts
+++ b/apps/api/tests/controllers/artifacts.test.ts
@@ -34,6 +34,12 @@ describe('an app is not somewhere strangers can read from or write to', () => {
     expect(response.status).toBe(StatusMap.Unauthorized);
   });
 
+  test('asking for a binary at a url to be fetched requires a session', async () => {
+    const response = await create({ url: 'https://releases.test/my-server' });
+
+    expect(response.status).toBe(StatusMap.Unauthorized);
+  });
+
   test('saying how an upload went requires a session', async () => {
     expect((await report({ upload: 'complete' })).status).toBe(StatusMap.Unauthorized);
   });
@@ -56,6 +62,20 @@ describe('a request that could not name a binary is not one', () => {
   // rather than sanitised into a different name.
   test('a filename that is a path is not a filename', async () => {
     const response = await create({ filename: '../../etc/passwd', sizeBytes: 1 });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
+  // The api is what follows this url, and a plaintext hop is one where what the guest ends up
+  // running was chosen by whoever sat between.
+  test('a url the api would not be alone on the wire for is refused', async () => {
+    expect((await create({ url: 'http://releases.test/my-server' })).status).toBe(
+      StatusMap['Bad Request'],
+    );
+  });
+
+  test('half of each way of naming a binary is neither', async () => {
+    const response = await create({ url: 'https://releases.test/my-server', sizeBytes: 'large' });
 
     expect(response.status).toBe(StatusMap['Bad Request']);
   });

--- a/apps/api/tests/lib/artifact-digest.test.ts
+++ b/apps/api/tests/lib/artifact-digest.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import { isValidMessage, ObjectKeySchema, Sha256DigestSchema, Value } from '@repo/protocol';
-import { type ArtifactInspection, inspectArtifact } from '#lib/artifact-digest.ts';
+import {
+  type ArtifactInspection,
+  ArtifactTooLargeError,
+  cappedTo,
+  inspectArtifact,
+} from '#lib/artifact-digest.ts';
 
 // The api refuses anything that is not a Linux executable, so every fixture that is meant to be
 // read to the end opens with the ELF magic the way a real upload does.
@@ -258,5 +263,45 @@ describe('a loader the guest does not have is refused before a host ever sees it
     await inspectArtifact({ stream, maxSizeBytes: PAST_THE_HEADER_BYTES });
 
     expect(delivered).toEqual([chunks[0] as Uint8Array]);
+  });
+});
+
+/**
+ * What holds a fetch to the size a store would accept. The inspection reaches the same verdict on
+ * its own, but only for the reader that asked: a stream being written somewhere at the same time
+ * has to be stopped where it is, not judged after the fact.
+ */
+describe('a stream is capped at what could be stored', () => {
+  async function drain(stream: ReadableStream<Uint8Array>): Promise<number> {
+    let sizeBytes = 0;
+    for await (const chunk of stream) {
+      sizeBytes += chunk.byteLength;
+    }
+    return sizeBytes;
+  }
+
+  function streamed(chunks: string[]): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(bytesOf(chunk));
+        }
+        controller.close();
+      },
+    });
+  }
+
+  test('everything within it is passed on untouched', async () => {
+    const capped = streamed([BINARY]).pipeThrough(cappedTo({ maxSizeBytes: NO_LIMIT }));
+
+    expect(await drain(capped)).toBe(BINARY.length);
+  });
+
+  test('a stream past it errors rather than ending short', async () => {
+    const capped = streamed([BINARY, OTHER_BINARY]).pipeThrough(
+      cappedTo({ maxSizeBytes: BINARY.length }),
+    );
+
+    await expect(drain(capped)).rejects.toBeInstanceOf(ArtifactTooLargeError);
   });
 });

--- a/apps/api/tests/lib/artifact-digest.test.ts
+++ b/apps/api/tests/lib/artifact-digest.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from 'bun:test';
 import { isValidMessage, ObjectKeySchema, Sha256DigestSchema, Value } from '@repo/protocol';
 import {
   type ArtifactInspection,
-  ArtifactTooLargeError,
-  cappedTo,
   inspectArtifact,
+  inspectingPassThrough,
+  RefusedArtifactError,
 } from '#lib/artifact-digest.ts';
 
 // The api refuses anything that is not a Linux executable, so every fixture that is meant to be
@@ -267,19 +267,11 @@ describe('a loader the guest does not have is refused before a host ever sees it
 });
 
 /**
- * What holds a fetch to the size a store would accept. The inspection reaches the same verdict on
- * its own, but only for the reader that asked: a stream being written somewhere at the same time
- * has to be stopped where it is, not judged after the fact.
+ * The inspection made of bytes on their way into the store, which is how a fetched binary is read:
+ * once, with one chunk in hand. What it refuses it refuses into the stream, so the upload carrying
+ * those bytes stops where it is rather than finishing something nobody will deploy.
  */
-describe('a stream is capped at what could be stored', () => {
-  async function drain(stream: ReadableStream<Uint8Array>): Promise<number> {
-    let sizeBytes = 0;
-    for await (const chunk of stream) {
-      sizeBytes += chunk.byteLength;
-    }
-    return sizeBytes;
-  }
-
+describe('bytes are inspected on their way past', () => {
   function streamed(chunks: string[]): ReadableStream<Uint8Array> {
     return new ReadableStream<Uint8Array>({
       start(controller) {
@@ -291,17 +283,43 @@ describe('a stream is capped at what could be stored', () => {
     });
   }
 
-  test('everything within it is passed on untouched', async () => {
-    const capped = streamed([BINARY]).pipeThrough(cappedTo({ maxSizeBytes: NO_LIMIT }));
+  async function written(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+    const chunks: number[] = [];
+    for await (const chunk of stream) {
+      chunks.push(...chunk);
+    }
+    return Uint8Array.from(chunks);
+  }
 
-    expect(await drain(capped)).toBe(BINARY.length);
+  test('what comes out is what went in, and the verdict is the same as reading it whole', async () => {
+    const { through, inspection } = inspectingPassThrough({ maxSizeBytes: NO_LIMIT });
+
+    const bytes = await written(streamed([BINARY]).pipeThrough(through));
+
+    expect(bytes).toEqual(bytesOf(BINARY));
+    expect(await inspection).toEqual(
+      await inspectArtifact({ stream: streamed([BINARY]), maxSizeBytes: NO_LIMIT }),
+    );
   });
 
-  test('a stream past it errors rather than ending short', async () => {
-    const capped = streamed([BINARY, OTHER_BINARY]).pipeThrough(
-      cappedTo({ maxSizeBytes: BINARY.length }),
-    );
+  test('a refusal stops whoever is writing, and says what it was', async () => {
+    const { through } = inspectingPassThrough({ maxSizeBytes: NO_LIMIT });
 
-    await expect(drain(capped)).rejects.toBeInstanceOf(ArtifactTooLargeError);
+    const refused = written(streamed(['not an executable']).pipeThrough(through));
+
+    await expect(refused).rejects.toBeInstanceOf(RefusedArtifactError);
+    await expect(refused).rejects.toMatchObject({
+      inspection: { outcome: 'not-executable' },
+    });
+  });
+
+  // The reason a cap is not needed beside this: a source that keeps sending is cut off by the same
+  // pass, at the byte the store would not have taken anyway.
+  test('a stream past what could be stored is cut off rather than finished', async () => {
+    const { through } = inspectingPassThrough({ maxSizeBytes: BINARY.length });
+
+    const refused = written(streamed([BINARY, OTHER_BINARY]).pipeThrough(through));
+
+    await expect(refused).rejects.toMatchObject({ inspection: { outcome: 'too-large' } });
   });
 });

--- a/apps/api/tests/lib/binary-url.test.ts
+++ b/apps/api/tests/lib/binary-url.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { FilenameSchema, Value } from '@repo/protocol';
+import {
+  filenameFromUrl,
+  isBinaryUrl,
+  MAX_BINARY_URL_LENGTH,
+  withoutCredentials,
+} from '#lib/binary-url.ts';
+
+const MY_SERVER = Value.Parse(FilenameSchema, 'my-server');
+
+/**
+ * The name a host writes into an export archive, taken from the only place a fetched binary has
+ * one. Every answer here is a name or the absence of one: the url arrived as a request body, so a
+ * url this cannot read is a request to refuse rather than something to raise.
+ */
+describe('a binary is named after the file at the end of the url', () => {
+  test('the last segment of the path is the name', () => {
+    expect(filenameFromUrl('https://releases.test/download/v1.2.0/my-server')).toBe(MY_SERVER);
+  });
+
+  test('a query is not part of the path, and so not part of the name', () => {
+    expect(filenameFromUrl('https://releases.test/my-server?token=abc')).toBe(MY_SERVER);
+  });
+
+  test('nor is a fragment', () => {
+    expect(filenameFromUrl('https://releases.test/my-server#sha256')).toBe(MY_SERVER);
+  });
+
+  test('an escaped name is the name it stands for', () => {
+    expect(filenameFromUrl('https://releases.test/my%2Dserver')).toBe(MY_SERVER);
+  });
+
+  // Decoded first and checked after, so `%2F` is a name with a separator in it rather than a path.
+  test('a segment that decodes to a path is not a name', () => {
+    expect(filenameFromUrl('https://releases.test/a%2Fb')).toBeUndefined();
+  });
+
+  test('a url ending in a slash names nothing', () => {
+    expect(filenameFromUrl('https://releases.test/downloads/')).toBeUndefined();
+  });
+
+  test('and neither does one with no path at all — a host is not a binary', () => {
+    expect(filenameFromUrl('https://releases.test')).toBeUndefined();
+  });
+
+  test('an escape that stands for nothing is a url without a name, not a throw', () => {
+    expect(filenameFromUrl('https://releases.test/%zz')).toBeUndefined();
+  });
+
+  test('so is something that is not a url', () => {
+    expect(filenameFromUrl('not a url')).toBeUndefined();
+  });
+});
+
+describe('the rule the request body is held to is one a redirect can be held to', () => {
+  test('an https address passes it', () => {
+    expect(isBinaryUrl('https://releases.test/my-server')).toBe(true);
+  });
+
+  test('a plaintext one does not', () => {
+    expect(isBinaryUrl('http://releases.test/my-server')).toBe(false);
+  });
+
+  test('nor does one longer than a url may be', () => {
+    expect(isBinaryUrl(`https://releases.test/${'a'.repeat(MAX_BINARY_URL_LENGTH)}`)).toBe(false);
+  });
+});
+
+/**
+ * What a caller authenticated with belongs to the fetch it was given for. The url is written into
+ * a row that outlives that fetch and read back in errors that reach a browser, and neither is
+ * somewhere a password was meant to end up.
+ */
+describe('where the bytes came from is said without what it took to get them', () => {
+  test('a password is not part of where a binary came from', () => {
+    expect(withoutCredentials('https://owner:ghp_secret@releases.test/my-server')).toBe(
+      'https://releases.test/my-server',
+    );
+  });
+
+  test('a url that carries none is the url it already was', () => {
+    expect(withoutCredentials('https://releases.test/my-server?token=abc')).toBe(
+      'https://releases.test/my-server?token=abc',
+    );
+  });
+
+  test('and one that is not a url is left alone rather than lost', () => {
+    expect(withoutCredentials('not a url')).toBe('not a url');
+  });
+});

--- a/apps/api/tests/repositories/binary-source.repository.test.ts
+++ b/apps/api/tests/repositories/binary-source.repository.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { TCPSocketListener } from 'bun';
+import {
+  type BinarySource,
+  BinarySourceRepository,
+  InterruptedSourceError,
+} from '#repositories/binary-source.repository.ts';
+
+const BINARY = 'a binary, as far as a source is concerned';
+// A chunked body sizes each chunk in hex, which is the one part of writing one out by hand.
+const HEX = 16;
+
+/**
+ * Answered by a real server rather than a fake handing over a `ReadableStream`, because what is
+ * worth testing here is the part nibrun does not run: a header a host omits, a redirect it answers
+ * with, and a body that stops arriving. None of those are things a stand-in can be wrong about.
+ */
+let releases: ReturnType<typeof Bun.serve>;
+let byHand: TCPSocketListener;
+const repo = new BinarySourceRepository();
+
+beforeAll(() => {
+  releases = Bun.serve({ port: 0, fetch: answer });
+  byHand = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data: answerByHand } });
+});
+
+afterAll(() => {
+  releases.stop(true);
+  byHand.stop(true);
+});
+
+function at(path: string): string {
+  return new URL(path, releases.url).toString();
+}
+
+function answer(request: Request): Response {
+  switch (new URL(request.url).pathname) {
+    case '/my-server':
+      return new Response(BINARY);
+    case '/elsewhere':
+      return new Response(null, { status: 302, headers: { location: '/my-server' } });
+    default:
+      return new Response('no such release', { status: 404 });
+  }
+}
+
+// Written onto the socket rather than served, because what these two answers are is what a server
+// framework decides for itself: `Bun.serve` measures a body it can measure, and a length is what
+// one of these is about not having.
+function byHandAt(path: string): string {
+  return `http://127.0.0.1:${byHand.port}${path}`;
+}
+
+// biome-ignore lint/complexity/useMaxParams: the shape a socket handler is called with
+function answerByHand(socket: Bun.Socket, data: Buffer): void {
+  const chunked = data.toString().startsWith('GET /chunked');
+  socket.write(
+    chunked
+      ? `HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n${BINARY.length.toString(HEX)}\r\n${BINARY}\r\n0\r\n\r\n`
+      : // Promises more than it sends and then hangs up, which is what a download interrupted part
+        // way through looks like from this end.
+        `HTTP/1.1 200 OK\r\nContent-Length: ${BINARY.length * 2}\r\n\r\n${BINARY}`,
+  );
+  if (!chunked) {
+    socket.end();
+  }
+}
+
+async function read(source: BinarySource): Promise<string> {
+  if (source.outcome !== 'open') {
+    throw new Error(`the source was ${source.outcome}`);
+  }
+  return await new Response(source.body).text();
+}
+
+describe('a url is opened, and what it answers with is what it is', () => {
+  test('a body is handed over with the length its host declared', async () => {
+    const source = await repo.open({ url: at('/my-server') });
+
+    expect(source).toMatchObject({ outcome: 'open', declaredSizeBytes: BINARY.length });
+    expect(await read(source)).toBe(BINARY);
+  });
+
+  // A host that says nothing about its length has not said zero, and reading it as zero would make
+  // every chunked release look like an empty one to whoever asks next.
+  test('a host that declares no length declares nothing, not nothing much', async () => {
+    const source = await repo.open({ url: byHandAt('/chunked') });
+
+    expect(source).toMatchObject({ outcome: 'open', declaredSizeBytes: undefined });
+    expect(await read(source)).toBe(BINARY);
+  });
+
+  test('a status is that status, not a nibrun failure', async () => {
+    expect(await repo.open({ url: at('/gone') })).toEqual({ outcome: 'refused', status: 404 });
+  });
+
+  test('a host nothing is listening on is unreachable rather than an error to read back', async () => {
+    expect(await repo.open({ url: 'https://not.a.host.nibrun.test/my-server' })).toEqual({
+      outcome: 'unreachable',
+    });
+  });
+});
+
+/**
+ * The https rule is what makes the api the only thing standing between the store and the guest, and
+ * a rule applied to the address that was typed alone is one a redirect walks straight around.
+ */
+describe('every hop is held to the rule the first one was', () => {
+  test('a redirect out of https is refused, and says where it pointed', async () => {
+    expect(await repo.open({ url: at('/elsewhere') })).toEqual({
+      outcome: 'insecure-redirect',
+      to: at('/my-server'),
+    });
+  });
+});
+
+describe('a source that stops part way is the url, not the api', () => {
+  test('the body errors as the source having gone rather than as a read that failed', async () => {
+    const source = await repo.open({ url: byHandAt('/cut-off') });
+
+    await expect(read(source)).rejects.toBeInstanceOf(InterruptedSourceError);
+  });
+});

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -14,7 +14,7 @@ import {
   TimestampSchema,
   Value,
 } from '@repo/protocol';
-import { BadRequestError, NotFoundError } from '#lib/errors.ts';
+import { BadRequestError, NotFoundError, TooManyRequestsError } from '#lib/errors.ts';
 import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
 import type {
   AbandonedArtifactRow,
@@ -24,14 +24,16 @@ import type {
   InsertPendingArtifactInput,
   PendingArtifactRow,
 } from '#repositories/artifacts.repository.ts';
-import type {
-  BinarySource,
-  BinarySourceRepositoryContract,
+import {
+  type BinarySource,
+  type BinarySourceRepositoryContract,
+  InterruptedSourceError,
 } from '#repositories/binary-source.repository.ts';
 import {
   type AppOwnership,
   ArtifactsService,
   MAX_ARTIFACT_SIZE_BYTES,
+  MAX_CONCURRENT_FETCHES,
 } from '#services/artifacts.service.ts';
 import { APP_ID, OTHER_OWNER_ID, OWNER_ID } from '#tests/services/support/fixtures.ts';
 
@@ -311,10 +313,13 @@ const appsRepo: AppOwnership = {
 class FakeBinarySource implements BinarySourceRepositoryContract {
   readonly opened: string[] = [];
   private answer: BinarySource = { outcome: 'unreachable' };
+  private gate: PromiseWithResolvers<void> | undefined;
+  private letGo = false;
 
-  open({ url }: { url: string }): Promise<BinarySource> {
+  async open({ url }: { url: string }): Promise<BinarySource> {
     this.opened.push(url);
-    return Promise.resolve(this.answer);
+    await this.gate?.promise;
+    return this.answer;
   }
 
   answers(source: BinarySource): void {
@@ -324,18 +329,69 @@ class FakeBinarySource implements BinarySourceRepositoryContract {
   serves({ text, declaredSizeBytes }: { text: string; declaredSizeBytes?: number }): void {
     this.answers({
       outcome: 'open',
-      body: streamOf(text),
+      body: streamOf({
+        text,
+        onCancel: () => {
+          this.letGo = true;
+        },
+      }),
       declaredSizeBytes,
     });
   }
+
+  /** A body that arrives in part and then does not, which is a download interrupted. */
+  stopsPartWay(): void {
+    this.answers({ outcome: 'open', body: stoppingPartWay(), declaredSizeBytes: undefined });
+  }
+
+  /** Every fetch waits where it is until the returned function is called. */
+  holdsOpen(): () => void {
+    const gate = Promise.withResolvers<void>();
+    this.gate = gate;
+    return () => {
+      gate.resolve();
+    };
+  }
+
+  /** Whether a body handed over and then not wanted was let go of rather than left open. */
+  get wasLetGo(): boolean {
+    return this.letGo;
+  }
 }
 
-function streamOf(text: string): ReadableStream<Uint8Array> {
-  const bytes = bytesOf(text);
+function streamOf({
+  text,
+  onCancel,
+}: {
+  text: string;
+  onCancel?: () => void;
+}): ReadableStream<Uint8Array> {
+  let sent = false;
   return new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(bytes);
-      controller.close();
+    pull(controller) {
+      if (sent) {
+        controller.close();
+        return;
+      }
+      sent = true;
+      controller.enqueue(bytesOf(text));
+    },
+    cancel() {
+      onCancel?.();
+    },
+  });
+}
+
+function stoppingPartWay(): ReadableStream<Uint8Array> {
+  let sent = false;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent) {
+        controller.error(new InterruptedSourceError(new Error('the source went away')));
+        return;
+      }
+      sent = true;
+      controller.enqueue(bytesOf(BINARY_TEXT));
     },
   });
 }
@@ -825,5 +881,85 @@ describe('a binary is fetched from the url it was given', () => {
     ).rejects.toBeInstanceOf(BadRequestError);
     expect(artifactsRepo.rows.size).toBe(0);
     expect(storage.objects.size).toBe(0);
+  });
+
+  // Every other way this url could be unusable is answered as the url's; a socket that dropped
+  // part way is no more this api's fault than a 404, and reads as one to whoever has to retry.
+  test('a source that stops part way is the link, and leaves nothing behind either', async () => {
+    const { service, sourceRepo, artifactsRepo, storage } = build();
+    sourceRepo.stopsPartWay();
+
+    const refusal = service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL });
+
+    await expect(refusal).rejects.toBeInstanceOf(BadRequestError);
+    await expect(refusal).rejects.toThrow(BINARY_URL);
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect(storage.objects.size).toBe(0);
+  });
+
+  // The refusal comes after the fetch is already open, and a body nobody is going to read holds
+  // its connection until it is let go of.
+  test('a body handed over and then not wanted is let go of', async () => {
+    const { service, sourceRepo } = build();
+    sourceRepo.serves({ text: BINARY_TEXT, declaredSizeBytes: MAX_ARTIFACT_SIZE_BYTES + 1 });
+
+    await expect(
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(sourceRepo.wasLetGo).toBe(true);
+  });
+
+  test('a redirect out of https is said back as the hop the caller never saw', async () => {
+    const { service, sourceRepo } = build();
+    sourceRepo.answers({ outcome: 'insecure-redirect', to: 'http://mirror.test/my-server' });
+
+    await expect(
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL }),
+    ).rejects.toThrow('http://mirror.test/my-server');
+  });
+
+  test('what a caller authenticated with is fetched with and not written down', async () => {
+    const { service, sourceRepo, artifactsRepo } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+    const withToken = 'https://owner:ghp_secret@releases.test/v1/my-server';
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: withToken,
+    });
+
+    expect(sourceRepo.opened).toEqual([withToken]);
+    expect(artifactsRepo.rows.get(artifact.id)?.original_file_url).toBe(
+      'https://releases.test/v1/my-server',
+    );
+  });
+
+  /**
+   * A fetched binary passes through this process, which is the cost signing an upload away was
+   * meant to avoid paying — so what is bounded is how many of them it carries at once, and a
+   * caller told to come back has a request that ended rather than one still being held.
+   */
+  test('only so many binaries are fetched through this end at once', async () => {
+    const { service, sourceRepo } = build();
+    sourceRepo.answers({ outcome: 'unreachable' });
+    const letThemGo = sourceRepo.holdsOpen();
+
+    const held = Array.from({ length: MAX_CONCURRENT_FETCHES }, () =>
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL }),
+    );
+    await Bun.sleep(0);
+
+    await expect(
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL }),
+    ).rejects.toBeInstanceOf(TooManyRequestsError);
+
+    letThemGo();
+    await Promise.allSettled(held);
+
+    // The slot each was holding is given back, so the next caller is not refused for their sake.
+    await expect(
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL }),
+    ).rejects.toBeInstanceOf(BadRequestError);
   });
 });

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -21,8 +21,13 @@ import type {
   ArtifactRow,
   ArtifactsRepositoryContract,
   CompleteArtifactInput,
+  InsertPendingArtifactInput,
   PendingArtifactRow,
 } from '#repositories/artifacts.repository.ts';
+import type {
+  BinarySource,
+  BinarySourceRepositoryContract,
+} from '#repositories/binary-source.repository.ts';
 import {
   type AppOwnership,
   ArtifactsService,
@@ -72,11 +77,8 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
     appId,
     ownerId,
     originalFileName,
-  }: {
-    appId: AppId;
-    ownerId: OwnerId;
-    originalFileName: Filename;
-  }): Promise<PendingArtifactRow | null> {
+    originalFileUrl,
+  }: InsertPendingArtifactInput): Promise<PendingArtifactRow | null> {
     if (ownerId !== this.ownedBy) {
       return Promise.resolve(null);
     }
@@ -87,6 +89,7 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
       size_bytes: null,
       object_key: null,
       original_file_name: originalFileName,
+      original_file_url: originalFileUrl,
       created_at: SEEDED_CREATED_AT,
     };
     this.rows.set(row.id, row);
@@ -94,6 +97,7 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
       id: row.id,
       app_id: row.app_id,
       original_file_name: row.original_file_name,
+      original_file_url: row.original_file_url,
       created_at: row.created_at,
     });
   }
@@ -153,6 +157,7 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
       id: row.id,
       app_id: row.app_id,
       original_file_name: row.original_file_name,
+      original_file_url: row.original_file_url,
       created_at: row.created_at,
     });
   }
@@ -212,6 +217,7 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
       size_bytes: String(SEEDED_SIZE_BYTES),
       object_key: Value.Parse(ObjectKeySchema, SEEDED_DIGEST),
       original_file_name: UPLOADED_NAME,
+      original_file_url: null,
       created_at: SEEDED_CREATED_AT,
     };
     this.rows.set(row.id, row);
@@ -237,6 +243,20 @@ class FakeStorage implements ArtifactStorageRepositoryContract {
   signUpload(input: { objectKey: ObjectKey; sizeBytes: number }): Promise<string> {
     this.signed.push(input);
     return Promise.resolve(`${SIGNED_URL}/${input.objectKey}`);
+  }
+
+  async write({
+    objectKey,
+    body,
+  }: {
+    objectKey: ObjectKey;
+    body: ReadableStream<Uint8Array>;
+  }): Promise<void> {
+    const written: number[] = [];
+    for await (const chunk of body) {
+      written.push(...chunk);
+    }
+    this.objects.set(objectKey, Uint8Array.from(written));
   }
 
   read({ objectKey }: { objectKey: ObjectKey }): ReadableStream<Uint8Array> {
@@ -287,12 +307,47 @@ const appsRepo: AppOwnership = {
   isOwnedBy: ({ ownerId }) => Promise.resolve(ownerId === OWNER_ID),
 };
 
+/** The url as whatever it answers with, so what a fetch runs into is set by the test asking. */
+class FakeBinarySource implements BinarySourceRepositoryContract {
+  readonly opened: string[] = [];
+  private answer: BinarySource = { outcome: 'unreachable' };
+
+  open({ url }: { url: string }): Promise<BinarySource> {
+    this.opened.push(url);
+    return Promise.resolve(this.answer);
+  }
+
+  answers(source: BinarySource): void {
+    this.answer = source;
+  }
+
+  serves({ text, declaredSizeBytes }: { text: string; declaredSizeBytes?: number }): void {
+    this.answers({
+      outcome: 'open',
+      body: streamOf(text),
+      declaredSizeBytes,
+    });
+  }
+}
+
+function streamOf(text: string): ReadableStream<Uint8Array> {
+  const bytes = bytesOf(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
 function build(storageRepo: FakeStorage = new FakeStorage()) {
   const artifactsRepo = new FakeArtifactsRepository(OWNER_ID);
+  const sourceRepo = new FakeBinarySource();
   return {
     storage: storageRepo,
     artifactsRepo,
-    service: new ArtifactsService({ artifactsRepo, storageRepo, appsRepo }),
+    sourceRepo,
+    service: new ArtifactsService({ artifactsRepo, storageRepo, sourceRepo, appsRepo }),
   };
 }
 
@@ -652,5 +707,123 @@ describe('a row becomes the wire shape the dashboard and the agent both read', (
     expect(artifact.sizeBytes).toBe(SEEDED_SIZE_BYTES);
     expect(artifact.createdAt).toBe(Value.Parse(TimestampSchema, SEEDED_CREATED_AT.toISOString()));
     expect(isValidMessage({ schema: ArtifactSchema, value: artifact })).toBe(true);
+  });
+});
+
+const BINARY_URL = 'https://releases.test/v1/my-server';
+const FETCHED_NAME = Value.Parse(FilenameSchema, 'my-server');
+
+/**
+ * A binary the api fetched itself. Every refusal here is about a url somebody typed, so each one
+ * has to leave the app exactly as it was — an artifact half made is a deploy that cannot be
+ * retried by following the same link again.
+ */
+describe('a binary is fetched from the url it was given', () => {
+  test('the bytes are stored under their digest, named and addressed by the url', async () => {
+    const { service, sourceRepo, storage } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+    });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+    expect(artifact.originalFileName).toBe(FETCHED_NAME);
+    expect(storage.objects.has(Value.Parse(ObjectKeySchema, BINARY_DIGEST))).toBe(true);
+    expect(isValidMessage({ schema: ArtifactSchema, value: artifact })).toBe(true);
+  });
+
+  // Kept where the bytes are described rather than answered with: nothing downstream is told
+  // where a binary was found, and a host least of all.
+  test('where it came from is written down beside the name it was given', async () => {
+    const { service, sourceRepo, artifactsRepo } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+    });
+
+    expect(artifactsRepo.rows.get(artifact.id)?.original_file_url).toBe(BINARY_URL);
+    expect(Object.keys(artifact)).not.toContain('originalFileUrl');
+  });
+
+  test('the staging slot it came through is given up', async () => {
+    const { service, sourceRepo, storage } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    await service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL });
+
+    expect([...storage.objects.keys()]).toEqual([Value.Parse(ObjectKeySchema, BINARY_DIGEST)]);
+  });
+
+  test('an app the caller does not own is never fetched for', async () => {
+    const { service, sourceRepo } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    await expect(
+      service.createFromUrl({ appId: APP_ID, ownerId: OTHER_OWNER_ID, url: BINARY_URL }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+    expect(sourceRepo.opened).toEqual([]);
+  });
+
+  test('a url nibrun cannot reach is said back with the url in it', async () => {
+    const { service, sourceRepo, artifactsRepo } = build();
+    sourceRepo.answers({ outcome: 'unreachable' });
+
+    const refusal = service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL });
+
+    await expect(refusal).rejects.toBeInstanceOf(BadRequestError);
+    await expect(refusal).rejects.toThrow(BINARY_URL);
+    expect(artifactsRepo.rows.size).toBe(0);
+  });
+
+  test('a url that answers with a status is that status, not a nibrun failure', async () => {
+    const { service, sourceRepo, artifactsRepo } = build();
+    sourceRepo.answers({ outcome: 'refused', status: 404 });
+
+    await expect(
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL }),
+    ).rejects.toThrow('404');
+    expect(artifactsRepo.rows.size).toBe(0);
+  });
+
+  test('a url ending in nothing an export could be named after is refused unread', async () => {
+    const { service, sourceRepo } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    await expect(
+      service.createFromUrl({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        url: 'https://releases.test/downloads/',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(sourceRepo.opened).toEqual([]);
+  });
+
+  test('a source declaring more than may be stored is refused before it is read', async () => {
+    const { service, sourceRepo, artifactsRepo, storage } = build();
+    sourceRepo.serves({ text: BINARY_TEXT, declaredSizeBytes: MAX_ARTIFACT_SIZE_BYTES + 1 });
+
+    await expect(
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect(storage.objects.size).toBe(0);
+  });
+
+  test('what the url served is refused on its own terms, and leaves nothing behind', async () => {
+    const { service, sourceRepo, artifactsRepo, storage } = build();
+    sourceRepo.serves({ text: 'not an executable' });
+
+    await expect(
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect(storage.objects.size).toBe(0);
   });
 });

--- a/packages/app-operations/src/deploy.ts
+++ b/packages/app-operations/src/deploy.ts
@@ -50,9 +50,18 @@ function binaryName(binary: DeployableBinary): string | undefined {
   return isFetchable(binary) ? lastSegment(binary.url) : binary.name;
 }
 
+/**
+ * Parsed rather than split: the api names the artifact from the url's *path*, and a name taken any
+ * other way is one it will refuse after this end has already made the app. A url with no path at
+ * all ends in the host, which is a name for a website and not for a binary.
+ */
 function lastSegment(url: string): string | undefined {
-  const segment = url.split('?')[0]?.split('/').at(-1);
-  return segment === undefined || segment === '' ? undefined : decodeURIComponent(segment);
+  try {
+    const segment = decodeURIComponent(new URL(url).pathname.split('/').at(-1) ?? '');
+    return segment === '' ? undefined : segment;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/app-operations/src/deploy.ts
+++ b/packages/app-operations/src/deploy.ts
@@ -26,6 +26,36 @@ export type UploadableBinary = {
 };
 
 /**
+ * A binary the api fetches for itself. Nothing is sent from here at all: a release asset is served
+ * by a store that answers no cross-origin request, so the end that can read one is the api — and
+ * the bytes travel once, between the two ends that are not this one.
+ */
+export type FetchableBinary = {
+  url: string;
+};
+
+export type DeployableBinary = UploadableBinary | FetchableBinary;
+
+function isFetchable(binary: DeployableBinary): binary is FetchableBinary {
+  return 'url' in binary;
+}
+
+/**
+ * What to call the app when the caller named none: the binary, however it is being delivered.
+ *
+ * A url is read for a name here only to have one to call the app — what the binary is called once
+ * it is stored is the api's to decide, from the url it is the one fetching.
+ */
+function binaryName(binary: DeployableBinary): string | undefined {
+  return isFetchable(binary) ? lastSegment(binary.url) : binary.name;
+}
+
+function lastSegment(url: string): string | undefined {
+  const segment = url.split('?')[0]?.split('/').at(-1);
+  return segment === undefined || segment === '' ? undefined : decodeURIComponent(segment);
+}
+
+/**
  * The wait around the upload, given what the upload is doing rather than a line to print: how far
  * along it is reads as a spinner in one place and a meter in another, and neither belongs here.
  */
@@ -36,7 +66,7 @@ export type UploadWait = (input: {
 
 export type DeployInput = ConfigEdit & {
   api: PublicApiClient;
-  binary: UploadableBinary;
+  binary: DeployableBinary;
   // Required where the rest of the edit is optional: what the caller typed is what the binary is
   // asked to run with, and carrying over the last release's arguments because none were given
   // this time would run something nobody asked for.
@@ -70,11 +100,13 @@ export async function deploy({
 
   const app =
     target === null
-      ? unwrap(await api.api.apps.post({ name: name ?? binary.name, config }))
+      ? await createApp({ api, name: name ?? binaryName(binary), config })
       : unwrap(await api.api.apps({ appId: target.app.id }).patch(config));
   onStep?.({ kind: 'app', appId: app.id, slug: app.slug });
 
-  const artifact = await uploadBinary({ api, appId: app.id, binary, whileUploading, upload });
+  const artifact = isFetchable(binary)
+    ? await fetchBinary({ api, appId: app.id, binary })
+    : await uploadBinary({ api, appId: app.id, binary, whileUploading, upload });
   onStep?.({ kind: 'artifact', artifactId: artifact.id, digest: artifact.digest });
 
   const deployment = unwrap(
@@ -88,6 +120,59 @@ export async function deploy({
     deploymentId: deployment.id,
     url: `https://${servingHostname(app.hostnames)}`,
   };
+}
+
+/**
+ * Named before anything is made rather than by the request that makes it: an app created for a
+ * deploy that cannot go on is one the caller is left to go and delete.
+ */
+async function createApp({
+  api,
+  name,
+  config,
+}: {
+  api: PublicApiClient;
+  name: string | undefined;
+  config: ReturnType<typeof configPatch>;
+}) {
+  if (name === undefined) {
+    throw new ApiError('An app needs a name, and this url ends in nothing to take one from.');
+  }
+  return unwrap(await api.api.apps.post({ name, config }));
+}
+
+/**
+ * The one request the bytes happen during: the api fetches, hashes and stores them while it is
+ * held open, so there is nothing to report on and nothing to say afterwards about how it went.
+ */
+async function fetchBinary({
+  api,
+  appId,
+  binary,
+}: {
+  api: PublicApiClient;
+  appId: string;
+  binary: FetchableBinary;
+}): Promise<StoredArtifact> {
+  const created = unwrap(await api.api.apps({ appId }).artifacts.post({ url: binary.url }));
+  if (!isStored(created)) {
+    throw new ApiError('The api answered a fetched binary with somewhere to upload one.');
+  }
+  return created;
+}
+
+/**
+ * Which of the two answers `POST artifacts` gave. A caller knows which it is owed by what it
+ * asked for, so this is only ever the check that the api agreed.
+ */
+type CreatedArtifact = Awaited<
+  ReturnType<ReturnType<PublicApiClient['api']['apps']>['artifacts']['post']>
+>['data'];
+
+type StoredArtifact = Extract<NonNullable<CreatedArtifact>, { digest: string }>;
+
+function isStored(created: NonNullable<CreatedArtifact>): created is StoredArtifact {
+  return 'digest' in created;
 }
 
 /**
@@ -112,12 +197,16 @@ async function uploadBinary({
   whileUploading: UploadWait;
   upload: UploadTransport;
 }) {
-  const { artifactId, url } = unwrap(
+  const created = unwrap(
     await api.api.apps({ appId }).artifacts.post({
       filename: binary.name,
       sizeBytes: binary.body.size,
     }),
   );
+  if (isStored(created)) {
+    throw new ApiError('The api answered an upload with an artifact nobody sent it.');
+  }
+  const { artifactId, url } = created;
   const artifact = api.api.apps({ appId }).artifacts({ artifactId });
 
   try {

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -12,9 +12,11 @@ export {
 export { deleteApp } from '#delete.ts';
 export {
   awaitDeploymentSettled,
+  type DeployableBinary,
   type DeployInput,
   deploy,
   describeUnservedDeployment,
+  type FetchableBinary,
   type SettledDeployment,
   type UploadableBinary,
   type UploadWait,

--- a/packages/app-operations/tests/deploy.test.ts
+++ b/packages/app-operations/tests/deploy.test.ts
@@ -29,11 +29,15 @@ function apiHolding({
   apps,
   sent,
   completed = { id: ARTIFACT_ID, digest: DIGEST },
+  created = { artifactId: ARTIFACT_ID, url: PUT_URL },
   hostnames = [PENDING_CUSTOM, PLATFORM],
 }: {
   apps: Array<{ id: string; slug: string; state?: string }>;
   sent: Sent[];
   completed?: { id: string; digest: string } | null;
+  // Somewhere to send bytes, or the artifact those bytes already made: one endpoint answers both,
+  // and which one a caller is owed is decided by what it asked for.
+  created?: { artifactId: string; url: string } | { id: string; digest: string };
   hostnames?: HostnameRow[];
 }): PublicApiClient {
   function app(id: string) {
@@ -57,7 +61,7 @@ function apiHolding({
       artifacts: Object.assign(artifact, {
         post: (body: unknown) => {
           sent.push({ what: 'artifact', body });
-          return Promise.resolve({ data: { artifactId: ARTIFACT_ID, url: PUT_URL }, error: null });
+          return Promise.resolve({ data: created, error: null });
         },
       }),
       deployments: {
@@ -382,5 +386,111 @@ describe('a release that settled without serving accounts for itself', () => {
     expect(describeUnservedDeployment({ id: 'dep-1', state: 'superseded' })).toBe(
       'Deployment dep-1 is superseded.',
     );
+  });
+});
+
+const BINARY_URL = 'https://releases.test/v1.2.0/my-server';
+const FETCHED = { id: ARTIFACT_ID, digest: DIGEST };
+
+/**
+ * A release asset is served by a store that answers no cross-origin request, so the end that can
+ * read one is the api. Nothing is sent from here at all: the bytes travel once, between the two
+ * ends that are not this one.
+ */
+describe('a binary the api fetches is never sent from this end', () => {
+  test('the url is asked for and the artifact comes back, with nothing put anywhere', async () => {
+    const sent: Sent[] = [];
+    storeAnswering({ sent });
+
+    const deployed = await deploy({
+      api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent, created: FETCHED }),
+      binary: { url: BINARY_URL },
+      args: [],
+      app: SLUG,
+    });
+
+    expect(sent.map((each) => each.what)).toEqual(['app patch', 'artifact', 'deployment']);
+    expect(sent[1]).toEqual({ what: 'artifact', body: { url: BINARY_URL } });
+    expect(deployed.deploymentId).toBe('deployment-1');
+  });
+
+  test('an app made for one is named after the file at the end of the url', async () => {
+    const sent: Sent[] = [];
+
+    await deploy({
+      api: apiHolding({ apps: [], sent, created: FETCHED }),
+      binary: { url: BINARY_URL },
+      args: [],
+    });
+
+    expect(sent[0]).toMatchObject({ what: 'create', body: { name: 'my-server' } });
+  });
+
+  // The api names the artifact from the url's *path*, so a name read out of one any other way is
+  // one it will refuse — after this end has already made the app the caller is then left to delete.
+  test('a url with no path is refused before an app is made for it', async () => {
+    const sent: Sent[] = [];
+
+    await expect(
+      deploy({
+        api: apiHolding({ apps: [], sent, created: FETCHED }),
+        binary: { url: 'https://releases.test' },
+        args: [],
+      }),
+    ).rejects.toThrow('An app needs a name');
+    expect(sent).toEqual([]);
+  });
+
+  test('and neither does one that ends in a slash name anything', async () => {
+    const sent: Sent[] = [];
+
+    await expect(
+      deploy({
+        api: apiHolding({ apps: [], sent, created: FETCHED }),
+        binary: { url: 'https://releases.test/downloads/' },
+        args: [],
+      }),
+    ).rejects.toThrow('An app needs a name');
+    expect(sent).toEqual([]);
+  });
+
+  test('a name given outright is the name, whatever the url ends in', async () => {
+    const sent: Sent[] = [];
+
+    await deploy({
+      api: apiHolding({ apps: [], sent, created: FETCHED }),
+      binary: { url: 'https://releases.test' },
+      args: [],
+      name: 'chosen',
+    });
+
+    expect(sent[0]).toMatchObject({ what: 'create', body: { name: 'chosen' } });
+  });
+
+  test('an api that answers a fetch with somewhere to upload has not agreed', async () => {
+    const sent: Sent[] = [];
+
+    await expect(
+      deploy({
+        api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent }),
+        binary: { url: BINARY_URL },
+        args: [],
+        app: SLUG,
+      }),
+    ).rejects.toThrow('The api answered a fetched binary with somewhere to upload one.');
+  });
+
+  test('nor has one that answers an upload with an artifact nobody sent it', async () => {
+    const sent: Sent[] = [];
+    storeAnswering({ sent });
+
+    await expect(
+      deploy({
+        api: apiHolding({ apps: [{ id: APP_ID, slug: SLUG }], sent, created: FETCHED }),
+        binary: binary(),
+        args: [],
+        app: SLUG,
+      }),
+    ).rejects.toThrow('The api answered an upload with an artifact nobody sent it.');
   });
 });


### PR DESCRIPTION
`POST /apps/:appId/artifacts` now takes either half of the same question:

- `{ filename, sizeBytes }` — bytes the caller holds, answered with somewhere to PUT them. Unchanged, so a published CLI keeps working.
- `{ url }` — bytes at an https url, answered with the artifact: fetched, hashed and stored while the request is held open.

One endpoint, one question — where is the binary — with a union for the two ways to answer it. What differs is who moves the bytes, which is not a different thing to have asked for.

**Why the api and not the browser.** A GitHub release asset redirects to a store that sends no `Access-Control-Allow-Origin`, so page JS cannot read one at all. Fetching it here is the only path that works, and it is the shorter one: the fetch is teed, so the read that writes the staging object is the same read that hashes and inspects it — an upload gets read back out of the store afterwards to be hashed.

**Where it is recorded.** `artifacts.original_file_url`, nullable, beside `original_file_name`. It belongs to the bytes, not to a deployment: the same artifact is deployed again by a rollback, and the url is the only part of such a deploy anyone could repeat.

**Reachability.** The url is fetched from where the api runs, so one that answers only on the caller's own network fails — refused with the url in the message rather than silently.

**Bounds.** A source declaring more than the 256 MB limit is refused before a byte is read; one that declares nothing is capped mid-stream, which errors rather than truncating. Every refusal removes the pending row and the staged object, so a bad link leaves no half-made artifact behind.

Artifacts are created under an app, so this works for an app that already exists as much as for a new one — the CLI surface for that follows in its own PR.

Not guarded against internal addresses, per the call on where the api may fetch from — an authenticated caller can aim it at any address the api can reach. The check is a small, separate change if you want it later.