### PR TITLE
test(api): the usage bounds are proved against a real refusal

### DIFF
--- a/apps/api/tests/repositories/apps.test.ts
+++ b/apps/api/tests/repositories/apps.test.ts
@@ -21,6 +21,7 @@ import { configWithDefaults, type SealedEnvironmentPatch } from '#lib/app-config
 import { openSecret, sealEnvironment, sealedFromStore } from '#lib/tenant-secrets.ts';
 import { AppsRepository, LIVE_APP_STATES } from '#repositories/apps.repository.ts';
 import { startTestDatabase, stopTestDatabase } from '#tests/support/database.ts';
+import { refusedBy } from '#tests/support/postgres.ts';
 import { TEST_SECRETS_KEY } from '#tests/support/secrets.ts';
 
 const DATABASE_START_TIMEOUT_MS = 180_000;
@@ -515,6 +516,79 @@ describe('what a host measured of a guest is kept beside how full its filesystem
 
     expect(Number(both.volume_used_bytes)).toBe(VOLUME_USED_BYTES);
     expect(both.cpu_share).toBe(BUSY_SHARE);
+  });
+
+  /**
+   * The bounds are the one guarantee that outlives every caller. Both readings are a subtraction
+   * on the guest's side — total less free, total less available — and a subtraction is what
+   * produces a number below zero when the two ends come from different units. Nothing upstream
+   * can write one of these today; a constraint is what keeps that true of what is added later.
+   */
+  describe('a reading the guest could not have taken is refused by the table', () => {
+    function writeDirectly({ columns, values }: { columns: string; values: string }) {
+      return () =>
+        sql.unsafe(
+          `INSERT INTO nibrun.app_usage (app_id, ${columns})
+           SELECT id, ${values} FROM nibrun.apps LIMIT 1`,
+        );
+    }
+
+    test('memory spent beyond what the guest has is not a reading', async () => {
+      expect(
+        await refusedBy(
+          writeDirectly({
+            columns: 'memory_total_bytes, memory_used_bytes, compute_measured_at',
+            values: '100, 101, now()',
+          }),
+        ),
+      ).toBe('app_usage_memory_within_itself');
+    });
+
+    test('memory spent below nothing is not a reading either', async () => {
+      expect(
+        await refusedBy(
+          writeDirectly({
+            columns: 'memory_total_bytes, memory_used_bytes, compute_measured_at',
+            values: '100, -1, now()',
+          }),
+        ),
+      ).toBe('app_usage_memory_within_itself');
+    });
+
+    test('a volume fuller than it is holds to the same rule', async () => {
+      expect(
+        await refusedBy(
+          writeDirectly({
+            columns: 'volume_total_bytes, volume_used_bytes, volume_measured_at',
+            values: '100, 101, now()',
+          }),
+        ),
+      ).toBe('app_usage_volume_within_itself');
+    });
+
+    // A rate is a rate: the agent clamps it, and this is what says so where it is stored.
+    test('a share of more than every vCPU is not a share', async () => {
+      expect(
+        await refusedBy(
+          writeDirectly({
+            columns: 'memory_total_bytes, memory_used_bytes, cpu_share, compute_measured_at',
+            values: '100, 10, 1.5, now()',
+          }),
+        ),
+      ).toBe('app_usage_cpu_share_is_a_share');
+    });
+
+    // Half a reading is worse than none, because whoever reads one column reads all three.
+    test('a family written without its moment is half a reading', async () => {
+      expect(
+        await refusedBy(
+          writeDirectly({
+            columns: 'memory_total_bytes, memory_used_bytes',
+            values: '100, 10',
+          }),
+        ),
+      ).toBe('app_usage_compute_whole');
+    });
   });
 
   test('every reading in one report is written by one statement', async () => {

--- a/apps/api/tests/support/postgres.ts
+++ b/apps/api/tests/support/postgres.ts
@@ -35,3 +35,21 @@ export function malformedArrayLiteral(): SQL.PostgresError {
 export function uniqueViolation(constraint: string): SQL.PostgresError {
   return postgresError({ sqlstate: UNIQUE_VIOLATION, constraint });
 }
+
+/**
+ * The constraint that refused a statement, named — or what happened instead of a refusal.
+ *
+ * A returned name rather than a thrown assertion, because `expect(query).rejects` on one of these
+ * never settles: a Bun SQL query is a thenable and not a promise, and the matcher waits on it
+ * until the test times out. Five of those wedged every suite behind them once already. Awaiting
+ * the query outright is what makes the rejection ordinary, and the name is what a test asserts on
+ * — a statement refused by the wrong rule is not the rule being proved.
+ */
+export async function refusedBy(attempt: () => Promise<unknown>): Promise<string> {
+  try {
+    await attempt();
+  } catch (error) {
+    return (error as { constraint?: string }).constraint ?? `refused without naming one: ${error}`;
+  }
+  return 'nothing was refused';
+}


### PR DESCRIPTION
#364 shipped two CHECK constraints on `app_usage` with nothing proving they bite — the tests written for them hung and were removed to unblock CI. This puts them back on a pattern that works.

The hang was not what the removal commit claimed. `sql.unsafe` rejects correctly on a refused statement — divide-by-zero, CHECK, foreign key, with or without parameters — and the connection survives. What never settles is `expect(query).rejects`: a Bun SQL query is a thenable rather than a promise, so the matcher waits on it until the test times out, and five of those wedged every suite behind them.

`refusedBy` awaits the query in a try/catch and returns the constraint that refused it, so a test asserts on which rule held rather than that something went wrong. A statement refused by the wrong constraint is not the constraint being proved.

Verified: full API suite 524 pass / 0 fail in 17s, and mutation-checked — a wrong constraint name fails the tests that name it.