### PR TITLE
chore(deps): drop the bun-types override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@commitlint/config-conventional": "^21.2.0",
         "@commitlint/format": "^21.2.0",
         "@commitlint/types": "^21.2.0",
-        "@types/bun": "^1.3.14",
+        "@types/bun": "^1.4.0",
         "turbo": "^2.10.7",
         "typescript": "catalog:",
       },
@@ -142,7 +142,7 @@
     },
     "packages/cli": {
       "name": "@repo/cli",
-      "version": "2026.8.25-1",
+      "version": "2026.8.28-2",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
         "@parshjs/core": "^0.0.10",
@@ -214,9 +214,6 @@
         "typescript": "catalog:",
       },
     },
-  },
-  "overrides": {
-    "bun-types": "^1.4.0",
   },
   "catalog": {
     "@tailwindcss/vite": "^4.3.3",
@@ -943,7 +940,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 

--- a/package.json
+++ b/package.json
@@ -39,12 +39,9 @@
     "@commitlint/config-conventional": "^21.2.0",
     "@commitlint/format": "^21.2.0",
     "@commitlint/types": "^21.2.0",
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "typescript": "catalog:",
     "turbo": "^2.10.7"
-  },
-  "overrides": {
-    "bun-types": "^1.4.0"
   },
   "packageManager": "bun@1.4.0"
 }


### PR DESCRIPTION
`@types/bun` 1.4.0 pins `bun-types` 1.4.0 itself, so the override that forced it past the old 1.3.14 pin is now dead weight.