### PR TITLE
feat(api): a fetch unwraps a tarball to the executable inside it

### DIFF
--- a/apps/api/src/lib/archive/bytes.ts
+++ b/apps/api/src/lib/archive/bytes.ts
@@ -1,0 +1,239 @@
+// The bytes an archive is read out of, a piece at a time and forwards only, which is the shape a
+// fetch gives them in. Nothing here knows what an archive is: a zip and a tarball ask the same
+// things of a source, and only what they make of the answers differs.
+
+import { Buffer } from 'node:buffer';
+import type { Duplex } from 'node:stream';
+import { Readable } from 'node:stream';
+import { EntryTooLargeError, UnreadableArchiveError } from '#lib/archive/walk.ts';
+import { ArtifactTooLargeError } from '#lib/artifact-digest.ts';
+
+/** The stream's first bytes, and the stream itself with them still in front of it. */
+export async function peeked({
+  stream,
+  count,
+}: {
+  stream: ReadableStream<Uint8Array>;
+  count: number;
+}): Promise<{ head: Uint8Array; body: ReadableStream<Uint8Array> }> {
+  const rest = stream[Symbol.asyncIterator]();
+  const opening: Uint8Array[] = [];
+  let held = 0;
+
+  while (held < count) {
+    const { done, value } = await rest.next();
+    if (done) {
+      break;
+    }
+    opening.push(value);
+    held += value.byteLength;
+  }
+
+  return { head: Buffer.concat(opening), body: streamed(replayed({ opening, rest })) };
+}
+
+async function* replayed({
+  opening,
+  rest,
+}: {
+  opening: Uint8Array[];
+  rest: AsyncIterator<Uint8Array>;
+}): AsyncGenerator<Uint8Array> {
+  try {
+    yield* opening;
+    while (true) {
+      const { done, value } = await rest.next();
+      if (done) {
+        return;
+      }
+      yield value;
+    }
+  } finally {
+    await rest.return?.();
+  }
+}
+
+/** What the entry came to, stopping at the point reading more of it would prove nothing. */
+export async function drained({
+  stream,
+  budget,
+}: {
+  stream: ReadableStream<Uint8Array>;
+  budget: number;
+}): Promise<number> {
+  let read = 0;
+  for await (const chunk of stream) {
+    read += chunk.byteLength;
+    // Leaving the loop cancels the read: an entry already past what will be walked is one nobody
+    // is going to reach the end of.
+    if (read > budget) {
+      break;
+    }
+  }
+  return read;
+}
+
+/**
+ * The source as bytes to be read a piece at a time, holding whatever has arrived and not yet been
+ * taken. Chunks are joined only where something reaches across two of them — a header, or the
+ * window a descriptor could be sitting in — so what is held is a chunk and a remainder rather than
+ * the archive.
+ */
+export type Queued = {
+  /** At least `count` bytes, left where they are; `undefined` where the source ended first. */
+  need(count: number): Promise<Buffer | undefined>;
+  take(count: number): Promise<Buffer | undefined>;
+  /** Whatever is in hand, after pulling once where there is nothing. */
+  holding(): Promise<Buffer>;
+  drop(count: number): void;
+  more(): Promise<boolean>;
+  /** What is left of the source, the bytes in hand first. */
+  rest(): ReadableStream<Uint8Array>;
+  cancel(): Promise<void>;
+};
+
+export function queued(source: ReadableStream<Uint8Array>): Queued {
+  const chunks = source[Symbol.asyncIterator]();
+  let held = Buffer.alloc(0);
+  let ended = false;
+
+  async function pull(): Promise<boolean> {
+    if (ended) {
+      return false;
+    }
+    const { done, value } = await chunks.next();
+    if (done) {
+      ended = true;
+      return false;
+    }
+    held = Buffer.concat([held, value]);
+    return true;
+  }
+
+  async function need(count: number): Promise<Buffer | undefined> {
+    while (held.length < count) {
+      if (!(await pull())) {
+        return undefined;
+      }
+    }
+    return held.subarray(0, count);
+  }
+
+  function drop(count: number): void {
+    held = held.subarray(count);
+  }
+
+  return {
+    need,
+    drop,
+    more: pull,
+    async take(count) {
+      const head = await need(count);
+      if (head === undefined) {
+        return undefined;
+      }
+      const taken = Buffer.from(head);
+      drop(count);
+      return taken;
+    },
+    async holding() {
+      while (held.length === 0) {
+        if (!(await pull())) {
+          break;
+        }
+      }
+      return held;
+    },
+    rest() {
+      return streamed(replayed({ opening: [held], rest: chunks }));
+    },
+    async cancel() {
+      await chunks.return?.();
+    },
+  };
+}
+
+/** A generator as the stream everything downstream of here reads, pulled one chunk at a time. */
+export function streamed(source: AsyncGenerator<Uint8Array>): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await source.next();
+      if (done) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(value);
+    },
+    async cancel() {
+      await source.return(undefined);
+    },
+  });
+}
+
+/**
+ * The executable's bytes, and the source let go of after the last of them. What follows the entry
+ * is the rest of the archive's own bookkeeping, which nothing here reads.
+ */
+export async function* closing({
+  body,
+  bytes,
+}: {
+  body: ReadableStream<Uint8Array>;
+  bytes: Queued;
+}): AsyncGenerator<Uint8Array> {
+  try {
+    yield* body;
+  } finally {
+    await bytes.cancel();
+  }
+}
+
+/**
+ * A source read through a zlib engine — whatever the compressed bytes turn out to be, including
+ * that they were never in that compression at all.
+ */
+export async function* decompressed({
+  engine,
+  data,
+}: {
+  engine: Duplex;
+  data: AsyncIterable<Uint8Array>;
+}): AsyncGenerator<Uint8Array> {
+  const compressed = Readable.from(data);
+  // Piping does not carry a failure the other way, and the source failing is the ordinary way
+  // this ends: an archive that stopped part way has to stop the inflate reading it.
+  compressed.on('error', (failure) => engine.destroy(failure));
+  compressed.pipe(engine);
+
+  try {
+    yield* engine;
+  } catch (failure) {
+    // The source running out of what it was allowed to send, and an entry whose length nothing
+    // could read: those are verdicts on the bytes rather than on the archive, and the two this is
+    // not entitled to restate as an archive that ended early.
+    throw failure instanceof ArtifactTooLargeError || failure instanceof EntryTooLargeError
+      ? failure
+      : new UnreadableArchiveError();
+  }
+}
+
+/** Exactly the length the entry said, and an archive that ended early where it is not there. */
+export async function* ofSize({
+  bytes,
+  sizeBytes,
+}: {
+  bytes: Queued;
+  sizeBytes: number;
+}): AsyncGenerator<Uint8Array> {
+  let left = sizeBytes;
+  while (left > 0) {
+    const held = await bytes.holding();
+    if (held.length === 0) {
+      throw new UnreadableArchiveError();
+    }
+    const taken = Math.min(left, held.length);
+    yield held.subarray(0, taken);
+    bytes.drop(taken);
+    left -= taken;
+  }
+}

--- a/apps/api/src/lib/archive/bytes.ts
+++ b/apps/api/src/lib/archive/bytes.ts
@@ -1,6 +1,8 @@
 // The bytes an archive is read out of, a piece at a time and forwards only, which is the shape a
-// fetch gives them in. Nothing here knows what an archive is: a zip and a tarball ask the same
-// things of a source, and only what they make of the answers differs.
+// fetch gives them in. Nothing here knows what shape an archive has: a zip and a tarball ask the
+// same things of a source, and only what they make of the answers differs. What they share beyond
+// the asking is how a source that stops short is reported, which is why the two errors a walk can
+// end on are raised from here as well as from the formats.
 
 import { Buffer } from 'node:buffer';
 import type { Duplex } from 'node:stream';
@@ -214,6 +216,11 @@ export async function* decompressed({
     throw failure instanceof ArtifactTooLargeError || failure instanceof EntryTooLargeError
       ? failure
       : new UnreadableArchiveError();
+  } finally {
+    // Whoever gives up on the decompressed bytes is giving up on the compressed ones too, and a
+    // pipe carries that no further than the engine: unpiping a destroyed destination leaves the
+    // source sitting on a connection nobody is ever going to read again.
+    compressed.destroy();
   }
 }
 

--- a/apps/api/src/lib/archive/tar.ts
+++ b/apps/api/src/lib/archive/tar.ts
@@ -36,8 +36,23 @@ export const TAR_IDENTITY_BYTES = MAGIC_AT + MAGIC.length;
 const TYPE_FILE = '0';
 const TYPE_FILE_UNSET = '\0';
 
+/**
+ * The entry gnu tar writes in front of one whose path is longer than a header can hold, carrying
+ * that path as its data. Gnu is what `tar czf` writes by default on linux, which is where release
+ * tarballs come from.
+ */
+const TYPE_LONG_NAME = 'L';
+
+/**
+ * As much of one of those as will be held to read a path out of. Longer than any path a release
+ * archive carries, and far short of what the entry could claim: the name is read into memory,
+ * where every other entry is walked past a chunk at a time.
+ */
+const MAX_LONG_NAME_BYTES = 4096;
+
 /** Lengths are octal text, except where the high bit says the rest of the field is base 256. */
 const OCTAL = 8;
+const OCTAL_DIGITS = /^[0-7]+$/;
 const BASE_256_MARKER = 0x80;
 
 const NUL = 0;
@@ -52,6 +67,8 @@ type Entry = {
   name: string;
   sizeBytes: number;
   isFile: boolean;
+  /** Carries the path of the entry after it rather than any content of its own. */
+  isLongName: boolean;
 };
 
 /**
@@ -69,28 +86,32 @@ export async function executableInTarball({
 }): Promise<Unwrapping> {
   let skipped = 0;
   let entries = 0;
+  let announced: string | undefined;
 
   while (skipped <= maxSkippedBytes && entries < MAX_ENTRIES) {
-    const block = await bytes.take(BLOCK_BYTES);
-    if (block === undefined) {
+    const header = await readHeader(bytes);
+    if (header.outcome !== 'entry') {
       await bytes.cancel();
-      return { outcome: 'unreadable' };
+      return header.outcome === 'end' ? { outcome: 'no-executable' } : { outcome: 'unreadable' };
     }
-    // A block of nothing is how a tar says it is over; what follows is padding to a tape length.
-    if (isEnd(block)) {
-      await bytes.cancel();
-      return { outcome: 'no-executable' };
-    }
-
-    const entry = entryIn(block);
-    if (entry === undefined) {
-      await bytes.cancel();
-      return { outcome: 'unreadable' };
-    }
+    const { entry } = header;
     skipped += BLOCK_BYTES;
     entries += 1;
 
-    const found = await walkedPast({ bytes, entry, maxSkippedBytes: maxSkippedBytes - skipped });
+    if (carriesLongName(entry)) {
+      const carried = await longNameIn({ bytes, sizeBytes: entry.sizeBytes });
+      announced = carried.name;
+      skipped += carried.readBytes;
+      continue;
+    }
+
+    const found = await walkedPast({
+      bytes,
+      entry,
+      name: announced ?? entry.name,
+      maxSkippedBytes: maxSkippedBytes - skipped,
+    });
+    announced = undefined;
     if (found.outcome !== 'skipped') {
       return found.outcome === 'unwrapped' ? found.unwrapping : { outcome: 'walked-too-far' };
     }
@@ -99,6 +120,57 @@ export async function executableInTarball({
 
   await bytes.cancel();
   return { outcome: 'walked-too-far' };
+}
+
+type Header =
+  | { outcome: 'entry'; entry: Entry }
+  /** A block of nothing, which is how a tar says its entries have stopped. */
+  | { outcome: 'end' }
+  | { outcome: 'unreadable' };
+
+async function readHeader(bytes: Queued): Promise<Header> {
+  const block = await bytes.take(BLOCK_BYTES);
+  if (block === undefined) {
+    return { outcome: 'unreadable' };
+  }
+  // What follows the block of nothing is padding out to a tape length, which nothing here reads.
+  if (isEnd(block)) {
+    return { outcome: 'end' };
+  }
+  const entry = entryIn(block);
+  return entry === undefined ? { outcome: 'unreadable' } : { outcome: 'entry', entry };
+}
+
+/**
+ * Whether this entry is one to read a path out of rather than walk past.
+ *
+ * The path is held in memory, where every other entry is read a chunk at a time — so one claiming
+ * more than a path could be is skipped like anything else, and the name falls back to the header's
+ * own truncated copy.
+ */
+function carriesLongName(entry: Entry): boolean {
+  return entry.isLongName && entry.sizeBytes <= MAX_LONG_NAME_BYTES;
+}
+
+/**
+ * The path a long-name entry carries, and what it cost to read. The header that follows keeps only
+ * the first hundred bytes of that path, and those are the leading directories rather than the
+ * trailing name — so a walk reading the header alone would call the binary after a fragment of the
+ * folder it sits in.
+ */
+async function longNameIn({
+  bytes,
+  sizeBytes,
+}: {
+  bytes: Queued;
+  sizeBytes: number;
+}): Promise<{ name: string; readBytes: number }> {
+  const path = await bytes.take(sizeBytes);
+  const padding = paddingAfter(sizeBytes);
+  if (path === undefined || (padding > 0 && (await bytes.take(padding)) === undefined)) {
+    throw new UnreadableArchiveError();
+  }
+  return { name: textIn(path), readBytes: sizeBytes + padding };
 }
 
 type Walked =
