### PR TITLE
refactor(protocol): the default volume size moves next to the volume it sizes

### DIFF
--- a/apps/api/src/lib/app-config.ts
+++ b/apps/api/src/lib/app-config.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_HTTP_PORT,
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
+  DEFAULT_VOLUME_SIZE_BYTES,
   REDACTED,
   type SecretString,
   type TenantEnvironment,
@@ -11,10 +12,6 @@ import {
 } from '@repo/protocol';
 import type { Queries } from '#db/queries.gen.ts';
 import type { SealedEnvironment } from '#lib/tenant-secrets.ts';
-
-// Every app gets the same filesystem for now, so this is a constant rather than a column: a
-// value an owner cannot vary is one there is nothing to store per app.
-export const VOLUME_SIZE_BYTES = 8_589_934_592;
 
 // An owner reads which variables are set, never what they hold: the values are sealed in the
 // database and only opened where desired state is built, so there is nothing here to return.
@@ -112,7 +109,7 @@ export function configWithDefaults(
   patch: AppConfigPatch = {},
 ): Omit<PublicAppConfig, 'environment'> {
   return {
-    volumeSizeBytes: VOLUME_SIZE_BYTES,
+    volumeSizeBytes: DEFAULT_VOLUME_SIZE_BYTES,
     resources: DEFAULT_INSTANCE_RESOURCES,
     healthCheck: DEFAULT_HEALTH_CHECK,
     restartPolicy: DEFAULT_RESTART_POLICY,
@@ -127,7 +124,7 @@ export function configWithDefaults(
 export function toAppConfig(row: AppConfigColumns): PublicAppConfig {
   return {
     ...toRunConfig(row),
-    volumeSizeBytes: VOLUME_SIZE_BYTES,
+    volumeSizeBytes: DEFAULT_VOLUME_SIZE_BYTES,
     environment: redacted(row.environment_names),
   };
 }

--- a/apps/api/src/lib/deployments/desired-state.ts
+++ b/apps/api/src/lib/deployments/desired-state.ts
@@ -2,6 +2,7 @@ import {
   type AppConfig,
   type AppHostname,
   type AppId,
+  DEFAULT_VOLUME_SIZE_BYTES,
   type DesiredInstance,
   type DesiredVolume,
   Value,
@@ -9,7 +10,7 @@ import {
   VolumeIdSchema,
 } from '@repo/protocol';
 import type { Queries } from '#db/queries.gen.ts';
-import { toRunConfig, VOLUME_SIZE_BYTES } from '#lib/app-config.ts';
+import { toRunConfig } from '#lib/app-config.ts';
 import {
   openEnvironment,
   type SealedEnvironment,
@@ -40,7 +41,7 @@ export function toDesiredVolume(row: DesiredVolumeRow): DesiredVolume {
   return {
     volumeId: volumeIdOf(row.app_id),
     appId: row.app_id,
-    sizeBytes: VOLUME_SIZE_BYTES,
+    sizeBytes: DEFAULT_VOLUME_SIZE_BYTES,
     desiredState: row.state === 'deleting' ? 'absent' : 'present',
   };
 }

--- a/apps/api/tests/services/deployments.test.ts
+++ b/apps/api/tests/services/deployments.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
+  DEFAULT_VOLUME_SIZE_BYTES,
   type DeploymentId,
   type DeploymentState,
   HostPortSchema,
@@ -15,7 +16,7 @@ import {
   Value,
 } from '@repo/protocol';
 import { schema } from '#db/queries.gen.ts';
-import { type PublicAppConfig, VOLUME_SIZE_BYTES } from '#lib/app-config.ts';
+import type { PublicAppConfig } from '#lib/app-config.ts';
 import { STARTUP_DEADLINE_MS } from '#lib/deployments/lifecycle.ts';
 import { ConflictError, NotFoundError } from '#lib/errors.ts';
 import type {
@@ -213,7 +214,7 @@ describe('a deployment publishes the config version it pins', () => {
     });
 
     expect(deployment.config).toEqual({
-      volumeSizeBytes: VOLUME_SIZE_BYTES,
+      volumeSizeBytes: DEFAULT_VOLUME_SIZE_BYTES,
       environment: {},
       httpPort: HTTP_PORT,
       hasExtraPublicPort: false,

--- a/apps/api/tests/services/support/fixtures.ts
+++ b/apps/api/tests/services/support/fixtures.ts
@@ -5,16 +5,12 @@ import {
   DEFAULT_HTTP_PORT,
   DEFAULT_INSTANCE_RESOURCES,
   DEFAULT_RESTART_POLICY,
+  DEFAULT_VOLUME_SIZE_BYTES,
   DeploymentIdSchema,
   OwnerIdSchema,
   Value,
 } from '@repo/protocol';
-import {
-  type AppConfigColumns,
-  type PublicAppConfig,
-  type StoredAppConfig,
-  VOLUME_SIZE_BYTES,
-} from '#lib/app-config.ts';
+import type { AppConfigColumns, PublicAppConfig, StoredAppConfig } from '#lib/app-config.ts';
 import type {
   DeploymentByIdInput,
   DeploymentLookup,
@@ -49,7 +45,7 @@ export function deploymentLookup(
 // Spelled out from the protocol's own defaults rather than built with `configWithDefaults`,
 // which is the thing under test wherever this is the expected value.
 export const DEFAULT_CONFIG: PublicAppConfig = {
-  volumeSizeBytes: VOLUME_SIZE_BYTES,
+  volumeSizeBytes: DEFAULT_VOLUME_SIZE_BYTES,
   environment: {},
   httpPort: DEFAULT_HTTP_PORT,
   hasExtraPublicPort: false,

--- a/packages/protocol/src/domain/volume.ts
+++ b/packages/protocol/src/domain/volume.ts
@@ -3,6 +3,10 @@ import { AppIdSchema, VolumeIdSchema } from '#domain/identifiers.ts';
 import { stringEnum } from '#lib/string-enum.ts';
 import { ByteSizeSchema, ObjectKeySchema, TimestampSchema } from '#lib/wire.ts';
 
+// Every app gets the same filesystem for now, so this is a constant rather than a column: a
+// value an owner cannot vary is one there is nothing to store per app.
+export const DEFAULT_VOLUME_SIZE_BYTES = 8_589_934_592;
+
 // `deleted` is reported once the filesystem is actually gone, which is what lets the control
 // plane finish deleting an app rather than leave it saying `deleting` forever.
 export const VOLUME_STATES = ['pending', 'ready', 'detached', 'deleted', 'failed'] as const;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -203,6 +203,7 @@ export {
   TenantLogStreamSchema,
 } from '#domain/log.ts';
 export {
+  DEFAULT_VOLUME_SIZE_BYTES,
   VOLUME_STATES,
   type Volume,
   VolumeSchema,


### PR DESCRIPTION
`VOLUME_SIZE_BYTES` lived in `apps/api`, so nothing outside that app could import it — the literal `8_589_934_592` was re-typed by hand wherever else it was needed.

It now sits beside `VolumeSchema` as `DEFAULT_VOLUME_SIZE_BYTES`, mirroring where the wire puts it: `DesiredVolume.sizeBytes` is its own top-level desired-state entry, separate from the instance that references the volume.

Render fixtures in the CLI and dashboard tests keep their local literals — they sit beside deliberately non-default `VCPU_COUNT`/`MEMORY_MIB` values, so they mean "some size", not "the default", and coupling them would silently change what they assert if the default ever moves.