### PR TITLE
fix(api): a binary is only fetched from somewhere the caller could have reached

### DIFF
--- a/apps/api/src/lib/public-address.ts
+++ b/apps/api/src/lib/public-address.ts
@@ -1,0 +1,79 @@
+import { isIP } from 'node:net';
+
+/**
+ * Every IPv4 address that is not the public internet: this network, the private ranges, loopback,
+ * link-local — where the instance metadata service sits — carrier-grade NAT, the protocol and
+ * benchmarking assignments, multicast, and the reserved space above them.
+ */
+const RESERVED_V4 = [
+  '0.0.0.0/8',
+  '10.0.0.0/8',
+  '100.64.0.0/10',
+  '127.0.0.0/8',
+  '169.254.0.0/16',
+  '172.16.0.0/12',
+  '192.0.0.0/24',
+  '192.168.0.0/16',
+  '198.18.0.0/15',
+  '224.0.0.0/4',
+  '240.0.0.0/4',
+];
+
+/**
+ * Allowed rather than refused, because IPv6 says outright which range is the internet: `2000::/3`
+ * is global unicast, and everything outside it is loopback, link-local, unique-local, multicast,
+ * or an IPv4 address embedded in a v6 one — which would have to be judged as an IPv4 address
+ * anyway, and is refused here rather than unwrapped.
+ */
+const GLOBAL_UNICAST_FIRST = 0x2000;
+const GLOBAL_UNICAST_LAST = 0x3fff;
+
+const V4_BITS = 32;
+const OCTET_VALUES = 256;
+const HEX = 16;
+
+export const IP_V4 = 4;
+export const IP_V6 = 6;
+
+/**
+ * Whether an address is one the world can reach, rather than one only this network can.
+ *
+ * What it is for: a url is the caller's to name and the api's to dial, so without this the api is
+ * a way to knock on doors inside the network that nobody outside it can reach — and to be told,
+ * by which refusal comes back, which of them answered.
+ */
+export function isPublicAddress(address: string): boolean {
+  switch (isIP(address)) {
+    case IP_V4:
+      return !RESERVED_V4.some((range) => within({ address, range }));
+    case IP_V6:
+      return isGlobalUnicast(address);
+    default:
+      return false;
+  }
+}
+
+/** The host as `isIP` reads it: a url brackets an IPv6 literal and an address is not bracketed. */
+export function hostnameOf(url: URL): string {
+  return url.hostname.startsWith('[') ? url.hostname.slice(1, -1) : url.hostname;
+}
+
+function within({ address, range }: { address: string; range: string }): boolean {
+  const [base = '', bits = ''] = range.split('/');
+  const addresses = 2 ** (V4_BITS - Number(bits));
+  return Math.floor(asNumber(address) / addresses) === Math.floor(asNumber(base) / addresses);
+}
+
+function asNumber(address: string): number {
+  let total = 0;
+  for (const octet of address.split('.')) {
+    total = total * OCTET_VALUES + Number(octet);
+  }
+  return total;
+}
+
+// A leading `::` is an address whose first hextet is zero, which no global unicast address has.
+function isGlobalUnicast(address: string): boolean {
+  const first = address.startsWith('::') ? 0 : Number.parseInt(address.split(':')[0] ?? '', HEX);
+  return first >= GLOBAL_UNICAST_FIRST && first <= GLOBAL_UNICAST_LAST;
+}

--- a/apps/api/src/repositories/binary-source.repository.ts
+++ b/apps/api/src/repositories/binary-source.repository.ts
@@ -1,4 +1,7 @@
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
 import { isBinaryUrl } from '#lib/binary-url.ts';
