### PR TITLE
fix(dashboard): a variable a link carried is a variable it shows

### DIFF
--- a/apps/dashboard/src/components/apps/deploy-configuration.tsx
+++ b/apps/dashboard/src/components/apps/deploy-configuration.tsx
@@ -17,7 +17,7 @@ import { Input } from '@repo/ui/components/input';
 import { Textarea } from '@repo/ui/components/textarea';
 import { DeployEnvironmentField } from '#components/apps/deploy-environment-field.tsx';
 import { DeployNameField } from '#components/apps/deploy-name-field.tsx';
-import type { DeploySuggestion } from '#lib/deploy-link.ts';
+import { type DeploySuggestion, namesVariables } from '#lib/deploy-link.ts';
 import { filledVariables, storedVariables } from '#lib/environment-variables.ts';
 import { type DeployFormState, tenantArguments, validatePort } from '#lib/hooks/use-deploy-form.ts';
 
@@ -150,9 +150,10 @@ export function DeployConfiguration({
         </AccordionItem>
       </Accordion>
 
-      {/* Open where a link asked for a variable it could not carry: the owner is the only one who
-          holds the value, and a shut section is no way to ask them for it. */}
-      <Accordion defaultValue={asksForVariables(suggested) ? [ENVIRONMENT] : []}>
+      {/* Open where a link named a variable at all: the owner is the only one who holds a value it
+          could not carry, and a shut section is no way to ask them for it — nor to say what a
+          value it did carry is about to make the app run with. */}
+      <Accordion defaultValue={namesVariables(suggested) ? [ENVIRONMENT] : []}>
         <AccordionItem value={ENVIRONMENT}>
           <AccordionTrigger>
             <span className="flex items-baseline gap-2">
@@ -183,14 +184,6 @@ export function DeployConfiguration({
       </Accordion>
     </>
   );
-}
-
-/**
- * Whether the link named a variable it carried no value for. Such a link cannot deploy on its own,
- * whatever it asked to show: the owner is the only one who has the value.
- */
-export function asksForVariables(suggested: DeploySuggestion | undefined): boolean {
-  return suggested?.environment?.some((entry) => entry.value.length === 0) ?? false;
 }
 
 /** What the section says while it is shut, in the one word a count would be. */

--- a/apps/dashboard/src/components/apps/deploy-form.tsx
+++ b/apps/dashboard/src/components/apps/deploy-form.tsx
@@ -2,10 +2,10 @@ import { Button } from '@repo/ui/components/button';
 import { useStore } from '@tanstack/react-form';
 import { AdvancedConfiguration } from '#components/apps/advanced-configuration.tsx';
 import { DeployBinaryField } from '#components/apps/deploy-binary-field.tsx';
-import { asksForVariables, DeployConfiguration } from '#components/apps/deploy-configuration.tsx';
+import { DeployConfiguration } from '#components/apps/deploy-configuration.tsx';
 import { MinimalBinaryField } from '#components/apps/minimal-binary-field.tsx';
 import { binaryName } from '#lib/binary-source.ts';
-import type { DeploySuggestion } from '#lib/deploy-link.ts';
+import { asksForVariables, type DeploySuggestion } from '#lib/deploy-link.ts';
 import { type DeployFormValues, useDeployForm } from '#lib/hooks/use-deploy-form.ts';
 import type { AppSummary } from '#queries/apps.ts';
 

--- a/apps/dashboard/src/lib/deploy-link.ts
+++ b/apps/dashboard/src/lib/deploy-link.ts
@@ -80,6 +80,23 @@ export type DeploySuggestion = { [K in keyof typeof CONFIGURED]?: Meant[K] } & {
   binary?: string | undefined;
 };
 
+/**
+ * Whether the link named a variable it carried no value for. Such a link cannot deploy on its own,
+ * whatever it asked to show: the owner is the only one who has the value.
+ */
+export function asksForVariables(suggested: DeploySuggestion | undefined): boolean {
+  return suggested?.environment?.some((entry) => entry.value.length === 0) ?? false;
+}
+
+/**
+ * Whether the link named a variable at all. A value it carried is one everybody who follows the
+ * link can already read, so there is nothing left for a shut section to keep from them — and
+ * plenty it would keep from them about what the app is a press away from running with.
+ */
+export function namesVariables(suggested: DeploySuggestion | undefined): boolean {
+  return (suggested?.environment?.length ?? 0) > 0;
+}
+
 /** The link as the deploy it describes. A parameter renamed above is a line here that stops compiling. */
 export function deploySuggestion(link: DeployLink): DeploySuggestion {
   return {

--- a/apps/dashboard/tests/lib/deploy-link.test.ts
+++ b/apps/dashboard/tests/lib/deploy-link.test.ts
@@ -2,10 +2,12 @@ import { expect, test } from 'bun:test';
 import { RUNTIME_VALUES, writtenRuntimeValue } from '@repo/protocol';
 import { defaultParseSearch, defaultStringifySearch } from '@tanstack/react-router';
 import {
+  asksForVariables,
   type DeployLink,
   type DeploySuggestion,
   deployLink,
   deploySuggestion,
+  namesVariables,
 } from '#lib/deploy-link.ts';
 
 const HOSTNAME = writtenRuntimeValue(RUNTIME_VALUES.HOSTNAME.name);
@@ -129,4 +131,23 @@ test('and the rest of it survives that parameter going', () => {
 
   expect(written(configured).minimal).toBeUndefined();
   expect(followed(configured)).toEqual(ASKED);
+});
+
+/**
+ * The section opens on both, and for the same reason it holds them: a value written into a link is
+ * one everybody who follows it can already read, so shutting it keeps that value from nobody but
+ * the owner about to deploy an app that runs with it.
+ */
+test('a link that names a variable is a link the environment is shown for', () => {
+  expect(namesVariables(followed('?env=GREETING=hello'))).toBe(true);
+  expect(namesVariables(followed('?env=API_KEY'))).toBe(true);
+  expect(namesVariables(followed('?port=9000'))).toBe(false);
+  expect(namesVariables(undefined)).toBe(false);
+});
+
+// The narrower question, which is what the form waits on rather than what it shows.
+test('and only one it carried no value for is one the owner has to fill in', () => {
+  expect(asksForVariables(followed('?env=API_KEY'))).toBe(true);
+  expect(asksForVariables(followed('?env=GREETING=hello'))).toBe(false);
+  expect(asksForVariables(undefined)).toBe(false);
 });


### PR DESCRIPTION
The environment section on `/deploy` opened only where the link named a variable it carried no value for. A link that carried the values kept them behind a shut section — hidden from the one person who has to vet them and from nobody else, since everyone who follows the link reads them in the address bar.

It now opens where the link named a variable at all.

`?minimal` is untouched: it still strips the form down to the binary, and coming out of it through Advanced configuration lands on the section open, holding what the link asked for. A form no link seeded is untouched too — releasing an app again still starts shut, with what it already runs with dotted and replaceable.

Closes #356