### PR TITLE
feat(dashboard): a link may ask for the form stripped to the binary

### DIFF
--- a/apps/dashboard/src/components/apps/configure-deployment.tsx
+++ b/apps/dashboard/src/components/apps/configure-deployment.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@repo/ui/components/button';
+import { Link } from '@tanstack/react-router';
+
+/** The way out of the minimal form: the link stops asking for less, and the rest of it appears. */
+export function ConfigureDeployment() {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="self-center text-muted-foreground"
+      render={<Link to="/deploy" search={(previous) => ({ ...previous, minimal: undefined })} />}
+    >
+      Configure deployment
+    </Button>
+  );
+}

--- a/apps/dashboard/src/components/apps/deploy-configuration.tsx
+++ b/apps/dashboard/src/components/apps/deploy-configuration.tsx
@@ -1,0 +1,211 @@
+import { EXTRA_PUBLIC_PORT_VALUES, RUNTIME_VALUES, writtenRuntimeValue } from '@repo/protocol';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@repo/ui/components/accordion';
+import { Checkbox } from '@repo/ui/components/checkbox';
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '@repo/ui/components/field';
+import { Input } from '@repo/ui/components/input';
+import { Textarea } from '@repo/ui/components/textarea';
+import { DeployEnvironmentField } from '#components/apps/deploy-environment-field.tsx';
+import { DeployNameField } from '#components/apps/deploy-name-field.tsx';
+import type { DeploySuggestion } from '#lib/deploy-link.ts';
+import { filledVariables, storedVariables } from '#lib/environment-variables.ts';
+import { type DeployFormState, tenantArguments, validatePort } from '#lib/hooks/use-deploy-form.ts';
+
+const ARGUMENTS = 'Arguments';
+const ADDITIONAL_PORTS = 'Additional ports';
+const ENVIRONMENT = 'environment';
+
+/** Everything a deploy is beyond the binary itself, which is everything a link can carry. */
+export function DeployConfiguration({
+  form,
+  suggested,
+}: {
+  form: DeployFormState;
+  suggested: DeploySuggestion | undefined;
+}) {
+  const { api, locked, replacing, defaultPort, defaultExtraPublicPort, defaultArgs } = form;
+
+  return (
+    <>
+      {!locked && <DeployNameField api={api} />}
+
+      <api.Field name="port" validators={{ onChange: validatePort }}>
+        {(field) => (
+          <Field data-invalid={field.state.meta.errors.length > 0 || undefined}>
+            <FieldLabel htmlFor="deploy-port">HTTP port</FieldLabel>
+            <Input
+              id="deploy-port"
+              value={field.state.value ?? defaultPort}
+              onChange={(event) => field.handleChange(event.target.value)}
+              inputMode="numeric"
+              autoComplete="off"
+              className="font-mono tabular-nums"
+            />
+            {field.state.meta.errors.length > 0 ? (
+              <FieldError>{field.state.meta.errors[0]}</FieldError>
+            ) : (
+              <FieldDescription>The port the binary listens on inside the guest.</FieldDescription>
+            )}
+          </Field>
+        )}
+      </api.Field>
+
+      <Accordion>
+        <AccordionItem>
+          <AccordionTrigger>
+            <span className="flex items-baseline gap-2">
+              {ADDITIONAL_PORTS}
+              <api.Subscribe
+                selector={(state) => state.values.extraPublicPort ?? defaultExtraPublicPort}
+              >
+                {(asked) => <CollapsedState on={asked} />}
+              </api.Subscribe>
+            </span>
+          </AccordionTrigger>
+          <AccordionContent keepMounted>
+            <api.Field name="extraPublicPort">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <Checkbox
+                    id="deploy-extra-public-port"
+                    checked={field.state.value ?? defaultExtraPublicPort}
+                    onCheckedChange={(checked) => field.handleChange(checked)}
+                  />
+                  <FieldContent>
+                    <FieldLabel htmlFor="deploy-extra-public-port">
+                      Give this app a public port besides HTTPS
+                    </FieldLabel>
+                    <FieldDescription>
+                      One port, TCP and UDP, for a protocol HTTPS cannot carry — WebRTC media, a
+                      game server, anything that has to be reached directly.
+                    </FieldDescription>
+                    <FieldDescription>
+                      You do not pick the number. nibrun assigns it and sets these for the app:
+                    </FieldDescription>
+                    <ul className="list-disc space-y-1 pt-2 pb-3 pl-4 text-muted-foreground text-sm">
+                      {EXTRA_PUBLIC_PORT_VALUES.map(({ name, description }) => (
+                        <li key={name}>
+                          <code className="font-mono">{name}</code> — {description}
+                        </li>
+                      ))}
+                    </ul>
+                    <FieldDescription>
+                      Your own variables may name them — set{' '}
+                      <code className="font-mono">
+                        ANNOUNCED_IP={writtenRuntimeValue(RUNTIME_VALUES.PUBLIC_IPV4.name)}
+                      </code>{' '}
+                      and the app reads it under the name it already expects.
+                    </FieldDescription>
+                    <FieldDescription>
+                      Free for now, and likely to become part of a paid plan later.
+                    </FieldDescription>
+                  </FieldContent>
+                </Field>
+              )}
+            </api.Field>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+
+      <Accordion>
+        <AccordionItem>
+          <AccordionTrigger>
+            <span className="flex items-baseline gap-2">
+              {ARGUMENTS}
+              <api.Subscribe
+                selector={(state) => tenantArguments(state.values.args ?? defaultArgs).length}
+              >
+                {(count) => <CollapsedCount count={count} />}
+              </api.Subscribe>
+            </span>
+          </AccordionTrigger>
+          <AccordionContent keepMounted>
+            <api.Field name="args">
+              {(field) => (
+                <Field>
+                  <Textarea
+                    aria-label={ARGUMENTS}
+                    value={field.state.value ?? defaultArgs}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                    placeholder={'serve\n--verbose'}
+                    className="font-mono"
+                  />
+                  <FieldDescription>
+                    One per line. What is here is what the binary runs with — empty runs it bare.
+                  </FieldDescription>
+                </Field>
+              )}
+            </api.Field>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+
+      {/* Open where a link asked for a variable it could not carry: the owner is the only one who
+          holds the value, and a shut section is no way to ask them for it. */}
+      <Accordion defaultValue={asksForVariables(suggested) ? [ENVIRONMENT] : []}>
+        <AccordionItem value={ENVIRONMENT}>
+          <AccordionTrigger>
+            <span className="flex items-baseline gap-2">
+              Environment variables
+              <api.Subscribe
+                selector={(state) =>
+                  filledVariables(state.values.environment ?? storedVariables(replacing)).length
+                }
+              >
+                {(count) => <CollapsedCount count={count} />}
+              </api.Subscribe>
+            </span>
+            {/* Collapsed, a refused variable would disable the button with nothing on screen
+                saying why, so the section that holds it says so itself. A shut panel keeps its
+                variables validated, which is what leaves anything to say. */}
+            <api.Subscribe selector={(state) => state.fieldMeta.environment?.errors.length ?? 0}>
+              {(refused) =>
+                refused > 0 ? (
+                  <span className="font-normal text-destructive">needs a look</span>
+                ) : null
+              }
+            </api.Subscribe>
+          </AccordionTrigger>
+          <AccordionContent keepMounted>
+            <DeployEnvironmentField api={api} replacing={replacing} />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </>
+  );
+}
+
+/**
+ * Whether the link named a variable it carried no value for. Such a link cannot deploy on its own,
+ * whatever it asked to show: the owner is the only one who has the value.
+ */
+export function asksForVariables(suggested: DeploySuggestion | undefined): boolean {
+  return suggested?.environment?.some((entry) => entry.value.length === 0) ?? false;
+}
+
+/** What the section says while it is shut, in the one word a count would be. */
+function CollapsedState({ on }: { on: boolean }) {
+  return (
+    <span className="font-normal text-muted-foreground text-xs group-aria-expanded/accordion-trigger:hidden">
+      {on ? 'one' : 'none'}
+    </span>
+  );
+}
+
+function CollapsedCount({ count }: { count: number }) {
+  return (
+    <span className="font-normal text-muted-foreground text-xs group-aria-expanded/accordion-trigger:hidden">
+      {count === 0 ? 'none' : count}
+    </span>
+  );
+}

