### PR TITLE
feat: a deploy link may say what the binary should hash to

### DIFF
--- a/apps/api/src/lib/artifact-digest.ts
+++ b/apps/api/src/lib/artifact-digest.ts
@@ -216,6 +216,66 @@ export function boundedTo({
   });
 }
 
+/**
+ * The source as it was, and the digest of everything it served.
+ *
+ * Read to the end whether or not anyone downstream still wants it: half a download has no digest,
+ * and the walk that finds an executable inside an archive lets go of the rest the moment it has
+ * one. So giving up on these bytes reads them rather than releasing the connection — which is what
+ * checking a published checksum costs, a checksum being over the file that was published and not
+ * over whatever is found inside it.
+ *
+ * Only wrapped around a source somebody said a digest for; nothing else pays that.
+ */
+export function digesting({ source }: { source: ReadableStream<Uint8Array> }): {
+  body: ReadableStream<Uint8Array>;
+  served: Promise<Sha256Digest>;
+} {
+  const reader = source.getReader();
+  const hasher = new Bun.CryptoHasher(DIGEST_ALGORITHM);
+  const { promise, resolve, reject } = Promise.withResolvers<Sha256Digest>();
+  // The source can fail on a path that never asks what it hashed to — a refused binary, an app
+  // that went — and a rejection nobody is waiting on yet is an unhandled one.
+  void promise.catch(() => undefined);
+
+  async function taken(): Promise<Uint8Array | undefined> {
+    const { done, value } = await reader.read();
+    if (done) {
+      resolve(Value.Parse(Sha256DigestSchema, hasher.digest(HEX_ENCODING)));
+      return undefined;
+    }
+    hasher.update(value);
+    return value;
+  }
+
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await taken();
+        if (chunk === undefined) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk);
+      } catch (failure) {
+        reject(failure);
+        throw failure;
+      }
+    },
+    async cancel() {
+      try {
+        while ((await taken()) !== undefined) {
+          // The rest of the download, which is not wanted for anything but the digest of it.
+        }
+      } catch (failure) {
+        reject(failure);
+      }
+    },
+  });
+
+  return { body, served: promise };
+}
+
 /** What a refusal is raised as, so that whoever was writing the bytes stops and says why. */
 export class RefusedArtifactError extends Error {
   readonly inspection: ArtifactInspection;

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
@@ -36,7 +36,12 @@ export const AppsAppIdArtifactsController = new Elysia()
       const ownerId = Value.Parse(OwnerIdSchema, user.id);
       const created =
         'url' in body
-          ? await artifactsService.createFromUrl({ appId, ownerId, url: body.url })
+          ? await artifactsService.createFromUrl({
+              appId,
+              ownerId,
+              url: body.url,
+              sha256: body.sha256,
+            })
           : await artifactsService.create({
               appId,
               ownerId,

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
@@ -23,9 +23,9 @@ const UploadedBinarySchema = t.Object({
 // the one that finds out how large the binary is and what the file at the end of the url is called.
 //
 // The digest is the one thing about them a caller can know before the fetch, and the only one this
-// end will take their word about — as an expectation to hold the bytes to rather than as a fact
-// about them. Optional because most callers have none: it is written down where a release
-// publishes its checksums, and nowhere else.
+// end will take their word about — as an expectation to hold the download to rather than as a fact
+// about it. Over the file the url serves, which for an archive is the archive: that is what a
+// release publishes a checksum for, and the only form one is ever written down in.
 const FetchedBinarySchema = t.Object({
   url: t.String({
     description: 'Public https url the api fetches the binary from.',

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/model.ts
@@ -1,4 +1,10 @@
-import { ArtifactIdSchema, ArtifactSchema, ByteSizeSchema, FilenameSchema } from '@repo/protocol';
+import {
+  ArtifactIdSchema,
+  ArtifactSchema,
+  ByteSizeSchema,
+  FilenameSchema,
+  Sha256DigestSchema,
+} from '@repo/protocol';
 import { t } from 'elysia';
 import { BINARY_URL_PATTERN, MAX_BINARY_URL_LENGTH } from '#lib/binary-url.ts';
 
@@ -15,12 +21,18 @@ const UploadedBinarySchema = t.Object({
 
 // Bytes the caller does not hold: no name and no size, because the api is the one fetching and so
 // the one that finds out how large the binary is and what the file at the end of the url is called.
+//
+// The digest is the one thing about them a caller can know before the fetch, and the only one this
+// end will take their word about — as an expectation to hold the bytes to rather than as a fact
+// about them. Optional because most callers have none: it is written down where a release
+// publishes its checksums, and nowhere else.
 const FetchedBinarySchema = t.Object({
   url: t.String({
     description: 'Public https url the api fetches the binary from.',
     pattern: BINARY_URL_PATTERN,
     maxLength: MAX_BINARY_URL_LENGTH,
   }),
+  sha256: t.Optional(Sha256DigestSchema),
 });
 
 // Where the binary is, however that is answered. One request either way: what differs is who ends

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -14,6 +14,7 @@ import {
   type ArtifactInspection,
   ArtifactTooLargeError,
   boundedTo,
+  digesting,
   inspectArtifact,
   inspectingPassThrough,
   RefusedArtifactError,
@@ -123,12 +124,51 @@ function unreadableArchive(url: string): string {
 }
 
 /**
- * The binary is not the one the caller said would be there. Both digests are named because either
+ * The url is not serving what the caller said it would. Both digests are named because either
  * could be the surprising one: the link may have been written against a release that has since
  * been replaced, or the checksum beside it may simply be the wrong one.
  */
-function wrongDigest({ expected, stored }: { expected: string; stored: string }): string {
-  return `The binary hashes to ${stored}, not the ${expected} that was asked for.`;
+function wrongDigest({ expected, served }: { expected: string; served: string }): string {
+  return `The url served ${served}, not the ${expected} that was asked for.`;
+}
+
+/** A digest somebody said the url would serve, and what it turned out to serve. */
+type DigestCheck = { expected: Sha256Digest; served: Promise<Sha256Digest> };
+
+/**
+ * The source, hashed on its way past where there is something to hold it to. Untouched where
+ * there is not: reading a download to the end is the cost of checking one, and nobody who did not
+ * ask for the check should pay it.
+ */
+function checking({
+  source,
+  sha256,
+}: {
+  source: ReadableStream<Uint8Array>;
+  sha256: Sha256Digest | undefined;
+}): { body: ReadableStream<Uint8Array>; check: DigestCheck | undefined } {
+  if (sha256 === undefined) {
+    return { body: source, check: undefined };
+  }
+  const { body, served } = digesting({ source });
+  return { body, check: { expected: sha256, served } };
+}
+
+/**
+ * The download held to the digest it was promised to be.
+ *
+ * Against the download rather than against the executable unwrapped from it, because a release
+ * publishes a checksum over the file it uploaded — a `checksums.txt` beside a zip is the zip's,
+ * and nobody publishes the digest of one file inside an archive.
+ */
+async function heldToDigest(check: DigestCheck | undefined): Promise<void> {
+  if (check === undefined) {
+    return;
+  }
+  const served = await check.served;
+  if (served !== check.expected) {
+    throw new BadRequestError(wrongDigest({ expected: check.expected, served }));
+  }
 }
 
 function unsupportedInterpreter(interpreter: string): string {
@@ -300,11 +340,10 @@ export class ArtifactsService extends Service {
    * Hashed on that same pass: the bytes are inspected as they are handed to the store, so what is
    * written to the staging key and what decides whether it is an artifact at all are one read.
    *
-   * A caller who knows what the url should be serving may say so, and what their digest is held
-   * against is the artifact's own — the binary that will be deployed, which for an archive is the
-   * executable inside it rather than the download it arrived in. It can only be checked once the
-   * bytes are read, so a url serving something else costs the fetch; what it does not cost is a
-   * deploy of whatever turned up.
+   * A caller who knows what the url should be serving may say so, and what is held to it is the
+   * download itself — the file a release published a checksum for. It can only be checked once
+   * the bytes are read, so a url serving something else costs the fetch; what it does not cost is
+   * a deploy of whatever turned up.
    */
   async createFromUrl({
     appId,
@@ -376,7 +415,8 @@ export class ArtifactsService extends Service {
     // Bounded on the way in whatever the host said about it: a declared length is a courtesy, and
     // a source that declares none is otherwise read for as long as it keeps sending. The bound is
     // on what the url sent rather than on what it came to, which for an archive is not the same.
-    const fetched = boundedTo({ source: source.body, maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES });
+    const bounded = boundedTo({ source: source.body, maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES });
+    const { body: fetched, check } = checking({ source: bounded, sha256 });
     const held = await unwrapped({ source: fetched, named: filename, url: said });
 
     const pending = await this.artifactsRepo.insertPending({
@@ -398,16 +438,10 @@ export class ArtifactsService extends Service {
       staged,
       body: held.body,
       url: said,
+      check,
     });
 
-    return await this.promote({
-      appId,
-      artifactId: pending.id,
-      ownerId,
-      staged,
-      inspection,
-      expected: sha256,
-    });
+    return await this.promote({ appId, artifactId: pending.id, ownerId, staged, inspection });
   }
 
   /**
@@ -424,6 +458,7 @@ export class ArtifactsService extends Service {
     staged,
     body,
     url,
+    check,
   }: {
     appId: AppId;
     artifactId: ArtifactId;
@@ -431,9 +466,12 @@ export class ArtifactsService extends Service {
     staged: ObjectKey;
     body: ReadableStream<Uint8Array>;
     url: string;
+    check: DigestCheck | undefined;
   }): Promise<ArtifactInspection> {
     try {
-      return await this.stage({ staged, body });
+      const inspection = await this.stage({ staged, body });
+      await heldToDigest(check);
+      return inspection;
     } catch (failure) {
       await this.abandon({ appId, artifactId, ownerId });
       if (failure instanceof InterruptedSourceError) {
@@ -489,10 +527,6 @@ export class ArtifactsService extends Service {
    * The staged bytes as the artifact they turned out to be, which is the same last step whether
    * they were uploaded or fetched: what the inspection settled is written down, the bytes are put
    * where their digest says, and the slot they came through is given up.
-   *
-   * A digest that was expected is checked here rather than where it was given, because here is
-   * where there is one to check it against — and it is refused like any other verdict on the
-   * bytes, which is to say the row and the staging slot go with it.
    */
   private async promote({
     appId,
@@ -500,14 +534,12 @@ export class ArtifactsService extends Service {
     ownerId,
     staged,
     inspection,
-    expected,
   }: {
     appId: AppId;
     artifactId: ArtifactId;
     ownerId: OwnerId;
     staged: ObjectKey;
     inspection: ArtifactInspection;
-    expected?: Sha256Digest | undefined;
   }): Promise<Artifact> {
     if (inspection.outcome !== 'stored') {
       await this.abandon({ appId, artifactId, ownerId });
@@ -515,10 +547,6 @@ export class ArtifactsService extends Service {
     }
 
     const { digest, sizeBytes, objectKey } = inspection;
-    if (expected !== undefined && digest !== expected) {
-      await this.abandon({ appId, artifactId, ownerId });
-      throw new BadRequestError(wrongDigest({ expected, stored: digest }));
-    }
     if (!(await this.storageRepo.exists({ objectKey }))) {
       await this.storageRepo.copy({ from: staged, to: objectKey });
     }

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -7,6 +7,7 @@ import {
   type ObjectKey,
   ObjectKeySchema,
   type OwnerId,
+  type Sha256Digest,
   Value,
 } from '@repo/protocol';
 import {
@@ -119,6 +120,15 @@ const ENTRY_TOO_LARGE =
 
 function unreadableArchive(url: string): string {
   return `The zip ended before the entry it was describing: ${url}`;
+}
+
+/**
+ * The binary is not the one the caller said would be there. Both digests are named because either
+ * could be the surprising one: the link may have been written against a release that has since
+ * been replaced, or the checksum beside it may simply be the wrong one.
+ */
+function wrongDigest({ expected, stored }: { expected: string; stored: string }): string {
+  return `The binary hashes to ${stored}, not the ${expected} that was asked for.`;
 }
 
 function unsupportedInterpreter(interpreter: string): string {
@@ -289,15 +299,23 @@ export class ArtifactsService extends Service {
    *
    * Hashed on that same pass: the bytes are inspected as they are handed to the store, so what is
    * written to the staging key and what decides whether it is an artifact at all are one read.
+   *
+   * A caller who knows what the url should be serving may say so, and what their digest is held
+   * against is the artifact's own — the binary that will be deployed, which for an archive is the
+   * executable inside it rather than the download it arrived in. It can only be checked once the
+   * bytes are read, so a url serving something else costs the fetch; what it does not cost is a
+   * deploy of whatever turned up.
    */
   async createFromUrl({
     appId,
     ownerId,
     url,
+    sha256,
   }: {
     appId: AppId;
     ownerId: OwnerId;
     url: string;
+    sha256?: Sha256Digest | undefined;
   }): Promise<Artifact> {
     if (!(await this.appsRepo.isOwnedBy({ appId, ownerId }))) {
       throw new NotFoundError(NO_SUCH_APP);
@@ -315,7 +333,7 @@ export class ArtifactsService extends Service {
 
     this.fetchesInFlight += 1;
     try {
-      return await this.fetchInto({ appId, ownerId, url, filename });
+      return await this.fetchInto({ appId, ownerId, url, filename, sha256 });
     } finally {
       this.fetchesInFlight -= 1;
     }
@@ -333,11 +351,13 @@ export class ArtifactsService extends Service {
     ownerId,
     url,
     filename,
+    sha256,
   }: {
     appId: AppId;
     ownerId: OwnerId;
     url: string;
     filename: Filename;
+    sha256: Sha256Digest | undefined;
   }): Promise<Artifact> {
     const said = withoutCredentials(url);
 
@@ -380,7 +400,14 @@ export class ArtifactsService extends Service {
       url: said,
     });
 
-    return await this.promote({ appId, artifactId: pending.id, ownerId, staged, inspection });
+    return await this.promote({
+      appId,
+      artifactId: pending.id,
+      ownerId,
+      staged,
+      inspection,
+      expected: sha256,
+    });
   }
 
   /**
@@ -462,6 +489,10 @@ export class ArtifactsService extends Service {
    * The staged bytes as the artifact they turned out to be, which is the same last step whether
    * they were uploaded or fetched: what the inspection settled is written down, the bytes are put
    * where their digest says, and the slot they came through is given up.
+   *
+   * A digest that was expected is checked here rather than where it was given, because here is
+   * where there is one to check it against — and it is refused like any other verdict on the
+   * bytes, which is to say the row and the staging slot go with it.
    */
   private async promote({
     appId,
@@ -469,12 +500,14 @@ export class ArtifactsService extends Service {
     ownerId,
     staged,
     inspection,
+    expected,
   }: {
     appId: AppId;
     artifactId: ArtifactId;
     ownerId: OwnerId;
     staged: ObjectKey;
     inspection: ArtifactInspection;
+    expected?: Sha256Digest | undefined;
   }): Promise<Artifact> {
     if (inspection.outcome !== 'stored') {
       await this.abandon({ appId, artifactId, ownerId });
@@ -482,6 +515,10 @@ export class ArtifactsService extends Service {
     }
 
     const { digest, sizeBytes, objectKey } = inspection;
+    if (expected !== undefined && digest !== expected) {
+      await this.abandon({ appId, artifactId, ownerId });
+      throw new BadRequestError(wrongDigest({ expected, stored: digest }));
+    }
     if (!(await this.storageRepo.exists({ objectKey }))) {
       await this.storageRepo.copy({ from: staged, to: objectKey });
     }

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -825,6 +825,45 @@ describe('a binary is fetched from the url it was given', () => {
     expect(isValidMessage({ schema: ArtifactSchema, value: artifact })).toBe(true);
   });
 
+  /**
+   * The one thing about the bytes a caller can know before the fetch, and so the one thing worth
+   * taking their word about — as an expectation, checked against what they came to.
+   */
+  test('a checksum the bytes hash to is the fetch going ahead as it would have', async () => {
+    const { service, sourceRepo, storage } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+      sha256: Value.Parse(Sha256DigestSchema, BINARY_DIGEST),
+    });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+    expect(storage.objects.has(Value.Parse(ObjectKeySchema, BINARY_DIGEST))).toBe(true);
+  });
+
+  // Both digests, because either could be the surprising one: the release the link was written
+  // against may have been replaced, or the checksum beside it may never have been this binary's.
+  test('and a checksum they hash to nothing like is refused, leaving nothing behind', async () => {
+    const { service, sourceRepo, artifactsRepo, storage } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const refusal = service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+      sha256: SEEDED_DIGEST,
+    });
+
+    await expect(refusal).rejects.toBeInstanceOf(BadRequestError);
+    await expect(refusal).rejects.toThrow(SEEDED_DIGEST);
+    await expect(refusal).rejects.toThrow(BINARY_DIGEST);
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect(storage.objects.size).toBe(0);
+  });
+
   // Kept where the bytes are described rather than answered with: nothing downstream is told
   // where a binary was found, and a host least of all.
   test('where it came from is written down beside the name it was given', async () => {
@@ -1015,6 +1054,27 @@ describe('a binary is fetched from the url it was given', () => {
     expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
     expect(storage.objects.has(Value.Parse(ObjectKeySchema, BINARY_DIGEST))).toBe(true);
     expect(artifactsRepo.rows.get(artifact.id)?.original_file_url).toBe(ARCHIVE_URL);
+  });
+
+  /**
+   * Held against the binary rather than against the download, because the binary is what a host
+   * verifies before it will run one — and the digest of a zip says nothing about whether the
+   * executable inside it is the one that was published.
+   */
+  test('and a checksum is what the executable inside hashes to, not the zip', async () => {
+    const { service, sourceRepo } = build();
+    sourceRepo.servesBytes({
+      bytes: archiveOf([{ name: 'my-server', content: bytesOf(BINARY_TEXT) }]),
+    });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: ARCHIVE_URL,
+      sha256: Value.Parse(Sha256DigestSchema, BINARY_DIGEST),
+    });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
   });
 
   // The name an export writes the binary out as, which the url only ever spells `.zip`.

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -10,6 +10,7 @@ import {
   type ObjectKey,
   ObjectKeySchema,
   type OwnerId,
+  type Sha256Digest,
   Sha256DigestSchema,
   TimestampSchema,
   Value,
@@ -55,6 +56,14 @@ const PAST_THE_SWEEP_MS = A_DAY_SECONDS * MS_PER_SECOND + AN_HOUR_MS;
 
 function bytesOf(text: string): Uint8Array {
   return Uint8Array.from(text, (character) => character.charCodeAt(0));
+}
+
+/** What a release would publish beside the file: the digest of the file, whatever is inside it. */
+function digestOf(bytes: Uint8Array): Sha256Digest {
+  return Value.Parse(
+    Sha256DigestSchema,
+    new Bun.CryptoHasher('sha256').update(bytes).digest('hex'),
+  );
 }
 
 type StoredRow = Omit<ArtifactRow, 'digest' | 'size_bytes' | 'object_key'> & {
@@ -1057,24 +1066,47 @@ describe('a binary is fetched from the url it was given', () => {
   });
 
   /**
-   * Held against the binary rather than against the download, because the binary is what a host
-   * verifies before it will run one — and the digest of a zip says nothing about whether the
-   * executable inside it is the one that was published.
+   * Held against the download rather than against the executable unwrapped from it: a release
+   * publishes a checksum over the file it uploaded, so a `checksums.txt` beside a zip is the
+   * zip's — nobody anywhere publishes the digest of one file inside an archive.
+   *
+   * The walk stops at the entry it wanted, so this is also the one case where checking a checksum
+   * means reading the rest of a download nothing else needed.
    */
-  test('and a checksum is what the executable inside hashes to, not the zip', async () => {
+  test('and a checksum is what the zip hashes to, not the executable inside it', async () => {
     const { service, sourceRepo } = build();
+    const bytes = archiveOf([
+      { name: 'my-server', content: bytesOf(BINARY_TEXT) },
+      { name: 'CHANGELOG.md', content: bytesOf('# Changelog\n') },
+    ]);
+    sourceRepo.servesBytes({ bytes });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: ARCHIVE_URL,
+      sha256: digestOf(bytes),
+    });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+  });
+
+  test('and the digest of that executable is not what the zip is held to', async () => {
+    const { service, sourceRepo, artifactsRepo, storage } = build();
     sourceRepo.servesBytes({
       bytes: archiveOf([{ name: 'my-server', content: bytesOf(BINARY_TEXT) }]),
     });
 
-    const artifact = await service.createFromUrl({
+    const refusal = service.createFromUrl({
       appId: APP_ID,
       ownerId: OWNER_ID,
       url: ARCHIVE_URL,
       sha256: Value.Parse(Sha256DigestSchema, BINARY_DIGEST),
     });
 
-    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+    await expect(refusal).rejects.toBeInstanceOf(BadRequestError);
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect(storage.objects.size).toBe(0);
   });
 
   // The name an export writes the binary out as, which the url only ever spells `.zip`.

--- a/apps/dashboard/src/lib/binary-source.ts
+++ b/apps/dashboard/src/lib/binary-source.ts
@@ -1,5 +1,13 @@
-import type { FetchableBinary } from '@repo/app-operations';
 import { namedByUrl } from '@repo/deploy-link';
+
+/**
+ * A url for the api to fetch, and what a link said the binary there should hash to.
+ *
+ * The checksum is text rather than a digest because it is whatever the link was written with, and
+ * what is not a sha256 is refused by name rather than dropped — see `refusedChecksum`. A checksum
+ * quietly ignored is a deploy nobody verified, which is the one thing carrying one was for.
+ */
+export type FetchedBinary = { url: string; sha256?: string | undefined };
 
 /**
  * Where the binary is coming from: a file on this machine, or a url the api fetches it at.
@@ -7,17 +15,27 @@ import { namedByUrl } from '@repo/deploy-link';
  * The two are one value because a deploy has one binary. Whichever box was last used is what the
  * form holds, and the other is empty because there is nothing else it could be.
  */
-export type BinarySource = File | FetchableBinary;
+export type BinarySource = File | FetchedBinary;
 
 export function pickedFile(source: BinarySource | undefined): File | undefined {
   return source instanceof File ? source : undefined;
 }
 
-export function fetchedUrl(source: BinarySource | undefined): string | undefined {
-  return source === undefined || source instanceof File ? undefined : source.url;
+export function fetchedBinary(source: BinarySource | undefined): FetchedBinary | undefined {
+  return source === undefined || source instanceof File ? undefined : source;
 }
 
-/** A url the owner is still typing is not yet a source, and an empty box is not one at all. */
+export function fetchedUrl(source: BinarySource | undefined): string | undefined {
+  return fetchedBinary(source)?.url;
+}
+
+/**
+ * A url the owner is still typing is not yet a source, and an empty box is not one at all.
+ *
+ * Whatever a link brought is gone as soon as one is typed over it: a checksum belongs to the url
+ * it was written beside, and held against a different one it would refuse a deploy for a reason
+ * nobody on this side of the form can see.
+ */
 export function sourceFromUrl(url: string): BinarySource | undefined {
   return url.trim() === '' ? undefined : { url: url.trim() };
 }

--- a/apps/dashboard/src/lib/binary-source.ts
+++ b/apps/dashboard/src/lib/binary-source.ts
@@ -1,7 +1,7 @@
 import { namedByUrl } from '@repo/deploy-link';
 
 /**
- * A url for the api to fetch, and what a link said the binary there should hash to.
+ * A url for the api to fetch, and what a link said the file there should hash to.
  *
  * The checksum is text rather than a digest because it is whatever the link was written with, and
  * what is not a sha256 is refused by name rather than dropped — see `refusedChecksum`. A checksum

--- a/apps/dashboard/src/lib/hooks/use-deploy-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy-form.ts
@@ -1,12 +1,18 @@
 import {
   type DeployableBinary,
+  type FetchableBinary,
   InvalidEnvironmentError,
   parseEnvironmentPatch,
 } from '@repo/app-operations';
-import { type DeploySuggestion, namedByUrl, refusedUrl } from '@repo/deploy-link';
-import { DEFAULT_HTTP_PORT, FilenameSchema, Value } from '@repo/protocol';
+import { type DeploySuggestion, namedByUrl, refusedChecksum, refusedUrl } from '@repo/deploy-link';
+import { DEFAULT_HTTP_PORT, FilenameSchema, Sha256DigestSchema, Value } from '@repo/protocol';
 import { type ReactFormExtendedApi, useForm } from '@tanstack/react-form';
-import { type BinarySource, fetchedUrl, pickedFile } from '#lib/binary-source.ts';
+import {
+  type BinarySource,
+  type FetchedBinary,
+  fetchedBinary,
+  pickedFile,
+} from '#lib/binary-source.ts';
 import {
   askedVariables,
   type EnvironmentVariable,
@@ -81,9 +87,9 @@ export function validateKeptBinary({
 }
 
 function validateBinarySource(source: BinarySource): string | undefined {
-  const url = fetchedUrl(source);
-  if (url !== undefined) {
-    return refusedUrl(url);
+  const fetched = fetchedBinary(source);
+  if (fetched !== undefined) {
+    return refusedUrl(fetched.url) ?? refusedChecksum(fetched.sha256);
   }
   const file = pickedFile(source);
   return file !== undefined && !Value.Check(FilenameSchema, file.name)
@@ -186,7 +192,11 @@ function suggestedValues({
     ...UNTOUCHED,
     // A binary handed over from the landing page is one somebody dropped, which outranks a url a
     // link they followed happened to name.
-    binary: binary ?? (suggested?.binary === undefined ? undefined : { url: suggested.binary }),
+    binary:
+      binary ??
+      (suggested?.binary === undefined
+        ? undefined
+        : { url: suggested.binary, sha256: suggested.sha256 }),
     name: suggested?.name ?? namedByUrl(suggested?.binary ?? '') ?? UNTOUCHED.name,
     port: suggested?.port === undefined ? undefined : String(suggested.port),
     extraPublicPort: suggested?.extraPublicPort,
@@ -247,15 +257,23 @@ function asReleaseRequest({
  * api, which is the end that can read it.
  */
 function deployableFrom(source: BinarySource): DeployableBinary | undefined {
-  const url = fetchedUrl(source);
-  if (url !== undefined) {
-    return refusedUrl(url) === undefined ? { url } : undefined;
+  const fetched = fetchedBinary(source);
+  if (fetched !== undefined) {
+    return refusedUrl(fetched.url) === undefined ? fetchable(fetched) : undefined;
   }
   const file = pickedFile(source);
   if (file === undefined) {
     return undefined;
   }
   return Value.Check(FilenameSchema, file.name) ? { name: file.name, body: file } : undefined;
+}
+
+/** The url as the api takes it. Nothing at all where the checksum beside it is not one. */
+function fetchable({ url, sha256 }: FetchedBinary): FetchableBinary | undefined {
+  if (sha256 === undefined) {
+    return { url };
+  }
+  return Value.Check(Sha256DigestSchema, sha256) ? { url, sha256 } : undefined;
 }
 
 /** The lines that are arguments: what a blank one is not, and what the trailing newline is not. */

--- a/apps/dashboard/tests/lib/binary-source.test.ts
+++ b/apps/dashboard/tests/lib/binary-source.test.ts
@@ -1,8 +1,15 @@
 import { expect, test } from 'bun:test';
-import { binaryName, fetchedUrl, pickedFile, sourceFromUrl } from '#lib/binary-source.ts';
+import {
+  binaryName,
+  fetchedBinary,
+  fetchedUrl,
+  pickedFile,
+  sourceFromUrl,
+} from '#lib/binary-source.ts';
 
 const URL_SOURCE = 'https://github.com/me/app/releases/download/v1/my-server';
 const FILE = new File([], 'my-server');
+const CHECKSUM = 'd9403d88cdf0684fbb9d8e97cf3508e9fb4506cf309a34e42653a1c2bc04a298';
 
 test('a file and a url are both the binary, and each is only itself', () => {
   expect(pickedFile(FILE)).toBe(FILE);
@@ -23,4 +30,14 @@ test('an empty box is not a binary', () => {
   expect(sourceFromUrl('')).toBeUndefined();
   expect(sourceFromUrl('   ')).toBeUndefined();
   expect(sourceFromUrl(` ${URL_SOURCE} `)).toEqual({ url: URL_SOURCE });
+});
+
+/**
+ * The checksum belongs to the url it was written beside. Typing over that url is choosing a
+ * different binary, and holding the old checksum against it would refuse the deploy for a reason
+ * nothing on the form could show.
+ */
+test('a url typed over the one a link brought carries none of its checksum', () => {
+  expect(fetchedBinary({ url: URL_SOURCE, sha256: CHECKSUM })?.sha256).toBe(CHECKSUM);
+  expect(sourceFromUrl(URL_SOURCE)).toEqual({ url: URL_SOURCE });
 });

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -5,6 +5,9 @@ export const DEPLOY_PRESETS = {
     name: 'pocketbase',
     binary:
       'https://github.com/pocketbase/pocketbase/releases/download/v0.40.1/pocketbase_0.40.1_linux_amd64.zip',
+    // The digest that release publishes for that zip, in its own checksums.txt. A version pinned
+    // in a link everybody shares is worth pinning to the bytes as well as to the number.
+    sha256: '0f3442d2e57b03b56fbff0d09289e4a30b4f561a44338c38d2dcd4a1a0cfa91e',
     port: 8090,
     arg: ['serve', '--http=0.0.0.0:8090', '--dir=./data/pb_data'],
     minimal: true,

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -5,8 +5,6 @@ export const DEPLOY_PRESETS = {
     name: 'pocketbase',
     binary:
       'https://github.com/pocketbase/pocketbase/releases/download/v0.40.1/pocketbase_0.40.1_linux_amd64.zip',
-    // The digest that release publishes for that zip, in its own checksums.txt. A version pinned
-    // in a link everybody shares is worth pinning to the bytes as well as to the number.
     sha256: '0f3442d2e57b03b56fbff0d09289e4a30b4f561a44338c38d2dcd4a1a0cfa91e',
     port: 8090,
     arg: ['serve', '--http=0.0.0.0:8090', '--dir=./data/pb_data'],

--- a/packages/app-operations/src/deploy.ts
+++ b/packages/app-operations/src/deploy.ts
@@ -1,6 +1,6 @@
 import type { PublicApiClient } from '@repo/api-client/public';
 import { ApiError, unwrap } from '@repo/api-client/unwrap';
-import type { DeploymentState, Filename, TenantArguments } from '@repo/protocol';
+import type { DeploymentState, Filename, Sha256Digest, TenantArguments } from '@repo/protocol';
 import { appFor } from '#apps.ts';
 import {
   type ConfigEdit,
@@ -32,6 +32,9 @@ export type UploadableBinary = {
  */
 export type FetchableBinary = {
   url: string;
+  // What the url should be serving, where whoever wrote it knew: the api hashes the bytes it
+  // fetches either way, and refuses them where they come to anything else.
+  sha256?: Sha256Digest | undefined;
 };
 
 export type DeployableBinary = UploadableBinary | FetchableBinary;
@@ -163,7 +166,9 @@ async function fetchBinary({
   appId: string;
   binary: FetchableBinary;
 }): Promise<StoredArtifact> {
-  const created = unwrap(await api.api.apps({ appId }).artifacts.post({ url: binary.url }));
+  const created = unwrap(
+    await api.api.apps({ appId }).artifacts.post({ url: binary.url, sha256: binary.sha256 }),
+  );
   if (!isStored(created)) {
     throw new ApiError('The api answered a fetched binary with somewhere to upload one.');
   }

--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -25,7 +25,7 @@ export const command = defineCommand('run [command]', {
     sha256: {
       schema: z.string().optional(),
       description:
-        'What the binary at the url should hash to, as its release publishes it. nibrun refuses one that hashes to anything else. Only for a url — a file on this machine is not fetched.',
+        'What the file at the url should hash to, as its release publishes it — for an archive, the archive rather than the executable inside it. nibrun refuses a download that hashes to anything else. Only for a url: a file on this machine is not fetched.',
     },
     [SHARED_OPTIONS.port.name]: SHARED_OPTIONS.port.option,
     [SHARED_OPTIONS.extraPublicPort.name]: SHARED_OPTIONS.extraPublicPort.option,

--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -22,6 +22,11 @@ export const command = defineCommand('run [command]', {
       schema: z.string().optional(),
       description: 'Name for the new app. Defaults to the binary filename.',
     },
+    sha256: {
+      schema: z.string().optional(),
+      description:
+        'What the binary at the url should hash to, as its release publishes it. nibrun refuses one that hashes to anything else. Only for a url — a file on this machine is not fetched.',
+    },
     [SHARED_OPTIONS.port.name]: SHARED_OPTIONS.port.option,
     [SHARED_OPTIONS.extraPublicPort.name]: SHARED_OPTIONS.extraPublicPort.option,
     [SHARED_OPTIONS.env.name]: SHARED_OPTIONS.env.option,
@@ -32,7 +37,12 @@ export const command = defineCommand('run [command]', {
   handler: async ({ params, options, context, print }) => {
     // parsh names an option as it is typed, so a flag with hyphens in it does not arrive under the
     // name the deploy takes and has to be renamed rather than spread through.
-    const { detach, [SHARED_OPTIONS.extraPublicPort.name]: extraPublicPort, ...flags } = options;
+    const {
+      detach,
+      sha256,
+      [SHARED_OPTIONS.extraPublicPort.name]: extraPublicPort,
+      ...flags
+    } = options;
     const given = { ...flags, extraPublicPort };
     const { binarySource, args } = parseCommandLine(params.command);
     const { api } = context;
@@ -43,7 +53,7 @@ export const command = defineCommand('run [command]', {
     // Before anything is asked, so a path nobody can read costs one line rather than a
     // questionnaire whose answers are then thrown away. A url is not opened here at all: the api
     // is the end that fetches it, and it is the end that says whether it could.
-    const binary = await binaryFrom(binarySource);
+    const binary = await binaryFrom({ source: binarySource, sha256 });
     ui.open('nib run');
 
     const resolved = interactive

--- a/packages/cli/src/lib/deploy.test.ts
+++ b/packages/cli/src/lib/deploy.test.ts
@@ -1,8 +1,13 @@
 import { expect, test } from 'bun:test';
+import { Sha256DigestSchema, Value } from '@repo/protocol';
 import { binaryFrom } from '#lib/deploy.ts';
 import { UsageError } from '#lib/errors.ts';
 
 const URL_SOURCE = 'https://releases.test/v1/my-server';
+const CHECKSUM = Value.Parse(
+  Sha256DigestSchema,
+  'd9403d88cdf0684fbb9d8e97cf3508e9fb4506cf309a34e42653a1c2bc04a298',
+);
 
 /**
  * A url is handed on rather than opened: this machine is not the end that fetches it, so nothing
@@ -10,19 +15,41 @@ const URL_SOURCE = 'https://releases.test/v1/my-server';
  * deploy.
  */
 test('an https url is a binary for the api to fetch', async () => {
-  expect(await binaryFrom(URL_SOURCE)).toEqual({ url: URL_SOURCE });
+  expect(await binaryFrom({ source: URL_SOURCE })).toEqual({ url: URL_SOURCE, sha256: undefined });
 });
 
 test('a url the api would not be alone on the wire for is named as the mistake it is', async () => {
-  await expect(binaryFrom('http://releases.test/v1/my-server')).rejects.toBeInstanceOf(UsageError);
+  await expect(binaryFrom({ source: 'http://releases.test/v1/my-server' })).rejects.toBeInstanceOf(
+    UsageError,
+  );
+});
+
+/**
+ * Sent as the api reads it, and refused here where it could never be one: what the checksum would
+ * have caught is at the far end of a whole transfer, so a mistyped one is worth a line now.
+ */
+test('a checksum travels with the url, in the spelling the api takes', async () => {
+  expect(await binaryFrom({ source: URL_SOURCE, sha256: ` ${CHECKSUM.toUpperCase()} ` })).toEqual({
+    url: URL_SOURCE,
+    sha256: CHECKSUM,
+  });
+  await expect(binaryFrom({ source: URL_SOURCE, sha256: 'nope' })).rejects.toThrow('64 hex');
 });
 
 test('anything that is not a url is a file on this machine', async () => {
-  const binary = await binaryFrom(import.meta.path);
+  const binary = await binaryFrom({ source: import.meta.path });
 
   expect(binary).toMatchObject({ name: 'deploy.test.ts' });
 });
 
+// Refused rather than dropped: a deploy that went ahead without checking the checksum it was
+// given is the one outcome giving one has to rule out.
+test('and a checksum is not something a file on this machine is deployed with', async () => {
+  await expect(binaryFrom({ source: import.meta.path, sha256: CHECKSUM })).rejects.toThrow(
+    '--sha256',
+  );
+});
+
 test('a file nobody can read costs a line rather than a deploy', async () => {
-  await expect(binaryFrom('./nothing-is-here')).rejects.toThrow('No such file');
+  await expect(binaryFrom({ source: './nothing-is-here' })).rejects.toThrow('No such file');
 });

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -5,7 +5,14 @@ import {
   deploy as startDeployment,
   type UploadableBinary,
 } from '@repo/app-operations';
-import { type Filename, FilenameSchema, type TenantArguments, Value } from '@repo/protocol';
+import {
+  type Filename,
+  FilenameSchema,
+  type Sha256Digest,
+  Sha256DigestSchema,
+  type TenantArguments,
+  Value,
+} from '@repo/protocol';
 import { environmentEdit } from '#lib/environment.ts';
 import { UsageError } from '#lib/errors.ts';
 import type { RunOptions } from '#lib/plan.ts';
@@ -73,14 +80,42 @@ const INSECURE_SCHEME = 'http://';
  * take is the api's to say — this only refuses the one mistake whose other reading is a file
  * nobody could ever find.
  */
-export async function binaryFrom(source: string): Promise<DeployableBinary> {
+export async function binaryFrom({
+  source,
+  sha256,
+}: {
+  source: string;
+  sha256?: string | undefined;
+}): Promise<DeployableBinary> {
   if (source.startsWith(SECURE_SCHEME)) {
-    return { url: source };
+    return { url: source, sha256: sha256 === undefined ? undefined : asDigest(sha256) };
   }
   if (source.startsWith(INSECURE_SCHEME)) {
     throw new UsageError(`A binary is fetched over https, and this is not: ${source}`);
   }
+  // Said rather than ignored: a checksum that went unchecked is the one outcome passing one has
+  // to rule out. What it would have checked is a fetch, and this deploy is not one.
+  if (sha256 !== undefined) {
+    throw new UsageError(
+      `--sha256 is for a url nibrun fetches, and this is a file on this machine: ${source}`,
+    );
+  }
   return await openBinary(source);
+}
+
+/**
+ * What the url should be serving, in the one spelling the api reads it in. Refused here rather
+ * than sent, so a mistyped digest costs a line rather than the whole transfer it would fail at
+ * the end of.
+ */
+function asDigest(sha256: string): Sha256Digest {
+  try {
+    return Value.Parse(Sha256DigestSchema, sha256.trim().toLowerCase());
+  } catch {
+    throw new UsageError(
+      `A checksum is the 64 hex characters sha256sum prints, and this is not: ${sha256}`,
+    );
+  }
 }
 
 /**

--- a/packages/deploy-link/src/binary-url.test.ts
+++ b/packages/deploy-link/src/binary-url.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from 'bun:test';
-import { namedByUrl, refusedUrl } from '#binary-url.ts';
+import { namedByUrl, refusedChecksum, refusedUrl } from '#binary-url.ts';
 
 const RELEASE = 'https://github.com/me/app/releases/download/v1/my-server';
+const CHECKSUM = 'd9403d88cdf0684fbb9d8e97cf3508e9fb4506cf309a34e42653a1c2bc04a298';
 
 /**
  * Said here rather than by the api, because the api is the end that follows the url: a mistake it
@@ -16,4 +17,13 @@ test('a url nibrun could not fetch a binary from is refused before the deploy', 
 test('what the binary at a url is called is the segment it ends in', () => {
   expect(namedByUrl(RELEASE)).toBe('my-server');
   expect(namedByUrl('https://releases.test/../etc/passwd')).toBe('passwd');
+});
+
+// Refused rather than ignored: what a dropped checksum would let through is the deploy nobody
+// verified, which is the one thing carrying one was for.
+test('a checksum that is not a sha256 is refused before the deploy', () => {
+  expect(refusedChecksum(undefined)).toBeUndefined();
+  expect(refusedChecksum(CHECKSUM)).toBeUndefined();
+  expect(refusedChecksum(CHECKSUM.slice(1))).toContain('64 hex');
+  expect(refusedChecksum(`sha256:${CHECKSUM}`)).toContain('64 hex');
 });

--- a/packages/deploy-link/src/binary-url.ts
+++ b/packages/deploy-link/src/binary-url.ts
@@ -1,4 +1,4 @@
-import { FilenameSchema, Value } from '@repo/protocol';
+import { FilenameSchema, Sha256DigestSchema, Value } from '@repo/protocol';
 
 const SECURE_SCHEME = 'https://';
 
@@ -13,6 +13,17 @@ export function refusedUrl(url: string): string | undefined {
   return namedByUrl(url) === undefined
     ? 'The url has to end in the binary’s own name, as a release download does.'
     : undefined;
+}
+
+/**
+ * What the api would refuse, said here for the same reason the url is: the checksum comes from
+ * whoever wrote the link, and following one is how anybody finds out it was mistyped. Refused
+ * rather than ignored — the deploy it would let through is the unverified one.
+ */
+export function refusedChecksum(sha256: string | undefined): string | undefined {
+  return sha256 === undefined || Value.Check(Sha256DigestSchema, sha256)
+    ? undefined
+    : 'The link’s checksum is not a sha256: 64 hex characters.';
 }
 
 /** What the binary at a url is called, which is the name an export would carry. */

--- a/packages/deploy-link/src/index.ts
+++ b/packages/deploy-link/src/index.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/performance/noBarrelFile: index is the only allowed file where we can export other files */
 
-export { namedByUrl, refusedUrl } from '#binary-url.ts';
+export { namedByUrl, refusedChecksum, refusedUrl } from '#binary-url.ts';
 export {
   type DeployLink,
   type DeploySuggestion,

--- a/packages/deploy-link/src/link.test.ts
+++ b/packages/deploy-link/src/link.test.ts
@@ -4,8 +4,11 @@ import { defaultParseSearch, defaultStringifySearch } from '@tanstack/react-rout
 import { type DeployLink, type DeploySuggestion, deployLink, deploySuggestion } from '#link.ts';
 
 const HOSTNAME = writtenRuntimeValue(RUNTIME_VALUES.HOSTNAME.name);
+const CHECKSUM = 'd9403d88cdf0684fbb9d8e97cf3508e9fb4506cf309a34e42653a1c2bc04a298';
 
 const EVERYTHING = `?name=my-app&port=9000&extra-public-port=true&arg=serve&arg=--verbose&env=API_KEY&env=GREETING=hello&env=URL=https://${HOSTNAME}`;
+
+const BINARY_URL = 'https://releases.test/v1/my-server';
 
 const ASKED: DeploySuggestion = {
   name: 'my-app',
@@ -41,12 +44,22 @@ function rewritten(link: string): string {
  * one is the difference between a form to fill in and a button to press.
  */
 test('a link may carry the binary itself', () => {
-  expect(followed('?binary=https://releases.test/v1/my-server').binary).toBe(
-    'https://releases.test/v1/my-server',
-  );
-  expect(followed(rewritten('?binary=https://releases.test/v1/my-server')).binary).toBe(
-    'https://releases.test/v1/my-server',
-  );
+  expect(followed(`?binary=${BINARY_URL}`).binary).toBe(BINARY_URL);
+  expect(followed(rewritten(`?binary=${BINARY_URL}`)).binary).toBe(BINARY_URL);
+});
+
+/**
+ * Carried as it was written rather than checked here: what this end drops, nothing downstream can
+ * miss — and a deploy that went ahead without the checksum the link came with is the one outcome
+ * carrying one has to rule out. The form is where a malformed one is refused by name.
+ */
+test('a link may carry what that binary should hash to', () => {
+  expect(followed(`?binary=${BINARY_URL}&sha256=${CHECKSUM}`).sha256).toBe(CHECKSUM);
+  expect(followed(rewritten(`?binary=${BINARY_URL}&sha256=${CHECKSUM}`)).sha256).toBe(CHECKSUM);
+  expect(followed(`?sha256=${CHECKSUM.toUpperCase()}`).sha256).toBe(CHECKSUM);
+  expect(followed('?sha256=').sha256).toBeUndefined();
+  expect(followed('?sha256=not-a-digest').sha256).toBe('not-a-digest');
+  expect(followed(`?sha256=${CHECKSUM}&sha256=${CHECKSUM}`).sha256).not.toBeUndefined();
 });
 
 test('a url nibrun could not fetch a binary from prefills nothing', () => {
@@ -102,6 +115,7 @@ test('a link that asks for nothing suggests nothing', () => {
   expect(followed('')).toEqual({
     name: undefined,
     binary: undefined,
+    sha256: undefined,
     port: undefined,
     extraPublicPort: undefined,
     args: undefined,

--- a/packages/deploy-link/src/link.test.ts
+++ b/packages/deploy-link/src/link.test.ts
@@ -53,7 +53,7 @@ test('a link may carry the binary itself', () => {
  * miss — and a deploy that went ahead without the checksum the link came with is the one outcome
  * carrying one has to rule out. The form is where a malformed one is refused by name.
  */
-test('a link may carry what that binary should hash to', () => {
+test('a link may carry what the url should hash to', () => {
   expect(followed(`?binary=${BINARY_URL}&sha256=${CHECKSUM}`).sha256).toBe(CHECKSUM);
   expect(followed(rewritten(`?binary=${BINARY_URL}&sha256=${CHECKSUM}`)).sha256).toBe(CHECKSUM);
   expect(followed(`?sha256=${CHECKSUM.toUpperCase()}`).sha256).toBe(CHECKSUM);

--- a/packages/deploy-link/src/link.ts
+++ b/packages/deploy-link/src/link.ts
@@ -96,8 +96,8 @@ export type DeploySuggestion = { [K in keyof typeof CONFIGURED]?: Meant[K] } & {
   // Not part of what a deploy configures — it is what is being deployed. A link carrying one is
   // the difference between a form with one thing left to do and a form with none.
   binary?: string | undefined;
-  // What that binary should hash to, for the api to hold the bytes it fetches to. Never shown:
-  // there is nothing to decide about it, and the owner is not the one who wrote it down.
+  // What the url should serve, for the api to hold what it fetches to. Never shown: there is
+  // nothing to decide about it, and the owner is not the one who wrote it down.
   sha256?: string | undefined;
 };
 

--- a/packages/deploy-link/src/link.ts
+++ b/packages/deploy-link/src/link.ts
@@ -38,6 +38,7 @@ type Written = {
 export type DeployLink = Written & {
   name?: string | undefined;
   binary?: string | undefined;
+  sha256?: string | undefined;
   minimal?: boolean | undefined;
 };
 
@@ -45,6 +46,7 @@ export function deployLink(search: Record<string, unknown>): DeployLink {
   return {
     name: asText(search.name),
     binary: asBinaryUrl(search.binary),
+    sha256: asChecksum(search.sha256),
     minimal: asFlag(search.minimal),
     ...written(search),
   };
@@ -55,6 +57,22 @@ export function deployLink(search: Record<string, unknown>): DeployLink {
 function asBinaryUrl(value: unknown): string | undefined {
   const url = asText(value);
   return url !== undefined && refusedUrl(url) === undefined ? url : undefined;
+}
+
+/**
+ * The one parameter carried however it was written rather than dropped where it is wrong: what
+ * this end drops is a deploy that goes ahead unverified, which is the single outcome a checksum
+ * exists to rule out. Whatever it turns out to be, the form refuses it by name.
+ *
+ * Lowercased because a digest is one number however it was printed, and the api takes it in the
+ * spelling `sha256sum` writes.
+ */
+function asChecksum(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const written = String(value).trim().toLowerCase();
+  return written === '' ? undefined : written;
 }
 
 // Read off the parameters rather than the keys: `Object.fromEntries` cannot carry which reader
@@ -78,6 +96,9 @@ export type DeploySuggestion = { [K in keyof typeof CONFIGURED]?: Meant[K] } & {
   // Not part of what a deploy configures — it is what is being deployed. A link carrying one is
   // the difference between a form with one thing left to do and a form with none.
   binary?: string | undefined;
+  // What that binary should hash to, for the api to hold the bytes it fetches to. Never shown:
+  // there is nothing to decide about it, and the owner is not the one who wrote it down.
+  sha256?: string | undefined;
 };
 
 /** The link as the deploy it describes. A parameter renamed above is a line here that stops compiling. */
@@ -85,6 +106,7 @@ export function deploySuggestion(link: DeployLink): DeploySuggestion {
   return {
     name: link.name,
     binary: link.binary,
+    sha256: link.sha256,
     port: link.port,
     extraPublicPort: link['extra-public-port'],
     args: link.arg,


### PR DESCRIPTION
`?sha256=` on `/deploy` and `--sha256` on `nib run`, both optional and neither shown on the deploy form. They ride to `POST /apps/:appId/artifacts`, where the api holds what the url served to the digest given — refusing, and keeping nothing, when it comes to anything else.

The checksum is over the **download**, which is what a release publishes one for: goreleaser's `checksums.txt`, a `SHA256SUMS` asset, a Homebrew `sha256` — all of them cover the file at the url. For an archive that means the archive, so the walk that finds the executable inside reads the rest of the download rather than stopping at the entry it wanted. Nothing pays that but a fetch someone gave a checksum for.

Verified end to end against the real PocketBase v0.40.1 zip: `pocketbase` unwrapped, and the digest of the whole download matching the `0f3442d2…` in that release's own `checksums.txt`. The `nibrun.com/deploy/pocketbase` preset is pinned to it.

A checksum is never quietly dropped where it cannot be read — the form refuses a malformed one by name, and `nib run` refuses it beside a local file, where there is no fetch to hold to it.