### PR TITLE
fix(dashboard): a link asking for a variable is waited on, not refused

### DIFF
--- a/apps/dashboard/src/components/apps/environment-row.tsx
+++ b/apps/dashboard/src/components/apps/environment-row.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@repo/ui/components/button';
 import { Input } from '@repo/ui/components/input';
 import { TableCell, TableRow } from '@repo/ui/components/table';
+import { cn } from '@repo/ui/lib/utils';
 import { PencilIcon, Trash2Icon, XIcon } from 'lucide-react';
 import { useState } from 'react';
-import type { EnvironmentVariable } from '#lib/environment-variables.ts';
+import { awaitsValue, type EnvironmentVariable } from '#lib/environment-variables.ts';
 
 const HIDDEN_VALUE = '••••••••••••';
 
@@ -29,6 +30,7 @@ export function EnvironmentRow({
   const [kept, setKept] = useState<Kept | undefined>(undefined);
   const named = variable.name.trim();
   const hidden = variable.sealed ? SEALED : variable.value.includes('\n') ? MANY_LINES : undefined;
+  const awaiting = awaitsValue(variable);
 
   function replace(): void {
     setKept({ value: variable.value, sealed: variable.sealed });
@@ -65,7 +67,7 @@ export function EnvironmentRow({
             aria-label={named === '' ? 'Variable value' : `Value of ${named}`}
             autoComplete="off"
             spellCheck={false}
-            className="font-mono"
+            className={cn('font-mono', awaiting && 'border-warning/60 ring-3 ring-warning/25')}
           />
         ) : (
           <span className="px-2.5 font-mono text-muted-foreground" title={hidden}>

--- a/apps/dashboard/src/components/deploy/deploy-configuration.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-configuration.tsx
@@ -18,12 +18,19 @@ import { Textarea } from '@repo/ui/components/textarea';
 import { DeployEnvironmentField } from '#components/deploy/deploy-environment-field.tsx';
 import { DeployNameField } from '#components/deploy/deploy-name-field.tsx';
 import type { DeploySuggestion } from '#lib/deploy-link.ts';
-import { filledVariables, storedVariables } from '#lib/environment-variables.ts';
+import {
+  type EnvironmentVariable,
+  filledVariables,
+  storedVariables,
+  unfilledAsked,
+} from '#lib/environment-variables.ts';
 import { type DeployFormState, tenantArguments, validatePort } from '#lib/hooks/use-deploy-form.ts';
 
 const ARGUMENTS = 'Arguments';
 const ADDITIONAL_PORTS = 'Additional ports';
 const ENVIRONMENT = 'environment';
+
+const AWAITING = 'Waiting on a value the link asked for.';
 
 /** Everything a deploy is beyond the binary itself, which is everything a link can carry. */
 export function DeployConfiguration({
@@ -164,12 +171,15 @@ export function DeployConfiguration({
             {/* Collapsed, a refused variable would disable the button with nothing on screen
                 saying why, so the section that holds it says so itself. A shut panel keeps its
                 variables validated, which is what leaves anything to say. */}
-            <api.Subscribe selector={(state) => state.fieldMeta.environment?.errors.length ?? 0}>
-              {(refused) =>
-                refused > 0 ? (
-                  <span className="font-normal text-destructive">needs a look</span>
-                ) : null
+            <api.Subscribe
+              selector={(state) =>
+                environmentMark({
+                  variables: state.values.environment,
+                  refused: (state.fieldMeta.environment?.errors.length ?? 0) > 0,
+                })
               }
+            >
+              {(mark) => <EnvironmentMark mark={mark} />}
             </api.Subscribe>
           </AccordionTrigger>
           <AccordionContent keepMounted>
@@ -187,6 +197,41 @@ export function DeployConfiguration({
  */
 export function asksForVariables(suggested: DeploySuggestion | undefined): boolean {
   return suggested?.environment?.some((entry) => entry.value.length === 0) ?? false;
+}
+
+type EnvironmentMarkKind = 'awaiting' | 'refused' | undefined;
+
+/**
+ * A link asks for the variables only the owner holds, and the form waits on them. That is not a
+ * mistake, so the section is marked rather than told off — and it outranks anything else the
+ * table has to say, which is what lets the mark stand for whichever issue the field is showing.
+ */
+function environmentMark({
+  variables,
+  refused,
+}: {
+  variables: EnvironmentVariable[] | undefined;
+  refused: boolean;
+}): EnvironmentMarkKind {
+  if (unfilledAsked(variables ?? []).length > 0) {
+    return 'awaiting';
+  }
+  return refused ? 'refused' : undefined;
+}
+
+function EnvironmentMark({ mark }: { mark: EnvironmentMarkKind }) {
+  if (mark === 'refused') {
+    return <span className="font-normal text-destructive">needs a look</span>;
+  }
+  if (mark === 'awaiting') {
+    return (
+      <span className="flex h-5 shrink-0 items-center" title={AWAITING}>
+        <span className="size-1.5 rounded-full bg-warning motion-safe:animate-pulse" />
+        <span className="sr-only">{AWAITING}</span>
+      </span>
+    );
+  }
+  return null;
 }
 
 /** What the section says while it is shut, in the one word a count would be. */

--- a/apps/dashboard/src/components/deploy/deploy-configuration.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-configuration.tsx
@@ -30,7 +30,7 @@ const ARGUMENTS = 'Arguments';
 const ADDITIONAL_PORTS = 'Additional ports';
 const ENVIRONMENT = 'environment';
 
-const AWAITING = 'Waiting on a value the link asked for.';
+const AWAITING = 'Fill these in.';
 
 /** Everything a deploy is beyond the binary itself, which is everything a link can carry. */
 export function DeployConfiguration({

--- a/apps/dashboard/src/components/deploy/deploy-environment-field.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-environment-field.tsx
@@ -1,7 +1,7 @@
 import { Field, FieldError } from '@repo/ui/components/field';
 import { EnvironmentTable } from '#components/apps/environment-table.tsx';
 import { EnvFilePicker } from '#components/deploy/env-file-picker.tsx';
-import { storedVariables, withEntries } from '#lib/environment-variables.ts';
+import { storedVariables, unfilledAsked, withEntries } from '#lib/environment-variables.ts';
 import { type DeployFormApi, validateEnvironment } from '#lib/hooks/use-deploy-form.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
@@ -23,9 +23,14 @@ export function DeployEnvironmentField({
         // Seeded from the app rather than held as a default: the app is read while the dialog is
         // already open, and a form's defaults are fixed when it mounts.
         const variables = field.state.value ?? storedVariables(replacing);
+        const [issue] = field.state.meta.errors;
+        // The one thing the form stops for that nobody got wrong: the value is the owner's to
+        // give, so it is asked for in its own colour rather than reported in the colour of a
+        // mistake. Checked first by the validator, so this is the issue whenever there is one.
+        const awaiting = unfilledAsked(variables).length > 0;
 
         return (
-          <Field data-invalid={field.state.meta.errors.length > 0 || undefined}>
+          <Field data-invalid={(issue !== undefined && !awaiting) || undefined}>
             <EnvironmentTable variables={variables} onChange={field.handleChange}>
               {replacing === undefined && (
                 <EnvFilePicker
@@ -33,9 +38,14 @@ export function DeployEnvironmentField({
                 />
               )}
             </EnvironmentTable>
-            {field.state.meta.errors.length > 0 && (
-              <FieldError>{field.state.meta.errors[0]}</FieldError>
-            )}
+            {issue !== undefined &&
+              (awaiting ? (
+                <p role="status" className="text-sm text-warning">
+                  {issue}
+                </p>
+              ) : (
+                <FieldError>{issue}</FieldError>
+              ))}
           </Field>
         );
       }}

--- a/apps/dashboard/src/lib/environment-variables.ts
+++ b/apps/dashboard/src/lib/environment-variables.ts
@@ -48,11 +48,14 @@ export function askedVariables(entries: readonly EnvironmentAssignment[]): Envir
   }));
 }
 
+/** A row a link asked for and nobody has filled: what a deploy waits on rather than refuses. */
+export function awaitsValue(variable: EnvironmentVariable): boolean {
+  return variable.asked && variable.value.length === 0;
+}
+
 /** The names a link asked for that still hold nothing, which is what a deploy cannot be made of. */
 export function unfilledAsked(variables: readonly EnvironmentVariable[]): string[] {
-  return variables
-    .filter((variable) => variable.asked && variable.value.length === 0)
-    .map((variable) => variable.name.trim());
+  return variables.filter(awaitsValue).map((variable) => variable.name.trim());
 }
 
 /** A row nobody has filled in yet is not a variable, and is not sent as one. */

--- a/apps/dashboard/src/lib/hooks/use-deploy-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy-form.ts
@@ -109,15 +109,17 @@ export function validateEnvironment({
   value: EnvironmentVariable[] | undefined;
 }): string | undefined {
   const variables = filledVariables(value ?? []);
-  if (variables.some((variable) => variable.name.trim().length === 0)) {
-    return 'A variable needs a name.';
-  }
 
-  // A link names what the app needs and carries no value for it, so this is the one thing on the
-  // form that nothing else could supply: not the link, not the app, not a default.
+  // First, and not only because it is the one thing on the form that nothing else could supply —
+  // not the link, not the app, not a default. It is also the one the form waits on rather than
+  // refuses, and the field reads it as such by having no other issue to show while it stands.
   const unfilled = unfilledAsked(variables);
   if (unfilled.length > 0) {
     return `Fill in what the link asked for: ${unfilled.join(', ')}.`;
+  }
+
+  if (variables.some((variable) => variable.name.trim().length === 0)) {
+    return 'A variable needs a name.';
   }
 
   // Two rows under one name are one variable by the time they are a record, so the row that lost


### PR DESCRIPTION
A deploy link that names variables it carries no value for turned the whole
environment table red, as if something had gone wrong. Nothing has: the owner is
the only one who holds those values, and the form is waiting on them.

The section is now marked with a pulsing dot rather than a red word, the rows a
link asked for glow, and the ask is written under the table in the same colour.
A genuine mistake still reads as one.