### PR TITLE
refactor(dashboard): the deploy form asks, and stops explaining itself

### DIFF
--- a/apps/dashboard/src/components/apps/deploy-binary-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-binary-field.tsx
@@ -1,8 +1,6 @@
-import { Field, FieldDescription, FieldError, FieldLabel } from '@repo/ui/components/field';
+import { Field, FieldError, FieldLabel } from '@repo/ui/components/field';
 import { BINARY_INPUT_ID } from '#components/apps/binary-drop-zone.tsx';
 import { BinarySourcePicker } from '#components/apps/binary-source-picker.tsx';
-import { type BinarySource, fetchedUrl, pickedFile } from '#lib/binary-source.ts';
-import { formatBytes } from '#lib/format-bytes.ts';
 import {
   type DeployFormApi,
   validateBinary,
@@ -32,35 +30,10 @@ export function DeployBinaryField({
               keeping={replacing !== undefined}
               onChange={field.handleChange}
             />
-            {rejected ? (
-              <FieldError>{field.state.meta.errors[0]}</FieldError>
-            ) : (
-              <FieldDescription>
-                {describeBinary({ binary: field.state.value, replacing })}
-              </FieldDescription>
-            )}
+            {rejected && <FieldError>{field.state.meta.errors[0]}</FieldError>}
           </Field>
         );
       }}
     </api.Field>
   );
-}
-
-function describeBinary({
-  binary,
-  replacing,
-}: {
-  binary: BinarySource | undefined;
-  replacing: AppSummary | undefined;
-}): string {
-  const file = pickedFile(binary);
-  if (file !== undefined) {
-    return `${formatBytes(file.size)}, uploaded straight to the store.`;
-  }
-  if (fetchedUrl(binary) !== undefined) {
-    return 'Fetched by nibrun when you deploy, so nothing crosses this browser.';
-  }
-  return replacing === undefined
-    ? 'The compiled binary to run in the guest.'
-    : 'Leave it empty and the app runs the binary it already has, with what you change here.';
 }

--- a/apps/dashboard/src/components/apps/deploy-configuration.tsx
+++ b/apps/dashboard/src/components/apps/deploy-configuration.tsx
@@ -51,10 +51,8 @@ export function DeployConfiguration({
               autoComplete="off"
               className="font-mono tabular-nums"
             />
-            {field.state.meta.errors.length > 0 ? (
+            {field.state.meta.errors.length > 0 && (
               <FieldError>{field.state.meta.errors[0]}</FieldError>
-            ) : (
-              <FieldDescription>The port the binary listens on inside the guest.</FieldDescription>
             )}
           </Field>
         )}
@@ -140,9 +138,7 @@ export function DeployConfiguration({
                     placeholder={'serve\n--verbose'}
                     className="font-mono"
                   />
-                  <FieldDescription>
-                    One per line. What is here is what the binary runs with — empty runs it bare.
-                  </FieldDescription>
+                  <FieldDescription>One per line.</FieldDescription>
                 </Field>
               )}
             </api.Field>

--- a/apps/dashboard/src/components/apps/deploy-environment-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-environment-field.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldDescription, FieldError } from '@repo/ui/components/field';
+import { Field, FieldError } from '@repo/ui/components/field';
 import { EnvFilePicker } from '#components/apps/env-file-picker.tsx';
 import { EnvironmentTable } from '#components/apps/environment-table.tsx';
 import { storedVariables, withEntries } from '#lib/environment-variables.ts';
@@ -33,21 +33,12 @@ export function DeployEnvironmentField({
                 />
               )}
             </EnvironmentTable>
-            {field.state.meta.errors.length > 0 ? (
+            {field.state.meta.errors.length > 0 && (
               <FieldError>{field.state.meta.errors[0]}</FieldError>
-            ) : (
-              <FieldDescription>{describeEnvironment(replacing)}</FieldDescription>
             )}
           </Field>
         );
       }}
     </api.Field>
   );
