### PR TITLE
feat(dashboard): the deploy button names the app it is about to deploy

### DIFF
--- a/apps/dashboard/src/components/apps/advanced-configuration.tsx
+++ b/apps/dashboard/src/components/apps/advanced-configuration.tsx
@@ -2,7 +2,7 @@ import { Button } from '@repo/ui/components/button';
 import { Link } from '@tanstack/react-router';
 
 /** The way out of the minimal form: the link stops asking for less, and the rest of it appears. */
-export function ConfigureDeployment() {
+export function AdvancedConfiguration() {
   return (
     <Button
       type="button"
@@ -11,7 +11,7 @@ export function ConfigureDeployment() {
       className="self-center text-muted-foreground"
       render={<Link to="/deploy" search={(previous) => ({ ...previous, minimal: undefined })} />}
     >
-      Configure deployment
+      Advanced configuration
     </Button>
   );
 }

--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -1,11 +1,12 @@
 import { Button } from '@repo/ui/components/button';
 import { useStore } from '@tanstack/react-form';
-import { ConfigureDeployment } from '#components/apps/configure-deployment.tsx';
+import { AdvancedConfiguration } from '#components/apps/advanced-configuration.tsx';
 import { DeployBinaryField } from '#components/apps/deploy-binary-field.tsx';
 import { asksForVariables, DeployConfiguration } from '#components/apps/deploy-configuration.tsx';
 import { MinimalBinaryField } from '#components/apps/minimal-binary-field.tsx';
 import type { DeploySuggestion } from '#lib/deploy-link.ts';
-import { useDeployForm } from '#lib/hooks/use-deploy-form.ts';
+import { type DeployFormValues, useDeployForm } from '#lib/hooks/use-deploy-form.ts';
+import type { AppSummary } from '#queries/apps.ts';
 
 export function DeployForm({
   appId,
@@ -19,8 +20,9 @@ export function DeployForm({
   minimal?: boolean | undefined;
 }) {
   const form = useDeployForm({ appId, binary, suggested });
-  const { api, locked, replacing, targetResolved } = form;
+  const { api, replacing, targetResolved } = form;
   const picked = useStore(api.store, (state) => state.values.binary !== undefined);
+  const appName = useStore(api.store, (state) => deployedName({ values: state.values, replacing }));
   // One form either way, so the binary survives the way out of the stripped one.
   const stripped = minimal && !asksForVariables(suggested);
 
@@ -38,11 +40,7 @@ export function DeployForm({
         <DeployBinaryField api={api} replacing={replacing} />
       )}
 
-      {stripped ? (
-        <ConfigureDeployment />
-      ) : (
-        <DeployConfiguration form={form} suggested={suggested} />
-      )}
+      {!stripped && <DeployConfiguration form={form} suggested={suggested} />}
 
       {replacing !== undefined && (
         <p className="wrap-anywhere rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
@@ -52,30 +50,48 @@ export function DeployForm({
         </p>
       )}
 
-      <api.Subscribe selector={(state) => state.canSubmit}>
-        {(canSubmit) => (
-          <Button type="submit" size="lg" disabled={!canSubmit || !targetResolved}>
-            <span className="truncate">
-              {submitLabel({ replacing: replacing?.slug, locked, picked })}
-            </span>
-          </Button>
-        )}
-      </api.Subscribe>
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <api.Subscribe selector={(state) => state.canSubmit}>
+          {(canSubmit) => (
+            <Button type="submit" size="lg" disabled={!canSubmit || !targetResolved}>
+              <span className="truncate">{submitLabel({ appName, targetResolved })}</span>
+            </Button>
+          )}
+        </api.Subscribe>
+        {stripped && <AdvancedConfiguration />}
+      </div>
     </form>
   );
 }
 
-function submitLabel({
+/**
+ * The app this deploys, as it is known right now: the one being released again, the name that was
+ * typed or asked for, or the binary the app would be named after. Whichever it is, the button says
+ * it as soon as the form knows it.
+ */
+function deployedName({
+  values,
   replacing,
-  locked,
-  picked,
 }: {
-  replacing: string | undefined;
-  locked: boolean;
-  picked: boolean;
-}): string {
+  values: DeployFormValues;
+  replacing: AppSummary | undefined;
+}): string | undefined {
   if (replacing !== undefined) {
-    return picked ? `Replace what ${replacing} runs` : `Redeploy ${replacing}`;
+    return replacing.slug;
   }
-  return locked ? 'Reading the app…' : 'Create the app and deploy';
+  const typed = values.name.trim();
+  return typed === '' ? values.binary?.name : typed;
+}
+
+function submitLabel({
+  appName,
+  targetResolved,
+}: {
+  appName: string | undefined;
+  targetResolved: boolean;
+}): string {
+  if (!targetResolved) {
+    return 'Reading the app…';
+  }
+  return appName === undefined ? 'Deploy the app' : `Deploy ${appName}`;
 }


### PR DESCRIPTION
Every deploy button now reads `Deploy <app>`, on whichever name the form already knows — the app being released again, the one typed or asked for by the link, or the binary the app would be named after — falling back to `Deploy the app`. It follows the form live: dropping a binary names the button before anything is read.

This replaces three labels for one act: "Create the app and deploy", "Redeploy X" and "Replace what X runs". The environment dialog keeps "Save and redeploy X", since saving there is a release rather than a deploy screen — say the word if you want that one folded in too.

The way out of the minimal form is now "Advanced configuration", under the deploy button and close enough to read as its footnote.