@@ -111,10 +183,12 @@ type Walked =
 async function walkedPast({
   bytes,
   entry,
+  name,
   maxSkippedBytes,
 }: {
   bytes: Queued;
   entry: Entry;
+  name: string;
   maxSkippedBytes: number;
 }): Promise<Walked> {
   const content = streamed(ofSize({ bytes, sizeBytes: entry.sizeBytes }));
@@ -125,7 +199,7 @@ async function walkedPast({
       outcome: 'unwrapped',
       unwrapping: {
         outcome: 'unwrapped',
-        name: named(entry.name),
+        name: named(name),
         body: streamed(closing({ body, bytes })),
       },
     };
@@ -165,6 +239,7 @@ function entryIn(block: Buffer): Entry | undefined {
     name: textAt({ block, at: NAME_AT, bytes: NAME_BYTES }),
     sizeBytes,
     isFile: type === TYPE_FILE || type === TYPE_FILE_UNSET,
+    isLongName: type === TYPE_LONG_NAME,
   };
 }
 
@@ -184,12 +259,18 @@ function sizeIn(block: Buffer): number | undefined {
   if (digits.length === 0) {
     return 0;
   }
-  const size = Number.parseInt(digits, OCTAL);
-  return Number.isSafeInteger(size) && size >= 0 ? size : undefined;
+  // Read rather than parsed: `parseInt` takes whatever digits a field opens with and stops at the
+  // first byte it cannot use, so a corrupt length would come back as a plausible shorter one and
+  // put the walk a few bytes out of step with the headers rather than refusing the archive.
+  return OCTAL_DIGITS.test(digits) ? Number.parseInt(digits, OCTAL) : undefined;
 }
 
 function textAt({ block, at, bytes }: { block: Buffer; at: number; bytes: number }): string {
-  const field = block.subarray(at, at + bytes);
+  return textIn(block.subarray(at, at + bytes));
+}
+
+/** A fixed-width field as what was written in it, which ends at the first NUL where there is one. */
+function textIn(field: Buffer): string {
   const end = field.indexOf(NUL);
   return field.subarray(0, end < 0 ? field.length : end).toString('utf8');
 }

--- a/apps/api/src/lib/archive/tar.ts
+++ b/apps/api/src/lib/archive/tar.ts
@@ -1,0 +1,200 @@
+// A tarball read the way a fetch hands it over: forwards, once, with a chunk in hand.
+//
+// A tar has no index to be behind — it is headers and data alternating to the end — so a walk of
+// one is what a walk of a zip has to work to be. Every header is a 512-byte block, every length is
+// in the header that precedes its data, and the data is padded out to the next block.
+
+import { Buffer } from 'node:buffer';
+import { closing, drained, ofSize, peeked, type Queued, streamed } from '#lib/archive/bytes.ts';
+import {
+  EntryTooLargeError,
+  MAX_ENTRIES,
+  UnreadableArchiveError,
+  type Unwrapping,
+} from '#lib/archive/walk.ts';
+import { ELF_MAGIC_LENGTH, isElfExecutable } from '#lib/elf.ts';
+
+const BLOCK_BYTES = 512;
+
+const NAME_AT = 0;
+const NAME_BYTES = 100;
+const SIZE_AT = 124;
+const SIZE_FIELD_BYTES = 12;
+const TYPE_AT = 156;
+const MAGIC_AT = 257;
+
+/**
+ * What every tar written this side of 1988 carries, in the one form both of its dialects share:
+ * posix follows it with a NUL and gnu with a space, so five characters is what they agree on.
+ */
+const MAGIC = 'ustar';
+
+/** Through the magic, which is the last of what says a stream of bytes is a tar at all. */
+export const TAR_IDENTITY_BYTES = MAGIC_AT + MAGIC.length;
+
+/** A regular file, written as a digit by anything modern and as a NUL by anything that is not. */
+const TYPE_FILE = '0';
+const TYPE_FILE_UNSET = '\0';
+
+/** Lengths are octal text, except where the high bit says the rest of the field is base 256. */
+const OCTAL = 8;
+const BASE_256_MARKER = 0x80;
+
+const NUL = 0;
+const PATH_SEPARATOR = '/';
+
+/** Whether these opening bytes are a tar's first header, which is the only thing that says so. */
+export function isTarball(opening: Uint8Array): boolean {
+  return Buffer.from(opening).subarray(MAGIC_AT, TAR_IDENTITY_BYTES).toString('latin1') === MAGIC;
+}
+
+type Entry = {
+  name: string;
+  sizeBytes: number;
+  isFile: boolean;
+};
+
+/**
+ * The executable inside a tarball, walked to from the front.
+ *
+ * Every entry's length is known before its data, so what a zip has to find by looking for the
+ * record after it, this only has to count.
+ */
+export async function executableInTarball({
+  bytes,
+  maxSkippedBytes,
+}: {
+  bytes: Queued;
+  maxSkippedBytes: number;
+}): Promise<Unwrapping> {
+  let skipped = 0;
+  let entries = 0;
+
+  while (skipped <= maxSkippedBytes && entries < MAX_ENTRIES) {
+    const block = await bytes.take(BLOCK_BYTES);
+    if (block === undefined) {
+      await bytes.cancel();
+      return { outcome: 'unreadable' };
+    }
+    // A block of nothing is how a tar says it is over; what follows is padding to a tape length.
+    if (isEnd(block)) {
+      await bytes.cancel();
+      return { outcome: 'no-executable' };
+    }
+
+    const entry = entryIn(block);
+    if (entry === undefined) {
+      await bytes.cancel();
+      return { outcome: 'unreadable' };
+    }
+    skipped += BLOCK_BYTES;
+    entries += 1;
+
+    const found = await walkedPast({ bytes, entry, maxSkippedBytes: maxSkippedBytes - skipped });
+    if (found.outcome !== 'skipped') {
+      return found.outcome === 'unwrapped' ? found.unwrapping : { outcome: 'walked-too-far' };
+    }
+    skipped += found.readBytes;
+  }
+
+  await bytes.cancel();
+  return { outcome: 'walked-too-far' };
+}
+
+type Walked =
+  | { outcome: 'unwrapped'; unwrapping: Unwrapping }
+  | { outcome: 'skipped'; readBytes: number }
+  /** The entry was not read to its end, so there is no next header to line up on. */
+  | { outcome: 'gave-up' };
+
+/** The entry read far enough to say whether it is the executable, and past where it is not. */
+async function walkedPast({
+  bytes,
+  entry,
+  maxSkippedBytes,
+}: {
+  bytes: Queued;
+  entry: Entry;
+  maxSkippedBytes: number;
+}): Promise<Walked> {
+  const content = streamed(ofSize({ bytes, sizeBytes: entry.sizeBytes }));
+  const { head, body } = await peeked({ stream: content, count: ELF_MAGIC_LENGTH });
+
+  if (entry.isFile && isElfExecutable(head)) {
+    return {
+      outcome: 'unwrapped',
+      unwrapping: {
+        outcome: 'unwrapped',
+        name: named(entry.name),
+        body: streamed(closing({ body, bytes })),
+      },
+    };
+  }
+
+  const readBytes = await drained({ stream: body, budget: maxSkippedBytes });
+  if (readBytes < entry.sizeBytes) {
+    await bytes.cancel();
+    return { outcome: 'gave-up' };
+  }
+  // The data is written out to a whole number of blocks, and the next header starts after them.
+  const padding = paddingAfter(entry.sizeBytes);
+  if (padding > 0 && (await bytes.take(padding)) === undefined) {
+    throw new UnreadableArchiveError();
+  }
+  return { outcome: 'skipped', readBytes: readBytes + padding };
+}
+
+function paddingAfter(sizeBytes: number): number {
+  return (BLOCK_BYTES - (sizeBytes % BLOCK_BYTES)) % BLOCK_BYTES;
+}
+
+function isEnd(block: Buffer): boolean {
+  return block.every((byte) => byte === NUL);
+}
+
+/** The header as what a walk needs of it, or nothing where it does not say a length it can use. */
+function entryIn(block: Buffer): Entry | undefined {
+  const sizeBytes = sizeIn(block);
+  if (sizeBytes === undefined) {
+    return undefined;
+  }
+  const type = String.fromCharCode(block[TYPE_AT] ?? NUL);
+  return {
+    // The prefix a long path is split across is left where it is: it holds the leading directories,
+    // and the name this reports is the last segment either way.
+    name: textAt({ block, at: NAME_AT, bytes: NAME_BYTES }),
+    sizeBytes,
+    isFile: type === TYPE_FILE || type === TYPE_FILE_UNSET,
+  };
+}
+
+/**
+ * The entry's length, which a tar writes as octal text.
+ *
+ * Eleven digits of octal cannot say more than eight gibibytes, and the way out of that is to set
+ * the high bit and use the rest as base 256 — a length past anything storable, and this format's
+ * own answer to the problem a zip answers with a field beside the header.
+ */
+function sizeIn(block: Buffer): number | undefined {
+  const field = block.subarray(SIZE_AT, SIZE_AT + SIZE_FIELD_BYTES);
+  if (((field[0] ?? NUL) & BASE_256_MARKER) !== 0) {
+    throw new EntryTooLargeError();
+  }
+  const digits = field.toString('latin1').replaceAll('\0', ' ').trim();
+  if (digits.length === 0) {
+    return 0;
+  }
+  const size = Number.parseInt(digits, OCTAL);
+  return Number.isSafeInteger(size) && size >= 0 ? size : undefined;
+}
+
+function textAt({ block, at, bytes }: { block: Buffer; at: number; bytes: number }): string {
+  const field = block.subarray(at, at + bytes);
+  const end = field.indexOf(NUL);
+  return field.subarray(0, end < 0 ? field.length : end).toString('utf8');
+}
+
+/** The entry's own name, which is the last segment where the tar kept it in a directory. */
+function named(path: string): string {
+  return path.split(PATH_SEPARATOR).at(-1) ?? path;
+}

--- a/apps/api/src/lib/archive/unwrap.ts
+++ b/apps/api/src/lib/archive/unwrap.ts
@@ -1,0 +1,94 @@
+// What a url answered with, as the binary it holds. A release is published as a bare executable, as
+// a zip, or as a tarball — and for Linux far more often as the last of the three than the second —
+// so what a fetch has in hand is decided by the bytes rather than by what the link was called.
+
+import { Buffer } from 'node:buffer';
+import { createGunzip } from 'node:zlib';
+import { decompressed, type Queued, queued, streamed } from '#lib/archive/bytes.ts';
+import { executableInTarball, isTarball, TAR_IDENTITY_BYTES } from '#lib/archive/tar.ts';
+import { EntryTooLargeError, UnreadableArchiveError, type Unwrapping } from '#lib/archive/walk.ts';
+import { executableInZip, ZIP_MAGIC } from '#lib/archive/zip.ts';
+
+/** What a gzip opens with, whatever it turns out to be wrapped around. */
+const GZIP_MAGIC = Buffer.from('\x1f\x8b', 'latin1');
+
+/** Enough to tell every container apart, which is the longest of the openings that name one. */
+const OPENING_BYTES = Math.max(ZIP_MAGIC.length, GZIP_MAGIC.length);
+
+/**
+ * The executable inside whatever the url answered with, or the bytes back where they are already
+ * one. A project that publishes its build in an archive is publishing a url nobody could deploy
+ * from otherwise — the alternative is downloading it, unpacking it, and uploading the one file.
+ *
+ * `maxSkippedBytes` bounds the walk. An archive is a claim about its own contents, and an entry
+ * claiming a petabyte of text before the binary would otherwise be read until it ended.
+ */
+export async function unwrapExecutable({
+  archive,
+  maxSkippedBytes,
+}: {
+  archive: ReadableStream<Uint8Array>;
+  maxSkippedBytes: number;
+}): Promise<Unwrapping> {
+  const bytes = queued(archive);
+  const opening = await bytes.need(OPENING_BYTES);
+  if (opening === undefined) {
+    return { outcome: 'not-an-archive', body: bytes.rest() };
+  }
+
+  if (opening.equals(ZIP_MAGIC)) {
+    return await walked({ bytes, walk: () => executableInZip({ bytes, maxSkippedBytes }) });
+  }
+  if (opening.subarray(0, GZIP_MAGIC.length).equals(GZIP_MAGIC)) {
+    return await walked({ bytes, walk: () => gunzipped({ bytes, maxSkippedBytes }) });
+  }
+  return { outcome: 'not-an-archive', body: bytes.rest() };
+}
+
+/**
+ * What a gzip holds: the executable inside the tarball it turns out to be, or the executable it is
+ * itself. Releases are published both ways — `my-server_linux_amd64.tar.gz` beside a bare
+ * `my-server.gz` — and both are one gunzip away from the same question.
+ *
+ * What is not a tarball is handed on rather than refused. Whether those bytes are an executable is
+ * a question the inspection asks of everything, and asking it twice would only answer it worse.
+ */
+async function gunzipped({
+  bytes,
+  maxSkippedBytes,
+}: {
+  bytes: Queued;
+  maxSkippedBytes: number;
+}): Promise<Unwrapping> {
+  const content = queued(streamed(decompressed({ engine: createGunzip(), data: bytes.rest() })));
+  const opening = await content.need(TAR_IDENTITY_BYTES);
+  if (opening === undefined || !isTarball(opening)) {
+    return { outcome: 'not-an-archive', body: content.rest() };
+  }
+  return await executableInTarball({ bytes: content, maxSkippedBytes });
+}
+
+/**
+ * The walk, with the source let go of whatever it failed on. A walk is also what feeds the
+ * executable onward, so one that goes wrong is one nobody downstream is going to finish reading.
+ */
+async function walked({
+  bytes,
+  walk,
+}: {
+  bytes: Queued;
+  walk: () => Promise<Unwrapping>;
+}): Promise<Unwrapping> {
+  try {
+    return await walk();
+  } catch (failure) {
+    await bytes.cancel();
+    if (failure instanceof UnreadableArchiveError) {
+      return { outcome: 'unreadable' };
+    }
+    if (failure instanceof EntryTooLargeError) {
+      return { outcome: 'entry-too-large' };
+    }
+    throw failure;
+  }
+}

--- a/apps/api/src/lib/archive/unwrap.ts
+++ b/apps/api/src/lib/archive/unwrap.ts
@@ -12,7 +12,7 @@ import { executableInZip, ZIP_MAGIC } from '#lib/archive/zip.ts';
 /** What a gzip opens with, whatever it turns out to be wrapped around. */
 const GZIP_MAGIC = Buffer.from('\x1f\x8b', 'latin1');
 
-/** Enough to tell every container apart, which is the longest of the openings that name one. */
+/** Enough to tell the two containers apart that say what they are in their first bytes. */
 const OPENING_BYTES = Math.max(ZIP_MAGIC.length, GZIP_MAGIC.length);
 
 /**
@@ -32,15 +32,18 @@ export async function unwrapExecutable({
 }): Promise<Unwrapping> {
   const bytes = queued(archive);
   const opening = await bytes.need(OPENING_BYTES);
-  if (opening === undefined) {
-    return { outcome: 'not-an-archive', body: bytes.rest() };
-  }
 
-  if (opening.equals(ZIP_MAGIC)) {
+  if (opening?.equals(ZIP_MAGIC)) {
     return await walked({ bytes, walk: () => executableInZip({ bytes, maxSkippedBytes }) });
   }
-  if (opening.subarray(0, GZIP_MAGIC.length).equals(GZIP_MAGIC)) {
+  if (opening?.subarray(0, GZIP_MAGIC.length).equals(GZIP_MAGIC)) {
     return await walked({ bytes, walk: () => gunzipped({ bytes, maxSkippedBytes }) });
+  }
+  // A tar says what it is a quarter of a kibibyte in, so it is asked for last and asked for
+  // separately: a zip small enough to end before that is still a zip.
+  const header = await bytes.need(TAR_IDENTITY_BYTES);
+  if (header !== undefined && isTarball(header)) {
+    return await walked({ bytes, walk: () => executableInTarball({ bytes, maxSkippedBytes }) });
   }
   return { outcome: 'not-an-archive', body: bytes.rest() };
 }

--- a/apps/api/src/lib/archive/walk.ts
+++ b/apps/api/src/lib/archive/walk.ts
@@ -1,0 +1,55 @@
+// What a walk of an archive can come to, and the two ways one can stop being followable. Held
+// apart from the formats themselves because a zip and a tarball reach the same ends by different
+// roads, and whoever asked for the executable inside one does not care which road it was.
+
+/** Not a container this reads, handed back with the bytes that were read to tell. */
+export type Unwrapping =
+  | { outcome: 'not-an-archive'; body: ReadableStream<Uint8Array> }
+  | { outcome: 'unwrapped'; name: string; body: ReadableStream<Uint8Array> }
+  | { outcome: 'no-executable' }
+  | { outcome: 'walked-too-far' }
+  | { outcome: 'entry-too-large' }
+  | { outcome: 'unreadable' };
+
+/**
+ * How many entries a walk will read the headers of.
+ *
+ * An entry that declares no data costs nothing against `maxSkippedBytes`, so an archive that is
+ * headers the whole way down is bounded only by how many of them fit inside the cap on the fetch.
+ * Each one pays for a header, a peek and the streams to read it through — tens of microseconds —
+ * so it is the count that bounds the work rather than the bytes.
+ *
+ * A release archive is a binary and a couple of text files. One with hundreds of files in front of
+ * the binary is shipping what a deploy does nothing with, and is answered rather than walked.
+ */
+export const MAX_ENTRIES = 512;
+
+/**
+ * What an archive this cannot follow is raised as, wherever it stops being followable — a walk is
+ * also what feeds the executable onward, so one that goes wrong after the entry was found goes
+ * wrong inside a stream somebody else is already reading.
+ *
+ * Everything an archive can do to this end arrives as this one error, a source that stopped part
+ * way included: from here they are the same event, an archive that ended before it said it would.
+ */
+export class UnreadableArchiveError extends Error {
+  constructor() {
+    super('The archive ended before the entry it was describing.');
+    this.name = 'UnreadableArchiveError';
+  }
+}
+
+/**
+ * What an entry too long for its own header to say so is raised as.
+ *
+ * Both formats have a field too narrow for the lengths they may carry, and both answer it by
+ * writing a marker and putting the real number somewhere this does not read. The lengths that need
+ * one start past four gibibytes, which is past what could be stored — and an entry whose length is
+ * unknown is one there is no way to walk past to reach whatever follows it.
+ */
+export class EntryTooLargeError extends Error {
+  constructor() {
+    super('An entry declares a length its own header could not hold.');
+    this.name = 'EntryTooLargeError';
+  }
+}

--- a/apps/api/src/lib/archive/zip.ts
+++ b/apps/api/src/lib/archive/zip.ts
@@ -6,9 +6,22 @@
 // is a binary and a couple of text files, so that is a walk of two or three entries.
 
 import { Buffer } from 'node:buffer';
-import { Readable } from 'node:stream';
 import { createInflateRaw } from 'node:zlib';
-import { ArtifactTooLargeError } from '#lib/artifact-digest.ts';
+import {
+  closing,
+  decompressed,
+  drained,
+  ofSize,
+  peeked,
+  type Queued,
+  streamed,
+} from '#lib/archive/bytes.ts';
+import {
+  EntryTooLargeError,
+  MAX_ENTRIES,
+  UnreadableArchiveError,
+  type Unwrapping,
+} from '#lib/archive/walk.ts';
 import { ELF_MAGIC_LENGTH, isElfExecutable } from '#lib/elf.ts';
 
 const LOCAL_HEADER = signature('PK\x03\x04');
@@ -92,98 +105,17 @@ const ZIP64_SIZES_BYTES = 16;
 
 const PATH_SEPARATOR = '/';
 
-/**
- * How many entries a walk will read the headers of.
- *
- * An entry that declares no data costs nothing against `maxSkippedBytes`, so an archive that is
- * headers the whole way down is bounded only by how many of them fit inside the cap on the fetch.
- * Each one pays for a header, a peek and the streams to read it through — tens of microseconds —
- * so it is the count that bounds the work rather than the bytes.
- *
- * A release archive is a binary and a couple of text files. One with hundreds of files in front of
- * the binary is shipping what a deploy does nothing with, and is answered rather than walked.
- */
-export const MAX_ENTRIES = 512;
-
-export type Unwrapping =
-  /** Not a zip at all, handed back with the bytes that were read to tell. */
-  | { outcome: 'not-an-archive'; body: ReadableStream<Uint8Array> }
-  | { outcome: 'unwrapped'; name: string; body: ReadableStream<Uint8Array> }
-  | { outcome: 'no-executable' }
-  | { outcome: 'walked-too-far' }
-  | { outcome: 'entry-too-large' }
-  | { outcome: 'unreadable' };
+/** What a zip opens with, which is the only thing that says it is one before the index at its end. */
+export const ZIP_MAGIC = LOCAL_HEADER;
 
 /**
- * What an archive this cannot follow is raised as, wherever it stops being followable — the walk
- * is also what feeds the executable onward, so one that goes wrong after the entry was found goes
- * wrong inside a stream somebody else is already reading.
+ * The executable inside a zip, walked to from the front.
  *
- * Everything a zip can do to this end arrives as this one error, a source that stopped part way
- * included: from here they are the same event, an archive that ended before it said it would.
+ * It comes back once the entry has been found and its first bytes read, which is a name and a body
+ * rather than the promise of one: everything before the executable has been walked past by then,
+ * and only its own bytes are still to come.
  */
-export class UnreadableArchiveError extends Error {
-  constructor() {
-    super('The zip ended before the entry it was describing.');
-    this.name = 'UnreadableArchiveError';
-  }
-}
-
-/**
- * What an entry too long for its own header to say so is raised as.
- *
- * A size field is four bytes, so a length that does not fit is written as all ones and kept in a
- * zip64 extra field instead. Nothing here reads that field: the length it holds starts at four
- * gibibytes, which is past what could be stored — and an entry whose length is unknown is one
- * there is no way to walk past to reach whatever follows it.
- */
-export class EntryTooLargeError extends Error {
-  constructor() {
-    super('An entry declares a length only a zip64 field could hold.');
-    this.name = 'EntryTooLargeError';
-  }
-}
-
-/**
- * The executable inside a zip, or the bytes back where they are not one.
- *
- * It comes back once the entry has been found and its first bytes read, which is a name and a
- * body rather than the promise of one: everything before the executable has been walked past by
- * then, and only its own bytes are still to come.
- *
- * `maxSkippedBytes` bounds that walk. An archive is a claim about its own contents, and an entry
- * claiming a petabyte of text before the binary would otherwise be read until it ended.
- */
-export async function unwrapExecutable({
-  archive,
-  maxSkippedBytes,
-}: {
-  archive: ReadableStream<Uint8Array>;
-  maxSkippedBytes: number;
-}): Promise<Unwrapping> {
-  const bytes = queued(archive);
-  const opening = await bytes.need(SIGNATURE_BYTES);
-  if (opening === undefined || !opening.equals(LOCAL_HEADER)) {
-    return { outcome: 'not-an-archive', body: bytes.rest() };
-  }
-
-  try {
-    return await executableIn({ bytes, maxSkippedBytes });
-  } catch (failure) {
-    // Whatever went wrong, the archive is not going to be read any further, and a source nobody
-    // is reading holds its connection open until it is let go of.
-    await bytes.cancel();
-    if (failure instanceof UnreadableArchiveError) {
-      return { outcome: 'unreadable' };
-    }
-    if (failure instanceof EntryTooLargeError) {
-      return { outcome: 'entry-too-large' };
-    }
-    throw failure;
-  }
-}
-
-async function executableIn({
+export async function executableInZip({
   bytes,
   maxSkippedBytes,
 }: {
@@ -315,46 +247,7 @@ function readable({
   data: AsyncGenerator<Uint8Array>;
 }): ReadableStream<Uint8Array> {
   const deflated = entry.method === METHOD_DEFLATE && (entry.flags & FLAG_ENCRYPTED) === 0;
-  return streamed(deflated ? inflated(data) : data);
-}
-
-/** Whatever the compressed bytes turn out to be, including that they were not deflate at all. */
-async function* inflated(data: AsyncGenerator<Uint8Array>): AsyncGenerator<Uint8Array> {
-  const engine = createInflateRaw();
-  const compressed = Readable.from(data);
-  // Piping does not carry a failure the other way, and the source failing is the ordinary way
-  // this ends: an archive that stopped part way has to stop the inflate reading it.
-  compressed.on('error', (failure) => engine.destroy(failure));
-  compressed.pipe(engine);
-
-  try {
-    yield* engine;
-  } catch (failure) {
-    // The source running out of what it was allowed to send, and an entry whose length nothing
-    // could read: those are verdicts on the bytes rather than on the archive, and the two this is
-    // not entitled to restate as an archive that ended early.
-    throw failure instanceof ArtifactTooLargeError || failure instanceof EntryTooLargeError
-      ? failure
-      : new UnreadableArchiveError();
-  }
-}
-
-/**
- * The executable's bytes, and the source let go of after the last of them. What follows the entry
- * is the rest of the archive's own bookkeeping, which nothing here reads.
- */
-async function* closing({
-  body,
-  bytes,
-}: {
-  body: ReadableStream<Uint8Array>;
-  bytes: Queued;
-}): AsyncGenerator<Uint8Array> {
-  try {
-    yield* body;
-  } finally {
-    await bytes.cancel();
-  }
+  return streamed(deflated ? decompressed({ engine: createInflateRaw(), data }) : data);
 }
 
 /** The entry's own name, which is the last segment where the archive kept it in a directory. */
@@ -362,13 +255,8 @@ function named(path: string): string {
   return path.split(PATH_SEPARATOR).at(-1) ?? path;
 }
 
-function entryData({ bytes, entry }: { bytes: Queued; entry: Entry }): AsyncGenerator<Uint8Array> {
-  return (entry.flags & FLAG_SIZES_IN_DESCRIPTOR) === 0
-    ? ofDeclaredSize({ bytes, sizeBytes: entry.compressedSizeBytes })
-    : untilDescriptor(bytes);
-}
-
-async function* ofDeclaredSize({
+/** The entry's data, refused where its length was one the header could only point at. */
+function ofDeclaredSize({
   bytes,
   sizeBytes,
 }: {
@@ -378,17 +266,13 @@ async function* ofDeclaredSize({
   if (sizeBytes === SIZE_IN_ZIP64_EXTRA) {
     throw new EntryTooLargeError();
   }
-  let left = sizeBytes;
-  while (left > 0) {
-    const held = await bytes.holding();
-    if (held.length === 0) {
-      throw new UnreadableArchiveError();
-    }
-    const taken = Math.min(left, held.length);
-    yield held.subarray(0, taken);
-    bytes.drop(taken);
-    left -= taken;
-  }
+  return ofSize({ bytes, sizeBytes });
+}
+
+function entryData({ bytes, entry }: { bytes: Queued; entry: Entry }): AsyncGenerator<Uint8Array> {
+  return (entry.flags & FLAG_SIZES_IN_DESCRIPTOR) === 0
+    ? ofDeclaredSize({ bytes, sizeBytes: entry.compressedSizeBytes })
+    : untilDescriptor(bytes);
 }
 
 /**
@@ -505,166 +389,4 @@ function claimedSize({
   return shape.sizeBytes === ZIP64_SIZE_BYTES
     ? Number(held.readBigUInt64LE(size))
     : held.readUInt32LE(size);
-}
-
-/** The stream's first bytes, and the stream itself with them still in front of it. */
-async function peeked({
-  stream,
-  count,
-}: {
-  stream: ReadableStream<Uint8Array>;
-  count: number;
-}): Promise<{ head: Uint8Array; body: ReadableStream<Uint8Array> }> {
-  const rest = stream[Symbol.asyncIterator]();
-  const opening: Uint8Array[] = [];
-  let held = 0;
-
-  while (held < count) {
-    const { done, value } = await rest.next();
-    if (done) {
-      break;
-    }
-    opening.push(value);
-    held += value.byteLength;
-  }
-
-  return { head: Buffer.concat(opening), body: streamed(replayed({ opening, rest })) };
-}
-
-async function* replayed({
-  opening,
-  rest,
-}: {
-  opening: Uint8Array[];
-  rest: AsyncIterator<Uint8Array>;
-}): AsyncGenerator<Uint8Array> {
-  try {
-    yield* opening;
-    while (true) {
-      const { done, value } = await rest.next();
-      if (done) {
-        return;
-      }
-      yield value;
-    }
-  } finally {
-    await rest.return?.();
-  }
-}
-
-/** What the entry came to, stopping at the point reading more of it would prove nothing. */
-async function drained({
-  stream,
-  budget,
-}: {
-  stream: ReadableStream<Uint8Array>;
-  budget: number;
-}): Promise<number> {
-  let read = 0;
-  for await (const chunk of stream) {
-    read += chunk.byteLength;
-    // Leaving the loop cancels the read: an entry already past what will be walked is one nobody
-    // is going to reach the end of.
-    if (read > budget) {
-      break;
-    }
-  }
-  return read;
-}
-
-/**
- * The source as bytes to be read a piece at a time, holding whatever has arrived and not yet been
- * taken. Chunks are joined only where something reaches across two of them — a header, or the
- * window a descriptor could be sitting in — so what is held is a chunk and a remainder rather than
- * the archive.
- */
-type Queued = {
-  /** At least `count` bytes, left where they are; `undefined` where the source ended first. */
-  need(count: number): Promise<Buffer | undefined>;
-  take(count: number): Promise<Buffer | undefined>;
-  /** Whatever is in hand, after pulling once where there is nothing. */
-  holding(): Promise<Buffer>;
-  drop(count: number): void;
-  more(): Promise<boolean>;
-  /** What is left of the source, the bytes in hand first. */
-  rest(): ReadableStream<Uint8Array>;
-  cancel(): Promise<void>;
-};
-
-function queued(source: ReadableStream<Uint8Array>): Queued {
-  const chunks = source[Symbol.asyncIterator]();
-  let held = Buffer.alloc(0);
-  let ended = false;
-
-  async function pull(): Promise<boolean> {
-    if (ended) {
-      return false;
-    }
-    const { done, value } = await chunks.next();
-    if (done) {
-      ended = true;
-      return false;
-    }
-    held = Buffer.concat([held, value]);
-    return true;
-  }
-
-  async function need(count: number): Promise<Buffer | undefined> {
-    while (held.length < count) {
-      if (!(await pull())) {
-        return undefined;
-      }
-    }
-    return held.subarray(0, count);
-  }
-
-  function drop(count: number): void {
-    held = held.subarray(count);
-  }
-
-  return {
-    need,
-    drop,
-    more: pull,
-    async take(count) {
-      const head = await need(count);
-      if (head === undefined) {
-        return undefined;
-      }
-      const taken = Buffer.from(head);
-      drop(count);
-      return taken;
-    },
-    async holding() {
-      while (held.length === 0) {
-        if (!(await pull())) {
-          break;
-        }
-      }
-      return held;
-    },
-    rest() {
-      return streamed(replayed({ opening: [held], rest: chunks }));
-    },
-    async cancel() {
-      await chunks.return?.();
-    },
-  };
-}
-
-/** A generator as the stream everything downstream of here reads, pulled one chunk at a time. */
-function streamed(source: AsyncGenerator<Uint8Array>): ReadableStream<Uint8Array> {
-  return new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      const { done, value } = await source.next();
-      if (done) {
-        controller.close();
-        return;
-      }
-      controller.enqueue(value);
-    },
-    async cancel() {
-      await source.return(undefined);
-    },
-  });
 }

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -630,9 +630,9 @@ async function unwrapped({
 
   switch (unwrapping.outcome) {
     case 'not-an-archive':
-      return { body: unwrapping.body, filename: named };
+      return { body: unwrapping.body, filename: unpacked(named) };
     case 'unwrapped':
-      return { body: unwrapping.body, filename: entryName(unwrapping.name) ?? named };
+      return { body: unwrapping.body, filename: entryName(unwrapping.name) ?? unpacked(named) };
     case 'no-executable':
       throw new BadRequestError(NOTHING_EXECUTABLE);
     case 'walked-too-far':
@@ -668,6 +668,22 @@ async function walked({
 /** The entry's name where it is one an export could carry, and nothing where it is not. */
 function entryName(name: string): Filename | undefined {
   return Value.Check(FilenameSchema, name) ? name : undefined;
+}
+
+/**
+ * The suffixes that name what the bytes arrived in rather than what they are. Longest first, so a
+ * `.tar.gz` is not read as a `.gz` of something called `.tar`.
+ */
+const CONTAINER_SUFFIXES = ['.tar.gz', '.tgz', '.tar', '.zip', '.gz'];
+
+/**
+ * The url's own name with the container taken off it. What is stored is always the bare executable
+ * — everything else is refused — so a url ending in one of these is describing the download, and an
+ * export that wrote it back out would name a binary after the archive it stopped being.
+ */
+function unpacked(named: Filename): Filename {
+  const suffix = CONTAINER_SUFFIXES.find((candidate) => named.endsWith(candidate));
+  return (suffix === undefined ? undefined : entryName(named.slice(0, -suffix.length))) ?? named;
 }
 
 /** A body nobody is going to read holds its connection open until it is let go of. */

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -9,6 +9,8 @@ import {
   type OwnerId,
   Value,
 } from '@repo/protocol';
+import { unwrapExecutable } from '#lib/archive/unwrap.ts';
+import { MAX_ENTRIES, UnreadableArchiveError, type Unwrapping } from '#lib/archive/walk.ts';
 import {
   type ArtifactInspection,
   ArtifactTooLargeError,
@@ -20,12 +22,6 @@ import {
 import { filenameFromUrl, withoutCredentials } from '#lib/binary-url.ts';
 import { BadRequestError, NotFoundError, TooManyRequestsError } from '#lib/errors.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
-import {
-  MAX_ENTRIES,
-  UnreadableArchiveError,
-  type Unwrapping,
-  unwrapExecutable,
-} from '#lib/zip.ts';
 import type { AppsRepositoryContract } from '#repositories/apps.repository.ts';
 import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
 import type {
@@ -111,14 +107,14 @@ function interruptedSource(url: string): string {
   return `The url stopped sending before the binary was whole: ${url}`;
 }
 
-const NOTHING_EXECUTABLE = 'Nothing inside that zip is a Linux executable.';
-const WALKED_TOO_FAR = `nibrun read as far into that zip as it will — ${MAX_ARTIFACT_MEBIBYTES} MB, or ${MAX_ENTRIES} entries — without reaching an executable.`;
+const NOTHING_EXECUTABLE = 'Nothing inside that archive is a Linux executable.';
+const WALKED_TOO_FAR = `nibrun read as far into that archive as it will — ${MAX_ARTIFACT_MEBIBYTES} MB, or ${MAX_ENTRIES} entries — without reaching an executable.`;
 
 const ENTRY_TOO_LARGE =
-  'An entry in that zip is longer than a zip header can say, which is more than nibrun will read past.';
+  'An entry in that archive is longer than its own header can say, which is more than nibrun will read past.';
 
 function unreadableArchive(url: string): string {
-  return `The zip ended before the entry it was describing: ${url}`;
+  return `The archive ended before the entry it was describing: ${url}`;
 }
 
 function unsupportedInterpreter(interpreter: string): string {
@@ -417,7 +413,7 @@ export class ArtifactsService extends Service {
       if (failure instanceof ArtifactTooLargeError) {
         throw new BadRequestError(TOO_LARGE);
       }
-      // The archive was still being walked as the executable inside it was written, so a zip that
+      // The archive was still being walked as the executable inside it was written, so one that
       // turns out not to hold what its headers said reaches this end as the write failing.
       if (failure instanceof UnreadableArchiveError) {
         throw new BadRequestError(unreadableArchive(url));
@@ -614,12 +610,12 @@ function sourceRefusal({
 }
 
 /**
- * The source as the binary it holds: its own bytes, or the executable inside the zip they turn out
- * to be. A project that publishes its build zipped is publishing a url nobody could deploy from
- * otherwise — the alternative is downloading it, unzipping it, and uploading the one file inside.
+ * The source as the binary it holds: its own bytes, or the executable inside the archive they turn
+ * out to be. A project that publishes its build packed is publishing a url nobody could deploy from
+ * otherwise — the alternative is downloading it, unpacking it, and uploading the one file inside.
  *
  * The entry names the artifact where it can, because it is the name the binary actually has: a url
- * ending in `.zip` would otherwise be what an export writes the executable out as.
+ * ending in `.tar.gz` would otherwise be what an export writes the executable out as.
  */
 async function unwrapped({
   source,

--- a/apps/api/tests/lib/archive/support/fixtures.ts
+++ b/apps/api/tests/lib/archive/support/fixtures.ts
@@ -70,28 +70,6 @@ export function sourceOf({
   return { stream: new ReadableStream<Uint8Array>({ pull, cancel }), wasLetGo };
 }
 
-/**
- * Bytes a compressor cannot shrink, so a fixture built around them is as long on the way in as it
- * is on the way out. A walk that gives up on a source short enough to have already arrived proves
- * nothing about letting go of it: that source was going to end either way.
- */
-export function incompressible(sizeBytes: number): Uint8Array {
-  const bytes = Buffer.alloc(sizeBytes);
-  // Xorshift rather than a linear congruential generator, which gzip finds the shape of and packs
-  // thirty times over however many of its bits are taken. Written out rather than drawn at random
-  // so that a fixture that starts failing is the same fixture it was passing on.
-  let state = 0x9e37_79b9;
-  for (let at = 0; at < sizeBytes; at++) {
-    state ^= state << 13;
-    state >>>= 0;
-    state ^= state >>> 17;
-    state ^= state << 5;
-    state >>>= 0;
-    bytes[at] = state & 0xff;
-  }
-  return bytes;
-}
-
 export async function collected(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
   const chunks: Uint8Array[] = [];
   for await (const chunk of stream) {

--- a/apps/api/tests/lib/archive/support/fixtures.ts
+++ b/apps/api/tests/lib/archive/support/fixtures.ts
@@ -1,0 +1,101 @@
+// What every walk of an archive is handed and what it is looking for, shared by the two formats:
+// a zip and a tarball are read through the same source and answered in the same terms, so the
+// fixtures that stand for a release download belong to neither of them.
+
+import { Buffer } from 'node:buffer';
+import { MAX_ENTRIES } from '#lib/archive/walk.ts';
+
+const NOTE_LINES = 8;
+
+/** What the api will store, and the only thing a walk of an archive is looking for. */
+export const BINARY = bytesOf('\x7fELFnibrun-test-binary');
+export const NOTES = bytesOf('# Changelog\n\nEverything, all at once.\n'.repeat(NOTE_LINES));
+export const LICENCE = bytesOf('The MIT Licence, as every release archive carries it.\n');
+export const NOTHING = new Uint8Array(0);
+
+/** Larger than any fixture here, so a walk only stops early when stopping early is the test. */
+export const NO_LIMIT = 1_048_576;
+
+/**
+ * Small enough to fall inside a header, a name and the window a descriptor is looked for in, so
+ * every fixture is read across chunk boundaries rather than out of one buffer.
+ */
+export const CHUNK_BYTES = 7;
+
+/** Shorter than the notes a release archive opens with, so the walk gives up inside them. */
+export const A_SHORT_WALK = 8;
+
+/** One past what a walk will read the headers of. */
+export const PAST_THE_ENTRY_LIMIT = MAX_ENTRIES + 1;
+
+export function bytesOf(text: string): Uint8Array {
+  return Buffer.from(text, 'utf8');
+}
+
+export function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return sourceOf({ bytes }).stream;
+}
+
+/** An archive, and whether whoever was reading it let go of it before it ended. */
+export function sourceOf({
+  bytes,
+  chunkBytes = CHUNK_BYTES,
+}: {
+  bytes: Uint8Array;
+  chunkBytes?: number;
+}): {
+  stream: ReadableStream<Uint8Array>;
+  wasLetGo: () => boolean;
+} {
+  let at = 0;
+  let letGo = false;
+
+  function pull(controller: ReadableStreamDefaultController<Uint8Array>): void {
+    if (at >= bytes.byteLength) {
+      controller.close();
+      return;
+    }
+    controller.enqueue(bytes.subarray(at, at + chunkBytes));
+    at += chunkBytes;
+  }
+
+  function cancel(): void {
+    letGo = true;
+  }
+
+  function wasLetGo(): boolean {
+    return letGo;
+  }
+
+  return { stream: new ReadableStream<Uint8Array>({ pull, cancel }), wasLetGo };
+}
+
+/**
+ * Bytes a compressor cannot shrink, so a fixture built around them is as long on the way in as it
+ * is on the way out. A walk that gives up on a source short enough to have already arrived proves
+ * nothing about letting go of it: that source was going to end either way.
+ */
+export function incompressible(sizeBytes: number): Uint8Array {
+  const bytes = Buffer.alloc(sizeBytes);
+  // Xorshift rather than a linear congruential generator, which gzip finds the shape of and packs
+  // thirty times over however many of its bits are taken. Written out rather than drawn at random
+  // so that a fixture that starts failing is the same fixture it was passing on.
+  let state = 0x9e37_79b9;
+  for (let at = 0; at < sizeBytes; at++) {
+    state ^= state << 13;
+    state >>>= 0;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    bytes[at] = state & 0xff;
+  }
+  return bytes;
+}
+
+export async function collected(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}

--- a/apps/api/tests/lib/archive/tar.test.ts
+++ b/apps/api/tests/lib/archive/tar.test.ts
@@ -7,7 +7,6 @@ import {
   BINARY,
   bytesOf,
   collected,
-  incompressible,
   LICENCE,
   NO_LIMIT,
   NOTES,
@@ -16,6 +15,7 @@ import {
   sourceOf,
   streamOf,
 } from '#tests/lib/archive/support/fixtures.ts';
+import { incompressible } from '#tests/support/downloads.ts';
 import {
   BLOCK_BYTES,
   gzippedTarballOf,

--- a/apps/api/tests/lib/archive/tar.test.ts
+++ b/apps/api/tests/lib/archive/tar.test.ts
@@ -1,31 +1,48 @@
 import { describe, expect, test } from 'bun:test';
-import { Buffer } from 'node:buffer';
 import { gzipSync } from 'node:zlib';
 import { unwrapExecutable } from '#lib/archive/unwrap.ts';
-import { MAX_ENTRIES, UnreadableArchiveError } from '#lib/archive/walk.ts';
-import { BLOCK_BYTES, gzippedTarballOf, type TarballEntry } from '#tests/support/tarballs.ts';
-
-const NOTE_LINES = 8;
-
-// What the api will store, and the only thing a walk of an archive is looking for.
-const BINARY = bytesOf('\x7fELFnibrun-test-binary');
-const NOTES = bytesOf('# Changelog\n\nEverything, all at once.\n'.repeat(NOTE_LINES));
-const LICENCE = bytesOf('The MIT Licence, as every release archive carries it.\n');
-const NOTHING = new Uint8Array(0);
-
-const NO_LIMIT = 1_048_576;
-
-/** Small enough to fall inside a header, so every fixture is read across chunk boundaries. */
-const CHUNK_BYTES = 7;
-
-/** Shorter than the notes a release archive opens with, so the walk gives up inside them. */
-const A_SHORT_WALK = 8;
-
-/** One past what a walk will read the headers of. */
-const PAST_THE_ENTRY_LIMIT = MAX_ENTRIES + 1;
+import { UnreadableArchiveError } from '#lib/archive/walk.ts';
+import {
+  A_SHORT_WALK,
+  BINARY,
+  bytesOf,
+  collected,
+  incompressible,
+  LICENCE,
+  NO_LIMIT,
+  NOTES,
+  NOTHING,
+  PAST_THE_ENTRY_LIMIT,
+  sourceOf,
+  streamOf,
+} from '#tests/lib/archive/support/fixtures.ts';
+import {
+  BLOCK_BYTES,
+  gzippedTarballOf,
+  type TarballEntry,
+  tarballOf,
+} from '#tests/support/tarballs.ts';
 
 const TYPE_DIRECTORY = '5';
 const TYPE_SYMLINK = '2';
+
+/** What gnu tar writes a path too long for a header as, in front of the entry it names. */
+const TYPE_LONG_NAME = 'L';
+const LONG_NAME_ENTRY = '././@LongLink';
+
+/** As much of the path as the header that follows a long-name entry keeps. */
+const NAME_FIELD_BYTES = 100;
+
+/** Longer than that, which is the whole reason gnu tar writes the path out on its own. */
+const A_LONG_PATH =
+  'dist/a-long-release-directory-segment/another-segment-of-similar-length/and-one-more-for-good-measure/my-server';
+
+/**
+ * More than a gunzip reads ahead of what it has been asked for, so a walk that gives up early
+ * leaves the rest of the source still on its way rather than already arrived.
+ */
+const A_LONG_DOWNLOAD = 524_288;
+const A_TRANSFER_CHUNK = 65_536;
 
 describe('a tarball is walked to the executable inside it', () => {
   test('past the notes and the licence a release ships beside the binary', async () => {
@@ -89,6 +106,55 @@ describe('a tarball is walked to the executable inside it', () => {
 
     expect(unwrapped.outcome === 'unwrapped' && (await collected(unwrapped.body))).toEqual(BINARY);
   });
+
+  /**
+   * Gnu is what `tar czf` writes by default on linux, which is where release tarballs come from.
+   * The header after a long-name entry keeps the first hundred bytes of the path, and those are
+   * the leading directories — so a walk reading the header alone names the binary after a piece
+   * of the folder it sits in.
+   */
+  test('under the path a gnu long-name entry carries rather than the truncated header', async () => {
+    expect(A_LONG_PATH.length).toBeGreaterThan(NAME_FIELD_BYTES);
+
+    const unwrapped = await walk({ entries: longNamed({ path: A_LONG_PATH, content: BINARY }) });
+
+    expect(unwrapped.outcome).toBe('unwrapped');
+    if (unwrapped.outcome !== 'unwrapped') {
+      return;
+    }
+    expect(unwrapped.name).toBe('my-server');
+    expect(await collected(unwrapped.body)).toEqual(BINARY);
+  });
+
+  // The path is read into memory where every other entry is walked past a chunk at a time, so an
+  // entry claiming more than a path could be is skipped like any other rather than held.
+  test('past a long-name entry claiming more than a path could be', async () => {
+    const unwrapped = await walk({
+      entries: [
+        { name: LONG_NAME_ENTRY, content: NOTES, type: TYPE_LONG_NAME },
+        { name: 'my-server', content: BINARY },
+      ],
+    });
+
+    expect(unwrapped.outcome === 'unwrapped' && (await collected(unwrapped.body))).toEqual(BINARY);
+  });
+
+  // A tar says what it is a quarter of a kibibyte in rather than in its first bytes, so nothing
+  // about the opening of an uncompressed one distinguishes it from a binary until that far.
+  test('where the tarball was published without being compressed at all', async () => {
+    const unwrapped = await unwrapExecutable({
+      archive: streamOf(
+        tarballOf([
+          { name: 'CHANGELOG.md', content: NOTES },
+          { name: 'my-server', content: BINARY },
+        ]),
+      ),
+      maxSkippedBytes: NO_LIMIT,
+    });
+
+    expect(unwrapped.outcome).toBe('unwrapped');
+    expect(unwrapped.outcome === 'unwrapped' && (await collected(unwrapped.body))).toEqual(BINARY);
+  });
 });
 
 describe('a tarball that holds no executable is not one to fetch from', () => {
@@ -119,7 +185,7 @@ describe('a tarball that holds no executable is not one to fetch from', () => {
     ]);
 
     const unwrapped = await unwrapExecutable({
-      archive: streamOf(whole.subarray(0, whole.byteLength / 2)),
+      archive: streamOf(whole.subarray(0, Math.floor(whole.byteLength / 2))),
       maxSkippedBytes: NO_LIMIT,
     });
 
@@ -157,6 +223,43 @@ describe('a tarball that holds no executable is not one to fetch from', () => {
     });
 
     expect(unwrapped.outcome).toBe('entry-too-large');
+  });
+
+  // A length is octal text read as a whole. Taking the digits a corrupt field opens with and
+  // stopping at the first byte that is not one would put the walk a few bytes out of step with the
+  // headers, and everything after that is read out of the middle of something.
+  test('an archive whose entry declares a length that is not octal at all', async () => {
+    const unwrapped = await walk({
+      entries: [
+        { name: 'CHANGELOG.md', content: NOTES, sizeText: '00000000012x' },
+        { name: 'my-server', content: BINARY },
+      ],
+    });
+
+    expect(unwrapped.outcome).toBe('unreadable');
+  });
+
+  /**
+   * The walk stops with the rest of the archive still on its way, and a source nobody is reading
+   * holds its connection open until it is let go of. Through the gunzip as much as around it: a
+   * pipe carries being given up on no further than the engine it feeds.
+   */
+  test('and the source it stopped part way through is let go of', async () => {
+    const source = sourceOf({
+      bytes: gzippedTarballOf([
+        { name: 'CHANGELOG.md', content: incompressible(A_LONG_DOWNLOAD) },
+        { name: 'my-server', content: BINARY },
+      ]),
+      chunkBytes: A_TRANSFER_CHUNK,
+    });
+
+    const unwrapped = await unwrapExecutable({
+      archive: source.stream,
+      maxSkippedBytes: A_SHORT_WALK,
+    });
+
+    expect(unwrapped.outcome).toBe('walked-too-far');
+    expect(source.wasLetGo()).toBe(true);
   });
 });
 
@@ -216,28 +319,10 @@ function entryOfNothing(index: number): TarballEntry {
   return { name: `note-${index}`, content: NOTHING };
 }
 
-function bytesOf(text: string): Uint8Array {
-  return Buffer.from(text, 'utf8');
-}
-
-function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
-  let at = 0;
-  return new ReadableStream<Uint8Array>({
-    pull(controller) {
-      if (at >= bytes.byteLength) {
-        controller.close();
-        return;
-      }
-      controller.enqueue(bytes.subarray(at, at + CHUNK_BYTES));
-      at += CHUNK_BYTES;
-    },
-  });
-}
-
-async function collected(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
-  const chunks: Uint8Array[] = [];
-  for await (const chunk of stream) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks);
+/** The pair gnu tar writes for a path a header cannot hold: the path, then the entry it belongs to. */
+function longNamed({ path, content }: { path: string; content: Uint8Array }): TarballEntry[] {
+  return [
+    { name: LONG_NAME_ENTRY, content: bytesOf(`${path}\0`), type: TYPE_LONG_NAME },
+    { name: path.slice(0, NAME_FIELD_BYTES), content },
+  ];
 }

--- a/apps/api/tests/lib/archive/tar.test.ts
+++ b/apps/api/tests/lib/archive/tar.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import { gzipSync } from 'node:zlib';
+import { unwrapExecutable } from '#lib/archive/unwrap.ts';
+import { MAX_ENTRIES, UnreadableArchiveError } from '#lib/archive/walk.ts';
+import { BLOCK_BYTES, gzippedTarballOf, type TarballEntry } from '#tests/support/tarballs.ts';
+
+const NOTE_LINES = 8;
+
+// What the api will store, and the only thing a walk of an archive is looking for.
+const BINARY = bytesOf('\x7fELFnibrun-test-binary');
+const NOTES = bytesOf('# Changelog\n\nEverything, all at once.\n'.repeat(NOTE_LINES));
+const LICENCE = bytesOf('The MIT Licence, as every release archive carries it.\n');
+const NOTHING = new Uint8Array(0);
+
+const NO_LIMIT = 1_048_576;
+
+/** Small enough to fall inside a header, so every fixture is read across chunk boundaries. */
+const CHUNK_BYTES = 7;
+
+/** Shorter than the notes a release archive opens with, so the walk gives up inside them. */
+const A_SHORT_WALK = 8;
+
+/** One past what a walk will read the headers of. */
+const PAST_THE_ENTRY_LIMIT = MAX_ENTRIES + 1;
+
+const TYPE_DIRECTORY = '5';
+const TYPE_SYMLINK = '2';
+
+describe('a tarball is walked to the executable inside it', () => {
+  test('past the notes and the licence a release ships beside the binary', async () => {
+    const unwrapped = await walk({
+      entries: [
+        { name: 'CHANGELOG.md', content: NOTES },
+        { name: 'LICENSE.md', content: LICENCE },
+        { name: 'my-server', content: BINARY },
+      ],
+    });
+
+    expect(unwrapped.outcome).toBe('unwrapped');
+    if (unwrapped.outcome !== 'unwrapped') {
+      return;
+    }
+    expect(unwrapped.name).toBe('my-server');
+    expect(await collected(unwrapped.body)).toEqual(BINARY);
+  });
+
+  // Every entry is padded out to a whole block, so a walk that counted only the length it was told
+  // would start reading the next header partway through the padding of the last one.
+  test('past an entry whose length is not a whole number of blocks', async () => {
+    const odd = bytesOf('x'.repeat(BLOCK_BYTES + 1));
+
+    const unwrapped = await walk({
+      entries: [
+        { name: 'CHANGELOG.md', content: odd },
+        { name: 'my-server', content: BINARY },
+      ],
+    });
+
+    expect(unwrapped.outcome).toBe('unwrapped');
+    expect(unwrapped.outcome === 'unwrapped' && (await collected(unwrapped.body))).toEqual(BINARY);
+  });
+
+  test('under the name the entry has, not the directory it was kept in', async () => {
+    const unwrapped = await walk({
+      entries: [{ name: 'dist/linux-amd64/my-server', content: BINARY }],
+    });
+
+    expect(unwrapped.outcome === 'unwrapped' && unwrapped.name).toBe('my-server');
+  });
+
+  // `tar czf` of a directory writes an entry for the directory itself before the files in it.
+  test('past the directory entries a recursive tar writes', async () => {
+    const unwrapped = await walk({
+      entries: [
+        { name: 'dist/', content: NOTHING, type: TYPE_DIRECTORY },
+        { name: 'dist/linux-amd64/', content: NOTHING, type: TYPE_DIRECTORY },
+        { name: 'dist/linux-amd64/my-server', content: BINARY },
+      ],
+    });
+
+    expect(unwrapped.outcome === 'unwrapped' && (await collected(unwrapped.body))).toEqual(BINARY);
+  });
+
+  test('where the entry says it is a file with a NUL rather than a digit', async () => {
+    const unwrapped = await walk({
+      entries: [{ name: 'my-server', content: BINARY, typeUnset: true }],
+    });
+
+    expect(unwrapped.outcome === 'unwrapped' && (await collected(unwrapped.body))).toEqual(BINARY);
+  });
+});
+
+describe('a tarball that holds no executable is not one to fetch from', () => {
+  test('an archive of documents alone', async () => {
+    const unwrapped = await walk({
+      entries: [
+        { name: 'CHANGELOG.md', content: NOTES },
+        { name: 'LICENSE.md', content: LICENCE },
+      ],
+    });
+
+    expect(unwrapped.outcome).toBe('no-executable');
+  });
+
+  // A symlink's target is its header, not its data, so what it points at is nothing a walk holds.
+  test('an archive whose only executable is something a link points at', async () => {
+    const unwrapped = await walk({
+      entries: [{ name: 'my-server', content: NOTHING, type: TYPE_SYMLINK }],
+    });
+
+    expect(unwrapped.outcome).toBe('no-executable');
+  });
+
+  test('an archive that stops in the middle of the entry it was walking past', async () => {
+    const whole = gzippedTarballOf([
+      { name: 'CHANGELOG.md', content: NOTES },
+      { name: 'my-server', content: BINARY },
+    ]);
+
+    const unwrapped = await unwrapExecutable({
+      archive: streamOf(whole.subarray(0, whole.byteLength / 2)),
+      maxSkippedBytes: NO_LIMIT,
+    });
+
+    expect(unwrapped.outcome).toBe('unreadable');
+  });
+
+  test('an archive that would have to be read past what will be walked', async () => {
+    const unwrapped = await walk({
+      entries: [
+        { name: 'CHANGELOG.md', content: NOTES },
+        { name: 'my-server', content: BINARY },
+      ],
+      maxSkippedBytes: A_SHORT_WALK,
+    });
+
+    expect(unwrapped.outcome).toBe('walked-too-far');
+  });
+
+  test('an archive of more entries than a walk will read the headers of', async () => {
+    const unwrapped = await walk({
+      entries: Array.from(Array(PAST_THE_ENTRY_LIMIT).keys(), entryOfNothing),
+    });
+
+    expect(unwrapped.outcome).toBe('walked-too-far');
+  });
+
+  // Eleven octal digits stop at eight gibibytes; past that the field is base 256 and says a length
+  // there is no storing and no walking past.
+  test('an archive whose entry declares a length in base 256', async () => {
+    const unwrapped = await walk({
+      entries: [
+        { name: 'huge.bin', content: NOTES, sizeInBase256: true },
+        { name: 'my-server', content: BINARY },
+      ],
+    });
+
+    expect(unwrapped.outcome).toBe('entry-too-large');
+  });
+});
+
+describe('a gzip that is not a tarball is the binary itself', () => {
+  // A release published as a bare `my-server.gz` is a gunzip away from being deployable, and
+  // whether what comes out is an executable is a question the inspection asks of everything.
+  test('handed on as the bytes it holds', async () => {
+    const unwrapped = await unwrapExecutable({
+      archive: streamOf(gzipSync(BINARY)),
+      maxSkippedBytes: NO_LIMIT,
+    });
+
+    expect(unwrapped.outcome).toBe('not-an-archive');
+    expect(unwrapped.outcome === 'not-an-archive' && (await collected(unwrapped.body))).toEqual(
+      BINARY,
+    );
+  });
+
+  test('including a gzip too short to hold a tar header at all', async () => {
+    const unwrapped = await unwrapExecutable({
+      archive: streamOf(gzipSync(bytesOf('no'))),
+      maxSkippedBytes: NO_LIMIT,
+    });
+
+    expect(unwrapped.outcome).toBe('not-an-archive');
+  });
+
+  // Found by whoever is storing the bytes rather than here: nothing about the opening of a gzip
+  // says whether the rest of it will arrive.
+  test('and a gzip that stops part way fails inside the bytes it handed on', async () => {
+    const whole = gzipSync(NOTES);
+
+    const unwrapped = await unwrapExecutable({
+      archive: streamOf(whole.subarray(0, whole.byteLength - 1)),
+      maxSkippedBytes: NO_LIMIT,
+    });
+
+    expect(unwrapped.outcome).toBe('not-an-archive');
+    if (unwrapped.outcome !== 'not-an-archive') {
+      return;
+    }
+    await expect(collected(unwrapped.body)).rejects.toBeInstanceOf(UnreadableArchiveError);
+  });
+});
+
+function walk({
+  entries,
+  maxSkippedBytes = NO_LIMIT,
+}: {
+  entries: TarballEntry[];
+  maxSkippedBytes?: number;
+}) {
+  return unwrapExecutable({ archive: streamOf(gzippedTarballOf(entries)), maxSkippedBytes });
+}
+
+function entryOfNothing(index: number): TarballEntry {
+  return { name: `note-${index}`, content: NOTHING };
+}
+
+function bytesOf(text: string): Uint8Array {
+  return Buffer.from(text, 'utf8');
+}
+
+function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  let at = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (at >= bytes.byteLength) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes.subarray(at, at + CHUNK_BYTES));
+      at += CHUNK_BYTES;
+    },
+  });
+}
+
+async function collected(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}

--- a/apps/api/tests/lib/archive/zip.test.ts
+++ b/apps/api/tests/lib/archive/zip.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Buffer } from 'node:buffer';
-import { MAX_ENTRIES, UnreadableArchiveError, unwrapExecutable } from '#lib/zip.ts';
+import { unwrapExecutable } from '#lib/archive/unwrap.ts';
+import { MAX_ENTRIES, UnreadableArchiveError } from '#lib/archive/walk.ts';
 import { type ArchiveEntry, archiveOf, LOCAL_HEADER_BYTES } from '#tests/support/archives.ts';
 
 const NOTE_LINES = 8;

--- a/apps/api/tests/lib/archive/zip.test.ts
+++ b/apps/api/tests/lib/archive/zip.test.ts
@@ -1,24 +1,22 @@
 import { describe, expect, test } from 'bun:test';
 import { Buffer } from 'node:buffer';
 import { unwrapExecutable } from '#lib/archive/unwrap.ts';
-import { MAX_ENTRIES, UnreadableArchiveError } from '#lib/archive/walk.ts';
+import { UnreadableArchiveError } from '#lib/archive/walk.ts';
+import {
+  A_SHORT_WALK,
+  BINARY,
+  bytesOf,
+  CHUNK_BYTES,
+  collected,
+  LICENCE,
+  NO_LIMIT,
+  NOTES,
+  NOTHING,
+  PAST_THE_ENTRY_LIMIT,
+  sourceOf,
+  streamOf,
+} from '#tests/lib/archive/support/fixtures.ts';
 import { type ArchiveEntry, archiveOf, LOCAL_HEADER_BYTES } from '#tests/support/archives.ts';
-
-const NOTE_LINES = 8;
-
-// What the api will store, and the only thing a walk of an archive is looking for.
-const BINARY = bytesOf('\x7fELFnibrun-test-binary');
-const NOTES = bytesOf('# Changelog\n\nEverything, all at once.\n'.repeat(NOTE_LINES));
-const LICENCE = bytesOf('The MIT Licence, as every release archive carries it.\n');
-
-// Larger than any fixture here, so a walk only stops early when stopping early is the test.
-const NO_LIMIT = 1_048_576;
-
-/**
- * Small enough to fall inside a header, a name and the window a descriptor is looked for in, so
- * every fixture is read across chunk boundaries rather than out of one buffer.
- */
-const CHUNK_BYTES = 7;
 
 /** The crc and the two sizes a descriptor carries after its signature. */
 const DESCRIPTOR_FIELD_BYTES = 12;
@@ -29,19 +27,11 @@ const A_FEW_BYTES_IN = 4;
 /** Enough of a stored entry for the magic at the front of it to have been handed on. */
 const PAST_THE_MAGIC = 8;
 
-/** Shorter than the notes a release archive opens with, so the walk gives up inside them. */
-const A_SHORT_WALK = 8;
-
 /** More entries than a budget counting only what they hold would ever stop a walk through. */
 const MANY_ENTRIES = 64;
 
 /** Room for a header or two, and nothing like room for all of them. */
 const A_FEW_HEADERS = 100;
-
-const NOTHING = new Uint8Array(0);
-
-/** One past what a walk will read the headers of. */
-const PAST_THE_ENTRY_LIMIT = MAX_ENTRIES + 1;
 
 describe('a zip is walked to the executable inside it', () => {
   test('past the notes and the licence a release ships beside the binary', async () => {
@@ -262,7 +252,7 @@ describe('a zip that holds no executable is not one to fetch from', () => {
       { name: 'CHANGELOG.md', content: NOTES },
       { name: 'my-server', content: BINARY },
     ]);
-    const source = sourceOf(archive);
+    const source = sourceOf({ bytes: archive });
 
     await unwrapExecutable({ archive: source.stream, maxSkippedBytes: A_SHORT_WALK });
 
@@ -343,52 +333,6 @@ describe('bytes that are not an archive are the binary themselves', () => {
   });
 });
 
-function bytesOf(text: string): Uint8Array {
-  return Buffer.from(text, 'utf8');
-}
-
-function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
-  let at = 0;
-  return new ReadableStream<Uint8Array>({
-    pull(controller) {
-      if (at >= bytes.byteLength) {
-        controller.close();
-        return;
-      }
-      controller.enqueue(bytes.subarray(at, at + CHUNK_BYTES));
-      at += CHUNK_BYTES;
-    },
-  });
-}
-
-/** An archive, and whether whoever was reading it let go of it before it ended. */
-function sourceOf(bytes: Uint8Array): {
-  stream: ReadableStream<Uint8Array>;
-  wasLetGo: () => boolean;
-} {
-  let at = 0;
-  let letGo = false;
-
-  function pull(controller: ReadableStreamDefaultController<Uint8Array>): void {
-    if (at >= bytes.byteLength) {
-      controller.close();
-      return;
-    }
-    controller.enqueue(bytes.subarray(at, at + CHUNK_BYTES));
-    at += CHUNK_BYTES;
-  }
-
-  function cancel(): void {
-    letGo = true;
-  }
-
-  function wasLetGo(): boolean {
-    return letGo;
-  }
-
-  return { stream: new ReadableStream<Uint8Array>({ pull, cancel }), wasLetGo };
-}
-
 /** An entry that declares no data at all, which is the whole of what it costs to walk past. */
 function entryOfNothing(index: number): ArchiveEntry {
   return { name: `note-${index}`, content: NOTHING, stored: true, sizesInDescriptor: false };
@@ -413,12 +357,4 @@ function haltingStreamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
       controller.enqueue(NOTHING);
     },
   });
-}
-
-async function collected(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
-  const chunks: Uint8Array[] = [];
-  for await (const chunk of stream) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks);
 }

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { gzipSync } from 'node:zlib';
 import {
   type AppId,
   type ArtifactId,
@@ -803,6 +804,7 @@ describe('a row becomes the wire shape the dashboard and the agent both read', (
 const BINARY_URL = 'https://releases.test/v1/my-server';
 const ARCHIVE_URL = 'https://releases.test/v1/my-server_1.2.3_linux_amd64.zip';
 const TARBALL_URL = 'https://releases.test/v1/my-server_1.2.3_linux_amd64.tar.gz';
+const COMPRESSED_URL = 'https://releases.test/v1/my-server.gz';
 const FETCHED_NAME = Value.Parse(FilenameSchema, 'my-server');
 
 /**
@@ -1058,6 +1060,26 @@ describe('a binary is fetched from the url it was given', () => {
     expect(artifact.originalFileName).toBe(FETCHED_NAME);
     expect(storage.objects.has(Value.Parse(ObjectKeySchema, BINARY_DIGEST))).toBe(true);
     expect(artifactsRepo.rows.get(artifact.id)?.original_file_url).toBe(TARBALL_URL);
+  });
+
+  /**
+   * A release published as a bare `my-server.gz` is one gunzip away from being deployable, and
+   * what is stored is the executable rather than the download — so the suffix that named the
+   * download is not the name a host writes it back out under.
+   */
+  test('a release that ships as a bare gzip is the executable inside it, unsuffixed', async () => {
+    const { service, sourceRepo, storage } = build();
+    sourceRepo.servesBytes({ bytes: gzipSync(bytesOf(BINARY_TEXT)) });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: COMPRESSED_URL,
+    });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+    expect(artifact.originalFileName).toBe(FETCHED_NAME);
+    expect(storage.objects.has(Value.Parse(ObjectKeySchema, BINARY_DIGEST))).toBe(true);
   });
 
   test('a tarball holding nothing executable is refused and leaves nothing behind', async () => {

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -39,6 +39,7 @@ import {
 } from '#services/artifacts.service.ts';
 import { APP_ID, OTHER_OWNER_ID, OWNER_ID } from '#tests/services/support/fixtures.ts';
 import { archiveOf } from '#tests/support/archives.ts';
+import { incompressible } from '#tests/support/downloads.ts';
 import { gzippedTarballOf } from '#tests/support/tarballs.ts';
 
 // The api refuses anything that is not a Linux executable, so the fixture opens with the ELF
@@ -348,17 +349,25 @@ class FakeBinarySource implements BinarySourceRepositoryContract {
     this.servesBytes({ bytes: bytesOf(text), declaredSizeBytes });
   }
 
+  /**
+   * `chunkBytes` is what makes a download arrive rather than appear. A body handed over whole is
+   * one whoever reads it has already finished with, which is no way to find out what happens to
+   * the rest of a download somebody stopped reading.
+   */
   servesBytes({
     bytes,
     declaredSizeBytes,
+    chunkBytes,
   }: {
     bytes: Uint8Array;
     declaredSizeBytes?: number;
+    chunkBytes?: number;
   }): void {
     this.answers({
       outcome: 'open',
       body: streamOf({
         bytes,
+        chunkBytes,
         onCancel: () => {
           this.letGo = true;
         },
@@ -405,20 +414,23 @@ class FakeBinarySource implements BinarySourceRepositoryContract {
 
 function streamOf({
   bytes,
+  chunkBytes,
   onCancel,
 }: {
   bytes: Uint8Array;
+  chunkBytes?: number;
   onCancel?: () => void;
 }): ReadableStream<Uint8Array> {
-  let sent = false;
+  const step = chunkBytes ?? bytes.byteLength;
+  let at = 0;
   return new ReadableStream<Uint8Array>({
     pull(controller) {
-      if (sent) {
+      if (at >= bytes.byteLength) {
         controller.close();
         return;
       }
-      sent = true;
-      controller.enqueue(bytes);
+      controller.enqueue(bytes.subarray(at, at + step));
+      at += step;
     },
     cancel() {
       onCancel?.();
@@ -817,6 +829,14 @@ const COMPRESSED_URL = 'https://releases.test/v1/my-server.gz';
 const FETCHED_NAME = Value.Parse(FilenameSchema, 'my-server');
 
 /**
+ * More of a download than a gunzip reads ahead of what it was asked for, arriving in the pieces a
+ * transfer arrives in — so a walk that stops at the entry it wanted stops with the rest of the
+ * download still to come, which is the only state in which reading it to the end costs anything.
+ */
+const A_LONG_DOWNLOAD = 524_288;
+const A_TRANSFER_CHUNK = 65_536;
+
+/**
  * A binary the api fetched itself. Every refusal here is about a url somebody typed, so each one
  * has to leave the app exactly as it was — an artifact half made is a deploy that cannot be
  * retried by following the same link again.
@@ -1093,6 +1113,68 @@ describe('a binary is fetched from the url it was given', () => {
     });
 
     expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+  });
+
+  /**
+   * The same, with a gunzip in the middle of it. What the walk lets go of is the decompressed
+   * bytes and what a checksum is over is the compressed ones, so the reading-to-the-end that
+   * checking one costs has to travel back through the engine to reach the download.
+   *
+   * The entry is first and the rest of the tarball is longer than a gunzip reads ahead, so the
+   * walk really does stop with most of the download still on its way.
+   */
+  test('and a checksum is what the tarball hashes to, gunzip and all', async () => {
+    const { service, sourceRepo } = build();
+    const bytes = gzippedTarballOf([
+      { name: 'my-server', content: bytesOf(BINARY_TEXT) },
+      { name: 'CHANGELOG.md', content: incompressible(A_LONG_DOWNLOAD) },
+    ]);
+    sourceRepo.servesBytes({ bytes, chunkBytes: A_TRANSFER_CHUNK });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: TARBALL_URL,
+      sha256: digestOf(bytes),
+    });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+  });
+
+  // A walk that gives up part way is the other side of the same thing: what it stopped reading is
+  // still what the checksum was published over.
+  test('and a tarball holding nothing executable is still read to the end of the download', async () => {
+    const { service, sourceRepo } = build();
+    sourceRepo.servesBytes({
+      bytes: gzippedTarballOf([{ name: 'LICENSE.md', content: bytesOf('The MIT Licence.\n') }]),
+    });
+
+    const refusal = service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: TARBALL_URL,
+      sha256: Value.Parse(Sha256DigestSchema, BINARY_DIGEST),
+    });
+
+    await expect(refusal).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  // A bare gzip is handed on rather than walked, so what reaches the store is already decompressed
+  // — and the digest is still the one a release would publish, over the file it uploaded.
+  test('and a bare gzip is held to what the gzip hashes to, not the binary inside it', async () => {
+    const { service, sourceRepo } = build();
+    const bytes = gzipSync(bytesOf(BINARY_TEXT));
+    sourceRepo.servesBytes({ bytes });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: COMPRESSED_URL,
+      sha256: digestOf(bytes),
+    });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+    expect(artifact.originalFileName).toBe(FETCHED_NAME);
   });
 
   test('and the digest of that executable is not what the zip is held to', async () => {

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -37,6 +37,7 @@ import {
 } from '#services/artifacts.service.ts';
 import { APP_ID, OTHER_OWNER_ID, OWNER_ID } from '#tests/services/support/fixtures.ts';
 import { archiveOf } from '#tests/support/archives.ts';
+import { gzippedTarballOf } from '#tests/support/tarballs.ts';
 
 // The api refuses anything that is not a Linux executable, so the fixture opens with the ELF
 // magic the way a real upload does.
@@ -801,6 +802,7 @@ describe('a row becomes the wire shape the dashboard and the agent both read', (
 
 const BINARY_URL = 'https://releases.test/v1/my-server';
 const ARCHIVE_URL = 'https://releases.test/v1/my-server_1.2.3_linux_amd64.zip';
+const TARBALL_URL = 'https://releases.test/v1/my-server_1.2.3_linux_amd64.tar.gz';
 const FETCHED_NAME = Value.Parse(FilenameSchema, 'my-server');
 
 /**
@@ -1031,6 +1033,44 @@ describe('a binary is fetched from the url it was given', () => {
     });
 
     expect(artifact.originalFileName).toBe(FETCHED_NAME);
+  });
+
+  /**
+   * Which is how a linux release is published far more often than zipped: the go and rust toolings
+   * both write one, and a url ending `.tar.gz` is the ordinary shape of a release download.
+   */
+  test('a release that ships as a tarball is the executable inside it', async () => {
+    const { service, sourceRepo, artifactsRepo, storage } = build();
+    sourceRepo.servesBytes({
+      bytes: gzippedTarballOf([
+        { name: 'CHANGELOG.md', content: bytesOf('# Changelog\n\nAll of it.\n') },
+        { name: 'dist/my-server', content: bytesOf(BINARY_TEXT) },
+      ]),
+    });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: TARBALL_URL,
+    });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+    expect(artifact.originalFileName).toBe(FETCHED_NAME);
+    expect(storage.objects.has(Value.Parse(ObjectKeySchema, BINARY_DIGEST))).toBe(true);
+    expect(artifactsRepo.rows.get(artifact.id)?.original_file_url).toBe(TARBALL_URL);
+  });
+
+  test('a tarball holding nothing executable is refused and leaves nothing behind', async () => {
+    const { service, sourceRepo, artifactsRepo, storage } = build();
+    sourceRepo.servesBytes({
+      bytes: gzippedTarballOf([{ name: 'LICENSE.md', content: bytesOf('The MIT Licence.\n') }]),
+    });
+
+    await expect(
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: TARBALL_URL }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect(storage.objects.size).toBe(0);
   });
 
   test('a zip holding nothing executable is refused and leaves nothing behind', async () => {

--- a/apps/api/tests/support/downloads.ts
+++ b/apps/api/tests/support/downloads.ts
@@ -1,0 +1,24 @@
+import { Buffer } from 'node:buffer';
+
+/**
+ * Bytes a compressor cannot shrink, so a fixture built around them is as long on the way in as it
+ * is on the way out — and long enough that whoever stops reading one stops with the rest of it
+ * still on its way. A download short enough to have already arrived was going to end either way,
+ * and proves nothing about what happens to what is left of it.
+ */
+export function incompressible(sizeBytes: number): Uint8Array {
+  const bytes = Buffer.alloc(sizeBytes);
+  // Xorshift rather than a linear congruential generator, which gzip finds the shape of and packs
+  // thirty times over however many of its bits are taken. Written out rather than drawn at random
+  // so that a fixture that starts failing is the same fixture it was passing on.
+  let state = 0x9e37_79b9;
+  for (let at = 0; at < sizeBytes; at++) {
+    state ^= state << 13;
+    state >>>= 0;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    bytes[at] = state & 0xff;
+  }
+  return bytes;
+}

--- a/apps/api/tests/support/tarballs.ts
+++ b/apps/api/tests/support/tarballs.ts
@@ -1,0 +1,100 @@
+import { Buffer } from 'node:buffer';
+import { gzipSync } from 'node:zlib';
+
+/** An entry as a release tarball carries one, and the ways a writer can have written it. */
+export type TarballEntry = {
+  name: string;
+  content: Uint8Array;
+  /** A regular file unless said otherwise: a directory, a symlink, or a header carrying a name. */
+  type?: string;
+  /** Written as a NUL rather than a digit, which is what anything predating ustar does. */
+  typeUnset?: boolean;
+  /** Declares its length in base 256, which is what a length past eight gibibytes needs. */
+  sizeInBase256?: boolean;
+};
+
+export const BLOCK_BYTES = 512;
+
+const NAME_AT = 0;
+const MODE_AT = 100;
+const SIZE_AT = 124;
+const SIZE_FIELD_BYTES = 12;
+const CHECKSUM_AT = 148;
+const CHECKSUM_FIELD_BYTES = 8;
+const TYPE_AT = 156;
+const MAGIC_AT = 257;
+const VERSION_AT = 263;
+const OCTAL = 8;
+const BASE_256_MARKER = 0x80;
+const END_BLOCKS = 2;
+const SPACE = 0x20;
+/** Six octal digits and a NUL, then a space, which is the shape a checksum field takes. */
+const CHECKSUM_DIGITS = 7;
+const FILE_MODE = 0o644;
+const MODE_FIELD_BYTES = 8;
+
+/**
+ * A tar as far as this end reads one: a 512-byte header before each entry, its data padded out to
+ * a whole number of blocks, and two blocks of nothing to say the entries have stopped.
+ *
+ * The checksum is written properly even though nothing here reads it, so that a fixture that stops
+ * working can be handed to `tar` to find out which of the two is wrong.
+ */
+export function tarballOf(entries: TarballEntry[]): Uint8Array {
+  const written: Uint8Array[] = [];
+
+  for (const entry of entries) {
+    written.push(headerOf(entry), entry.content, paddingAfter(entry.content.byteLength));
+  }
+  written.push(Buffer.alloc(END_BLOCKS * BLOCK_BYTES));
+
+  return Buffer.concat(written);
+}
+
+/** The same, as a url actually serves one. */
+export function gzippedTarballOf(entries: TarballEntry[]): Uint8Array {
+  return gzipSync(tarballOf(entries));
+}
+
+function headerOf(entry: TarballEntry): Uint8Array {
+  const header = Buffer.alloc(BLOCK_BYTES);
+  header.write(entry.name, NAME_AT, 'utf8');
+  header.write(octal({ value: FILE_MODE, bytes: MODE_FIELD_BYTES }), MODE_AT, 'latin1');
+  writeSize({ header, entry });
+  header.write(entry.typeUnset === true ? '\0' : (entry.type ?? '0'), TYPE_AT, 'latin1');
+  header.write('ustar\0', MAGIC_AT, 'latin1');
+  header.write('00', VERSION_AT, 'latin1');
+  writeChecksum(header);
+  return header;
+}
+
+function writeSize({ header, entry }: { header: Buffer; entry: TarballEntry }): void {
+  if (entry.sizeInBase256 === true) {
+    header[SIZE_AT] = BASE_256_MARKER;
+    return;
+  }
+  header.write(
+    octal({ value: entry.content.byteLength, bytes: SIZE_FIELD_BYTES }),
+    SIZE_AT,
+    'latin1',
+  );
+}
+
+/** Octal text in a fixed width, NUL-terminated, which is how a tar writes every number it has. */
+function octal({ value, bytes }: { value: number; bytes: number }): string {
+  return `${value.toString(OCTAL).padStart(bytes - 1, '0')}\0`;
+}
+
+/** The sum of every byte in the header, taken as though the checksum field were spaces. */
+function writeChecksum(header: Buffer): void {
+  header.fill(SPACE, CHECKSUM_AT, CHECKSUM_AT + CHECKSUM_FIELD_BYTES);
+  let sum = 0;
+  for (const byte of header) {
+    sum += byte;
+  }
+  header.write(`${octal({ value: sum, bytes: CHECKSUM_DIGITS })} `, CHECKSUM_AT, 'latin1');
+}
+
+function paddingAfter(sizeBytes: number): Uint8Array {
+  return Buffer.alloc((BLOCK_BYTES - (sizeBytes % BLOCK_BYTES)) % BLOCK_BYTES);
+}

--- a/apps/api/tests/support/tarballs.ts
+++ b/apps/api/tests/support/tarballs.ts
@@ -11,6 +11,8 @@ export type TarballEntry = {
   typeUnset?: boolean;
   /** Declares its length in base 256, which is what a length past eight gibibytes needs. */
   sizeInBase256?: boolean;
+  /** Written into the size field as it stands, which is how a corrupt length reaches a walk. */
+  sizeText?: string;
 };
 
 export const BLOCK_BYTES = 512;
@@ -73,11 +75,9 @@ function writeSize({ header, entry }: { header: Buffer; entry: TarballEntry }): 
     header[SIZE_AT] = BASE_256_MARKER;
     return;
   }
-  header.write(
-    octal({ value: entry.content.byteLength, bytes: SIZE_FIELD_BYTES }),
-    SIZE_AT,
-    'latin1',
-  );
+  const field =
+    entry.sizeText ?? octal({ value: entry.content.byteLength, bytes: SIZE_FIELD_BYTES });
+  header.write(field, SIZE_AT, SIZE_FIELD_BYTES, 'latin1');
 }
 
 /** Octal text in a fixed width, NUL-terminated, which is how a tar writes every number it has. */


### PR DESCRIPTION
Follows #357, which landed while this was being written — so it targets `main` rather than stacking.

A Linux release is published as a `.tar.gz` far more often than as a zip: the Go and Rust release toolings both write one, and `.zip` is more the Windows and PocketBase convention. #357 therefore covers the less common shape for the platform the guest actually runs. A url answering with either is now the binary it holds, picked from the bytes rather than from what the link was called.

A tar has no index to be behind — headers and data alternate to the end, and every length sits in the header before its data — which makes it the walk a zip has to work to be. The stream helpers both formats ask the same things of moved out to sit beside them in `bytes.ts`, and the choice of format moved to `unwrap.ts`. One published uncompressed is unwrapped too, sniffed last and separately: a tar says what it is a quarter of a kibibyte in, and a zip that ends before that is still a zip.

A gzip that turns out not to hold a tar is handed on as the bytes it holds, which is what a release published as a bare `my-server.gz` is. What gets stored either way is the bare executable, so the name it is stored under is the entry's own — including the path a gnu long-name entry carried, where the header could only hold the first hundred bytes of it — and never the `.tar.gz` or `.gz` the download was called.

`main` is merged in for #382, whose checksum is over the download rather than the executable inside it. That is what makes letting go of the source load-bearing here: `digesting` reads the rest of a download from its `cancel`, so a walk that gives up without cancelling is one whose digest never settles.

Verified against `tar czf` output in gnu, pax, ustar and uncompressed form, and the fixture read back by `tar` itself.