+import { hostnameOf, IP_V6, isPublicAddress } from '#lib/public-address.ts';
 
 /**
  * The whole fetch rather than the connect alone: the signal stays with the body, so this is also
@@ -32,7 +35,11 @@ export type BinarySource =
   | { outcome: 'refused'; status: number }
   | { outcome: 'empty' }
   | { outcome: 'insecure-redirect'; to: string }
-  | { outcome: 'too-many-redirects' };
+  | { outcome: 'too-many-redirects' }
+  | { outcome: 'private-address'; host: string };
+
+/** Whether an address is one this will dial; see the note on the constructor argument. */
+export type AddressPolicy = (address: string) => boolean;
 
 /**
  * What a source failing part way through is raised as. Everything downstream of the fetch is this
@@ -51,26 +58,36 @@ export abstract class BinarySourceRepositoryContract {
 }
 
 export class BinarySourceRepository implements BinarySourceRepositoryContract {
+  private readonly mayDial: AddressPolicy;
+
   /**
-   * Redirects are followed a hop at a time rather than by `fetch` itself, which is what makes the
-   * https rule mean anything: every store that hosts a release answers the address people share
-   * with a redirect, and a rule applied to the first address alone is one a `302` to plaintext
-   * walks straight around.
+   * Which addresses this will dial, defaulting to the only answer production has any business
+   * using. It is an argument at all so that a test can point one of these at a server on the
+   * machine running it — which is, by definition, an address the default refuses.
+   */
+  constructor({ mayDial = isPublicAddress }: { mayDial?: AddressPolicy } = {}) {
+    this.mayDial = mayDial;
+  }
+
+  /**
+   * Redirects are followed a hop at a time rather than by `fetch` itself, which is what makes both
+   * rules mean anything: every store that hosts a release answers the address people share with a
+   * redirect, and a rule applied to the first address alone is one a `302` walks straight around.
    */
   async open({ url }: { url: string }): Promise<BinarySource> {
     const deadline = AbortSignal.timeout(FETCH_DEADLINE_MS);
     let target = url;
 
     for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-      const response = await get({ url: target, deadline });
-      if (response === undefined) {
-        return { outcome: 'unreachable' };
+      const reached = await this.reach({ url: target, deadline });
+      if (reached.outcome !== 'answered') {
+        return reached;
       }
-      const location = redirectTarget({ response, from: target });
+      const location = redirectTarget({ response: reached.response, from: target });
       if (location === undefined) {
-        return await answered(response);
+        return await answered(reached.response);
       }
-      await discard(response);
+      await discard(reached.response);
       if (!isBinaryUrl(location)) {
         return { outcome: 'insecure-redirect', to: location };
       }
@@ -78,6 +95,62 @@ export class BinarySourceRepository implements BinarySourceRepositoryContract {
     }
 
     return { outcome: 'too-many-redirects' };
+  }
+
+  /**
+   * One hop, judged before it is dialled and then held to what was judged.
+   *
+   * Resolving to decide and resolving again to connect are two separate answers, and a name that
+   * gives a different one the second time is the whole of how a check on the first is walked
+   * around — so the address that passed is the address dialled, with the name carried in the
+   * handshake and in `Host` so the certificate is still checked against it.
+   */
+  private async reach({ url, deadline }: { url: string; deadline: AbortSignal }): Promise<Reached> {
+    const parsed = parse(url);
+    if (parsed === undefined) {
+      return { outcome: 'unreachable' };
+    }
+    const host = hostnameOf(parsed);
+    const addresses = await addressesOf(host);
+    if (addresses === undefined) {
+      return { outcome: 'unreachable' };
+    }
+    // Every one of them: a name answering with an address anyone can reach and one only this box
+    // can is a name that would otherwise be judged on whichever happened to come first.
+    if (!addresses.every(this.mayDial)) {
+      return { outcome: 'private-address', host };
+    }
+
+    for (const address of addresses) {
+      const response = await get({ url: parsed, address, deadline });
+      if (response !== undefined) {
+        return { outcome: 'answered', response };
+      }
+    }
+    return { outcome: 'unreachable' };
+  }
+}
+
+type Reached =
+  | { outcome: 'answered'; response: Response }
+  | { outcome: 'unreachable' }
+  | { outcome: 'private-address'; host: string };
+
+/**
+ * Every address the name answers with, or the literal it already is.
+ *
+ * A url that already names an address has nothing to look up and nothing to be held to that it
+ * does not already say, so it is its own answer.
+ */
+async function addressesOf(host: string): Promise<string[] | undefined> {
+  if (isIP(host) !== 0) {
+    return [host];
+  }
+  try {
+    const found = await lookup(host, { all: true });
+    return found.length === 0 ? undefined : found.map((each) => each.address);
+  } catch {
+    return undefined;
   }
 }
 
