### PR TITLE
feat(cli): a release publishes its checksums, and the install checks against them

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -45,4 +45,5 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
             --notes-file "$RELEASE_NOTES_FILE" \
-            packages/cli/dist/nib-*
+            packages/cli/dist/nib-* \
+            packages/cli/dist/checksums.txt

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -77,8 +77,9 @@ the layout under `src/commands/` is the command tree.
   package directory, so relative paths resolve against `packages/cli` rather than
   the caller's shell — pass absolute ones until the CLI ships as a real `bin`.
 - `bun run build` compiles one binary per released platform into `dist/`, named
-  `nib-<os>-<arch>`. That name is what a release asset is downloaded as, so
-  renaming it breaks whatever already points at the old one.
+  `nib-<os>-<arch>`, and a `checksums.txt` over them. Both names are what a
+  release asset is downloaded as, so renaming either breaks whatever already
+  points at the old one.
 - **Releasing is its own train, tagged `cli-v*`.** The `prepare-cli-release`
   workflow opens a PR bumping `version` and regenerating `CHANGELOG.md`; pushing
   the tag that PR names is what builds the binaries and cuts the release.

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -7,14 +7,16 @@
 # whatever machine an owner happens to have, and `sh` is the shell that is always there.
 #
 # Nothing here is nibrun-aware. It resolves a platform to one of the assets `release-cli.yml`
-# publishes, fetches it, and asks the result which version it is. Running it again is how an
-# owner upgrades, so it is written to be run any number of times.
+# publishes, fetches it, checks it against the checksums that release publishes, and asks the
+# result which version it is. Running it again is how an owner upgrades, so it is written to be run
+# any number of times.
 set -eu
 
 REPO="ilbertt/nibrun"
 # The CLI is tagged apart from anything else this repo may come to release, so the newest release
 # is not necessarily the newest *CLI* release.
 TAG_PREFIX="cli-v"
+CHECKSUMS_FILE="checksums.txt"
 DEFAULT_INSTALL_DIR="$HOME/.local/bin"
 
 # Styling is for a terminal to read: a pipe, a log file or NO_COLOR gets the same lines unadorned.
