### PR TITLE
fix(cli,dashboard): a settling release is said in the app's terms, not the guest's

### DIFF
--- a/apps/dashboard/src/components/apps/deploy-progress.tsx
+++ b/apps/dashboard/src/components/apps/deploy-progress.tsx
@@ -77,7 +77,7 @@ function waitingOn(phase: DeployPhase): string | undefined {
   if (phase === 'releasing') {
     return 'releasing the binary the app already has';
   }
-  return phase === 'settling' ? 'waiting for the guest to answer' : undefined;
+  return phase === 'settling' ? 'the app is coming online' : undefined;
 }
 
 function describeStep(step: DeployStep): string {

--- a/packages/cli/src/lib/release.ts
+++ b/packages/cli/src/lib/release.ts
@@ -42,7 +42,7 @@ export async function awaitServing({
 
   const startedAt = Date.now();
   const settled = await ui.waitingFor({
-    message: `starting deployment ${deployed.deploymentId}`,
+    message: `the app is coming online — deployment ${deployed.deploymentId}`,
     task: () =>
       awaitDeploymentSettled({
         api,


### PR DESCRIPTION
"waiting for the guest to answer" describes an internal, not what the owner is waiting on. Both the dashboard's settling phase and the CLI's release spinner now say the app is coming online.