@@ -88,13 +161,35 @@ export class BinarySourceRepository implements BinarySourceRepositoryContract {
  */
 async function get({
   url,
+  address,
   deadline,
 }: {
-  url: string;
+  url: URL;
+  address: string;
   deadline: AbortSignal;
 }): Promise<Response | undefined> {
+  const request: BunFetchRequestInit = { redirect: 'manual', signal: deadline };
+  const dialled = pinnedTo({ url, address });
+  if (dialled.hostname !== url.hostname) {
+    request.headers = { host: url.host };
+    request.tls = { serverName: url.hostname };
+  }
   try {
-    return await fetch(url, { redirect: 'manual', signal: deadline });
+    return await fetch(dialled, request);
+  } catch {
+    return undefined;
+  }
+}
+
+function pinnedTo({ url, address }: { url: URL; address: string }): URL {
+  const dialled = new URL(url);
+  dialled.hostname = isIP(address) === IP_V6 ? `[${address}]` : address;
+  return dialled;
+}
+
+function parse(url: string): URL | undefined {
+  try {
+    return new URL(url);
   } catch {
     return undefined;
   }

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -89,6 +89,15 @@ function insecureRedirect(to: string): string {
   return `The url redirected to ${withoutCredentials(to)}, which is not an https address nibrun will follow.`;
 }
 
+/**
+ * A url that resolves inside the network the api runs in. Refused rather than fetched: the api can
+ * reach addresses the caller cannot, so following one on their behalf lends them a position they
+ * were never given — and tells them, in which sentence comes back, what is listening there.
+ */
+function privateAddress(host: string): string {
+  return `${host} resolves inside the network nibrun runs in, which is not somewhere it will fetch from.`;
+}
+
 function interruptedSource(url: string): string {
   return `The url stopped sending before the binary was whole: ${url}`;
 }
@@ -564,6 +573,8 @@ function sourceRefusal({
       return insecureRedirect(source.to);
     case 'too-many-redirects':
       return TOO_MANY_REDIRECTS;
+    case 'private-address':
+      return privateAddress(source.host);
   }
 }
 

--- a/apps/api/tests/lib/public-address.test.ts
+++ b/apps/api/tests/lib/public-address.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { hostnameOf, isPublicAddress } from '#lib/public-address.ts';
+
+/**
+ * The api dials what a caller names, from inside a network the caller is not in. Everything below
+ * is about one question: is this an address they could have fetched from themselves, or one the
+ * api would only be reaching on their behalf?
+ */
+describe('an address is either one the world can reach or one only this network can', () => {
+  test.each([
+    ['8.8.8.8', 'a public v4 address'],
+    ['1.1.1.1', 'another'],
+    ['104.20.23.154', 'one a release host actually answers on'],
+    ['172.15.255.255', 'the address below the private range'],
+    ['172.32.0.0', 'the address above it'],
+    ['100.63.255.255', 'the address below carrier-grade NAT'],
+  ])('%s is dialled — %s', (address) => {
+    expect(isPublicAddress(address)).toBe(true);
+  });
+
+  test.each([
+    ['0.0.0.0', 'this network'],
+    ['10.1.2.3', 'a private range'],
+    ['172.16.0.1', 'the low end of another'],
+    ['172.31.255.254', 'the high end of the same one'],
+    ['192.168.1.1', 'the third'],
+    ['127.0.0.1', 'loopback'],
+    ['127.255.255.255', 'the rest of loopback'],
+    ['169.254.169.254', 'the instance metadata service'],
+    ['100.64.0.1', 'carrier-grade NAT'],
+    ['192.0.0.1', 'the protocol assignments'],
+    ['198.18.0.1', 'the benchmarking range'],
+    ['224.0.0.1', 'multicast'],
+    ['255.255.255.255', 'broadcast'],
+  ])('%s is refused — %s', (address) => {
+    expect(isPublicAddress(address)).toBe(false);
+  });
+});
+
+/**
+ * Allowed rather than refused, because IPv6 names its own internet: `2000::/3` is global unicast
+ * and everything else is loopback, link-local, unique-local, multicast, or a v4 address wearing a
+ * v6 address's clothes.
+ */
+describe('IPv6 is judged by the one range that is the internet', () => {
+  test.each([
+    ['2001:db8::1', 'documentation, inside global unicast'],
+    ['2606:4700::6810:85e5', 'a release host'],
+    ['3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 'the top of the range'],
+  ])('%s is dialled — %s', (address) => {
+    expect(isPublicAddress(address)).toBe(true);
+  });
+
+  test.each([
+    ['::1', 'loopback'],
+    ['::', 'the unspecified address'],
+    ['fe80::1', 'link-local'],
+    ['fc00::1', 'unique-local'],
+    ['fd12:3456::1', 'the rest of unique-local'],
+    ['ff02::1', 'multicast'],
+    ['::ffff:127.0.0.1', 'loopback wearing a v6 address'],
+    ['::ffff:10.0.0.1', 'a private v4 address wearing one'],
+    ['64:ff9b::8.8.8.8', 'NAT64, which embeds a v4 address this cannot judge as one'],
+    ['1fff::1', 'just below global unicast'],
+    ['4000::1', 'just above it'],
+  ])('%s is refused — %s', (address) => {
+    expect(isPublicAddress(address)).toBe(false);
+  });
+});
+
+describe('what is not an address at all is not one this dials', () => {
+  test.each([['releases.test'], ['localhost'], [''], ['999.1.1.1'], ['10.0.0']])(
+    '%s is refused',
+    (host) => {
+      expect(isPublicAddress(host)).toBe(false);
+    },
+  );
+});
+
+// A url brackets an IPv6 literal and an address does not, so the two disagree about the same host
+// unless one of them gives way.
+describe('the host of a url is read the way an address is written', () => {
+  test('a name is itself', () => {
+    expect(hostnameOf(new URL('https://releases.test/my-server'))).toBe('releases.test');
+  });
+
+  test('a v4 literal is itself', () => {
+    expect(hostnameOf(new URL('https://10.0.0.5/my-server'))).toBe('10.0.0.5');
+  });
+
+  test('a v6 literal comes out of its brackets', () => {
+    expect(hostnameOf(new URL('https://[2001:db8::1]/my-server'))).toBe('2001:db8::1');
+  });
+});

--- a/apps/api/tests/repositories/binary-source.repository.test.ts
+++ b/apps/api/tests/repositories/binary-source.repository.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import type { TCPSocketListener } from 'bun';
+import { isPublicAddress } from '#lib/public-address.ts';
 import {
   type BinarySource,
   BinarySourceRepository,
@@ -17,7 +18,19 @@ const HEX = 16;
  */
 let releases: ReturnType<typeof Bun.serve>;
 let byHand: TCPSocketListener;
-const repo = new BinarySourceRepository();
+/**
+ * Every server below is on this machine, and dialling this machine is the one thing the default
+ * address policy exists to refuse — so the transport tests say so outright, and the policy has a
+ * describe of its own where it is left at its default.
+ */
+const repo = new BinarySourceRepository({ mayDial: () => true });
+const guarded = new BinarySourceRepository();
+// The default policy loosened by exactly this machine, so a test about which *hop* is judged is
+// not answered by the first one being on the wrong side of the rule.
+const fromHere = new BinarySourceRepository({
+  mayDial: (address) => LOOPBACK.has(address) || isPublicAddress(address),
+});
+const LOOPBACK = new Set(['127.0.0.1', '::1']);
 
 beforeAll(() => {
   releases = Bun.serve({ port: 0, fetch: answer });
@@ -39,6 +52,11 @@ function answer(request: Request): Response {
       return new Response(BINARY);
     case '/elsewhere':
       return new Response(null, { status: 302, headers: { location: '/my-server' } });
+    case '/inward':
+      return new Response(null, {
+        status: 302,
+        headers: { location: 'https://169.254.169.254/latest/meta-data/' },
+      });
     default:
       return new Response('no such release', { status: 404 });
   }
@@ -119,5 +137,45 @@ describe('a source that stops part way is the url, not the api', () => {
     const source = await repo.open({ url: byHandAt('/cut-off') });
 
     await expect(read(source)).rejects.toBeInstanceOf(InterruptedSourceError);
+  });
+});
+
+/**
+ * The api dials from inside a network the caller is not in. Without this it is a way to knock on
+ * doors nobody outside can reach, and to be told by which refusal comes back which of them
+ * answered — so an address is judged before it is dialled, and the address that passed is the one
+ * dialled.
+ */
+describe('a url is only followed to somewhere the caller could have gone themselves', () => {
+  test('a name that resolves onto this machine is refused, unfetched', async () => {
+    expect(await guarded.open({ url: at('/my-server') })).toEqual({
+      outcome: 'private-address',
+      host: 'localhost',
+    });
+  });
+
+  test('so is an address written out rather than resolved to', async () => {
+    expect(await guarded.open({ url: byHandAt('/my-server') })).toEqual({
+      outcome: 'private-address',
+      host: '127.0.0.1',
+    });
+  });
+
+  test.each([
+    ['https://169.254.169.254/latest/meta-data/', 'the instance metadata service'],
+    ['https://10.0.0.5/my-server', 'a private range'],
+    ['https://[::1]/my-server', 'loopback, in v6'],
+    ['https://[fd00::1]/my-server', 'unique-local'],
+  ])('and %s — %s', async (url) => {
+    expect(await guarded.open({ url })).toMatchObject({ outcome: 'private-address' });
+  });
+
+  // The hop the caller never saw is the one worth checking: a name they own can answer publicly
+  // and then redirect inward.
+  test('a redirect inward is refused at the hop it points to', async () => {
+    expect(await fromHere.open({ url: at('/inward') })).toEqual({
+      outcome: 'private-address',
+      host: '169.254.169.254',
+    });
   });
 });

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -909,6 +909,17 @@ describe('a binary is fetched from the url it was given', () => {
     expect(sourceRepo.wasLetGo).toBe(true);
   });
 
+  test('a url that resolves inside nibrun is said back as the host it resolved to', async () => {
+    const { service, sourceRepo, artifactsRepo } = build();
+    sourceRepo.answers({ outcome: 'private-address', host: 'internal.releases.test' });
+
+    const refusal = service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL });
+
+    await expect(refusal).rejects.toBeInstanceOf(BadRequestError);
+    await expect(refusal).rejects.toThrow('internal.releases.test');
+    expect(artifactsRepo.rows.size).toBe(0);
+  });
+
   test('a redirect out of https is said back as the hop the caller never saw', async () => {
     const { service, sourceRepo } = build();
     sourceRepo.answers({ outcome: 'insecure-redirect', to: 'http://mirror.test/my-server' });


### PR DESCRIPTION
The guard left out of #347, per the note there.

`POST /apps/:appId/artifacts { url }` makes the api dial from inside a network the caller is not in. Without this it is a way to knock on doors nobody outside can reach — and to learn, from which of `unreachable` / `answered <status>` / `not a Linux executable` comes back, which of them answered.

**What is refused.** Every address the name resolves to has to be one the world can reach; all of them, because a name answering with one public address and one private is otherwise judged on whichever came first. IPv4 goes by range — this network, the private ranges, loopback, link-local (where the metadata service sits), CGNAT, the protocol and benchmarking assignments, multicast, reserved. IPv6 is the other way round: `2000::/3` is global unicast and is allowed, everything else refused, which covers loopback, link-local, unique-local, multicast, and the v4-in-v6 forms in one rule rather than five.

**Held to what was judged.** Resolving to decide and resolving again to connect are two separate answers, and a name that gives a different one the second time is the whole of how a check on the first is walked around. So the address that passed is the address dialled, with the name carried in SNI and in `Host` — the certificate is still checked against the name, not the address.

**At every hop**, for the same reason the https rule is: a name the caller owns can answer publicly and then redirect inward.

Which addresses a repository will dial is a constructor argument defaulting to the real policy, because every server a test can stand up is on the machine running it — which is by definition an address the default refuses.