@@ -75,6 +77,8 @@ main() {
   url="https://github.com/$REPO/releases/download/$version/nib-$target"
   curl --fail --silent --show-error --location "$url" --output "$staged" ||
     die "Could not download $url"
+
+  verify_checksum "$staged" "nib-$target" "$version"
 
   # Explicit rather than +x: mktemp creates it 600, so +x would leave a binary nobody but its
   # owner can read — surprising in a shared install dir.
@@ -139,6 +143,51 @@ newest_from_api() {
     grep -o "\"tag_name\": *\"${TAG_PREFIX}[^\"]*\"" |
     head -n 1 |
     sed "s/.*\"\(${TAG_PREFIX}[^\"]*\)\"/\1/"
+}
+
+# The checksum is fetched from the same release over the same TLS as the binary, so what it catches
+# is a download that arrived wrong — truncated, or answered by a cache that had no business
+# answering — rather than a github.com handing out assets someone else put there. The build
+# provenance attestation linked from every release is what speaks to that second question.
+#
+# Only a checksum that is published and disagrees is fatal: releases cut before this file existed
+# publish none, and a machine with no sha256 tool on it still gets an install that works.
+verify_checksum() {
+  downloaded=$1 asset=$2 release=$3
+
+  expected=$(published_checksum "$asset" "$release")
+  if [ -z "$expected" ]; then
+    warn "$release publishes no checksum for $asset, so it was not verified."
+    return 0
+  fi
+
+  actual=$(sha256 "$downloaded")
+  if [ -z "$actual" ]; then
+    warn "This machine has no sha256sum, shasum or openssl, so $asset was not verified."
+    return 0
+  fi
+
+  [ "$actual" = "$expected" ] ||
+    die "$asset is not what $release publishes: expected $expected, got $actual."
+}
+
+# The name is the second field of a `sha256sum` line and the checksum the first, so a release that
+# stops carrying one — or never did — reads as no line rather than as a wrong answer.
+published_checksum() {
+  curl --fail --silent --location "https://github.com/$REPO/releases/download/$2/$CHECKSUMS_FILE" |
+    awk -v asset="$1" '$2 == asset { print $1 }'
+}
+
+# Whichever of the three this machine has: macOS ships shasum and no sha256sum, a Linux ships the
+# reverse, and openssl is what is left on an image too small for either.
+sha256() {
+  if command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "$1" | cut -d ' ' -f 1
+  elif command -v shasum > /dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d ' ' -f 1
+  elif command -v openssl > /dev/null 2>&1; then
+    openssl dgst -sha256 "$1" | awk '{ print $NF }'
+  fi
 }
 
 # Empty when nothing is installed there yet, which is what tells an install from an upgrade.

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -7,6 +7,7 @@ const CLI_DIR = join(import.meta.dir, '..');
 const DIST_DIR = join(CLI_DIR, 'dist');
 const BUN_VERSION_FILE = join(CLI_DIR, '../../.bun-version');
 const ENTRYPOINT = 'src/main.ts';
+const CHECKSUMS_FILE = 'checksums.txt';
 
 const FAILURE_EXIT_CODE = 1;
 
@@ -19,14 +20,17 @@ const bunVersion = (await Bun.file(BUN_VERSION_FILE).text()).trim();
 console.log('🧹 Cleaning dist dir...');
 await rm(DIST_DIR, { recursive: true, force: true });
 
+const checksums: string[] = [];
+
 for (const platform of RELEASE_PLATFORMS) {
   const binaryName = `${PROGRAM_NAME}-${platform}`;
+  const outfile = join(DIST_DIR, binaryName);
 
   console.log(`🔨 Compiling ${binaryName}...`);
   const buildResult = await Bun.build({
     entrypoints: [ENTRYPOINT],
     compile: {
-      outfile: join(DIST_DIR, binaryName),
+      outfile,
       target: `bun-v${bunVersion}-${platform}` as unknown as Bun.Build.CompileTarget,
     },
     // Startup is paid on every invocation of an interactive CLI and the size once, at download.
@@ -42,6 +46,23 @@ for (const platform of RELEASE_PLATFORMS) {
     console.error(`❌ Build failed for ${platform}:`, JSON.stringify(buildResult, null, 2));
     process.exit(FAILURE_EXIT_CODE);
   }
+
+  checksums.push(`${await sha256(outfile)}  ${binaryName}`);
 }
 
+console.log(`🧾 Writing ${CHECKSUMS_FILE}...`);
+await Bun.write(join(DIST_DIR, CHECKSUMS_FILE), `${checksums.join('\n')}\n`);
+
 console.log('✅ Done');
+
+/**
+ * Streamed rather than hashed in one go, because each of these is tens of megabytes and the whole
+ * point of the file is that it is produced for every platform on one machine.
+ */
+async function sha256(path: string): Promise<string> {
+  const hasher = new Bun.CryptoHasher('sha256');
+  for await (const chunk of Bun.file(path).stream()) {
+    hasher.update(chunk);
+  }
+  return hasher.digest('hex');
+}

--- a/packages/cli/tests/install.test.ts
+++ b/packages/cli/tests/install.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from 'bun:test';
-import { chmod, mkdtemp, rm } from 'node:fs/promises';
+import { chmod, mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { RELEASE_PLATFORMS } from '../scripts/release-platforms.ts';
@@ -17,6 +17,19 @@ const MACHINES = [
   { uname: { os: 'Linux', arch: 'aarch64' }, platform: 'linux-arm64' },
   { uname: { os: 'Linux', arch: 'arm64' }, platform: 'linux-arm64' },
 ];
+
+// A release invented for the tests, so what they assert on is the script's handling of an answer
+// rather than whatever github.com happens to be serving today.
+const RELEASE = 'cli-v2026.1.1-1';
+const RELEASE_VERSION = '2026.1.1-1';
+const RELEASE_MACHINE = { os: 'Linux', arch: 'x86_64' };
+const RELEASE_ASSET = 'nib-linux-x64';
+
+// Executable and answers `--version`, which is all the script asks of what it downloads.
+const RELEASED_BINARY = `#!/bin/sh\necho ${RELEASE_VERSION}\n`;
+const RELEASED_BINARY_SHA256 = new Bun.CryptoHasher('sha256').update(RELEASED_BINARY).digest('hex');
+
+const WRONG_SHA256 = '0'.repeat(RELEASED_BINARY_SHA256.length);
 
 const UNSUPPORTED = [
   { uname: { os: 'Darwin', arch: 'x86_64' }, because: 'no darwin-x64 asset is published' },
@@ -57,17 +70,46 @@ describe('a machine with no asset is told so rather than sent to a 404', () => {
   }
 });
 
+describe('a binary is checked against the checksum its release publishes', () => {
+  test('one that matches is installed and run', async () => {
+    const installed = await runInstall({
+      checksums: `${RELEASED_BINARY_SHA256}  ${RELEASE_ASSET}`,
+    });
+
+    expect(installed.exitCode).toBe(0);
+    expect(installed.entries).toEqual(['nib']);
+    expect(installed.binary).toBe(RELEASED_BINARY);
+    expect(installed.stderr).toContain(`nib ${RELEASE_VERSION} is installed`);
+  });
+
+  test('one that does not is refused, and nothing is left behind', async () => {
+    const installed = await runInstall({ checksums: `${WRONG_SHA256}  ${RELEASE_ASSET}` });
+
+    expect(installed.exitCode).not.toBe(0);
+    expect(installed.entries).toEqual([]);
+    expect(installed.binary).toBeNull();
+    expect(installed.stderr).toContain('install.sh:');
+    expect(installed.stderr).toContain(RELEASED_BINARY_SHA256);
+  });
+
+  // Every release cut before checksums.txt existed is still one NIB_VERSION can name, so a release
+  // carrying no checksum has to install rather than fail closed.
+  test('a release publishing none is installed anyway, and says so', async () => {
+    const installed = await runInstall({ checksums: null });
+
+    expect(installed.exitCode).toBe(0);
+    expect(installed.binary).toBe(RELEASED_BINARY);
+    expect(installed.stderr).toContain('publishes no checksum');
+  });
+});
+
 /**
  * Runs the real script against a `uname` that answers for the machine being described. Stubbing the
  * command rather than the script is what keeps this a test of the thing an owner actually runs.
  */
 async function resolveTarget({ os, arch }: { os: string; arch: string }) {
-  const dir = await mkdtemp(join(tmpdir(), 'nib-uname-'));
-  stubDirs.push(dir);
-
-  const stub = join(dir, 'uname');
-  await Bun.write(stub, `#!/bin/sh\ncase "$1" in\n-s) echo ${os} ;;\n-m) echo ${arch} ;;\nesac\n`);
-  await chmod(stub, EXECUTABLE);
+  const dir = await stubDir();
+  await writeStub({ dir, name: 'uname', body: unameStub({ os, arch }) });
 
   const proc = Bun.spawn(['sh', INSTALL_SH, '--print-target'], {
     env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
@@ -82,4 +124,88 @@ async function resolveTarget({ os, arch }: { os: string; arch: string }) {
   ]);
 
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+/**
+ * A whole install against a stubbed release: `curl` answers for both the asset and the checksums,
+ * and `NIB_VERSION` is what keeps the script from asking github.com which release is newest.
+ */
+async function runInstall({ checksums }: { checksums: string | null }) {
+  const dir = await stubDir();
+  const installDir = join(dir, 'bin');
+
+  await writeStub({ dir, name: 'uname', body: unameStub(RELEASE_MACHINE) });
+  await writeStub({ dir, name: 'curl', body: curlStub({ checksums }) });
+
+  const proc = Bun.spawn(['sh', INSTALL_SH], {
+    env: {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH}`,
+      NIB_VERSION: RELEASE,
+      NIB_INSTALL_DIR: installDir,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  const installed = Bun.file(join(installDir, 'nib'));
+
+  return {
+    stdout,
+    stderr,
+    exitCode,
+    binary: (await installed.exists()) ? await installed.text() : null,
+    entries: await readdir(installDir),
+  };
+}
+
+/**
+ * Answers the asset with a binary and the checksums with whatever the case under test publishes —
+ * `--fail` exiting non-zero being how curl reports the 404 of a release that carries none.
+ */
+function curlStub({ checksums }: { checksums: string | null }) {
+  const answer = checksums === null ? 'exit 22' : `printf '%s\\n' '${checksums}'`;
+
+  return `#!/bin/sh
+url=''
+out=''
+while [ $# -gt 0 ]; do
+  case $1 in
+    --output) out=$2; shift ;;
+    https://*) url=$1 ;;
+  esac
+  shift
+done
+
+case "$url" in
+  */checksums.txt) ${answer} ;;
+  *)
+    cat > "$out" <<'RELEASED'
+${RELEASED_BINARY.trimEnd()}
+RELEASED
+    ;;
+esac
+`;
+}
+
+function unameStub({ os, arch }: { os: string; arch: string }) {
+  return `#!/bin/sh\ncase "$1" in\n-s) echo ${os} ;;\n-m) echo ${arch} ;;\nesac\n`;
+}
+
+async function stubDir() {
+  const dir = await mkdtemp(join(tmpdir(), 'nib-stubs-'));
+  stubDirs.push(dir);
+  return dir;
+}
+
+async function writeStub({ dir, name, body }: { dir: string; name: string; body: string }) {
+  const stub = join(dir, name);
+  await Bun.write(stub, body);
+  await chmod(stub, EXECUTABLE);
 }


### PR DESCRIPTION
Every `cli-v*` release now carries a `checksums.txt` over its binaries, and `install.sh` checks what it downloaded against it before putting anything on disk.

Only a checksum that is published and disagrees is fatal — releases cut before this file existed publish none, and `NIB_VERSION` can still name one.

The other half of this is not in the diff: the **Release attestation (json)** asset comes from GitHub, not from a workflow step, and appears once **Settings → General → Releases → release immutability** is enabled. It applies to future releases only. Our CalVer `-N` same-day counter means we never move a tag, so immutability should cost us nothing.