-}
-
-function describeEnvironment(replacing: AppSummary | undefined): string {
-  if (replacing === undefined) {
-    return 'What the binary runs with.';
-  }
-  return 'What the binary runs with. A value already set can be replaced, and a row removed here is a variable the app stops running with.';
 }

--- a/apps/dashboard/src/components/apps/deploy-name-field.tsx
+++ b/apps/dashboard/src/components/apps/deploy-name-field.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldDescription, FieldLabel } from '@repo/ui/components/field';
+import { Field, FieldLabel } from '@repo/ui/components/field';
 import { Input } from '@repo/ui/components/input';
 import { binaryName } from '#lib/binary-source.ts';
 import type { DeployFormApi } from '#lib/hooks/use-deploy-form.ts';
@@ -18,9 +18,6 @@ export function DeployNameField({ api }: { api: DeployFormApi }) {
                 placeholder={named ?? 'Named after the binary'}
                 autoComplete="off"
               />
-              <FieldDescription>
-                The hostname is derived from this once, and never again.
-              </FieldDescription>
             </Field>
           )}
         </api.Field>

--- a/apps/dashboard/src/components/handoff/handoff-deploy.tsx
+++ b/apps/dashboard/src/components/handoff/handoff-deploy.tsx
@@ -1,39 +1,34 @@
 import { Button } from '@repo/ui/components/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@repo/ui/components/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
 import { Link } from '@tanstack/react-router';
 import { DeployForm } from '#components/apps/deploy-form.tsx';
 import { DeployProgress } from '#components/apps/deploy-progress.tsx';
 import { deploySuggestion } from '#lib/deploy-link.ts';
 import { useDeployLink } from '#lib/hooks/use-deploy-link.ts';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
-import type { DeployPhase } from '#lib/hooks/use-run-app.ts';
 import { Route as IndexRoute } from '#routes/(dashboard)/index.tsx';
 
 export function HandoffDeploy({ binary }: { binary: File | undefined }) {
   const run = useDeployRun();
   const link = useDeployLink();
+  const minimal = link.minimal ?? false;
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="text-xl">
-          {binary === undefined ? 'Deploy a binary' : 'Deploy this binary'}
-        </CardTitle>
-        <CardDescription>{describe({ phase: run.phase, binary })}</CardDescription>
-      </CardHeader>
+      {/* A link that asks for less is answered by the drop target alone: it says what to do with
+          itself, and a heading above it would only say it again. */}
+      {!minimal && (
+        <CardHeader>
+          <CardTitle className="text-xl">Deploy your app</CardTitle>
+        </CardHeader>
+      )}
       <CardContent>
         {run.phase === 'idle' ? (
           <DeployForm
             appId={undefined}
             binary={binary}
             suggested={deploySuggestion(link)}
-            minimal={link.minimal ?? false}
+            minimal={minimal}
           />
         ) : (
           // Only ever seen when the deploy failed: a run that lands leaves for the app it made
@@ -45,15 +40,4 @@ export function HandoffDeploy({ binary }: { binary: File | undefined }) {
       </CardContent>
     </Card>
   );
-}
-
-function describe({ phase, binary }: { phase: DeployPhase; binary: File | undefined }): string {
-  if (phase !== 'idle') {
-    return 'The binary is on its way. The dashboard takes over once it lands.';
-  }
-  // Nothing was handed over, so whoever followed the link still has to produce the binary —
-  // and nibrun compiles nothing, so saying where it comes from is the whole instruction.
-  return binary === undefined
-    ? 'Compile it on your own machine, then pick it below.'
-    : 'It is uploaded to the store, then released as what the app runs.';
 }


### PR DESCRIPTION
The minimal deploy page loses its title and subtitle — the drop target already says what to do — and the full one keeps a title alone, now `Deploy your app`.

Every field description goes with it, except the arguments one, which is `One per line.` The additional-ports accordion keeps its copy: it explains a feature, not a control.