### PR TITLE
feat(www): the needs table keeps two rows, and a section says what the app gets

### DIFF
--- a/apps/www/src/components/what-it-actually-needs.tsx
+++ b/apps/www/src/components/what-it-actually-needs.tsx
@@ -1,6 +1,3 @@
-import { CpuIcon, DatabaseIcon, GlobeIcon, PackageIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
-
 const CEREMONY = [
   'A container image',
   'A managed Postgres',
@@ -10,39 +7,7 @@ const CEREMONY = [
   'A YAML file you copied',
 ];
 
-const ESSENTIALS: { icon: typeof CpuIcon; name: string; detail: ReactNode }[] = [
-  {
-    icon: CpuIcon,
-    name: 'A machine to run on',
-    detail: 'One microVM per app. Nothing else runs in it.',
-  },
-  {
-    icon: DatabaseIcon,
-    name: 'A disk to write to',
-    detail: (
-      <>
-        <code className="text-foreground">data/</code> is yours: a SQLite file, uploads, both. It
-        survives every redeploy.
-      </>
-    ),
-  },
-  {
-    icon: GlobeIcon,
-    name: 'A URL right away',
-    detail: 'An HTTPS subdomain, the moment it boots. No DNS to point, no certificate to renew.',
-  },
-  {
-    icon: PackageIcon,
-    name: 'A way out',
-    detail: (
-      <>
-        One click gives you the binary, the entire disk and its{' '}
-        <code className="text-foreground">.env</code>. There&apos;s no managed database to migrate
-        off, because there was never a managed database.
-      </>
-    ),
-  },
-];
+const ESSENTIALS = ['A machine to run on', 'A disk to write to'];
 
 export function WhatItActuallyNeeds() {
   return (
@@ -53,15 +18,12 @@ export function WhatItActuallyNeeds() {
       <div className="grid gap-10 sm:grid-cols-2 sm:gap-0">
         <div className="flex flex-col gap-4 sm:pr-10">
           <h3 className="text-muted-foreground text-sm">What it usually gets</h3>
-          {/* Distributed rather than stacked: six one-line entries against four that each carry a
-              paragraph would otherwise leave the struck column bunched at the top of a much taller
-              row. The bottom inset gives the distribution less room to spread across, since
-              matching the row exactly pushed the entries far enough apart to stop reading as one
-              list — and it goes at the bottom so the label above stays attached to its first entry.
-              The gap is the floor for when the two columns stack. */}
-          <ul className="flex flex-1 flex-col justify-between gap-4 sm:pb-28">
+          <ul className="flex flex-col gap-3">
             {CEREMONY.map((item) => (
-              <li key={item} className="text-muted-foreground/70 line-through">
+              <li
+                key={item}
+                className="text-muted-foreground/70 line-through decoration-2 decoration-destructive/70"
+              >
                 {item}
               </li>
             ))}
@@ -69,16 +31,10 @@ export function WhatItActuallyNeeds() {
         </div>
         <div className="flex flex-col gap-4 sm:border-border/60 sm:border-l sm:pl-10 lg:pl-16">
           <h3 className="text-muted-foreground text-sm">What it actually needs</h3>
-          <ul className="flex flex-col gap-6">
-            {ESSENTIALS.map(({ icon: Icon, name, detail }) => (
-              <li key={name} className="flex items-start gap-4">
-                <span className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                  <Icon className="size-5" />
-                </span>
-                <div className="flex flex-col gap-1">
-                  <span className="font-medium">{name}</span>
-                  <span className="text-pretty text-muted-foreground">{detail}</span>
-                </div>
+          <ul className="flex flex-col gap-3">
+            {ESSENTIALS.map((item) => (
+              <li key={item} className="font-medium text-lg text-primary">
+                {item}
               </li>
             ))}
           </ul>

--- a/apps/www/src/components/what-your-app-gets.tsx
+++ b/apps/www/src/components/what-your-app-gets.tsx
@@ -1,8 +1,14 @@
+import { CpuIcon, GlobeIcon, HardDriveIcon, PackageIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 
-const OFFERINGS: { name: string; detail: ReactNode }[] = [
-  { name: 'A machine', detail: 'A Firecracker microVM of its own. Nothing else runs in it.' },
+const OFFERINGS: { icon: typeof CpuIcon; name: string; detail: ReactNode }[] = [
   {
+    icon: CpuIcon,
+    name: 'A machine',
+    detail: 'A Firecracker microVM of its own. Nothing else runs in it.',
+  },
+  {
+    icon: HardDriveIcon,
     name: 'A disk',
     detail: (
       <>
@@ -10,8 +16,9 @@ const OFFERINGS: { name: string; detail: ReactNode }[] = [
       </>
     ),
   },
-  { name: 'A URL', detail: 'An HTTPS subdomain, the moment it boots.' },
+  { icon: GlobeIcon, name: 'A URL', detail: 'An HTTPS subdomain, the moment it boots.' },
   {
+    icon: PackageIcon,
     name: 'A way out',
     detail: (
       <>
@@ -28,9 +35,12 @@ export function WhatYourAppGets() {
         What your app gets on nibrun.
       </h2>
       <ul className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
-        {OFFERINGS.map(({ name, detail }) => (
+        {OFFERINGS.map(({ icon: Icon, name, detail }) => (
           <li key={name} className="flex flex-col gap-2 border-border/60 border-t pt-4">
-            <span className="font-medium">{name}</span>
+            <span className="flex items-center gap-2 font-medium">
+              <Icon className="size-4 text-primary" />
+              {name}
+            </span>
             <span className="text-pretty text-muted-foreground text-sm">{detail}</span>
           </li>
         ))}

--- a/apps/www/src/components/what-your-app-gets.tsx
+++ b/apps/www/src/components/what-your-app-gets.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+const OFFERINGS: { name: string; detail: ReactNode }[] = [
+  { name: 'A machine', detail: 'A Firecracker microVM of its own. Nothing else runs in it.' },
+  {
+    name: 'A disk',
+    detail: (
+      <>
+        <code className="text-foreground">data/</code> is yours, and it survives every redeploy.
+      </>
+    ),
+  },
+  { name: 'A URL', detail: 'An HTTPS subdomain, the moment it boots.' },
+  {
+    name: 'A way out',
+    detail: (
+      <>
+        One export: the binary, the disk, its <code className="text-foreground">.env</code>.
+      </>
+    ),
+  },
+];
+
+export function WhatYourAppGets() {
+  return (
+    <section className="flex w-full flex-col gap-10 border-border/60 border-t py-16 sm:py-20">
+      <h2 className="max-w-2xl font-semibold text-2xl tracking-tight sm:text-3xl">
+        What your app gets on nibrun.
+      </h2>
+      <ul className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+        {OFFERINGS.map(({ name, detail }) => (
+          <li key={name} className="flex flex-col gap-2 border-border/60 border-t pt-4">
+            <span className="font-medium">{name}</span>
+            <span className="text-pretty text-muted-foreground text-sm">{detail}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -8,6 +8,7 @@ import { PageBackdrop } from '#components/page-backdrop.tsx';
 import { SiteHeader } from '#components/site-header.tsx';
 import { TryItOut } from '#components/try-it-out.tsx';
 import { WhatItActuallyNeeds } from '#components/what-it-actually-needs.tsx';
+import { WhatYourAppGets } from '#components/what-your-app-gets.tsx';
 import { pageHead } from '#lib/page-head.ts';
 import { SITE_DESCRIPTION, SITE_TITLE } from '#lib/site.ts';
 
@@ -35,6 +36,7 @@ function RouteComponent() {
           </div>
         </section>
         <WhatItActuallyNeeds />
+        <WhatYourAppGets />
         <DeployCta />
       </main>
     </>


### PR DESCRIPTION
The landing page's "What it actually needs" column now matches the README — two rows, no icons, red strike on the left and green on the right.

Below it, a new section names what an app gets on nibrun: the machine, the disk, the URL, the export.