### PR TITLE
feat(www): sharkord is a deploy the app already knows how to configure

### DIFF
--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -4,6 +4,7 @@ import {
   type ComputeUsage,
   EXTRA_PUBLIC_PORT_VALUES,
   type FilesystemUsage,
+  interpolableRuntimeValue,
   namesExtraPublicPortValues,
   OWNED_APP_STATES,
   type OwnedAppState,
@@ -12,7 +13,6 @@ import {
   type ReportedInstance,
   type ReportedVolume,
   type TenantEnvironment,
-  writtenRuntimeValue,
 } from '@repo/protocol';
 import { schema } from '#db/queries.gen.ts';
 import {
@@ -546,7 +546,7 @@ function refuseValuesNeedingAPort({
     .map(([name]) => name);
   if (naming.length > 0) {
     throw new BadRequestError(
-      `${EXTRA_PUBLIC_PORT_VALUES.map((value) => writtenRuntimeValue(value.name)).join(' and ')} are only set for an app with a public port besides HTTP, which this one has not asked for: ${naming.join(', ')}.`,
+      `${EXTRA_PUBLIC_PORT_VALUES.map((value) => interpolableRuntimeValue(value.name)).join(' and ')} are only set for an app with a public port besides HTTP, which this one has not asked for: ${naming.join(', ')}.`,
     );
   }
 }

--- a/apps/dashboard/src/components/apps/environment-table.tsx
+++ b/apps/dashboard/src/components/apps/environment-table.tsx
@@ -1,4 +1,8 @@
-import { EXTRA_PUBLIC_PORT_VALUES, RUNTIME_VALUE_NAMES, writtenRuntimeValue } from '@repo/protocol';
+import {
+  EXTRA_PUBLIC_PORT_VALUES,
+  interpolableRuntimeValue,
+  RUNTIME_VALUE_NAMES,
+} from '@repo/protocol';
 import { Button } from '@repo/ui/components/button';
 import {
   Table,
@@ -16,7 +20,7 @@ import { blankVariable, type EnvironmentVariable } from '#lib/environment-variab
 // Named rather than "the last two": they are second and fifth in the list above, and a reader
 // counting from the wrong end sets a variable the deploy then refuses.
 const PORT_VALUE_NAMES = EXTRA_PUBLIC_PORT_VALUES.map((value) =>
-  writtenRuntimeValue(value.name),
+  interpolableRuntimeValue(value.name),
 ).join(' and ');
 
 function separatorBefore(index: number): string {
@@ -87,7 +91,7 @@ export function EnvironmentTable({
         {[...RUNTIME_VALUE_NAMES.entries()].map(([index, name]) => (
           <Fragment key={name}>
             {index > 0 && separatorBefore(index)}
-            <code className="font-mono">{writtenRuntimeValue(name)}</code>
+            <code className="font-mono">{interpolableRuntimeValue(name)}</code>
           </Fragment>
         ))}
         . {PORT_VALUE_NAMES} only on an app with an additional port.

--- a/apps/dashboard/src/components/deploy/deploy-configuration.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-configuration.tsx
@@ -1,5 +1,5 @@
 import type { DeploySuggestion } from '@repo/deploy-link';
-import { EXTRA_PUBLIC_PORT_VALUES, RUNTIME_VALUES, writtenRuntimeValue } from '@repo/protocol';
+import { EXTRA_PUBLIC_PORT_VALUES, interpolableRuntimeValue, RUNTIME_VALUES } from '@repo/protocol';
 import {
   Accordion,
   AccordionContent,
@@ -107,7 +107,7 @@ export function DeployConfiguration({
                     <FieldDescription>
                       Your own variables may name them — set{' '}
                       <code className="font-mono">
-                        ANNOUNCED_IP={writtenRuntimeValue(RUNTIME_VALUES.PUBLIC_IPV4.name)}
+                        ANNOUNCED_IP={interpolableRuntimeValue(RUNTIME_VALUES.PUBLIC_IPV4.name)}
                       </code>{' '}
                       and the app reads it under the name it already expects.
                     </FieldDescription>

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -1,4 +1,5 @@
 import type { DeployLink } from '@repo/deploy-link';
+import { RUNTIME_VALUES, writtenRuntimeValue } from '@repo/protocol';
 
 export const DEPLOY_PRESETS = {
   pocketbase: {
@@ -8,6 +9,19 @@ export const DEPLOY_PRESETS = {
     sha256: '0f3442d2e57b03b56fbff0d09289e4a30b4f561a44338c38d2dcd4a1a0cfa91e',
     port: 8090,
     arg: ['serve', '--http=0.0.0.0:8090', '--dir=./data/pb_data'],
+    minimal: true,
+  },
+  sharkord: {
+    name: 'sharkord',
+    binary: 'https://github.com/sharkord/sharkord/releases/latest/download/sharkord-linux-x64',
+    port: 4991,
+    'extra-public-port': true,
+    env: [
+      'SHARKORD_DATA_PATH=data',
+      'SHARKORD_AUTOUPDATE=false',
+      `SHARKORD_WEBRTC_PORT=${writtenRuntimeValue(RUNTIME_VALUES.EXTRA_PUBLIC_PORT.name)}`,
+      `SHARKORD_WEBRTC_ANNOUNCED_ADDRESS=${writtenRuntimeValue(RUNTIME_VALUES.PUBLIC_IPV4.name)}`,
+    ],
     minimal: true,
   },
 } satisfies Record<string, DeployLink>;

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -13,7 +13,7 @@ export const DEPLOY_PRESETS = {
   },
   sharkord: {
     name: 'sharkord',
-    binary: 'https://github.com/sharkord/sharkord/releases/latest/download/sharkord-linux-x64',
+    binary: 'https://github.com/sharkord/sharkord/releases/download/v0.0.24/sharkord-linux-x64',
     sha256: '92c5036ddf1951e14fe8359e03a3a66df9e20cee543837621ad47eccb3090d47',
     port: 4991,
     'extra-public-port': true,

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -14,6 +14,7 @@ export const DEPLOY_PRESETS = {
   sharkord: {
     name: 'sharkord',
     binary: 'https://github.com/sharkord/sharkord/releases/latest/download/sharkord-linux-x64',
+    sha256: '92c5036ddf1951e14fe8359e03a3a66df9e20cee543837621ad47eccb3090d47',
     port: 4991,
     'extra-public-port': true,
     env: [

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -1,5 +1,5 @@
 import type { DeployLink } from '@repo/deploy-link';
-import { RUNTIME_VALUES, writtenRuntimeValue } from '@repo/protocol';
+import { interpolableRuntimeValue, RUNTIME_VALUES } from '@repo/protocol';
 
 export const DEPLOY_PRESETS = {
   pocketbase: {
@@ -19,8 +19,8 @@ export const DEPLOY_PRESETS = {
     env: [
       'SHARKORD_DATA_PATH=data',
       'SHARKORD_AUTOUPDATE=false',
-      `SHARKORD_WEBRTC_PORT=${writtenRuntimeValue(RUNTIME_VALUES.EXTRA_PUBLIC_PORT.name)}`,
-      `SHARKORD_WEBRTC_ANNOUNCED_ADDRESS=${writtenRuntimeValue(RUNTIME_VALUES.PUBLIC_IPV4.name)}`,
+      `SHARKORD_WEBRTC_PORT=${interpolableRuntimeValue(RUNTIME_VALUES.EXTRA_PUBLIC_PORT.name)}`,
+      `SHARKORD_WEBRTC_ANNOUNCED_ADDRESS=${interpolableRuntimeValue(RUNTIME_VALUES.PUBLIC_IPV4.name)}`,
     ],
     minimal: true,
   },

--- a/packages/app-operations/src/environment.ts
+++ b/packages/app-operations/src/environment.ts
@@ -1,10 +1,10 @@
 import {
+  interpolableRuntimeValue,
   namesOfferedRuntimeValues,
   RUNTIME_VALUE_NAMES,
   type TenantEnvironmentPatch,
   TenantEnvironmentPatchSchema,
   Value,
-  writtenRuntimeValue,
 } from '@repo/protocol';
 import { InvalidEnvironmentError } from '#errors.ts';
 
@@ -59,7 +59,7 @@ export function parseEnvironmentPatch(edits: readonly EnvironmentEdit[]): Tenant
     .map(({ name }) => name);
   if (naming.length > 0) {
     throw new InvalidEnvironmentError(
-      `A value may name a runtime value the guest sets — ${RUNTIME_VALUE_NAMES.map(writtenRuntimeValue).join(', ')} — and nothing else: ${naming.join(', ')}`,
+      `A value may name a runtime value the guest sets — ${RUNTIME_VALUE_NAMES.map(interpolableRuntimeValue).join(', ')} — and nothing else: ${naming.join(', ')}`,
     );
   }
 

--- a/packages/deploy-link/src/link.test.ts
+++ b/packages/deploy-link/src/link.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from 'bun:test';
-import { RUNTIME_VALUES, writtenRuntimeValue } from '@repo/protocol';
+import { interpolableRuntimeValue, RUNTIME_VALUES } from '@repo/protocol';
 import { defaultParseSearch, defaultStringifySearch } from '@tanstack/react-router';
 import { type DeployLink, type DeploySuggestion, deployLink, deploySuggestion } from '#link.ts';
 
-const HOSTNAME = writtenRuntimeValue(RUNTIME_VALUES.HOSTNAME.name);
+const HOSTNAME = interpolableRuntimeValue(RUNTIME_VALUES.HOSTNAME.name);
 const CHECKSUM = 'd9403d88cdf0684fbb9d8e97cf3508e9fb4506cf309a34e42653a1c2bc04a298';
 
 const EVERYTHING = `?name=my-app&port=9000&extra-public-port=true&arg=serve&arg=--verbose&env=API_KEY&env=GREETING=hello&env=URL=https://${HOSTNAME}`;

--- a/packages/protocol/src/domain/app.ts
+++ b/packages/protocol/src/domain/app.ts
@@ -110,7 +110,7 @@ export function namesOfferedRuntimeValues(value: string): boolean {
 }
 
 /** A runtime value as it is named in a tenant value, which is the form worth showing back. */
-export function writtenRuntimeValue(name: string): string {
+export function interpolableRuntimeValue(name: string): string {
   return `\${${name}}`;
 }
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -81,6 +81,7 @@ export {
   type AppState,
   AppStateSchema,
   EXTRA_PUBLIC_PORT_VALUES,
+  interpolableRuntimeValue,
   MIN_HOSTNAMES,
   namesExtraPublicPortValues,
   namesOfferedRuntimeValues,
@@ -97,7 +98,6 @@ export {
   type TenantEnvironmentPatch,
   TenantEnvironmentPatchSchema,
   TenantEnvironmentSchema,
-  writtenRuntimeValue,
 } from '#domain/app.ts';
 export {
   type Artifact,


### PR DESCRIPTION
`nibrun.com/deploy/sharkord` forwards to the deploy screen with the port, the extra public port, the four variables and the binary already filled in.

The two `SHARKORD_WEBRTC_*` values are written from `RUNTIME_VALUES` rather than spelled out, so a renamed one stops compiling instead of reaching the guest as a reference it refuses.