### PR TITLE
fix(agent): a status pass writes back only what it measured

### DIFF
--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -291,6 +291,14 @@ function probed({ record, nowMs }: { record: InstanceRecord; nowMs: number }) {
   });
 }
 
+/**
+ * What this pass measured is merged into the record as it stands, never written over it. A probe
+ * is the longest thing the loop does, and a reconcile landing a start while one runs has already
+ * cleared the `stopRequested` the pass read: writing the whole record back would put that flag on
+ * again, and an instance carrying it is `stopping` for as long as its unit is up — a state nothing
+ * forwards to and no later pass leaves, because the planner lets a running unit be. Merging is
+ * also what keeps an instance dropped mid-pass dropped.
+ */
 function settle({
   record,
   status,
@@ -313,17 +321,26 @@ function settle({
     });
 
     if (state === record.state) {
-      return yield* AgentState.putRecord({ ...record, health });
+      return yield* AgentState.updateRecord({
+        appId: record.appId,
+        change: (latest) => ({ ...latest, health }),
+      });
     }
 
-    yield* AgentState.putRecord({
-      ...record,
-      health,
-      state,
-      ...(status.exitCode !== undefined && !status.active ? { lastExitCode: status.exitCode } : {}),
-      // Cleared as readily as it is written: a message outliving the state it explains is
-      // read as an account of the state that replaced it.
-      message: yield* verdict({ state, status, health, record }),
+    // Cleared as readily as it is written: a message outliving the state it explains is
+    // read as an account of the state that replaced it.
+    const message = yield* verdict({ state, status, health, record });
+    yield* AgentState.updateRecord({
+      appId: record.appId,
+      change: (latest) => ({
+        ...latest,
+        health,
+        state,
+        ...(status.exitCode !== undefined && !status.active
+          ? { lastExitCode: status.exitCode }
+          : {}),
+        message,
+      }),
     });
     yield* Effect.logInfo('instance state changed').pipe(
       Effect.annotateLogs({

--- a/apps/agent/tests/lib/reconcile/instances.test.ts
+++ b/apps/agent/tests/lib/reconcile/instances.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+import { FetchHttpClient } from '@effect/platform';
+import { Deferred, Effect, Fiber, Layer } from 'effect';
+import { refreshStates } from '#lib/reconcile/instances.ts';
+import { AgentState } from '#services/agent-state.service.ts';
+import { CommandRunner } from '#services/command-runner.service.ts';
+import { ReportSignal } from '#services/report-signal.service.ts';
+import { succeeding } from '#tests/support/commands.ts';
+import { APP_ID, instanceRecord } from '#tests/support/fixtures.ts';
+import { platform, provided } from '#tests/support/run.ts';
+
+/** What `systemctl show` says about a microVM that is up, which is all a pass reads off it. */
+const ACTIVE_UNIT = [
+  'LoadState=loaded',
+  'ActiveState=active',
+  'SubState=running',
+  'Result=success',
+  'ExecMainStatus=0',
+  'InactiveExitTimestampMonotonic=1',
+].join('\n');
+
+/** Far enough out that no instance is due, so a pass turns on the unit alone and never probes. */
+const NEVER_DUE = Number.MAX_SAFE_INTEGER;
+
+const run = provided(
+  Layer.mergeAll(AgentState.Default, ReportSignal.Default, FetchHttpClient.layer).pipe(
+    Layer.provideMerge(platform),
+  ),
+);
+
+/**
+ * A pass held open at the one call it makes before it writes, which is where a reconcile lands in
+ * production: the pass has read the record and has yet to say anything about it.
+ */
+function passHeldOpen() {
+  return Effect.gen(function* () {
+    const reading = yield* Deferred.make<void>();
+    const held = yield* Deferred.make<void>();
+    const commands = Layer.succeed(
+      CommandRunner,
+      CommandRunner.make({
+        run: () =>
+          Deferred.succeed(reading, undefined).pipe(
+            Effect.andThen(Deferred.await(held)),
+            Effect.andThen(succeeding({ stdout: ACTIVE_UNIT })),
+          ),
+      }),
+    );
+    const pass = yield* Effect.fork(refreshStates.pipe(Effect.provide(commands)));
+    yield* Deferred.await(reading);
+    return {
+      finish: Deferred.succeed(held, undefined).pipe(Effect.andThen(Fiber.join(pass))),
+    };
+  });
+}
+
+const recordOf = Effect.map(AgentState.snapshot, (current) => current.records.get(APP_ID));
+
+describe('a settle writes back only what it measured', () => {
+  test('a start that lands mid-pass keeps the stop it cleared', () =>
+    run(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(
+          instanceRecord({ state: 'stopped', stopRequested: true, desiredRunning: true }),
+        );
+        yield* AgentState.modify((current) => ({
+          ...current,
+          nextProbeAtMs: new Map([[APP_ID, NEVER_DUE]]),
+        }));
+
+        const pass = yield* passHeldOpen();
+        // Exactly what `startInstance` writes once the boot it was waiting on comes up.
+        yield* AgentState.updateRecord({
+          appId: APP_ID,
+          change: (record) => ({ ...record, state: 'starting', stopRequested: false }),
+        });
+        yield* pass.finish;
+
+        // Were this put back, the instance would read `stopping` for as long as its unit stayed
+        // up: never forwarded, and never started again, because the planner lets it be.
+        expect((yield* recordOf)?.stopRequested).toBe(false);
+      }),
+    ));
+
+  test('an instance dropped mid-pass is not brought back', () =>
+    run(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ state: 'running' }));
+        yield* AgentState.modify((current) => ({
+          ...current,
+          nextProbeAtMs: new Map([[APP_ID, NEVER_DUE]]),
+        }));
+
+        const pass = yield* passHeldOpen();
+        yield* AgentState.dropRecord(APP_ID);
+        yield* pass.finish;
+
+        expect(yield* recordOf).toBeUndefined();
+      }),
+    ));
+});


### PR DESCRIPTION
`nib apps resume` could leave an app answering the activator's 503 indefinitely while `nib apps list`, `nib apps domains` and the tenant's own logs all called it healthy.

The status loop read an instance record, spent a `systemctl show` and a probe timeout away from it, then wrote the whole record back. A start landing in that window has already cleared `stopRequested`, and the stale write put it on again — which `evaluateInstanceState` short-circuits on for as long as the unit is up. The instance then sat at `stopping`: `forwardedInstances` only forwards `running`, so no DNAT rule went in, and the planner leaves a running unit alone, so nothing ever started it again to clear the flag. Suspend/resume was the reliable way in, because it is the one path that reuses a record already carrying `stopRequested: true`.

The pass now merges what it measured into the record as it stands, rather than overwriting it.