### PR TITLE
feat(cli): nib run takes a url where it takes a path

### DIFF
--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -3,13 +3,13 @@ import { z } from 'zod';
 import { SHARED_OPTIONS } from '#config.ts';
 import { parseCommandLine } from '#lib/command-line.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { deploy, openBinary } from '#lib/deploy.ts';
+import { binaryFrom, deploy } from '#lib/deploy.ts';
 import { completeOptions } from '#lib/plan.ts';
 import { createUi, isInteractive } from '#lib/ui.ts';
 
 export const command = defineCommand('run [command]', {
   description:
-    'Deploy a compiled binary and run it. Quote the binary with its arguments to pass them on: nib run "./my-server serve --port 8080".',
+    'Deploy a compiled binary and run it, from this machine or from an https url nibrun fetches it at. Quote the binary with its arguments to pass them on: nib run "./my-server serve --port 8080".',
   params: {
     command: { schema: z.string().min(1) },
   },
@@ -34,19 +34,20 @@ export const command = defineCommand('run [command]', {
     // name the deploy takes and has to be renamed rather than spread through.
     const { detach, [SHARED_OPTIONS.extraPublicPort.name]: extraPublicPort, ...flags } = options;
     const given = { ...flags, extraPublicPort };
-    const { binaryPath, args } = parseCommandLine(params.command);
+    const { binarySource, args } = parseCommandLine(params.command);
     const { api } = context;
 
     const interactive = isInteractive();
     const ui = createUi({ print, interactive });
 
     // Before anything is asked, so a path nobody can read costs one line rather than a
-    // questionnaire whose answers are then thrown away.
-    const binary = await openBinary(binaryPath);
+    // questionnaire whose answers are then thrown away. A url is not opened here at all: the api
+    // is the end that fetches it, and it is the end that says whether it could.
+    const binary = await binaryFrom(binarySource);
     ui.open('nib run');
 
     const resolved = interactive
-      ? await completeOptions({ api, options: given, binaryPath, args })
+      ? await completeOptions({ api, options: given, binarySource, args })
       : given;
 
     await deploy({ ...resolved, api, ui, binary, args, detach });

--- a/packages/cli/src/lib/command-line.test.ts
+++ b/packages/cli/src/lib/command-line.test.ts
@@ -2,12 +2,19 @@ import { expect, test } from 'bun:test';
 import { parseArguments, parseCommandLine } from '#lib/command-line.ts';
 
 test('a binary on its own is a command line with nothing to add', () => {
-  expect(parseCommandLine('./my-server')).toEqual({ binaryPath: './my-server', args: [] });
+  expect(parseCommandLine('./my-server')).toEqual({ binarySource: './my-server', args: [] });
+});
+
+test('a url is a binary the same way a path is: the first token, then its arguments', () => {
+  expect(parseCommandLine('https://releases.test/v1/my-server serve')).toEqual({
+    binarySource: 'https://releases.test/v1/my-server',
+    args: ['serve'],
+  });
 });
 
 test('everything after the binary is the binary its arguments', () => {
   expect(parseCommandLine('./my-server serve --port 8080')).toEqual({
-    binaryPath: './my-server',
+    binarySource: './my-server',
     args: ['serve', '--port', '8080'],
   });
 });
@@ -18,7 +25,7 @@ test('a flag written here is the tenant its own, whatever this program calls the
 
 test('quotes hold a value together, and are gone from the value they held', () => {
   expect(parseCommandLine(`'/my apps/server' --name "foo bar"`)).toEqual({
-    binaryPath: '/my apps/server',
+    binarySource: '/my apps/server',
     args: ['--name', 'foo bar'],
   });
 });
@@ -40,7 +47,7 @@ test('an argument may be deliberately empty', () => {
 
 test('runs of whitespace separate rather than produce arguments', () => {
   expect(parseCommandLine('  ./my-server   serve  ')).toEqual({
-    binaryPath: './my-server',
+    binarySource: './my-server',
     args: ['serve'],
   });
 });

--- a/packages/cli/src/lib/command-line.ts
+++ b/packages/cli/src/lib/command-line.ts
@@ -7,7 +7,8 @@ const SINGLE = "'";
 const DOUBLE = '"';
 
 export type CommandLine = {
-  binaryPath: string;
+  // A path on this machine or a url the api fetches; what it is, is decided where it is opened.
+  binarySource: string;
   args: TenantArguments;
 };
 
@@ -21,11 +22,11 @@ export type CommandLine = {
  * existing way of saying "this is one value".
  */
 export function parseCommandLine(line: string): CommandLine {
-  const [binaryPath, ...args] = tokenize(line);
-  if (binaryPath === undefined) {
+  const [binarySource, ...args] = tokenize(line);
+  if (binarySource === undefined) {
     throw new UsageError('Name the binary to run.');
   }
-  return { binaryPath, args };
+  return { binarySource, args };
 }
 
 /**

--- a/packages/cli/src/lib/deploy.test.ts
+++ b/packages/cli/src/lib/deploy.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'bun:test';
+import { binaryFrom } from '#lib/deploy.ts';
+import { UsageError } from '#lib/errors.ts';
+
+const URL_SOURCE = 'https://releases.test/v1/my-server';
+
+/**
+ * A url is handed on rather than opened: this machine is not the end that fetches it, so nothing
+ * here can say whether it answers — only the api can, and it is asked in the same breath as the
+ * deploy.
+ */
+test('an https url is a binary for the api to fetch', async () => {
+  expect(await binaryFrom(URL_SOURCE)).toEqual({ url: URL_SOURCE });
+});
+
+test('a url the api would not be alone on the wire for is named as the mistake it is', async () => {
+  await expect(binaryFrom('http://releases.test/v1/my-server')).rejects.toBeInstanceOf(UsageError);
+});
+
+test('anything that is not a url is a file on this machine', async () => {
+  const binary = await binaryFrom(import.meta.path);
+
+  expect(binary).toMatchObject({ name: 'deploy.test.ts' });
+});
+
+test('a file nobody can read costs a line rather than a deploy', async () => {
+  await expect(binaryFrom('./nothing-is-here')).rejects.toThrow('No such file');
+});

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -1,6 +1,10 @@
 import { basename } from 'node:path';
 import type { PublicApiClient } from '@repo/api-client/public';
-import { deploy as startDeployment, type UploadableBinary } from '@repo/app-operations';
+import {
+  type DeployableBinary,
+  deploy as startDeployment,
+  type UploadableBinary,
+} from '@repo/app-operations';
 import { type Filename, FilenameSchema, type TenantArguments, Value } from '@repo/protocol';
 import { environmentEdit } from '#lib/environment.ts';
 import { UsageError } from '#lib/errors.ts';
@@ -12,7 +16,7 @@ import { describeProgress } from '#lib/upload-progress.ts';
 export type DeployInput = RunOptions & {
   api: PublicApiClient;
   ui: Ui;
-  binary: UploadableBinary;
+  binary: DeployableBinary;
   args: TenantArguments;
   detach?: boolean | undefined;
 };
@@ -58,11 +62,32 @@ export async function deploy({
   await awaitServing({ api, ui, deployed, detach });
 }
 
+const SECURE_SCHEME = 'https://';
+const INSECURE_SCHEME = 'http://';
+
+/**
+ * Where the binary is coming from, as the command line said it: a url for the api to fetch, or a
+ * file on this machine to send.
+ *
+ * A path cannot begin with a scheme, so nothing else has to tell them apart. What the api will
+ * take is the api's to say — this only refuses the one mistake whose other reading is a file
+ * nobody could ever find.
+ */
+export async function binaryFrom(source: string): Promise<DeployableBinary> {
+  if (source.startsWith(SECURE_SCHEME)) {
+    return { url: source };
+  }
+  if (source.startsWith(INSECURE_SCHEME)) {
+    throw new UsageError(`A binary is fetched over https, and this is not: ${source}`);
+  }
+  return await openBinary(source);
+}
+
 /**
  * Opened rather than read: the bytes are streamed to the store when the time comes, and all
  * that is wanted here is that there is a file and what it is called.
  */
-export async function openBinary(path: string): Promise<UploadableBinary> {
+async function openBinary(path: string): Promise<UploadableBinary> {
   const body = Bun.file(path);
   if (!(await body.exists())) {
     throw new UsageError(`No such file: ${path}`);

--- a/packages/cli/src/lib/plan.test.ts
+++ b/packages/cli/src/lib/plan.test.ts
@@ -69,7 +69,7 @@ test('an owner with no apps is asked what to call one, not which to use', async 
   const resolved = await completeOptions({
     api: apiListing({ apps: [] }),
     options: {},
-    binaryPath: '/tmp/my-server',
+    binarySource: '/tmp/my-server',
     args: ['serve'],
   });
 
@@ -79,6 +79,17 @@ test('an owner with no apps is asked what to call one, not which to use', async 
     'text:Which HTTP port does the binary listen on? (3000)',
     'confirm:Create my-server and deploy?',
   ]);
+});
+
+test('a url suggests the same name the path to the same binary would', async () => {
+  const resolved = await completeOptions({
+    api: apiListing({ apps: [] }),
+    options: {},
+    binarySource: 'https://releases.test/v1/my-server',
+    args: [],
+  });
+
+  expect(resolved).toEqual({ name: 'my-server', port: 3000 });
 });
 
 test('an app the owner cannot deploy onto is not offered', async () => {
@@ -92,7 +103,7 @@ test('an app the owner cannot deploy onto is not offered', async () => {
       ],
     }),
     options: {},
-    binaryPath: '/tmp/my-server',
+    binarySource: '/tmp/my-server',
     args: [],
   });
 
@@ -107,7 +118,7 @@ test('a flag already given is not asked about again', async () => {
   const resolved = await completeOptions({
     api: apiListing({ apps: [] }),
     options: { name: 'my-app', port: 8080 },
-    binaryPath: '/tmp/my-server',
+    binarySource: '/tmp/my-server',
     args: ['serve', '--verbose'],
   });
 
@@ -119,7 +130,7 @@ test('what the binary will be run with is shown before anything is uploaded', as
   await completeOptions({
     api: apiListing({ apps: [{ slug: 'demo-abc123', state: 'active' }] }),
     options: { app: 'demo-abc123' },
-    binaryPath: '/tmp/my-server',
+    binarySource: '/tmp/my-server',
     args: ['serve', '--verbose'],
   });
 
@@ -133,7 +144,7 @@ test('a named app that cannot be deployed onto is refused before anything is ask
   const attempt = completeOptions({
     api: apiListing({ apps: [{ slug: 'demo-abc123', state: 'suspended' }], release: 'stopped' }),
     options: { app: 'demo-abc123' },
-    binaryPath: '/tmp/my-server',
+    binarySource: '/tmp/my-server',
     args: [],
   });
 
@@ -150,7 +161,7 @@ test('declining the confirmation cancels rather than deploying', async () => {
   const attempt = completeOptions({
     api: apiListing({ apps: [] }),
     options: {},
-    binaryPath: '/tmp/my-server',
+    binarySource: '/tmp/my-server',
     args: [],
   });
 

--- a/packages/cli/src/lib/plan.ts
+++ b/packages/cli/src/lib/plan.ts
@@ -18,7 +18,7 @@ export type RunOptions = {
 
 type Plan = {
   options: RunOptions;
-  binaryPath: string;
+  binarySource: string;
   args: TenantArguments;
 };
 
@@ -31,18 +31,18 @@ type Plan = {
 export async function completeOptions({
   api,
   options,
-  binaryPath,
+  binarySource,
   args,
 }: Plan & { api: PublicApiClient }) {
-  const completed = await fillGaps({ api, options, binaryPath });
-  await confirmPlan({ options: completed, binaryPath, args });
+  const completed = await fillGaps({ api, options, binarySource });
+  await confirmPlan({ options: completed, binarySource, args });
   return completed;
 }
 
 async function fillGaps({
   api,
   options,
-  binaryPath,
+  binarySource,
 }: Omit<Plan, 'args'> & { api: PublicApiClient }): Promise<RunOptions> {
   if (options.app !== undefined) {
     // A slug typed rather than chosen has been checked against nothing yet, and a summary saying
@@ -56,7 +56,7 @@ async function fillGaps({
   }
   return {
     ...options,
-    name: options.name ?? (await askName({ suggestion: basename(binaryPath) })),
+    name: options.name ?? (await askName({ suggestion: basename(binarySource) })),
     port: options.port ?? (await askPort()),
   };
 }
@@ -103,9 +103,9 @@ async function askPort(): Promise<number> {
   return Number(answered(answer));
 }
 
-async function confirmPlan({ options, binaryPath, args }: Plan): Promise<void> {
+async function confirmPlan({ options, binarySource, args }: Plan): Promise<void> {
   const creating = options.app === undefined;
-  note(summary({ options, binaryPath, args }), creating ? 'New app' : 'Existing app');
+  note(summary({ options, binarySource, args }), creating ? 'New app' : 'Existing app');
 
   const question = creating
     ? `Create ${options.name} and deploy?`
@@ -115,9 +115,9 @@ async function confirmPlan({ options, binaryPath, args }: Plan): Promise<void> {
   }
 }
 
-function summary({ options, binaryPath, args }: Plan): string {
+function summary({ options, binarySource, args }: Plan): string {
   const rows = [
-    ['binary', binaryPath],
+    ['binary', binarySource],
     ['app', options.app ?? options.name],
     ['port', options.port],
     // Only when it was asked for: a row saying no on every run is one nobody reads.

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -88,6 +88,13 @@ than carrying a number over from an example. It is the number the guest hands ba
 nib run ./my-server --app my-app
 ```
 
+The binary may be an https url instead of a path, and nibrun fetches it rather than this machine
+uploading it:
+
+```sh
+nib run https://github.com/me/my-app/releases/download/v1/my-server --app my-app
+```
+
 `nib run` waits until the deployment is actually serving and prints the URL. Add `--detach` to
 return as soon as it is created.
 


### PR DESCRIPTION
Stacked on #347 — review that one first; this targets its branch.

```sh
nib run https://github.com/me/app/releases/download/v1/my-server --app my-app
```

The positional already meant "the binary, then its arguments"; now it may be an https url as well as a path, for a new app or an existing one. Nothing is downloaded here and uploaded again — the url goes to the api, which fetches it.

A path cannot begin with a scheme, so nothing has to be said about which was meant. `http://` is refused as the mistake it is rather than looked for on disk. The positional is called a source rather than a path now, through the command line and the plan that reads it.

`nib apps update` is untouched: it exists to change how an app starts without touching its binary, and replacing the binary is what `nib run --app` is for.