--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -1,56 +1,28 @@
-import { EXTRA_PUBLIC_PORT_VALUES, RUNTIME_VALUES, writtenRuntimeValue } from '@repo/protocol';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@repo/ui/components/accordion';
 import { Button } from '@repo/ui/components/button';
-import { Checkbox } from '@repo/ui/components/checkbox';
-import {
-  Field,
-  FieldContent,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
-} from '@repo/ui/components/field';
-import { Input } from '@repo/ui/components/input';
-import { Textarea } from '@repo/ui/components/textarea';
 import { useStore } from '@tanstack/react-form';
+import { ConfigureDeployment } from '#components/apps/configure-deployment.tsx';
 import { DeployBinaryField } from '#components/apps/deploy-binary-field.tsx';
-import { DeployEnvironmentField } from '#components/apps/deploy-environment-field.tsx';
-import { DeployNameField } from '#components/apps/deploy-name-field.tsx';
+import { asksForVariables, DeployConfiguration } from '#components/apps/deploy-configuration.tsx';
+import { MinimalBinaryField } from '#components/apps/minimal-binary-field.tsx';
 import type { DeploySuggestion } from '#lib/deploy-link.ts';
-import { filledVariables, storedVariables } from '#lib/environment-variables.ts';
-import { tenantArguments, useDeployForm, validatePort } from '#lib/hooks/use-deploy-form.ts';
-
-const ARGUMENTS = 'Arguments';
-const ADDITIONAL_PORTS = 'Additional ports';
-const ENVIRONMENT = 'environment';
+import { useDeployForm } from '#lib/hooks/use-deploy-form.ts';
 
 export function DeployForm({
   appId,
   binary,
   suggested,
+  minimal = false,
 }: {
   appId: string | undefined;
   binary: File | undefined;
   suggested?: DeploySuggestion | undefined;
+  minimal?: boolean | undefined;
 }) {
-  const {
-    api,
-    locked,
-    replacing,
-    targetResolved,
-    defaultPort,
-    defaultExtraPublicPort,
-    defaultArgs,
-  } = useDeployForm({
-    appId,
-    binary,
-    suggested,
-  });
+  const form = useDeployForm({ appId, binary, suggested });
+  const { api, locked, replacing, targetResolved } = form;
   const picked = useStore(api.store, (state) => state.values.binary !== undefined);
+  // One form either way, so the binary survives the way out of the stripped one.
+  const stripped = minimal && !asksForVariables(suggested);
 
   return (
     <form
@@ -60,152 +32,17 @@ export function DeployForm({
         void api.handleSubmit();
       }}
     >
-      <DeployBinaryField api={api} replacing={replacing} />
+      {stripped ? (
+        <MinimalBinaryField api={api} appName={suggested?.name} />
+      ) : (
+        <DeployBinaryField api={api} replacing={replacing} />
+      )}
 
-      {!locked && <DeployNameField api={api} />}
-
-      <api.Field name="port" validators={{ onChange: validatePort }}>
-        {(field) => (
-          <Field data-invalid={field.state.meta.errors.length > 0 || undefined}>
-            <FieldLabel htmlFor="deploy-port">HTTP port</FieldLabel>
-            <Input
-              id="deploy-port"
-              value={field.state.value ?? defaultPort}
-              onChange={(event) => field.handleChange(event.target.value)}
-              inputMode="numeric"
-              autoComplete="off"
-              className="font-mono tabular-nums"
-            />
-            {field.state.meta.errors.length > 0 ? (
-              <FieldError>{field.state.meta.errors[0]}</FieldError>
-            ) : (
-              <FieldDescription>The port the binary listens on inside the guest.</FieldDescription>
-            )}
-          </Field>
-        )}
-      </api.Field>
-
-      <Accordion>
-        <AccordionItem>
-          <AccordionTrigger>
-            <span className="flex items-baseline gap-2">
-              {ADDITIONAL_PORTS}
-              <api.Subscribe
-                selector={(state) => state.values.extraPublicPort ?? defaultExtraPublicPort}
-              >
-                {(asked) => <CollapsedState on={asked} />}
-              </api.Subscribe>
-            </span>
-          </AccordionTrigger>
-          <AccordionContent keepMounted>
-            <api.Field name="extraPublicPort">
-              {(field) => (
-                <Field orientation="horizontal">
-                  <Checkbox
-                    id="deploy-extra-public-port"
-                    checked={field.state.value ?? defaultExtraPublicPort}
-                    onCheckedChange={(checked) => field.handleChange(checked)}
-                  />
-                  <FieldContent>
-                    <FieldLabel htmlFor="deploy-extra-public-port">
-                      Give this app a public port besides HTTPS
-                    </FieldLabel>
-                    <FieldDescription>
-                      One port, TCP and UDP, for a protocol HTTPS cannot carry — WebRTC media, a
-                      game server, anything that has to be reached directly.
-                    </FieldDescription>
-                    <FieldDescription>
-                      You do not pick the number. nibrun assigns it and sets these for the app:
-                    </FieldDescription>
-                    <ul className="list-disc space-y-1 pt-2 pb-3 pl-4 text-muted-foreground text-sm">
-                      {EXTRA_PUBLIC_PORT_VALUES.map(({ name, description }) => (
-                        <li key={name}>
-                          <code className="font-mono">{name}</code> — {description}
-                        </li>
-                      ))}
-                    </ul>
-                    <FieldDescription>
-                      Your own variables may name them — set{' '}
-                      <code className="font-mono">
-                        ANNOUNCED_IP={writtenRuntimeValue(RUNTIME_VALUES.PUBLIC_IPV4.name)}
-                      </code>{' '}
-                      and the app reads it under the name it already expects.
-                    </FieldDescription>
-                    <FieldDescription>
-                      Free for now, and likely to become part of a paid plan later.
-                    </FieldDescription>
-                  </FieldContent>
-                </Field>
-              )}
-            </api.Field>
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
-
-      <Accordion>
-        <AccordionItem>
-          <AccordionTrigger>
-            <span className="flex items-baseline gap-2">
-              {ARGUMENTS}
-              <api.Subscribe
-                selector={(state) => tenantArguments(state.values.args ?? defaultArgs).length}
-              >
-                {(count) => <CollapsedCount count={count} />}
-              </api.Subscribe>
-            </span>
-          </AccordionTrigger>
-          <AccordionContent keepMounted>
-            <api.Field name="args">
-              {(field) => (
-                <Field>
-                  <Textarea
-                    aria-label={ARGUMENTS}
-                    value={field.state.value ?? defaultArgs}
-                    onChange={(event) => field.handleChange(event.target.value)}
-                    placeholder={'serve\n--verbose'}
-                    className="font-mono"
-                  />
-                  <FieldDescription>
-                    One per line. What is here is what the binary runs with — empty runs it bare.
-                  </FieldDescription>
-                </Field>
-              )}
-            </api.Field>
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
-
-      {/* Open where a link asked for a variable it could not carry: the owner is the only one who
-          holds the value, and a shut section is no way to ask them for it. */}
-      <Accordion defaultValue={asksForVariables(suggested) ? [ENVIRONMENT] : []}>
-        <AccordionItem value={ENVIRONMENT}>
-          <AccordionTrigger>
-            <span className="flex items-baseline gap-2">
-              Environment variables
-              <api.Subscribe
-                selector={(state) =>
-                  filledVariables(state.values.environment ?? storedVariables(replacing)).length
-                }
-              >
-                {(count) => <CollapsedCount count={count} />}
-              </api.Subscribe>
-            </span>
-            {/* Collapsed, a refused variable would disable the button with nothing on screen
-                saying why, so the section that holds it says so itself. A shut panel keeps its
-                variables validated, which is what leaves anything to say. */}
-            <api.Subscribe selector={(state) => state.fieldMeta.environment?.errors.length ?? 0}>
-              {(refused) =>
-                refused > 0 ? (
-                  <span className="font-normal text-destructive">needs a look</span>
-                ) : null
-              }
-            </api.Subscribe>
-          </AccordionTrigger>
-          <AccordionContent keepMounted>
-            <DeployEnvironmentField api={api} replacing={replacing} />
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
+      {stripped ? (
+        <ConfigureDeployment />
+      ) : (
+        <DeployConfiguration form={form} suggested={suggested} />
+      )}
 
       {replacing !== undefined && (
         <p className="wrap-anywhere rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
@@ -225,27 +62,6 @@ export function DeployForm({
         )}
       </api.Subscribe>
     </form>
-  );
-}
-
-function asksForVariables(suggested: DeploySuggestion | undefined): boolean {
-  return suggested?.environment?.some((entry) => entry.value.length === 0) ?? false;
-}
-
-/** What the section says while it is shut, in the one word a count would be. */
-function CollapsedState({ on }: { on: boolean }) {
-  return (
-    <span className="font-normal text-muted-foreground text-xs group-aria-expanded/accordion-trigger:hidden">
-      {on ? 'one' : 'none'}
-    </span>
-  );
-}
-
-function CollapsedCount({ count }: { count: number }) {
-  return (
-    <span className="font-normal text-muted-foreground text-xs group-aria-expanded/accordion-trigger:hidden">
-      {count === 0 ? 'none' : count}
-    </span>
   );
 }
 

--- a/apps/dashboard/src/components/apps/minimal-binary-field.tsx
+++ b/apps/dashboard/src/components/apps/minimal-binary-field.tsx
@@ -1,0 +1,49 @@
+import { Field, FieldError } from '@repo/ui/components/field';
+import { BinaryDropTarget } from '@repo/ui/custom/binary-drop-target';
+import type { ReactNode } from 'react';
+import { BINARY_INPUT_ID } from '#components/apps/binary-drop-zone.tsx';
+import { type DeployFormApi, validateBinary } from '#lib/hooks/use-deploy-form.ts';
+
+/**
+ * The binary, asked for the way the landing page asks: a link carries everything else, so the one
+ * thing left to do is the only thing on screen.
+ */
+export function MinimalBinaryField({
+  api,
+  appName,
+}: {
+  api: DeployFormApi;
+  appName: string | undefined;
+}) {
+  return (
+    <api.Field name="binary" validators={{ onMount: validateBinary, onChange: validateBinary }}>
+      {(field) => {
+        const rejected = field.state.value !== undefined && field.state.meta.errors.length > 0;
+        return (
+          <Field data-invalid={rejected || undefined}>
+            <BinaryDropTarget
+              inputId={BINARY_INPUT_ID}
+              binary={field.state.value}
+              title={invitation(appName)}
+              invalid={rejected}
+              onPick={field.handleChange}
+            />
+            {rejected && <FieldError>{field.state.meta.errors[0]}</FieldError>}
+          </Field>
+        );
+      }}
+    </api.Field>
+  );
+}
+
+// Whoever followed the link compiled one binary for one app, and the link knows which.
+function invitation(appName: string | undefined): ReactNode {
+  if (appName === undefined) {
+    return 'Drop it here';
+  }
+  return (
+    <>
+      Drop the <span className="font-mono font-semibold">{appName}</span> binary here
+    </>
+  );
+}

--- a/apps/dashboard/src/components/handoff/handed-off-binary.tsx
+++ b/apps/dashboard/src/components/handoff/handed-off-binary.tsx
@@ -12,7 +12,6 @@ import { BrandMark } from '@repo/ui/custom/brand-mark';
 import { Link, useLocation } from '@tanstack/react-router';
 import { FileTerminalIcon } from 'lucide-react';
 import { HandoffDeploy } from '#components/handoff/handoff-deploy.tsx';
-import type { DeploySuggestion } from '#lib/deploy-link.ts';
 import { formatBytes } from '#lib/format-bytes.ts';
 import { useFinishHandoff } from '#lib/hooks/use-finish-handoff.ts';
 import { useHandedOffBinary } from '#lib/hooks/use-handed-off-binary.ts';
@@ -20,7 +19,7 @@ import { useSession } from '#lib/hooks/use-session.ts';
 import { DeployRunProvider } from '#lib/providers/deploy-run-provider.tsx';
 import { Route as LoginRoute } from '#routes/(auth)/login.tsx';
 
-export function HandedOffBinary({ suggested }: { suggested?: DeploySuggestion | undefined }) {
+export function HandedOffBinary() {
   const { binary, loading } = useHandedOffBinary();
   const session = useSession();
 
@@ -28,11 +27,7 @@ export function HandedOffBinary({ suggested }: { suggested?: DeploySuggestion | 
     <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
       <BrandMark />
       <div className="flex w-full max-w-lg flex-col gap-6 lg:max-w-3xl">
-        {loading ? (
-          <Spinner />
-        ) : (
-          <Waiting binary={binary} signedIn={session !== null} suggested={suggested} />
-        )}
+        {loading ? <Spinner /> : <Waiting binary={binary} signedIn={session !== null} />}
       </div>
     </div>
   );
@@ -43,15 +38,7 @@ export function HandedOffBinary({ suggested }: { suggested?: DeploySuggestion | 
  * carries a picker of its own, so an owner who arrived with nothing still has everything they
  * need to deploy — which is why there is no empty state to land in.
  */
-function Waiting({
-  binary,
-  signedIn,
-  suggested,
-}: {
-  binary: File | undefined;
-  signedIn: boolean;
-  suggested: DeploySuggestion | undefined;
-}) {
+function Waiting({ binary, signedIn }: { binary: File | undefined; signedIn: boolean }) {
   const finishHandoff = useFinishHandoff();
   // Whatever was handed over or asked for has to survive the trip through the login form, or
   // signing in is what loses it.
@@ -86,7 +73,7 @@ function Waiting({
 
   return (
     <DeployRunProvider onDeployed={finishHandoff}>
-      <HandoffDeploy binary={binary} suggested={suggested} />
+      <HandoffDeploy binary={binary} />
     </DeployRunProvider>
   );
 }

--- a/apps/dashboard/src/components/handoff/handoff-deploy.tsx
+++ b/apps/dashboard/src/components/handoff/handoff-deploy.tsx
@@ -9,19 +9,15 @@ import {
 import { Link } from '@tanstack/react-router';
 import { DeployForm } from '#components/apps/deploy-form.tsx';
 import { DeployProgress } from '#components/apps/deploy-progress.tsx';
-import type { DeploySuggestion } from '#lib/deploy-link.ts';
+import { deploySuggestion } from '#lib/deploy-link.ts';
+import { useDeployLink } from '#lib/hooks/use-deploy-link.ts';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
 import type { DeployPhase } from '#lib/hooks/use-run-app.ts';
 import { Route as IndexRoute } from '#routes/(dashboard)/index.tsx';
 
-export function HandoffDeploy({
-  binary,
-  suggested,
-}: {
-  binary: File | undefined;
-  suggested?: DeploySuggestion | undefined;
-}) {
+export function HandoffDeploy({ binary }: { binary: File | undefined }) {
   const run = useDeployRun();
+  const link = useDeployLink();
 
   return (
     <Card>
@@ -33,7 +29,12 @@ export function HandoffDeploy({
       </CardHeader>
       <CardContent>
         {run.phase === 'idle' ? (
-          <DeployForm appId={undefined} binary={binary} suggested={suggested} />
+          <DeployForm
+            appId={undefined}
+            binary={binary}
+            suggested={deploySuggestion(link)}
+            minimal={link.minimal ?? false}
+          />
         ) : (
           // Only ever seen when the deploy failed: a run that lands leaves for the app it made
           // on its own, and a failed one made none to offer.

--- a/apps/dashboard/src/lib/deploy-link.ts
+++ b/apps/dashboard/src/lib/deploy-link.ts
@@ -2,10 +2,12 @@ import type { ConfigEdit, EnvironmentAssignment } from '@repo/app-operations';
 
 const ASSIGNMENT = '=';
 
+type Carried = { param: string; read: (value: unknown) => unknown };
+
 /**
- * What a "Deploy on nibrun" link may ask for, as the parameter that carries each part of a deploy
- * and the way that parameter is read. Keyed by `ConfigEdit`, so anything a release grows the
- * ability to configure is a link that stops compiling until it can be written into one.
+ * Each part of a deploy a link may ask for, as the parameter that carries it and the way that
+ * parameter is read. Keyed by `ConfigEdit`, so anything a release grows the ability to configure
+ * is a link that stops compiling until it can carry it.
  *
  * Every one of these only prefills a field the owner can still edit, and the api validates what is
  * submitted, so an absurd value costs a correction rather than a refusal here.
@@ -16,29 +18,64 @@ const CONFIGURED = {
   // everyone who followed the link.
   port: { param: 'port', read: asPort },
   extraPublicPort: { param: 'extra-public-port', read: asFlag },
-  args: { param: 'arg', read: asArguments },
-  environment: { param: 'env', read: asAssignments },
-} as const satisfies {
-  [K in keyof Required<ConfigEdit>]: { param: string; read: (value: unknown) => unknown };
+  args: { param: 'arg', read: asWritten },
+  environment: { param: 'env', read: asWritten },
+} as const satisfies { [K in keyof Required<ConfigEdit>]: Carried };
+
+type Written = {
+  [K in keyof typeof CONFIGURED as (typeof CONFIGURED)[K]['param']]?: ReturnType<
+    (typeof CONFIGURED)[K]['read']
+  >;
 };
 
-type Configured = {
-  [K in keyof typeof CONFIGURED]?: ReturnType<(typeof CONFIGURED)[K]['read']>;
+/**
+ * A link as it is written, one property per parameter. The router rebuilds the address bar out of
+ * this every time the page navigates — following the ghost button out of the minimal form is one —
+ * so a property named anything but the parameter it was read from would be written back beside it,
+ * as a second copy nothing here reads.
+ */
+export type DeployLink = Written & {
+  name?: string | undefined;
+  minimal?: boolean | undefined;
+};
+
+export function deployLink(search: Record<string, unknown>): DeployLink {
+  return {
+    name: asText(search.name),
+    minimal: asFlag(search.minimal),
+    ...written(search),
+  };
+}
+
+// Read off the parameters rather than the keys: `Object.fromEntries` cannot carry which reader
+// answered for which, and it is the parameter each is written under that both halves agree on.
+function written(search: Record<string, unknown>): Written {
+  return Object.fromEntries(
+    Object.values(CONFIGURED).map(({ param, read }) => [param, read(search[param])]),
+  ) as Written;
+}
+
+type Meant = {
+  port: number;
+  extraPublicPort: boolean;
+  args: string[];
+  environment: EnvironmentAssignment[];
 };
 
 /** What a link asked for, before the owner has touched anything. */
-export type DeploySuggestion = Configured & { name?: string | undefined };
+export type DeploySuggestion = { [K in keyof typeof CONFIGURED]?: Meant[K] } & {
+  name?: string | undefined;
+};
 
-export function deploySuggestion(search: Record<string, unknown>): DeploySuggestion {
-  return { name: asText(search.name), ...configured(search) };
-}
-
-// `Object.fromEntries` cannot carry which reader answered for which key, and the record above is
-// what says so — the same keys, read in the same order, with what each reader returns.
-function configured(search: Record<string, unknown>): Configured {
-  return Object.fromEntries(
-    Object.entries(CONFIGURED).map(([key, { param, read }]) => [key, read(search[param])]),
-  ) as Configured;
+/** The link as the deploy it describes. A parameter renamed above is a line here that stops compiling. */
+export function deploySuggestion(link: DeployLink): DeploySuggestion {
+  return {
+    name: link.name,
+    port: link.port,
+    extraPublicPort: link['extra-public-port'],
+    args: link.arg,
+    environment: link.env && assignments(link.env),
+  };
 }
 
 // A value reaches here already taken for what it looks like: `?port=3000` is a number and
@@ -64,17 +101,20 @@ function asFlag(value: unknown): boolean | undefined {
   return value === '' ? true : undefined;
 }
 
-function asArguments(value: unknown): string[] | undefined {
-  const args = written(value);
-  return args.length === 0 ? undefined : args;
+/** What was written under a parameter: the router hands over one occurrence, or an array of them. */
+function asWritten(value: unknown): string[] | undefined {
+  const occurrences = Array.isArray(value) ? value : [value];
+  const written = occurrences.flatMap((occurrence) => {
+    const text = asText(occurrence);
+    return text === undefined || text.length === 0 ? [] : [text];
+  });
+  return written.length === 0 ? undefined : written;
 }
 
-function asAssignments(value: unknown): EnvironmentAssignment[] | undefined {
+function assignments(written: readonly string[]): EnvironmentAssignment[] {
   // A name given twice takes its last value, as the same words would in a shell.
-  const named = new Map(written(value).map(assigned));
-  return named.size === 0
-    ? undefined
-    : [...named].map(([name, assignedValue]) => ({ name, value: assignedValue }));
+  const named = new Map(written.map(assigned));
+  return [...named].map(([name, value]) => ({ name, value }));
 }
 
 /**
@@ -85,13 +125,4 @@ function asAssignments(value: unknown): EnvironmentAssignment[] | undefined {
 function assigned(entry: string): [string, string] {
   const at = entry.indexOf(ASSIGNMENT);
   return at < 0 ? [entry.trim(), ''] : [entry.slice(0, at).trim(), entry.slice(at + 1)];
-}
-
-/** What was written under a parameter: the router hands over one occurrence, or an array of them. */
-function written(value: unknown): string[] {
-  const occurrences = Array.isArray(value) ? value : [value];
-  return occurrences.flatMap((occurrence) => {
-    const text = asText(occurrence);
-    return text === undefined || text.length === 0 ? [] : [text];
-  });
 }

--- a/apps/dashboard/src/lib/hooks/use-deploy-link.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy-link.ts
@@ -1,0 +1,6 @@
+import type { DeployLink } from '#lib/deploy-link.ts';
+import { Route as DeployRoute } from '#routes/deploy.tsx';
+
+export function useDeployLink(): DeployLink {
+  return DeployRoute.useSearch();
+}

--- a/apps/dashboard/src/routes/deploy.tsx
+++ b/apps/dashboard/src/routes/deploy.tsx
@@ -1,18 +1,17 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { HandedOffBinary } from '#components/handoff/handed-off-binary.tsx';
-import { deploySuggestion } from '#lib/deploy-link.ts';
+import { deployLink } from '#lib/deploy-link.ts';
 import { useHandoffReceiver } from '#lib/hooks/use-handoff-receiver.ts';
 
 // Outside `(auth)` and `(dashboard)` on purpose: the landing page frames this route, and a
 // hidden frame should render neither the signed-in chrome nor the auth card.
 export const Route = createFileRoute('/deploy')({
-  validateSearch: deploySuggestion,
+  validateSearch: deployLink,
   component: RouteComponent,
 });
 
 function RouteComponent() {
   const framed = useHandoffReceiver();
-  const suggested = Route.useSearch();
 
-  return framed ? null : <HandedOffBinary suggested={suggested} />;
+  return framed ? null : <HandedOffBinary />;
 }

--- a/apps/dashboard/tests/lib/deploy-link.test.ts
+++ b/apps/dashboard/tests/lib/deploy-link.test.ts
@@ -1,7 +1,12 @@
 import { expect, test } from 'bun:test';
 import { RUNTIME_VALUES, writtenRuntimeValue } from '@repo/protocol';
 import { defaultParseSearch, defaultStringifySearch } from '@tanstack/react-router';
-import { type DeploySuggestion, deploySuggestion } from '#lib/deploy-link.ts';
+import {
+  type DeployLink,
+  type DeploySuggestion,
+  deployLink,
+  deploySuggestion,
+} from '#lib/deploy-link.ts';
 
 const HOSTNAME = writtenRuntimeValue(RUNTIME_VALUES.HOSTNAME.name);
 
@@ -19,24 +24,30 @@ const ASKED: DeploySuggestion = {
   ],
 };
 
+function written(link: string): DeployLink {
+  return deployLink(defaultParseSearch(link));
+}
+
 function followed(link: string): DeploySuggestion {
-  return deploySuggestion(defaultParseSearch(link));
+  return deploySuggestion(written(link));
 }
 
 /**
- * The link as the router writes it back, which is the form of it a sign-in carries: whoever
- * follows one while signed out reaches the form through a redirect holding this.
+ * The link as the router writes it back, which is what the address bar holds the moment the page
+ * navigates — following the ghost button out of the minimal form, or coming back through signing
+ * in. Whatever a link asked for has to survive being written by the router that read it.
  */
-function reopened(link: string): DeploySuggestion {
-  return followed(defaultStringifySearch(defaultParseSearch(link)));
+function rewritten(link: string): string {
+  return defaultStringifySearch(written(link));
 }
 
 test('a link may ask for everything a deploy configures', () => {
   expect(followed(EVERYTHING)).toEqual(ASKED);
 });
 
-test('and asks for the same after the round trip through signing in', () => {
-  expect(reopened(EVERYTHING)).toEqual(ASKED);
+test('and asks for the same once the router has written it back', () => {
+  expect(followed(rewritten(EVERYTHING))).toEqual(ASKED);
+  expect(rewritten(rewritten(EVERYTHING))).toBe(rewritten(EVERYTHING));
 });
 
 test('a repeatable parameter written once is that one thing', () => {
@@ -53,14 +64,13 @@ test('a runtime value survives however it was written into the link', () => {
 });
 
 test('a value the router could read as JSON is still the text it was', () => {
-  expect(reopened('?env=CONFIG={"port":1}').environment).toEqual([
-    { name: 'CONFIG', value: '{"port":1}' },
-  ]);
+  const link = '?env=CONFIG={"port":1}';
+  expect(followed(rewritten(link)).environment).toEqual([{ name: 'CONFIG', value: '{"port":1}' }]);
 });
 
 test('a flag is on where it is written at all', () => {
   expect(followed('?extra-public-port').extraPublicPort).toBe(true);
-  expect(reopened('?extra-public-port').extraPublicPort).toBe(true);
+  expect(followed(rewritten('?extra-public-port')).extraPublicPort).toBe(true);
   expect(followed('?extra-public-port=false').extraPublicPort).toBe(false);
 });
 
@@ -83,4 +93,21 @@ test('a link that asks for nothing suggests nothing', () => {
     args: undefined,
     environment: undefined,
   });
+});
+
+test('a link may ask for the form stripped to the binary', () => {
+  expect(written('?minimal').minimal).toBe(true);
+  expect(written(`${EVERYTHING}&minimal`).minimal).toBe(true);
+  expect(written('?minimal=false').minimal).toBe(false);
+  expect(written(EVERYTHING).minimal).toBeUndefined();
+});
+
+// What the ghost button does: the parameter that stripped the form goes, and the deploy the link
+// asked for is still every bit of what the form is holding.
+test('and the rest of it survives that parameter going', () => {
+  const stripped = written(`${EVERYTHING}&minimal`);
+  const configured = defaultStringifySearch({ ...stripped, minimal: undefined });
+
+  expect(written(configured).minimal).toBeUndefined();
+  expect(followed(configured)).toEqual(ASKED);
 });

--- a/apps/www/src/components/binary-drop.tsx
+++ b/apps/www/src/components/binary-drop.tsx
@@ -1,40 +1,22 @@
-import { useBinaryPicker } from '@repo/ui/hooks/use-binary-picker';
-import { FileTerminalIcon, LoaderCircleIcon, UploadIcon } from 'lucide-react';
+import { BinaryDropTarget } from '@repo/ui/custom/binary-drop-target';
 import { type BinaryHandoff, useBinaryHandoff } from '#lib/hooks/use-binary-handoff.ts';
 
 const BINARY_INPUT_ID = 'binary';
 
 export function BinaryDrop() {
   const handoff = useBinaryHandoff();
-  const picker = useBinaryPicker({ onPick: handoff.offer });
 
   return (
     <div className="flex w-full flex-col gap-3">
-      <div
-        data-dragging={picker.dragging || undefined}
-        data-invalid={handoff.failure !== undefined || undefined}
-        className="relative rounded-3xl border-2 border-muted-foreground/25 border-dashed bg-input/40 transition-[color,background-color,border-color] duration-200 hover:border-muted-foreground/40 hover:bg-input/70 has-[input:focus-visible]:border-ring has-[input:focus-visible]:ring-3 has-[input:focus-visible]:ring-ring/30 data-[dragging=true]:border-ring data-[invalid=true]:border-destructive/60 data-[dragging=true]:border-solid data-[dragging=true]:bg-primary/10 data-[dragging=true]:ring-4 data-[dragging=true]:ring-primary/20"
-        {...picker.dropHandlers}
-      >
-        <input
-          ref={picker.inputRef}
-          id={BINARY_INPUT_ID}
-          type="file"
-          className="sr-only"
-          disabled={handoff.sending}
-          onChange={(event) => handoff.offer(event.target.files?.[0])}
-        />
-        <label
-          htmlFor={BINARY_INPUT_ID}
-          className="flex cursor-pointer flex-col items-center gap-4 px-6 py-16 text-center sm:py-20"
-        >
-          <Glyph handoff={handoff} />
-          <span className="flex flex-col gap-1.5">
-            <span className="font-medium text-lg sm:text-xl">Drop it here</span>
-            <span className="text-muted-foreground text-sm">{caption(handoff)}</span>
-          </span>
-        </label>
-      </div>
+      <BinaryDropTarget
+        inputId={BINARY_INPUT_ID}
+        binary={handoff.binary}
+        title="Drop it here"
+        caption={sending(handoff)}
+        busy={handoff.sending}
+        invalid={handoff.failure !== undefined}
+        onPick={handoff.offer}
+      />
       {handoff.failure !== undefined && (
         <p role="alert" className="text-center text-destructive text-sm">
           {handoff.failure}
@@ -44,25 +26,7 @@ export function BinaryDrop() {
   );
 }
 
-function Glyph({ handoff }: { handoff: BinaryHandoff }) {
-  const className = 'size-8 text-muted-foreground';
-
-  if (handoff.sending) {
-    return <LoaderCircleIcon className={`${className} animate-spin`} />;
-  }
-  return handoff.binary === undefined ? (
-    <UploadIcon className={className} />
-  ) : (
-    <FileTerminalIcon className={className} />
-  );
-}
-
-function caption(handoff: BinaryHandoff): string {
-  if (handoff.sending) {
-    return `Sending ${handoff.binary?.name}…`;
-  }
-  if (handoff.binary === undefined) {
-    return 'or click to browse';
-  }
-  return handoff.binary.name;
+/** The one thing the target cannot say for itself: a binary of its own is already on its way. */
+function sending(handoff: BinaryHandoff): string | undefined {
+  return handoff.sending ? `Sending ${handoff.binary?.name}…` : undefined;
 }

--- a/packages/ui/src/custom/binary-drop-target.tsx
+++ b/packages/ui/src/custom/binary-drop-target.tsx
@@ -1,0 +1,74 @@
+import { useBinaryPicker } from '@repo/ui/hooks/use-binary-picker';
+import { FileTerminalIcon, LoaderCircleIcon, UploadIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+const BROWSE = 'or click to browse';
+
+/**
+ * The whole surface an owner drops a binary onto, in the one size that reads as the only thing on
+ * the page to do. The landing page and a deploy link stripped to its binary are the same moment
+ * seen from either side of signing in, so they are the same target.
+ */
+export function BinaryDropTarget({
+  inputId,
+  binary,
+  title,
+  caption,
+  busy = false,
+  invalid = false,
+  onPick,
+}: {
+  inputId: string;
+  binary: File | undefined;
+  title: ReactNode;
+  caption?: string | undefined;
+  busy?: boolean | undefined;
+  invalid?: boolean | undefined;
+  onPick: (binary: File | undefined) => void;
+}) {
+  const picker = useBinaryPicker({ onPick });
+
+  return (
+    <div
+      data-dragging={picker.dragging || undefined}
+      data-invalid={invalid || undefined}
+      className="relative rounded-3xl border-2 border-muted-foreground/25 border-dashed bg-input/40 transition-[color,background-color,border-color] duration-200 hover:border-muted-foreground/40 hover:bg-input/70 has-[input:focus-visible]:border-ring has-[input:focus-visible]:ring-3 has-[input:focus-visible]:ring-ring/30 data-[dragging=true]:border-ring data-[invalid=true]:border-destructive/60 data-[dragging=true]:border-solid data-[dragging=true]:bg-primary/10 data-[dragging=true]:ring-4 data-[dragging=true]:ring-primary/20"
+      {...picker.dropHandlers}
+    >
+      <input
+        ref={picker.inputRef}
+        id={inputId}
+        type="file"
+        className="sr-only"
+        aria-invalid={invalid}
+        disabled={busy}
+        onChange={(event) => onPick(event.target.files?.[0])}
+      />
+      <label
+        htmlFor={inputId}
+        className="flex cursor-pointer flex-col items-center gap-4 px-6 py-16 text-center sm:py-20"
+      >
+        <Glyph binary={binary} busy={busy} />
+        <span className="flex flex-col gap-1.5">
+          <span className="font-medium text-lg sm:text-xl">{title}</span>
+          <span className="wrap-anywhere text-muted-foreground text-sm">
+            {caption ?? binary?.name ?? BROWSE}
+          </span>
+        </span>
+      </label>
+    </div>
+  );
+}
+
+function Glyph({ binary, busy }: { binary: File | undefined; busy: boolean }) {
+  const className = 'size-8 text-muted-foreground';
+
+  if (busy) {
+    return <LoaderCircleIcon className={`${className} animate-spin`} />;
+  }
+  return binary === undefined ? (
+    <UploadIcon className={className} />
+  ) : (
+    <FileTerminalIcon className={className} />
+  );
+}


### PR DESCRIPTION
`?minimal` strips `/deploy` to the one thing a link cannot carry: the binary. It is dropped onto the landing page's own target — now shared through `@repo/ui` rather than described twice — and where the link named the app, the target asks for that app's binary by name.

```
/deploy?name=pocketbase&port=8090&arg=serve&env=GREETING=hello&minimal
```

A ghost button above the deploy button drops the parameter and the rest of the form appears, holding everything the link asked for and the binary already picked — one form behind both views.

A link naming a variable it carried no value for is never stripped: it cannot deploy on its own, and hiding what blocks the button is no way to ask for a secret.

One thing worth a look: the route's search is now the link as written, one property per parameter. The router rebuilds the address bar out of it on every navigation, and this ghost button is the first navigation `/deploy` ever had — keyed by anything but the parameter names, following it wrote every parameter twice, once as the link had it and once as nothing here reads.