### PR TITLE
fix(api): an archive is held to what it expands to, as it expands

### DIFF
--- a/apps/api/src/lib/archive/bytes.ts
+++ b/apps/api/src/lib/archive/bytes.ts
@@ -7,7 +7,13 @@
 import { Buffer } from 'node:buffer';
 import type { Duplex } from 'node:stream';
 import { Readable } from 'node:stream';
-import { EntryTooLargeError, UnreadableArchiveError } from '#lib/archive/walk.ts';
+import {
+  EntryTooLargeError,
+  EXPANSION_FLOOR_BYTES,
+  ExpandsTooFarError,
+  MAX_EXPANSION,
+  UnreadableArchiveError,
+} from '#lib/archive/walk.ts';
 import { ArtifactTooLargeError } from '#lib/artifact-digest.ts';
 
 /** The stream's first bytes, and the stream itself with them still in front of it. */
@@ -193,6 +199,10 @@ export async function* closing({
 /**
  * A source read through a zlib engine — whatever the compressed bytes turn out to be, including
  * that they were never in that compression at all.
+ *
+ * Held to what it expands to as it expands, rather than to the length of what comes out: the size
+ * an artifact may be is checked at the far end of this, and a source that only fails there has
+ * already been paid for in full.
  */
 export async function* decompressed({
   engine,
@@ -201,19 +211,32 @@ export async function* decompressed({
   engine: Duplex;
   data: AsyncIterable<Uint8Array>;
 }): AsyncGenerator<Uint8Array> {
-  const compressed = Readable.from(data);
+  const sent = counted(data);
+  const compressed = Readable.from(sent);
   // Piping does not carry a failure the other way, and the source failing is the ordinary way
   // this ends: an archive that stopped part way has to stop the inflate reading it.
   compressed.on('error', (failure) => engine.destroy(failure));
   compressed.pipe(engine);
 
+  let produced = 0;
   try {
-    yield* engine;
+    for await (const chunk of engine) {
+      produced += chunk.byteLength;
+      // What has been pulled from the source rather than what the engine has consumed of it,
+      // which is the same number or a larger one — so the expansion this reads is never more than
+      // the expansion there is.
+      if (expandsTooFar({ produced, sent: sent.read() })) {
+        throw new ExpandsTooFarError();
+      }
+      yield chunk;
+    }
   } catch (failure) {
-    // The source running out of what it was allowed to send, and an entry whose length nothing
-    // could read: those are verdicts on the bytes rather than on the archive, and the two this is
-    // not entitled to restate as an archive that ended early.
-    throw failure instanceof ArtifactTooLargeError || failure instanceof EntryTooLargeError
+    // The source running out of what it was allowed to send, an entry whose length nothing could
+    // read, and a source holding more than it sent: those are verdicts on the bytes rather than on
+    // the archive, and the three this is not entitled to restate as an archive that ended early.
+    throw failure instanceof ArtifactTooLargeError ||
+      failure instanceof EntryTooLargeError ||
+      failure instanceof ExpandsTooFarError
       ? failure
       : new UnreadableArchiveError();
   } finally {
@@ -222,6 +245,26 @@ export async function* decompressed({
     // source sitting on a connection nobody is ever going to read again.
     compressed.destroy();
   }
+}
+
+function expandsTooFar({ produced, sent }: { produced: number; sent: number }): boolean {
+  return produced > EXPANSION_FLOOR_BYTES && produced > sent * MAX_EXPANSION;
+}
+
+/** The same bytes, and how many of them have been taken so far. */
+type Counted = AsyncIterable<Uint8Array> & { read(): number };
+
+function counted(data: AsyncIterable<Uint8Array>): Counted {
+  let read = 0;
+
+  async function* passing(): AsyncGenerator<Uint8Array> {
+    for await (const chunk of data) {
+      read += chunk.byteLength;
+      yield chunk;
+    }
+  }
+
+  return { [Symbol.asyncIterator]: passing, read: () => read };
 }
 
 /** Exactly the length the entry said, and an archive that ended early where it is not there. */

--- a/apps/api/src/lib/archive/unwrap.ts
+++ b/apps/api/src/lib/archive/unwrap.ts
@@ -6,7 +6,12 @@ import { Buffer } from 'node:buffer';
 import { createGunzip } from 'node:zlib';
 import { decompressed, type Queued, queued, streamed } from '#lib/archive/bytes.ts';
 import { executableInTarball, isTarball, TAR_IDENTITY_BYTES } from '#lib/archive/tar.ts';
-import { EntryTooLargeError, UnreadableArchiveError, type Unwrapping } from '#lib/archive/walk.ts';
+import {
+  EntryTooLargeError,
+  ExpandsTooFarError,
+  UnreadableArchiveError,
+  type Unwrapping,
+} from '#lib/archive/walk.ts';
 import { executableInZip, ZIP_MAGIC } from '#lib/archive/zip.ts';
 
 /** What a gzip opens with, whatever it turns out to be wrapped around. */
@@ -91,6 +96,9 @@ async function walked({
     }
     if (failure instanceof EntryTooLargeError) {
       return { outcome: 'entry-too-large' };
+    }
+    if (failure instanceof ExpandsTooFarError) {
+      return { outcome: 'expands-too-far' };
     }
     throw failure;
   }

--- a/apps/api/src/lib/archive/walk.ts
+++ b/apps/api/src/lib/archive/walk.ts
@@ -9,6 +9,7 @@ export type Unwrapping =
   | { outcome: 'no-executable' }
   | { outcome: 'walked-too-far' }
   | { outcome: 'entry-too-large' }
+  | { outcome: 'expands-too-far' }
   | { outcome: 'unreadable' };
 
 /**
@@ -23,6 +24,30 @@ export type Unwrapping =
  * the binary is shipping what a deploy does nothing with, and is answered rather than walked.
  */
 export const MAX_ENTRIES = 512;
+
+/**
+ * How much more a compressed source may turn out to hold than it took to send.
+ *
+ * The cap on a fetch is on what the url sent, and what an archive expands to is decided after it.
+ * So the two are not the same bound at all: a quarter of a gibibyte of zeros is a 255 KB download,
+ * and reading it costs this end the whole of that quarter to decompress, hash and write to the
+ * store before the size it came to refuses it.
+ *
+ * A hundred is far above anything published: measured over real binaries and the archives they
+ * ship in, a release expands by two or three — `bun` by 2.5, a kernel by 2.7 — and the most
+ * compressible thing anyone actually ships, a binary carrying embedded text, reaches fifteen.
+ * A file of zeros reaches a thousand.
+ */
+export const MAX_EXPANSION = 100;
+
+/**
+ * How far a source is read before that ratio is asked about at all.
+ *
+ * Below this the ratio says nothing: a tarball of one small file is mostly the padding tar rounds
+ * every entry up to, and expands by twenty. It is also not worth asking — what an archive this
+ * side of the floor can cost is the floor.
+ */
+export const EXPANSION_FLOOR_BYTES = 8_388_608;
 
 /**
  * What an archive this cannot follow is raised as, wherever it stops being followable — a walk is
@@ -51,5 +76,19 @@ export class EntryTooLargeError extends Error {
   constructor() {
     super('An entry declares a length its own header could not hold.');
     this.name = 'EntryTooLargeError';
+  }
+}
+
+/**
+ * What a source holding far more than it took to send is raised as.
+ *
+ * Refused rather than read to the end and refused there: the length that would stop it is the one
+ * on the artifact, and reaching that means having already done the decompressing, the hashing and
+ * the writing that the bytes were sent to buy.
+ */
+export class ExpandsTooFarError extends Error {
+  constructor() {
+    super(`A compressed source holds more than ${MAX_EXPANSION} times what it took to send.`);
+    this.name = 'ExpandsTooFarError';
   }
 }

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -11,7 +11,13 @@ import {
   Value,
 } from '@repo/protocol';
 import { unwrapExecutable } from '#lib/archive/unwrap.ts';
-import { MAX_ENTRIES, UnreadableArchiveError, type Unwrapping } from '#lib/archive/walk.ts';
+import {
+  ExpandsTooFarError,
+  MAX_ENTRIES,
+  MAX_EXPANSION,
+  UnreadableArchiveError,
+  type Unwrapping,
+} from '#lib/archive/walk.ts';
 import {
   type ArtifactInspection,
   ArtifactTooLargeError,
@@ -114,6 +120,13 @@ const WALKED_TOO_FAR = `nibrun read as far into that archive as it will — ${MA
 
 const ENTRY_TOO_LARGE =
   'An entry in that archive is longer than its own header can say, which is more than nibrun will read past.';
+
+/**
+ * Said as what the url served rather than as what nibrun refused to do: whoever followed the link
+ * is being told their download is not the shape a release is, and the way past it is the upload
+ * that was always there.
+ */
+const EXPANDS_TOO_FAR = `That download holds more than ${MAX_EXPANSION} times the bytes it sent, which is past anything a release is published as. Upload the binary instead.`;
 
 function unreadableArchive(url: string): string {
   return `The archive ended before the entry it was describing: ${url}`;
@@ -483,6 +496,11 @@ export class ArtifactsService extends Service {
       if (failure instanceof UnreadableArchiveError) {
         throw new BadRequestError(unreadableArchive(url));
       }
+      // A gzip handed on rather than walked is decompressed as it is written, so one holding far
+      // more than it sent is found here rather than by the walk that never looked inside it.
+      if (failure instanceof ExpandsTooFarError) {
+        throw new BadRequestError(EXPANDS_TOO_FAR);
+      }
       throw failure;
     }
   }
@@ -704,6 +722,8 @@ async function unwrapped({
       throw new BadRequestError(WALKED_TOO_FAR);
     case 'entry-too-large':
       throw new BadRequestError(ENTRY_TOO_LARGE);
+    case 'expands-too-far':
+      throw new BadRequestError(EXPANDS_TOO_FAR);
     case 'unreadable':
       throw new BadRequestError(unreadableArchive(url));
   }

--- a/apps/api/tests/lib/archive/support/fixtures.ts
+++ b/apps/api/tests/lib/archive/support/fixtures.ts
@@ -3,7 +3,7 @@
 // fixtures that stand for a release download belong to neither of them.
 
 import { Buffer } from 'node:buffer';
-import { MAX_ENTRIES } from '#lib/archive/walk.ts';
+import { EXPANSION_FLOOR_BYTES, MAX_ENTRIES } from '#lib/archive/walk.ts';
 
 const NOTE_LINES = 8;
 
@@ -15,6 +15,13 @@ export const NOTHING = new Uint8Array(0);
 
 /** Larger than any fixture here, so a walk only stops early when stopping early is the test. */
 export const NO_LIMIT = 1_048_576;
+
+/**
+ * A budget past the point an expansion is asked about, which the api's own is and `NO_LIMIT` is
+ * not. Without it a walk reaches its own bound first and the ratio never comes up.
+ */
+const FLOORS_OF_HEADROOM = 4;
+export const PAST_THE_EXPANSION_FLOOR = EXPANSION_FLOOR_BYTES * FLOORS_OF_HEADROOM;
 
 /**
  * Small enough to fall inside a header, a name and the window a descriptor is looked for in, so

--- a/apps/api/tests/lib/archive/tar.test.ts
+++ b/apps/api/tests/lib/archive/tar.test.ts
@@ -12,10 +12,11 @@ import {
   NOTES,
   NOTHING,
   PAST_THE_ENTRY_LIMIT,
+  PAST_THE_EXPANSION_FLOOR,
   sourceOf,
   streamOf,
 } from '#tests/lib/archive/support/fixtures.ts';
-import { incompressible } from '#tests/support/downloads.ts';
+import { expandsTooFar, incompressible } from '#tests/support/downloads.ts';
 import {
   BLOCK_BYTES,
   gzippedTarballOf,
@@ -237,6 +238,33 @@ describe('a tarball that holds no executable is not one to fetch from', () => {
     });
 
     expect(unwrapped.outcome).toBe('unreadable');
+  });
+
+  /**
+   * The bound on a fetch is on what the url sent, and what a gzip holds is decided after it — so
+   * a download of a few kilobytes otherwise buys a quarter of a gibibyte of decompressing at this
+   * end. Refused where the expansion shows rather than where the size finally does, which is past
+   * everything the bytes were sent to buy.
+   */
+  test('an archive holding far more than the download it arrived as', async () => {
+    const unwrapped = await walk({
+      entries: [
+        { name: 'pad.bin', content: expandsTooFar() },
+        { name: 'my-server', content: BINARY },
+      ],
+      maxSkippedBytes: PAST_THE_EXPANSION_FLOOR,
+    });
+
+    expect(unwrapped.outcome).toBe('expands-too-far');
+  });
+
+  // The ratio says nothing about a small archive: a tarball of one short file is mostly the
+  // padding tar rounds every entry up to, and expands by twenty without holding anything.
+  test('and a tarball too small for that ratio to mean anything is not one of them', async () => {
+    const unwrapped = await walk({ entries: [{ name: 'my-server', content: BINARY }] });
+
+    expect(unwrapped.outcome).toBe('unwrapped');
+    expect(unwrapped.outcome === 'unwrapped' && (await collected(unwrapped.body))).toEqual(BINARY);
   });
 
   /**

--- a/apps/api/tests/lib/archive/zip.test.ts
+++ b/apps/api/tests/lib/archive/zip.test.ts
@@ -13,10 +13,12 @@ import {
   NOTES,
   NOTHING,
   PAST_THE_ENTRY_LIMIT,
+  PAST_THE_EXPANSION_FLOOR,
   sourceOf,
   streamOf,
 } from '#tests/lib/archive/support/fixtures.ts';
 import { type ArchiveEntry, archiveOf, LOCAL_HEADER_BYTES } from '#tests/support/archives.ts';
+import { expandsTooFar } from '#tests/support/downloads.ts';
 
 /** The crc and the two sizes a descriptor carries after its signature. */
 const DESCRIPTOR_FIELD_BYTES = 12;
@@ -279,6 +281,22 @@ describe('a zip that holds no executable is not one to fetch from', () => {
 
     expect(unwrapped.outcome).toBe('unwrapped');
     expect(unwrapped.outcome === 'unwrapped' && (await collected(unwrapped.body))).toEqual(BINARY);
+  });
+
+  // Every entry is inflated through the same engine a gzip is, so an entry that expands past what
+  // the archive around it took to send is refused on the same terms.
+  test('an entry holding far more than the archive it arrived in', async () => {
+    const archive = archiveOf([
+      { name: 'pad.bin', content: expandsTooFar() },
+      { name: 'my-server', content: BINARY },
+    ]);
+
+    const unwrapped = await unwrapExecutable({
+      archive: streamOf(archive),
+      maxSkippedBytes: PAST_THE_EXPANSION_FLOOR,
+    });
+
+    expect(unwrapped.outcome).toBe('expands-too-far');
   });
 
   // The header points at a field the archive never wrote, so the length is one nothing can know.

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -16,6 +16,7 @@ import {
   TimestampSchema,
   Value,
 } from '@repo/protocol';
+import { MAX_EXPANSION } from '#lib/archive/walk.ts';
 import { BadRequestError, NotFoundError, TooManyRequestsError } from '#lib/errors.ts';
 import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
 import type {
@@ -39,7 +40,7 @@ import {
 } from '#services/artifacts.service.ts';
 import { APP_ID, OTHER_OWNER_ID, OWNER_ID } from '#tests/services/support/fixtures.ts';
 import { archiveOf } from '#tests/support/archives.ts';
-import { incompressible } from '#tests/support/downloads.ts';
+import { expandsTooFar, incompressible } from '#tests/support/downloads.ts';
 import { gzippedTarballOf } from '#tests/support/tarballs.ts';
 
 // The api refuses anything that is not a Linux executable, so the fixture opens with the ELF
@@ -1254,6 +1255,32 @@ describe('a binary is fetched from the url it was given', () => {
     expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
     expect(artifact.originalFileName).toBe(FETCHED_NAME);
     expect(storage.objects.has(Value.Parse(ObjectKeySchema, BINARY_DIGEST))).toBe(true);
+  });
+
+  /**
+   * A bare gzip is handed on rather than walked, so nothing has looked inside it by the time it is
+   * being written — which makes this the one path where a download holding far more than it sent
+   * is found while the store is already taking it. It still has to leave nothing behind.
+   *
+   * Opening with the ELF magic is what makes it worth refusing: without that it is turned away on
+   * its first chunk for not being an executable, and never expands into anything.
+   */
+  test('a download holding far more than it sent is refused and leaves nothing behind', async () => {
+    const { service, sourceRepo, artifactsRepo, storage } = build();
+    sourceRepo.servesBytes({ bytes: gzipSync(expandsTooFar({ asExecutable: true })) });
+
+    const refusal = service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: COMPRESSED_URL,
+    });
+
+    await expect(refusal).rejects.toBeInstanceOf(BadRequestError);
+    // Said as the expansion rather than as bytes that turned out not to be an executable, which
+    // is what the same download refused at the far end would have come back as.
+    await expect(refusal).rejects.toThrow(String(MAX_EXPANSION));
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect(storage.objects.size).toBe(0);
   });
 
   test('a tarball holding nothing executable is refused and leaves nothing behind', async () => {

--- a/apps/api/tests/support/downloads.ts
+++ b/apps/api/tests/support/downloads.ts
@@ -1,4 +1,29 @@
 import { Buffer } from 'node:buffer';
+import { EXPANSION_FLOOR_BYTES } from '#lib/archive/walk.ts';
+
+/** What the inspection looks for in the first bytes of anything it is asked to store. */
+const ELF_MAGIC = Uint8Array.from('\x7fELF', (character) => character.charCodeAt(0));
+
+/**
+ * A payload that expands about a thousandfold and is past the point that ratio is asked about, so
+ * it stands for the download a compression bomb is: kilobytes on the wire against a quarter of a
+ * gibibyte of decompressing, hashing and storing at the other end.
+ *
+ * `asExecutable` opens it with the ELF magic. Bytes handed straight to the store rather than
+ * walked are refused on their first chunk for not being an executable at all, so a bomb that never
+ * claims to be one is stopped by something else entirely and says nothing about this.
+ */
+export function expandsTooFar({
+  asExecutable = false,
+}: {
+  asExecutable?: boolean;
+} = {}): Uint8Array {
+  const bytes = new Uint8Array(EXPANSION_FLOOR_BYTES * 2);
+  if (asExecutable) {
+    bytes.set(ELF_MAGIC);
+  }
+  return bytes;
+}
 
 /**
  * Bytes a compressor cannot shrink, so a fixture built around them is as long on the way in as it


### PR DESCRIPTION
The cap on a fetch is on what the url *sent*; what a compressed source turns out to *hold* is decided after it. Those are not the same bound, and the gap between them is what a caller gets to spend — 255 KB of gzipped zeros buys a quarter of a gibibyte of decompressing, hashing and writing to the store, eight of those at a time, before the size it came to is what finally refuses it.

An archive is now held to what it expands to as it expands: a hundredfold, asked about only past eight mebibytes. Both numbers are measured rather than picked.

| | expands by |
|---|---|
| `bun` (63 MB binary) | 2.5× |
| a kernel image | 2.7× |
| `ls` | 4.6× |
| prose, 23 MB | 7.2× |
| a repetitive JSON dataset, 16 MB | 15.1× |
| a tarball of one short file, mostly padding | ~19× |
| **a file of zeros** | **1029×** |

The floor is there for the last-but-one row: below it the ratio says nothing, because a small tarball is mostly the padding tar rounds every entry up to. It is also not worth asking below it — what an archive that side of the floor can cost is the floor.

Measured against the same 255 KB download, decompressing 256.0 MB before and 12.5 MB after. It applies on every path that decompresses at all: a gzip walked as a tarball, a gzip handed on as the binary it holds, and a deflated entry inside a zip.

A binary that genuinely does compress past a hundredfold is refused, and told so in those terms — the upload path is untouched and is what the message points at.
