### PR TITLE
feat(agent): an app can wait for a request instead of running

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -7,6 +7,7 @@ import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { AppActivator } from '#services/app-activator.service.ts';
+import { AppWaker } from '#services/app-waker.service.ts';
 import { ArtifactStore } from '#services/artifact-store.service.ts';
 import { CaddyProxy } from '#services/caddy-proxy.service.ts';
 import { CommandRunner } from '#services/command-runner.service.ts';
@@ -44,6 +45,7 @@ const agent = Layer.mergeAll(
   SlotAllocator.Default,
   ZerofsTopology.Default,
   HostFirewall.Default,
+  AppWaker.Default,
   AppActivator.Default,
   CaddyProxy.Default,
   TenantLogQueue.Default,

--- a/apps/agent/src/lib/agent/report.ts
+++ b/apps/agent/src/lib/agent/report.ts
@@ -6,6 +6,7 @@ import { nowTimestamp } from '#lib/clock.ts';
 import { buildReportedState } from '#lib/report/build-report.ts';
 import {
   allocatableCapacity,
+  committedResources,
   readAvailableCacheBytes,
   readHostCapacity,
 } from '#lib/report/capacity.ts';
@@ -66,9 +67,7 @@ const report = Effect.gen(function* () {
       capacity,
       allocatable: allocatableCapacity({
         capacity,
-        committed: records
-          .filter((record) => record.state !== 'stopped' && record.state !== 'failed')
-          .map((record) => record.resources),
+        committed: committedResources(records),
         availableCacheBytes: yield* readAvailableCacheBytes(config.stateDir),
       }),
       versions: sessions.versions,

--- a/apps/agent/src/lib/agent/usage.ts
+++ b/apps/agent/src/lib/agent/usage.ts
@@ -4,6 +4,7 @@ import { recordActivity } from '#lib/agent/activity.ts';
 import { supervised } from '#lib/agent/loop.ts';
 import type { MeasuredCompute } from '#lib/filesystem/protocol.ts';
 import { applySleep } from '#lib/reconcile/idle.ts';
+import { isIdle } from '#lib/report/instance-record.ts';
 import { type AgentSnapshot, AgentState } from '#services/agent-state.service.ts';
 import { FilesystemReader, type GuestReading } from '#services/filesystem-reader.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
@@ -100,6 +101,12 @@ function computeUsageAfter({
   const compute = new Map<AppId, ComputeUsage>();
   const ticks = new Map<AppId, MeasuredCompute>();
   for (const { appId, reading } of taken) {
+    // A guest that is not there is not a guest that failed to answer. The counters go with the
+    // microVM too: a wake is a cold boot, so the next reading is of a guest that started counting
+    // again and has nothing behind it to subtract.
+    if (isIdle(previous.records.get(appId))) {
+      continue;
+    }
     const before = previous.computeTicks.get(appId);
     const measured = reading?.compute;
     if (measured === undefined) {
@@ -126,6 +133,12 @@ function computeUsageAfter({
  * went with it, and the honest answer about it is what was true when it was last running rather
  * than nothing at all. Each reading carries the moment it was taken, which is what lets whoever
  * reads it tell the two apart.
+ *
+ * An app asleep between requests forgets instead. What a suspended app last spent answers a
+ * question its owner asked by taking it offline; an `on-request` app sleeps and wakes on its own
+ * all day, and a figure carried across every sleep would have an app that is holding nothing go
+ * on reporting what it held when it last ran. Not costing anything while asleep is the whole of
+ * the policy, so the reading goes with the microVM.
  */
 export const measureUsage = Effect.gen(function* () {
   const allocator = yield* SlotAllocator;

--- a/apps/agent/src/lib/agent/usage.ts
+++ b/apps/agent/src/lib/agent/usage.ts
@@ -3,6 +3,7 @@ import { type Duration, Effect, Schedule } from 'effect';
 import { recordActivity } from '#lib/agent/activity.ts';
 import { supervised } from '#lib/agent/loop.ts';
 import type { MeasuredCompute } from '#lib/filesystem/protocol.ts';
+import { applySleep } from '#lib/reconcile/idle.ts';
 import { type AgentSnapshot, AgentState } from '#services/agent-state.service.ts';
 import { FilesystemReader, type GuestReading } from '#services/filesystem-reader.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
@@ -159,8 +160,11 @@ export const measureUsage = Effect.gen(function* () {
  * carries otherwise is what the control plane converges a deploy on.
  */
 export const usageLoop = supervised({
+  // Deciding straight after measuring, because the measurement is the only thing that moves the
+  // answer: an app is let go to sleep on the reading that found it quiet rather than on a tick
+  // that happened to come later.
   once: Effect.andThen(
-    Effect.andThen(recordActivity, measureUsage),
+    Effect.andThen(recordActivity, Effect.andThen(applySleep, measureUsage)),
     Effect.sleep(MEASUREMENT_INTERVAL),
   ),
   onFailure: (cause) => Effect.logWarning('the usage loop failed', cause),

--- a/apps/agent/src/lib/health/state.ts
+++ b/apps/agent/src/lib/health/state.ts
@@ -133,10 +133,42 @@ export type LifecycleInputs = {
   tracker: HealthTracker;
   healthCheck: HealthCheck;
   desiredRunning: boolean;
+  onRequest: boolean;
   stopRequested: boolean;
   startedAtMs?: number;
   nowMs: number;
 };
+
+/**
+ * What a microVM that is not up means, which is four different things.
+ *
+ * `stopped` and `idle` are the same absence read against who is waiting: one is the end of the
+ * release, the other is the release between requests. `pending` is a start still in flight, and
+ * only a start this agent saw through records a time — systemd keeps a template instance loaded
+ * after it stops, so being loaded is not having been started.
+ *
+ * A boot that did happen rules out `idle` whatever the activation policy says: a microVM a
+ * request brought up and that then went down unasked is a crash, and calling that idle would
+ * wait for another request to find out.
+ */
+function evaluateStoppedState({
+  desiredRunning,
+  onRequest,
+  stopRequested,
+  startedAtMs,
+}: Pick<
+  LifecycleInputs,
+  'desiredRunning' | 'onRequest' | 'stopRequested' | 'startedAtMs'
+>): InstanceState {
+  const down = onRequest && desiredRunning ? 'idle' : 'stopped';
+  if (stopRequested || !desiredRunning) {
+    return down;
+  }
+  if (startedAtMs !== undefined) {
+    return 'failed';
+  }
+  return onRequest ? down : 'pending';
+}
 
 /**
  * A booted microVM is not a running app: `starting` has not accepted a connection and `running`
@@ -150,6 +182,7 @@ export function evaluateInstanceState({
   tracker,
   healthCheck,
   desiredRunning,
+  onRequest,
   stopRequested,
   startedAtMs,
   nowMs,
@@ -158,14 +191,7 @@ export function evaluateInstanceState({
     return 'failed';
   }
   if (!unit.active) {
-    if (stopRequested || !desiredRunning) {
-      return 'stopped';
-    }
-    // Being loaded is not having been started: systemd keeps a template instance loaded after
-    // it stops, so the unit a replace has just torn down is still loaded while the next one is
-    // being staged. Only a start this agent saw through records a time, which is what separates
-    // a boot still in flight from one that died.
-    return startedAtMs !== undefined ? 'failed' : 'pending';
+    return evaluateStoppedState({ desiredRunning, onRequest, stopRequested, startedAtMs });
   }
   if (stopRequested) {
     return 'stopping';

--- a/apps/agent/src/lib/proxy/forward.ts
+++ b/apps/agent/src/lib/proxy/forward.ts
@@ -1,0 +1,75 @@
+import type { HttpPort, Ipv4Address } from '@repo/protocol';
+import { Effect } from 'effect';
+
+/**
+ * Headers describing one hop of a connection rather than the message travelling on it. Copying
+ * them onto the next hop is how a proxy tells a client about a connection it does not have.
+ */
+const HOP_BY_HOP = [
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+];
+
+/**
+ * Dropped on the way out, which is what makes the way back simple: an origin asked for identity
+ * answers in it, so nothing here has to reason about a body `fetch` has already decoded while
+ * the header describing it says otherwise.
+ */
+const ENCODING_REQUEST_HEADERS = ['accept-encoding'];
+
+/** Both describe bytes this end reframes, so both are the previous hop's to state, not ours. */
+const ENCODING_RESPONSE_HEADERS = ['content-encoding', 'content-length'];
+
+function without({ headers, drop }: { headers: Headers; drop: readonly string[] }): Headers {
+  const kept = new Headers(headers);
+  for (const name of [...HOP_BY_HOP, ...drop]) {
+    kept.delete(name);
+  }
+  return kept;
+}
+
+/**
+ * Hands one request to a guest and its answer back, for the single request that had to wait for
+ * the microVM it woke. Every request after it reaches the guest through the forward rule instead
+ * — this end is not in the path once the app is up, and `connection: close` is what makes sure
+ * of that: the proxy pools its upstream connections, and one it keeps open to here would go on
+ * being answered here long after the rule that should have taken it over was in the kernel.
+ */
+export const forwardToGuest = Effect.fn('forwardToGuest')(
+  ({
+    request,
+    guestIpv4,
+    httpPort,
+  }: {
+    request: Request;
+    guestIpv4: Ipv4Address;
+    httpPort: HttpPort;
+  }) =>
+    Effect.tryPromise(async () => {
+      const target = new URL(request.url);
+      target.protocol = 'http:';
+      target.hostname = guestIpv4;
+      target.port = String(httpPort);
+
+      const upstream = await fetch(target, {
+        method: request.method,
+        headers: without({ headers: request.headers, drop: ENCODING_REQUEST_HEADERS }),
+        body: request.body,
+        redirect: 'manual',
+        duplex: 'half',
+      } as RequestInit);
+
+      const headers = without({
+        headers: upstream.headers,
+        drop: ENCODING_RESPONSE_HEADERS,
+      });
+      headers.set('connection', 'close');
+      return new Response(upstream.body, { status: upstream.status, headers });
+    }),
+);

--- a/apps/agent/src/lib/reconcile/idle.ts
+++ b/apps/agent/src/lib/reconcile/idle.ts
@@ -13,8 +13,15 @@ import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
  */
 export const DEFAULT_IDLE_TIMEOUT_MS = 900_000;
 
-/** Only a microVM that is up can be put down, and only one that is not on its way up. */
-const SLEEPABLE_STATES = new Set(['running', 'unhealthy']);
+/**
+ * Only a microVM that is up can be put down, and only one that is not on its way up.
+ *
+ * `unhealthy` is not among them, though it is up: an app failing its probes has gone quiet
+ * *because* it is broken, so the silence is a symptom of the fault rather than evidence nobody
+ * wants it. Sleeping it would turn a failure the owner can see into one they cannot, and take it
+ * out of the restart and backoff machinery that exists to answer exactly this.
+ */
+const SLEEPABLE_STATES = new Set(['running']);
 
 /**
  * An app with no activity recorded is never quiet: it is one this agent has not watched long

--- a/apps/agent/src/lib/reconcile/idle.ts
+++ b/apps/agent/src/lib/reconcile/idle.ts
@@ -1,6 +1,6 @@
 import type { AppId } from '@repo/protocol';
 import { Clock, Effect, Option } from 'effect';
-import { stopInstance } from '#lib/reconcile/instances.ts';
+import { suspendInstance } from '#lib/reconcile/instances.ts';
 import { applyNetwork } from '#lib/reconcile/network.ts';
 import type { InstanceRecord } from '#lib/report/instance-record.ts';
 import { AgentState } from '#services/agent-state.service.ts';
@@ -68,12 +68,12 @@ const idleTimeouts = Effect.gen(function* () {
 });
 
 /**
- * Stops the `on-request` apps nobody has asked for in a while.
+ * Puts the `on-request` apps nobody has asked for in a while to sleep.
  *
  * Runs on the measurement tick rather than the status one: the moment it reads is only written
- * there, so asking sixty times more often would be sixty readings of the same answer — and a stop
- * freezes a filesystem and waits on systemd, which is not work to put in front of the health
- * probes of every other app on the host.
+ * there, so asking sixty times more often would be sixty readings of the same answer — and a
+ * sleep freezes a filesystem, snapshots a microVM and waits on systemd, which is not work to put
+ * in front of the health probes of every other app on the host.
  */
 export const applySleep = Effect.gen(function* () {
   const timeouts = yield* idleTimeouts;
@@ -102,11 +102,20 @@ export const applySleep = Effect.gen(function* () {
             quietForMs: nowMs - (current.lastActiveAtMs.get(record.appId) ?? nowMs),
           }),
         )
-        .pipe(Effect.andThen(stopInstance({ appId: record.appId, reason: 'idle' }))),
+        .pipe(
+          Effect.andThen(
+            suspendInstance({
+              appId: record.appId,
+              deploymentId: record.deploymentId,
+              reason: 'idle',
+            }),
+          ),
+        ),
     { discard: true },
   );
   // Here rather than on the next status tick: the record already says the app is not running, so
   // until this runs the forward rule points at a guest that has gone, and a request arriving in
-  // that second is refused rather than answered by the activator.
+  // that second is refused rather than answered by the activator. A sleep that was refused leaves
+  // the record saying `running`, so this renders the forward it already had.
   yield* applyNetwork;
 });

--- a/apps/agent/src/lib/reconcile/idle.ts
+++ b/apps/agent/src/lib/reconcile/idle.ts
@@ -1,0 +1,105 @@
+import type { AppId } from '@repo/protocol';
+import { Clock, Effect, Option } from 'effect';
+import { stopInstance } from '#lib/reconcile/instances.ts';
+import { applyNetwork } from '#lib/reconcile/network.ts';
+import type { InstanceRecord } from '#lib/report/instance-record.ts';
+import { AgentState } from '#services/agent-state.service.ts';
+import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
+
+/**
+ * What an `on-request` app is given when the control plane names no timeout of its own — an api
+ * that predates the field, or one that could not read it. Long enough not to stop an app out
+ * from under somebody reading a page, short enough that most of a quiet day is reclaimed.
+ */
+export const DEFAULT_IDLE_TIMEOUT_MS = 900_000;
+
+/** Only a microVM that is up can be put down, and only one that is not on its way up. */
+const SLEEPABLE_STATES = new Set(['running', 'unhealthy']);
+
+/**
+ * An app with no activity recorded is never quiet: it is one this agent has not watched long
+ * enough to say anything about, and the first counter reading gives it a starting point. Erring
+ * towards awake is the only safe direction — the cost is memory, and the cost of the other
+ * mistake is somebody's request meeting a microVM being shut down underneath it.
+ */
+export function hasGoneQuiet({
+  record,
+  timeoutMs,
+  lastActiveAtMs,
+  nowMs,
+}: {
+  record: InstanceRecord;
+  timeoutMs: number | undefined;
+  lastActiveAtMs: number | undefined;
+  nowMs: number;
+}): boolean {
+  return (
+    record.onRequest &&
+    record.desiredRunning &&
+    SLEEPABLE_STATES.has(record.state) &&
+    timeoutMs !== undefined &&
+    lastActiveAtMs !== undefined &&
+    nowMs - lastActiveAtMs >= timeoutMs
+  );
+}
+
+/**
+ * The timeout is read from desired state rather than from the record, so an owner shortening it
+ * takes effect on the next poll rather than on the app's next boot. An app desired state no
+ * longer calls `on-request` has no timeout here and is left to the reconciler, which is the one
+ * that knows what should happen to it instead.
+ */
+const idleTimeouts = Effect.gen(function* () {
+  const desired = yield* (yield* DesiredStateCache).latest;
+  return new Map<AppId, number>(
+    Option.getOrUndefined(desired)?.instances.flatMap((instance) =>
+      instance.desiredState === 'on-request'
+        ? [[instance.appId, instance.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS] as const]
+        : [],
+    ) ?? [],
+  );
+});
+
+/**
+ * Stops the `on-request` apps nobody has asked for in a while.
+ *
+ * Runs on the measurement tick rather than the status one: the moment it reads is only written
+ * there, so asking sixty times more often would be sixty readings of the same answer — and a stop
+ * freezes a filesystem and waits on systemd, which is not work to put in front of the health
+ * probes of every other app on the host.
+ */
+export const applySleep = Effect.gen(function* () {
+  const timeouts = yield* idleTimeouts;
+  const current = yield* AgentState.snapshot;
+  const nowMs = yield* Clock.currentTimeMillis;
+
+  const quiet = [...current.records.values()].filter((record) =>
+    hasGoneQuiet({
+      record,
+      timeoutMs: timeouts.get(record.appId),
+      lastActiveAtMs: current.lastActiveAtMs.get(record.appId),
+      nowMs,
+    }),
+  );
+  if (quiet.length === 0) {
+    return;
+  }
+
+  yield* Effect.forEach(
+    quiet,
+    (record) =>
+      Effect.logInfo('app has gone quiet; letting it sleep')
+        .pipe(
+          Effect.annotateLogs({
+            appId: record.appId,
+            quietForMs: nowMs - (current.lastActiveAtMs.get(record.appId) ?? nowMs),
+          }),
+        )
+        .pipe(Effect.andThen(stopInstance({ appId: record.appId, reason: 'idle' }))),
+    { discard: true },
+  );
+  // Here rather than on the next status tick: the record already says the app is not running, so
+  // until this runs the forward rule points at a guest that has gone, and a request arriving in
+  // that second is refused rather than answered by the activator.
+  yield* applyNetwork;
+});

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -1,7 +1,8 @@
 import type { AppId, DesiredInstance, InstanceState } from '@repo/protocol';
-import { Clock, Effect } from 'effect';
+import { Clock, Duration, Effect } from 'effect';
 import { isReadyToRetry, nextAttemptWindow } from '#lib/backoff.ts';
 import { nowTimestamp } from '#lib/clock.ts';
+import { frozen } from '#lib/exports/freeze.ts';
 import { reportedMessage } from '#lib/failure.ts';
 import { probeInstance } from '#lib/health/probe.ts';
 import {
@@ -12,6 +13,7 @@ import {
   initialTracker,
   nextProbeDelayMs,
 } from '#lib/health/state.ts';
+import type { AppSlot } from '#lib/network/slot.ts';
 import type { ReconcilePlan } from '#lib/reconcile/plan.ts';
 import {
   graceInputs,
@@ -23,6 +25,7 @@ import { ensureArtifactImage } from '#lib/vm/artifacts.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { UNKNOWN_UNIT, type UnitStatus } from '#lib/vm/unit-status.ts';
 import { flush } from '#lib/volumes/zerofs.ts';
+import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
@@ -50,6 +53,40 @@ const flushEverything = Effect.gen(function* () {
   );
 });
 
+/**
+ * A stop pulls the plug: the unit signals the VMM, and the guest is not asked to shut down
+ * first. Freezing is what makes that survivable — the guest checkpoints its ext4 journal, so
+ * the writes it had acknowledged are on the device rather than in a page cache that is about to
+ * stop existing. The flush then carries them from ZeroFS to the bucket, and the freeze is held
+ * across both, because a guest that thawed in between could write again behind the flush.
+ *
+ * Bounded and best-effort. A guest too wedged to answer is exactly the one that has to be
+ * stopped, and it would otherwise hold up the deploy replacing it.
+ */
+const FREEZE_TIMEOUT_SECONDS = 5;
+const FREEZE_TIMEOUT = Duration.seconds(FREEZE_TIMEOUT_SECONDS);
+
+const settleAndStop = ({ appId, reason }: { appId: AppId; reason: string }) =>
+  Effect.gen(function* () {
+    const vms = yield* VmManager;
+    const config = yield* AgentConfig;
+    yield* frozen({ appId, vmDir: config.vmDir }).pipe(
+      Effect.asVoid,
+      Effect.timeout(FREEZE_TIMEOUT),
+      Effect.catchAll((error) =>
+        Effect.logWarning('stopping a guest that would not freeze', error).pipe(
+          Effect.annotateLogs({ appId, reason }),
+        ),
+      ),
+    );
+    yield* flushEverything;
+    yield* vms.stop(appId).pipe(
+      Effect.andThen(Effect.logInfo('instance stopped')),
+      Effect.catchAll((error) => Effect.logError('instance stop failed', error)),
+      Effect.annotateLogs({ appId, reason }),
+    );
+  }).pipe(Effect.scoped);
+
 export const stopInstance = Effect.fn('stopInstance')(function* ({
   appId,
   reason,
@@ -58,14 +95,8 @@ export const stopInstance = Effect.fn('stopInstance')(function* ({
   reason: string;
 }) {
   yield* Effect.annotateCurrentSpan({ appId, reason });
-  const vms = yield* VmManager;
   yield* setState({ appId, state: 'stopping', stopRequested: true });
-  yield* flushEverything;
-  yield* vms.stop(appId).pipe(
-    Effect.andThen(Effect.logInfo('instance stopped')),
-    Effect.catchAll((error) => Effect.logError('instance stop failed', error)),
-    Effect.annotateLogs({ appId, reason }),
-  );
+  yield* settleAndStop({ appId, reason });
   // The budget goes back with it: a stop that was asked for is not a failed start, and an app
   // suspended while it was struggling to boot would otherwise be one nothing could resume.
   yield* AgentState.updateRecord({
@@ -158,6 +189,57 @@ export const prefetchArtifacts = Effect.fn('prefetchArtifacts')((plan: Reconcile
   ),
 );
 
+/**
+ * What desired state says about an app, as the record's own fields. Named once because a start
+ * and a sleep write the same ones, and a field only one of them carried would be a record whose
+ * contents depended on how the app happened to come to be here.
+ */
+function recordFields({ desired, slot }: { desired: DesiredInstance; slot: AppSlot }) {
+  return {
+    appId: desired.appId,
+    deploymentId: desired.deploymentId,
+    volumeId: desired.volumeId,
+    hostnames: desired.hostnames,
+    hostPort: slot.hostPort,
+    httpPort: desired.config.httpPort,
+    hasExtraPublicPort: desired.config.hasExtraPublicPort,
+    guestIpv4: slot.guestIpv4,
+    artifactDigest: desired.artifact.digest,
+    healthCheck: desired.config.healthCheck,
+    resources: desired.config.resources,
+    desiredRunning: true,
+    onRequest: desired.desiredState === 'on-request',
+  };
+}
+
+/**
+ * An app that should be reachable with no microVM behind it yet. It takes a slot and a record
+ * like any other instance, because those are what a request has to find: the slot is the port
+ * the proxy is sent to and the activator listens on, and the record is what the routing config
+ * is rendered from. An app nobody has visited is still an app this host answers for.
+ *
+ * The state is left to the health loop, which reads `idle` off the same record. Writing it here
+ * would let a reconcile landing mid-boot overwrite a microVM that is on its way up.
+ */
+export const sleepInstance = Effect.fn('sleepInstance')(function* (desired: DesiredInstance) {
+  yield* Effect.annotateCurrentSpan({ appId: desired.appId });
+  const allocator = yield* SlotAllocator;
+  const slot = yield* allocator.allocate(desired.appId);
+  const existing = (yield* AgentState.snapshot).records.get(desired.appId);
+  const fields = recordFields({ desired, slot });
+
+  yield* AgentState.putRecord(
+    existing
+      ? { ...existing, ...fields }
+      : newInstanceRecord({ ...fields, state: 'idle', health: initialTracker() }),
+  );
+  if (!existing) {
+    yield* Effect.logInfo('app is waiting to be asked for').pipe(
+      Effect.annotateLogs({ appId: desired.appId, hostPort: slot.hostPort }),
+    );
+  }
+});
+
 export const startInstance = Effect.fn('startInstance')(function* (desired: DesiredInstance) {
   yield* Effect.annotateCurrentSpan({ appId: desired.appId });
   const allocator = yield* SlotAllocator;
@@ -172,28 +254,24 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
   const attempted: InstanceRecord = {
     ...(existing ??
       newInstanceRecord({
-        appId: desired.appId,
-        deploymentId: desired.deploymentId,
-        volumeId: desired.volumeId,
-        hostnames: desired.hostnames,
-        hostPort: slot.hostPort,
-        httpPort: desired.config.httpPort,
-        hasExtraPublicPort: desired.config.hasExtraPublicPort,
-        guestIpv4: slot.guestIpv4,
-        artifactDigest: desired.artifact.digest,
+        ...recordFields({ desired, slot }),
         state: 'pending',
         health: initialTracker(),
-        healthCheck: desired.config.healthCheck,
-        resources: desired.config.resources,
-        desiredRunning: true,
       })),
     startAttempts: nextAttemptWindow({
       window: existing?.startAttempts ?? NO_START_ATTEMPTS,
       nowMs,
       resetAfterMs: desired.config.restartPolicy.resetAfterMs,
     }),
+    // Whatever asked for the stop has been overtaken by whatever asked for this: an instance
+    // being started is one nobody is waiting to see go down, and leaving the flag set would have
+    // a wake that failed read as a sleeping app rather than a broken one.
+    stopRequested: false,
   };
   yield* AgentState.putRecord(attempted);
+  // Before the boot rather than after: the clock this starts is the one that decides when the
+  // app may sleep again, and a boot that takes seconds must not spend them.
+  yield* AgentState.markActive({ appId: desired.appId, nowMs });
 
   yield* Effect.matchEffect(vms.boot({ desired, slot, dataDevicePath: slot.nbdDevicePath }), {
     onSuccess: () =>
@@ -202,7 +280,6 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
           ...attempted,
           startedAt: yield* nowTimestamp,
           state: 'starting',
-          stopRequested: false,
           health: initialTracker(),
           restartCount: attempted.restartCount + (restarted(existing) ? ONE_RESTART : NO_RESTART),
           message: undefined,
@@ -316,6 +393,7 @@ function settle({
       unit: status,
       tracker: health,
       desiredRunning: record.desiredRunning,
+      onRequest: record.onRequest,
       stopRequested: record.stopRequested,
       ...graceInputs({ record, nowMs }),
     });

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -1,5 +1,11 @@
-import type { AppId, DesiredInstance, InstanceState } from '@repo/protocol';
-import { Clock, Duration, Effect } from 'effect';
+import type {
+  AppId,
+  DeploymentId,
+  DesiredInstance,
+  InstanceState,
+  Timestamp,
+} from '@repo/protocol';
+import { Clock, Duration, Effect, Option } from 'effect';
 import { isReadyToRetry, nextAttemptWindow } from '#lib/backoff.ts';
 import { nowTimestamp } from '#lib/clock.ts';
 import { frozen } from '#lib/exports/freeze.ts';
@@ -35,21 +41,22 @@ const ONE_RESTART = 1;
 const NO_RESTART = 0;
 
 /**
- * A stop pulls the plug: the unit signals the VMM, and the guest is not asked to shut down
- * first. Freezing is what makes that survivable — the guest checkpoints its ext4 journal, so
- * the writes it had acknowledged are on the device rather than in a page cache that is about to
- * stop existing. The flush then carries them from ZeroFS to the bucket, and the freeze is held
- * across both, because a guest that thawed in between could write again behind the flush.
- *
- * Bounded and best-effort. A guest too wedged to answer is exactly the one that has to be
- * stopped, and it would otherwise hold up the deploy replacing it.
+ * Bounded and best-effort. A guest too wedged to answer is exactly the one that has to be taken
+ * down, and it would otherwise hold up the deploy replacing it.
  */
 const FREEZE_TIMEOUT_SECONDS = 5;
 const FREEZE_TIMEOUT = Duration.seconds(FREEZE_TIMEOUT_SECONDS);
 
-const settleAndStop = ({ appId, reason }: { appId: AppId; reason: string }) =>
+/**
+ * The disk brought to a point a cold boot can start from, which is what both ways down need first.
+ *
+ * A microVM is not asked to shut down: the unit signals the VMM, or the VMM is paused where it
+ * stands. Freezing is what makes either survivable — the guest checkpoints its ext4 journal, so
+ * the writes it had acknowledged are on the device rather than in a page cache that is about to
+ * stop existing — and the flush then carries them from ZeroFS to the bucket.
+ */
+const settled = ({ appId, reason }: { appId: AppId; reason: string }) =>
   Effect.gen(function* () {
-    const vms = yield* VmManager;
     const config = yield* AgentConfig;
     yield* frozen({ appId, vmDir: config.vmDir }).pipe(
       Effect.asVoid,
@@ -61,12 +68,45 @@ const settleAndStop = ({ appId, reason }: { appId: AppId; reason: string }) =>
       ),
     );
     yield* (yield* ZerofsTopology).flushAll;
+  });
+
+/** The freeze is held across the stop: a guest that thawed in between could write behind the flush. */
+const settleAndStop = ({ appId, reason }: { appId: AppId; reason: string }) =>
+  Effect.gen(function* () {
+    const vms = yield* VmManager;
+    yield* settled({ appId, reason });
     yield* vms.stop(appId).pipe(
       Effect.andThen(Effect.logInfo('instance stopped')),
       Effect.catchAll((error) => Effect.logError('instance stop failed', error)),
       Effect.annotateLogs({ appId, reason }),
     );
   }).pipe(Effect.scoped);
+
+/**
+ * The same settling, with the freeze handed back before the microVM is captured rather than after
+ * it is killed.
+ *
+ * The lease is the vsock connection, and a snapshot is the one way down that outlives the
+ * connection it was taken over: a guest captured mid-freeze comes back still holding it, with its
+ * tenant blocked on the first write and nothing left on the far side to release it. What the
+ * freeze bought is already bought — the journal is checkpointed and the bytes are in the bucket —
+ * and `VmManager.sleep` flushes again on its way past, so the writes made in the moment between
+ * the thaw and the pause are carried too.
+ */
+const settleAndSleep = ({
+  appId,
+  deploymentId,
+  slot,
+  reason,
+}: {
+  appId: AppId;
+  deploymentId: DeploymentId;
+  slot: AppSlot;
+  reason: string;
+}) =>
+  Effect.scoped(settled({ appId, reason })).pipe(
+    Effect.andThen(Effect.flatMap(VmManager, (vms) => vms.sleep({ appId, deploymentId, slot }))),
+  );
 
 export const stopInstance = Effect.fn('stopInstance')(function* ({
   appId,
@@ -84,6 +124,74 @@ export const stopInstance = Effect.fn('stopInstance')(function* ({
     appId,
     change: (record) => ({ ...record, state: 'stopped', startAttempts: NO_START_ATTEMPTS }),
   });
+});
+
+/**
+ * A microVM taken down at a point it can be put back on, so the next request restores the guest
+ * that was serving rather than booting a new one.
+ *
+ * `stopRequested` is written after the snapshot and never before it. `VmManager.sleep` refuses a
+ * microVM with a stop in flight — waking one lands the guest supervisor's SIGTERM deadline in the
+ * past — so setting the flag first, the way `stopInstance` does, would refuse every sleep this
+ * asked for. It still has to be written afterwards: it is what tells the health loop that a
+ * microVM that is gone is asleep rather than crashed, and what keeps the boot that follows a
+ * discarded snapshot from being counted as a restart.
+ *
+ * The state stays `running` for the whole of it rather than going to `stopping` the way a stop
+ * does. That keeps the forward rule pointing at the guest while it is being captured, which is
+ * what the requests still arriving want: withdrawing it would hand them to the activator, which
+ * would find the unit still up, take that as nothing to wake, and probe a paused guest until the
+ * grace period ran out.
+ *
+ * Neither a refusal nor a VMM that would not take the snapshot is a failure here. `sleep` leaves
+ * the microVM running either way and the record untouched, so the app goes on serving and the
+ * next measurement tick asks again — which is the safe end of this to be wrong at.
+ */
+export const suspendInstance = Effect.fn('suspendInstance')(function* ({
+  appId,
+  deploymentId,
+  reason,
+}: {
+  appId: AppId;
+  deploymentId: DeploymentId;
+  reason: string;
+}) {
+  yield* Effect.annotateCurrentSpan({ appId, reason });
+  const slot = yield* (yield* SlotAllocator).lookup(appId);
+  if (Option.isNone(slot)) {
+    // No slot is no tap, no address and no NBD minor for a restore to land on, so there is
+    // nothing a snapshot could be loaded against. Stopping still reclaims the memory.
+    return yield* stopInstance({ appId, reason });
+  }
+
+  yield* settleAndSleep({ appId, deploymentId, slot: slot.value, reason }).pipe(
+    Effect.andThen(
+      AgentState.updateRecord({
+        appId,
+        change: (record) => ({
+          ...record,
+          state: 'idle',
+          stopRequested: true,
+          startAttempts: NO_START_ATTEMPTS,
+          message: undefined,
+        }),
+      }),
+    ),
+    // Loud, and carrying which refusal it was. `hasGoneQuiet` has already excluded every reason
+    // `VmManager.sleep` can refuse for something about this app, so one that reaches here is
+    // either a stop that landed in the moment since the records were read or a refusal about the
+    // host itself — and the second is an operator's to go and look at rather than a tenant's.
+    Effect.catchTag('SleepRefused', (refusal) =>
+      Effect.logWarning(
+        `this microVM may not be snapshotted, so it stays up: ${refusal.reason}`,
+      ).pipe(Effect.annotateLogs({ appId, reason })),
+    ),
+    Effect.catchAll((error) =>
+      Effect.logWarning('this microVM would not sleep; leaving it up', error).pipe(
+        Effect.annotateLogs({ appId, reason }),
+      ),
+    ),
+  );
 });
 
 function setState({
@@ -221,6 +329,15 @@ export const sleepInstance = Effect.fn('sleepInstance')(function* (desired: Desi
   }
 });
 
+/** A microVM that has just come up is not left waiting on a delay measured for the one before it. */
+function probeAtOnce(appId: AppId) {
+  return AgentState.modify((current) => {
+    const nextProbeAtMs = new Map(current.nextProbeAtMs);
+    nextProbeAtMs.delete(appId);
+    return { ...current, nextProbeAtMs };
+  });
+}
+
 export const startInstance = Effect.fn('startInstance')(function* (desired: DesiredInstance) {
   yield* Effect.annotateCurrentSpan({ appId: desired.appId });
   const allocator = yield* SlotAllocator;
@@ -265,11 +382,7 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
           restartCount: attempted.restartCount + (restarted(existing) ? ONE_RESTART : NO_RESTART),
           message: undefined,
         });
-        yield* AgentState.modify((current) => {
-          const nextProbeAtMs = new Map(current.nextProbeAtMs);
-          nextProbeAtMs.delete(desired.appId);
-          return { ...current, nextProbeAtMs };
-        });
+        yield* probeAtOnce(desired.appId);
         yield* Effect.logInfo('instance started').pipe(
           Effect.annotateLogs({
             appId: desired.appId,
@@ -293,6 +406,82 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
         );
       }),
   });
+});
+
+/**
+ * What a restore writes back, which is a great deal less than a start does.
+ *
+ * The health tracker is carried across rather than reset: it describes the guest being restored
+ * and is still true of it, where clearing it would say this app had never answered — the one
+ * thing that stops it being allowed to sleep again. `startedAt` is not carried across, because
+ * every health decision is measured from it and the grace period belongs to this run.
+ */
+function restored({ appId, startedAt }: { appId: AppId; startedAt: Timestamp }) {
+  return AgentState.updateRecord({
+    appId,
+    change: (record) => ({
+      ...record,
+      state: 'starting',
+      startedAt,
+      stopRequested: false,
+      message: undefined,
+    }),
+  }).pipe(Effect.andThen(probeAtOnce(appId)));
+}
+
+/**
+ * The microVM an idle app had, back where it was — and a cold boot only where there is nothing to
+ * come back to.
+ *
+ * None of the accounting a start does. No attempt is charged to the restart budget and
+ * `restartCount` does not move, because a wake is not a restart: an app woken every morning for a
+ * year would otherwise report three hundred crashes. The budget still bounds the damage, because
+ * the fallback below is a start and a start is what spends it — so a snapshot that will never
+ * load degrades into cold boots that give up, while a restore that works costs nothing.
+ *
+ * `SnapshotUnusable` is the only failure that boots instead. Every other one leaves the app down
+ * with the reason on its record: `VmManager.wake` discards the snapshot on its way out, so the
+ * request after this one is the cold boot rather than a second attempt at the same restore.
+ */
+export const resumeInstance = Effect.fn('resumeInstance')(function* (desired: DesiredInstance) {
+  yield* Effect.annotateCurrentSpan({ appId: desired.appId });
+  const allocator = yield* SlotAllocator;
+  const vms = yield* VmManager;
+  const slot = yield* allocator.allocate(desired.appId);
+
+  // Asked of systemd rather than of the record, because the record is a cache and this is a
+  // precondition: Firecracker takes `PUT /snapshot/load` only from a process that has configured
+  // nothing, and `systemctl start` on a unit already up is the no-op that would have let the load
+  // reach a booted microVM and be refused there. Nothing to wake is not a failure — whatever is
+  // waiting on this is about to be answered by the guest that is already there.
+  const unit = (yield* Systemd.statuses([desired.appId])).get(desired.appId) ?? UNKNOWN_UNIT;
+  if (unit.active) {
+    return;
+  }
+
+  // For the reason `startInstance` marks one before its boot: the clock this starts is the one
+  // that decides when the app may sleep again.
+  yield* AgentState.markActive({
+    appId: desired.appId,
+    nowMs: yield* Clock.currentTimeMillis,
+  });
+
+  yield* vms.wake({ appId: desired.appId, deploymentId: desired.deploymentId, slot }).pipe(
+    Effect.andThen(
+      Effect.flatMap(nowTimestamp, (startedAt) => restored({ appId: desired.appId, startedAt })),
+    ),
+    Effect.catchTag('SnapshotUnusable', (unusable) =>
+      Effect.logInfo('nothing to wake this app from; booting it instead', unusable)
+        .pipe(Effect.annotateLogs({ appId: desired.appId }))
+        .pipe(Effect.andThen(startInstance(desired))),
+    ),
+    Effect.tapError((error) =>
+      AgentState.updateRecord({
+        appId: desired.appId,
+        change: (record) => ({ ...record, message: reportedMessage(error) }),
+      }),
+    ),
+  );
 });
 
 /** Only a failure has anything to say: every other state is its own account of itself. */

--- a/apps/agent/src/lib/reconcile/plan.ts
+++ b/apps/agent/src/lib/reconcile/plan.ts
@@ -53,13 +53,24 @@ export type ObservedState = {
   readonly exports: readonly ObservedExport[];
 };
 
-export const INSTANCE_STOP_REASONS = ['desired-stopped', 'not-desired', 'superseded'] as const;
+export const INSTANCE_STOP_REASONS = [
+  'desired-stopped',
+  'not-desired',
+  'superseded',
+  'idle',
+] as const;
 
 export type InstanceStopReason = (typeof INSTANCE_STOP_REASONS)[number];
 
+/**
+ * `sleep` is not `stop`: it says this app should be here, holding its port and its hostnames,
+ * with no microVM until something asks for one. What it produces is the record and the slot a
+ * request needs to find, which is why an app nobody has ever visited still has to be planned.
+ */
 export type InstancePlan =
   | { readonly action: 'start'; readonly desired: DesiredInstance }
   | { readonly action: 'replace'; readonly desired: DesiredInstance }
+  | { readonly action: 'sleep'; readonly desired: DesiredInstance }
   | {
       readonly action: 'stop';
       readonly appId: AppId;
@@ -143,6 +154,18 @@ function planInstance({
     return current?.running
       ? { action: 'stop', appId: wanted.appId, reason: 'desired-stopped' }
       : { action: 'none', appId: wanted.appId };
+  }
+  // A microVM already up is reconciled the way any other is — new bytes must not go on being
+  // served by the release they replaced, and a deploy is the one moment an owner is watching, so
+  // the replacement comes up rather than waiting to be asked for. Everything else sleeps: the
+  // boot belongs to whoever visits next.
+  if (wanted.desiredState === 'on-request') {
+    if (!current?.running) {
+      return { action: 'sleep', desired: wanted };
+    }
+    return current.deploymentId === wanted.deploymentId
+      ? { action: 'none', appId: wanted.appId }
+      : { action: 'replace', desired: wanted };
   }
   if (!current?.present) {
     return { action: 'start', desired: wanted };

--- a/apps/agent/src/lib/report/capacity.ts
+++ b/apps/agent/src/lib/report/capacity.ts
@@ -22,12 +22,17 @@ const filesystemBytes = ({
 export const readAvailableCacheBytes = (cacheDir: string) =>
   filesystemBytes({ cacheDir, of: (stats) => Number(stats.bavail) * Number(stats.bsize) });
 
+/** Read rather than remembered: a host is resized by being replaced, but the agent outlives less. */
+export function readHostMemoryMib(): number {
+  return Math.floor(totalmem() / BYTES_PER_MIB);
+}
+
 export const readHostCapacity = (cacheDir: string): Effect.Effect<HostCapacity> =>
   Effect.map(
     filesystemBytes({ cacheDir, of: (stats) => Number(stats.blocks) * Number(stats.bsize) }),
     (cacheBytes) => ({
       vcpuCount: availableParallelism(),
-      memoryMib: Math.floor(totalmem() / BYTES_PER_MIB),
+      memoryMib: readHostMemoryMib(),
       cacheBytes,
     }),
   );
@@ -38,8 +43,8 @@ export const readHostCapacity = (cacheDir: string): Effect.Effect<HostCapacity> 
  * `idle` belongs here for the reason the whole of `on-request` does: the memory a sleeping app is
  * not using is the saving, and a host that went on reserving it would pay for every sleep and
  * collect on none of them. What that costs is that the request waking an app can find the host
- * full in the meantime — a real failure mode, and one for the waker to answer rather than one to
- * hide by reserving memory nothing is using.
+ * full in the meantime — a real failure mode, and one the waker answers with `memoryShortfallMib`
+ * rather than one to hide by reserving memory nothing is using.
  */
 const HOLDS_NOTHING: readonly InstanceState[] = ['idle', 'stopped', 'failed'];
 
@@ -60,6 +65,10 @@ const sum = (values: readonly number[]) => {
   return total;
 };
 
+function committedMemoryMib(committed: readonly InstanceResources[]): number {
+  return sum(committed.map((entry) => entry.memoryMib));
+}
+
 /** Floored at zero: an oversubscribed host is a fact to report, not a number to do arithmetic with. */
 export function allocatableCapacity({
   capacity,
@@ -71,10 +80,32 @@ export function allocatableCapacity({
   availableCacheBytes: number;
 }): HostCapacity {
   const usedVcpu = sum(committed.map((entry) => entry.vcpuCount));
-  const usedMemory = sum(committed.map((entry) => entry.memoryMib));
   return {
     vcpuCount: Math.max(capacity.vcpuCount - usedVcpu, NONE),
-    memoryMib: Math.max(capacity.memoryMib - usedMemory, NONE),
+    memoryMib: Math.max(capacity.memoryMib - committedMemoryMib(committed), NONE),
     cacheBytes: Math.max(Math.min(availableCacheBytes, capacity.cacheBytes), NONE),
   };
+}
+
+/**
+ * How much more memory this host would need to carry one more microVM, and zero when it has room.
+ *
+ * Memory alone. vCPUs are time-shared, so a host that has sold more of them than it has runs
+ * everything on it more slowly; memory is the one it cannot divide, and a guest that does not fit
+ * is not refused but killed — along with whichever neighbour the kernel picks instead.
+ *
+ * The arithmetic `allocatableCapacity` reports, deliberately and not by coincidence: a host that
+ * refused wakes by one measure while telling the control plane it had room by another would go on
+ * being placed onto for exactly as long as it went on refusing.
+ */
+export function memoryShortfallMib({
+  hostMemoryMib,
+  committed,
+  wanted,
+}: {
+  hostMemoryMib: number;
+  committed: readonly InstanceResources[];
+  wanted: InstanceResources;
+}): number {
+  return Math.max(committedMemoryMib(committed) + wanted.memoryMib - hostMemoryMib, NONE);
 }

--- a/apps/agent/src/lib/report/capacity.ts
+++ b/apps/agent/src/lib/report/capacity.ts
@@ -1,7 +1,8 @@
 import { statfs } from 'node:fs/promises';
 import { availableParallelism, totalmem } from 'node:os';
-import type { HostCapacity, InstanceResources } from '@repo/protocol';
+import type { HostCapacity, InstanceResources, InstanceState } from '@repo/protocol';
 import { Effect } from 'effect';
+import type { InstanceRecord } from '#lib/report/instance-record.ts';
 
 const BYTES_PER_MIB = 1_048_576;
 const NONE = 0;
@@ -30,6 +31,26 @@ export const readHostCapacity = (cacheDir: string): Effect.Effect<HostCapacity> 
       cacheBytes,
     }),
   );
+
+/**
+ * The states in which an app has no microVM, and so is holding nothing of the host.
+ *
+ * `idle` belongs here for the reason the whole of `on-request` does: the memory a sleeping app is
+ * not using is the saving, and a host that went on reserving it would pay for every sleep and
+ * collect on none of them. What that costs is that the request waking an app can find the host
+ * full in the meantime — a real failure mode, and one for the waker to answer rather than one to
+ * hide by reserving memory nothing is using.
+ */
+const HOLDS_NOTHING: readonly InstanceState[] = ['idle', 'stopped', 'failed'];
+
+/** What the apps on this host are holding of it, which is what `allocatable` is the remainder of. */
+export function committedResources(
+  records: readonly InstanceRecord[],
+): readonly InstanceResources[] {
+  return records
+    .filter((record) => !HOLDS_NOTHING.includes(record.state))
+    .map((record) => record.resources);
+}
 
 const sum = (values: readonly number[]) => {
   let total = NONE;

--- a/apps/agent/src/lib/report/instance-record.ts
+++ b/apps/agent/src/lib/report/instance-record.ts
@@ -38,6 +38,13 @@ export type InstanceRecord = {
   readonly healthCheck: HealthCheck;
   readonly resources: InstanceResources;
   readonly desiredRunning: boolean;
+  /**
+   * Whether a request is what brings this app's microVM up. Beside `desiredRunning` rather than
+   * folded into it, because they answer different questions — should this app be reachable, and
+   * what does having it reachable cost while nobody is asking. Never true without it: a suspended
+   * app is `stopped` whatever its activation policy says, so the policy never reaches the host.
+   */
+  readonly onRequest: boolean;
   readonly startAttempts: AttemptWindow;
   readonly restartCount: number;
   readonly stopRequested: boolean;

--- a/apps/agent/src/lib/report/instance-record.ts
+++ b/apps/agent/src/lib/report/instance-record.ts
@@ -70,6 +70,15 @@ export const newInstanceRecord = (
 });
 
 /**
+ * Whether this app is asleep between requests: a record holding its slot and its hostnames with
+ * no microVM behind them. Asked wherever a loop would otherwise treat the absence as a failure or
+ * as a guest it can still reach.
+ */
+export function isIdle(record: InstanceRecord | undefined): boolean {
+  return record?.state === 'idle';
+}
+
+/**
  * What every health decision about a record needs, in the one place that knows `startedAt` is a
  * wire timestamp here and a clock reading there — and that a record this agent never started has
  * no start time at all.

--- a/apps/agent/src/services/agent-state.service.ts
+++ b/apps/agent/src/services/agent-state.service.ts
@@ -43,8 +43,8 @@ export type AgentSnapshot = {
    */
   readonly appTraffic: ReadonlyMap<AppId, AppTraffic>;
   /**
-   * When each app was last reached from outside this host. Nothing acts on it yet — it is what a
-   * suspend would decide from, recorded from the moment there is anything to record.
+   * When each app was last reached by something that was not this host, which is what decides
+   * whether an `on-request` app may sleep.
    */
   readonly lastActiveAtMs: ReadonlyMap<AppId, number>;
   readonly volumeReports: readonly ReportedVolume[];
@@ -87,6 +87,17 @@ export class AgentState extends Effect.Service<AgentState>()('AgentState', {
       snapshot,
       modify,
       records,
+
+      /**
+       * A request is evidence of use before any counter has seen it. The counters are read on
+       * their own cadence and a woken app's is new, which `activityAfter` reads as no evidence
+       * rather than as use — so without this a wake would leave the moment that had it sleeping.
+       */
+      markActive: ({ appId, nowMs }: { appId: AppId; nowMs: number }) =>
+        modify((current) => ({
+          ...current,
+          lastActiveAtMs: new Map(current.lastActiveAtMs).set(appId, nowMs),
+        })),
 
       putRecord: (record: InstanceRecord) =>
         modify((current) => ({

--- a/apps/agent/src/services/app-activator.service.ts
+++ b/apps/agent/src/services/app-activator.service.ts
@@ -1,6 +1,9 @@
 import type { AppId, HostPort } from '@repo/protocol';
-import { Effect, Ref } from 'effect';
+import { Clock, Effect, Ref, Runtime } from 'effect';
 import type { AppSlot } from '#lib/network/slot.ts';
+import { forwardToGuest } from '#lib/proxy/forward.ts';
+import { AgentState } from '#services/agent-state.service.ts';
+import { AppWaker } from '#services/app-waker.service.ts';
 
 const LOOPBACK = '127.0.0.1';
 const HTTP_UNAVAILABLE = 503;
@@ -16,8 +19,8 @@ const HTTP_UNAVAILABLE = 503;
  * that connection is answered by this until it retires it. Refusing to be reused is what bounds
  * that to the one request already in flight.
  */
-function sayAppIsDown(): Response {
-  return new Response('This app is not running.\n', {
+function say(message: string): Response {
+  return new Response(`${message}\n`, {
     status: HTTP_UNAVAILABLE,
     headers: {
       'content-type': 'text/plain; charset=utf-8',
@@ -26,6 +29,26 @@ function sayAppIsDown(): Response {
     },
   });
 }
+
+const sayAppIsDown = () => say('This app is not running.');
+const sayAppWouldNotStart = () => say('This app could not be started.');
+
+/**
+ * A connection the proxy wants to upgrade cannot be carried across: what comes back from the
+ * guest here is one HTTP message, and a websocket is the opposite of that. The wake still
+ * happens, so the client that reconnects finds the app up and reaches it through the forward
+ * rule rather than through this.
+ */
+const sayToComeBack = () =>
+  new Response('This app is starting. Please reconnect.\n', {
+    status: HTTP_UNAVAILABLE,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'no-store',
+      'retry-after': '2',
+      connection: 'close',
+    },
+  });
 
 type Listener = {
   readonly hostPort: HostPort;
@@ -40,12 +63,54 @@ type Listener = {
  * Bound for the life of the slot rather than the life of the microVM: the rule is what switches
  * between the two, so there is no bind to race the reconciler and no window the port is nobody's.
  *
- * The 503 is where a wake will go: a request for a sleeping microVM is the thing that has a
- * reason to start one.
+ * For an app that runs on request this is the front door: the request that finds no microVM is
+ * what starts one, and it is held here and answered from the guest once that guest is up. For
+ * every other app a stopped microVM is somebody's decision or somebody's bug, and a request is
+ * not the thing that resolves either — so it is told so.
  */
 export class AppActivator extends Effect.Service<AppActivator>()('AppActivator', {
   scoped: Effect.gen(function* () {
+    const waker = yield* AppWaker;
     const listeners = yield* Ref.make(new Map<AppId, Listener>());
+
+    /**
+     * A request that finds no microVM. For an app that runs on request it is the thing that
+     * starts one, and it waits here until the guest answers — which is a cold boot, seconds
+     * rather than milliseconds, and the whole reason the request is held rather than refused.
+     *
+     * The record is read again after the wake because the wake is what wrote it: the port and
+     * address to forward to are the ones the microVM that just came up is on.
+     */
+    const handle = ({ appId, request }: { appId: AppId; request: Request }) =>
+      Effect.gen(function* () {
+        const record = (yield* AgentState.snapshot).records.get(appId);
+        if (!record?.onRequest || !record.desiredRunning) {
+          return sayAppIsDown();
+        }
+        yield* AgentState.markActive({ appId, nowMs: yield* Clock.currentTimeMillis });
+        yield* waker.wake(appId);
+
+        const woken = (yield* AgentState.snapshot).records.get(appId);
+        if (!woken) {
+          return sayAppWouldNotStart();
+        }
+        if (request.headers.get('upgrade') !== null) {
+          return sayToComeBack();
+        }
+        return yield* forwardToGuest({
+          request,
+          guestIpv4: woken.guestIpv4,
+          httpPort: woken.httpPort,
+        });
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.logWarning('a request could not be given an app', error)
+            .pipe(Effect.annotateLogs({ appId }))
+            .pipe(Effect.as(sayAppWouldNotStart())),
+        ),
+      );
+
+    type Handler = (input: { appId: AppId; request: Request }) => Promise<Response>;
 
     const close = (appId: AppId) =>
       Effect.gen(function* () {
@@ -63,8 +128,25 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
         yield* Effect.asVoid(Effect.sync(() => listener.server.stop(true)));
       });
 
-    const listen = ({ appId, hostPort }: { appId: AppId; hostPort: HostPort }) =>
-      Effect.try(() => Bun.serve({ hostname: LOOPBACK, port: hostPort, fetch: sayAppIsDown })).pipe(
+    const listen = ({
+      appId,
+      hostPort,
+      answer,
+    }: {
+      appId: AppId;
+      hostPort: HostPort;
+      answer: Handler;
+    }) =>
+      Effect.try(() =>
+        Bun.serve({
+          hostname: LOOPBACK,
+          port: hostPort,
+          // A cold boot outlasts Bun's own idle ceiling, and a request abandoned while the
+          // microVM it asked for is still coming up is the one thing this must not do.
+          idleTimeout: 0,
+          fetch: (request) => answer({ appId, request }),
+        }),
+      ).pipe(
         Effect.tap((server) =>
           Ref.update(listeners, (current) => new Map(current).set(appId, { hostPort, server })),
         ),
@@ -83,6 +165,14 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
       serve: Effect.fn('AppActivator.serve')(function* (
         slots: readonly Pick<AppSlot, 'appId' | 'hostPort'>[],
       ) {
+        // Bun hands the handler a request and wants a promise, so the fiber's own runtime is
+        // what carries the agent's services across that boundary. Taken here rather than when
+        // this service is built: asking for it in the constructor would put every service a
+        // wake touches into this layer's requirements, and each would then be built again.
+        const runPromise = Runtime.runPromise(
+          yield* Effect.runtime<Effect.Effect.Context<ReturnType<typeof handle>>>(),
+        );
+        const answer: Handler = (input) => runPromise(handle(input));
         const current = yield* Ref.get(listeners);
         const wanted = new Map(slots.map((slot) => [slot.appId, slot.hostPort] as const));
         for (const [appId, listener] of current) {
@@ -92,10 +182,11 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
         }
         yield* Effect.forEach(
           slots.filter((slot) => current.get(slot.appId)?.hostPort !== slot.hostPort),
-          listen,
+          (slot) => listen({ ...slot, answer }),
           { discard: true },
         );
       }),
     };
   }),
+  dependencies: [AppWaker.Default],
 }) {}

--- a/apps/agent/src/services/app-activator.service.ts
+++ b/apps/agent/src/services/app-activator.service.ts
@@ -34,6 +34,14 @@ const sayAppIsDown = () => say('This app is not running.');
 const sayAppWouldNotStart = () => say('This app could not be started.');
 
 /**
+ * Its own sentence rather than the one above. An app that could not be woken because its host had
+ * no memory left is not a broken app, and telling its visitor otherwise would have its owner
+ * reading a binary that is fine — while the repair, moving the app, is not something either of
+ * them can bring about by asking again.
+ */
+const sayHostIsFull = () => say('This app could not be started: its machine is out of memory.');
+
+/**
  * A connection the proxy wants to upgrade cannot be carried across: what comes back from the
  * guest here is one HTTP message, and a websocket is the opposite of that. The wake still
  * happens, so the client that reconnects finds the app up and reaches it through the forward
@@ -75,8 +83,9 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
 
     /**
      * A request that finds no microVM. For an app that runs on request it is the thing that
-     * starts one, and it waits here until the guest answers — which is a cold boot, seconds
-     * rather than milliseconds, and the whole reason the request is held rather than refused.
+     * brings one back, and it waits here until the guest answers — which is a snapshot restore
+     * where there is one to restore and a cold boot where there is not, and the second is the
+     * reason the request is held rather than refused.
      *
      * The record is read again after the wake because the wake is what wrote it: the port and
      * address to forward to are the ones the microVM that just came up is on.
@@ -103,6 +112,11 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
           httpPort: woken.httpPort,
         });
       }).pipe(
+        Effect.catchTag('HostHasNoRoom', (error) =>
+          Effect.logWarning('a request could not be given an app', error)
+            .pipe(Effect.annotateLogs({ appId }))
+            .pipe(Effect.as(sayHostIsFull())),
+        ),
         Effect.catchAll((error) =>
           Effect.logWarning('a request could not be given an app', error)
             .pipe(Effect.annotateLogs({ appId }))

--- a/apps/agent/src/services/app-waker.service.ts
+++ b/apps/agent/src/services/app-waker.service.ts
@@ -1,0 +1,158 @@
+import type { HttpClient } from '@effect/platform';
+import type { AppId } from '@repo/protocol';
+import { Data, Deferred, Duration, Effect, Option, Ref, Schedule } from 'effect';
+import { reportedMessage } from '#lib/failure.ts';
+import { probeInstance } from '#lib/health/probe.ts';
+import { startInstance } from '#lib/reconcile/instances.ts';
+import type { InstanceRecord } from '#lib/report/instance-record.ts';
+import { AgentConfig } from '#services/agent-config.service.ts';
+import { AgentState } from '#services/agent-state.service.ts';
+import { ArtifactStore } from '#services/artifact-store.service.ts';
+import { CommandRunner } from '#services/command-runner.service.ts';
+import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
+import { SlotAllocator } from '#services/slot-allocator.service.ts';
+import { VmManager } from '#services/vm-manager.service.ts';
+
+/**
+ * Tighter than the startup grid the status loop probes on, because somebody is holding a browser
+ * tab open on this one. The difference between finding out at 25ms and at 250ms is a quarter of
+ * a second added to every cold start.
+ */
+const PROBE_INTERVAL_MS = 25;
+const PROBE_INTERVAL = Duration.millis(PROBE_INTERVAL_MS);
+
+/**
+ * Everything starting a microVM touches, taken from where this service is built rather than left
+ * to whoever calls `wake`. The caller is a request handler bridged onto a Bun socket: it holds a
+ * runtime, and a runtime has to name what is in it — so a requirement that escaped here would be
+ * the whole agent, named again at that boundary and built a second time behind it.
+ */
+type WakeContext = Effect.Effect.Context<ReturnType<typeof startInstance>> | HttpClient.HttpClient;
+
+export class WakeFailed extends Data.TaggedError('WakeFailed')<{
+  readonly appId: AppId;
+  readonly reason: string;
+}> {
+  override get message() {
+    return `${this.appId} could not be woken: ${this.reason}`;
+  }
+}
+
+/**
+ * Brings an `on-request` app's microVM up because something asked for it, and does not come back
+ * until the guest is answering — the request that caused this is waiting on it.
+ *
+ * One wake per app at a time. A cold page load is a burst of requests, and every one of them
+ * arrives to find no microVM: without this the first would boot it and the rest would each spend
+ * the app's restart budget racing that boot.
+ */
+export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
+  effect: Effect.gen(function* () {
+    const cache = yield* DesiredStateCache;
+    const context = yield* Effect.context<WakeContext>();
+    const inFlight = yield* Ref.make(new Map<AppId, Deferred.Deferred<void, WakeFailed>>());
+
+    /**
+     * The grace period is the deadline: past it the health loop would call the instance failed
+     * anyway, so holding the request longer only delays telling whoever sent it.
+     */
+    const untilAnswering = (record: InstanceRecord) =>
+      probeInstance({
+        guestIpv4: record.guestIpv4,
+        httpPort: record.httpPort,
+        healthCheck: record.healthCheck,
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.spaced(PROBE_INTERVAL),
+          until: (answering) => answering,
+        }),
+        Effect.timeoutFail({
+          duration: Duration.millis(record.healthCheck.gracePeriodMs),
+          onTimeout: () =>
+            new WakeFailed({
+              appId: record.appId,
+              reason: `nothing answered on port ${record.httpPort} inside the guest`,
+            }),
+        }),
+        Effect.asVoid,
+      );
+
+    const boot = Effect.fn('AppWaker.boot')(function* (appId: AppId) {
+      const desired = yield* cache.latest;
+      const wanted = Option.getOrUndefined(desired)?.instances.find(
+        (instance) => instance.appId === appId,
+      );
+      if (!wanted) {
+        return yield* new WakeFailed({ appId, reason: 'the control plane no longer names it' });
+      }
+      if (wanted.desiredState !== 'on-request') {
+        return yield* new WakeFailed({ appId, reason: `it is ${wanted.desiredState}` });
+      }
+      // The same bar a reconcile start has to clear: a tenant boots onto a host whose isolation
+      // ruleset is in the kernel, and a request is not a reason to make an exception.
+      if (!(yield* AgentState.snapshot).isolated) {
+        return yield* new WakeFailed({ appId, reason: 'the isolation ruleset is not applied' });
+      }
+
+      // A slot table with nothing free is the one start failure a request can cause, and it is
+      // this host's problem rather than this app's — so it is said in the same breath as any
+      // other reason the microVM is not there.
+      yield* startInstance(wanted).pipe(
+        Effect.catchAll((error) => new WakeFailed({ appId, reason: reportedMessage(error) })),
+      );
+
+      const record = (yield* AgentState.snapshot).records.get(appId);
+      if (!record?.startedAt) {
+        // A start that wrote no time never reached the VMM: the artifact would not fetch, or the
+        // restart budget was spent on boots that already failed.
+        return yield* new WakeFailed({
+          appId,
+          reason: record?.message ?? 'the microVM would not start',
+        });
+      }
+      yield* untilAnswering(record);
+      yield* Effect.logInfo('app woken by a request').pipe(Effect.annotateLogs({ appId }));
+    });
+
+    return {
+      wake: Effect.fn('AppWaker.wake')(function* (appId: AppId) {
+        const claim = yield* Deferred.make<void, WakeFailed>();
+        const held = yield* Ref.modify(inFlight, (current) => {
+          const existing = current.get(appId);
+          return existing
+            ? ([Option.some(existing), current] as const)
+            : ([
+                Option.none<Deferred.Deferred<void, WakeFailed>>(),
+                new Map(current).set(appId, claim),
+              ] as const);
+        });
+        if (Option.isSome(held)) {
+          return yield* Deferred.await(held.value);
+        }
+        return yield* boot(appId).pipe(
+          Effect.provide(context),
+          Effect.onExit((exit) =>
+            Deferred.done(claim, exit).pipe(
+              Effect.andThen(
+                Ref.update(inFlight, (current) => {
+                  const remaining = new Map(current);
+                  remaining.delete(appId);
+                  return remaining;
+                }),
+              ),
+            ),
+          ),
+        );
+      }),
+    };
+  }),
+  dependencies: [
+    AgentConfig.Default,
+    AgentState.Default,
+    ArtifactStore.Default,
+    CommandRunner.Default,
+    DesiredStateCache.Default,
+    SlotAllocator.Default,
+    VmManager.Default,
+  ],
+}) {}

--- a/apps/agent/src/services/app-waker.service.ts
+++ b/apps/agent/src/services/app-waker.service.ts
@@ -1,9 +1,10 @@
 import type { HttpClient } from '@effect/platform';
-import type { AppId } from '@repo/protocol';
+import type { AppId, DesiredInstance } from '@repo/protocol';
 import { Data, Deferred, Duration, Effect, Option, Ref, Schedule } from 'effect';
 import { reportedMessage } from '#lib/failure.ts';
 import { probeInstance } from '#lib/health/probe.ts';
-import { startInstance } from '#lib/reconcile/instances.ts';
+import { resumeInstance } from '#lib/reconcile/instances.ts';
+import { committedResources, memoryShortfallMib, readHostMemoryMib } from '#lib/report/capacity.ts';
 import type { InstanceRecord } from '#lib/report/instance-record.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
@@ -21,13 +22,15 @@ import { VmManager } from '#services/vm-manager.service.ts';
 const PROBE_INTERVAL_MS = 25;
 const PROBE_INTERVAL = Duration.millis(PROBE_INTERVAL_MS);
 
+const NO_SHORTFALL = 0;
+
 /**
- * Everything starting a microVM touches, taken from where this service is built rather than left
+ * Everything waking a microVM touches, taken from where this service is built rather than left
  * to whoever calls `wake`. The caller is a request handler bridged onto a Bun socket: it holds a
  * runtime, and a runtime has to name what is in it — so a requirement that escaped here would be
  * the whole agent, named again at that boundary and built a second time behind it.
  */
-type WakeContext = Effect.Effect.Context<ReturnType<typeof startInstance>> | HttpClient.HttpClient;
+type WakeContext = Effect.Effect.Context<ReturnType<typeof resumeInstance>> | HttpClient.HttpClient;
 
 export class WakeFailed extends Data.TaggedError('WakeFailed')<{
   readonly appId: AppId;
@@ -39,18 +42,43 @@ export class WakeFailed extends Data.TaggedError('WakeFailed')<{
 }
 
 /**
- * Brings an `on-request` app's microVM up because something asked for it, and does not come back
- * until the guest is answering — the request that caused this is waiting on it.
+ * Its own failure and not a `WakeFailed`, because it is not about this app at all: nothing is
+ * wrong with it, and nothing it or its owner can do will make it start here.
+ *
+ * The alternative was to evict a neighbour, and it is not one. Evicting makes one tenant's
+ * traffic a reason to take another tenant's app offline, and on a host that is already over its
+ * memory every wake evicts somebody whose next visitor evicts somebody else — it never settles.
+ * Refusing converges: the app stays down, its owner is told why, and the repair is to move it,
+ * which is placement's to make and not something a request can bring about.
+ */
+export class HostHasNoRoom extends Data.TaggedError('HostHasNoRoom')<{
+  readonly appId: AppId;
+  readonly shortfallMib: number;
+}> {
+  override get message() {
+    return `${this.appId} could not be woken: its host is ${this.shortfallMib} MiB short of the memory it needs`;
+  }
+}
+
+/**
+ * Brings an `on-request` app's microVM back because something asked for it, and does not come
+ * back until the guest is answering — the request that caused this is waiting on it.
+ *
+ * A restore where there is a snapshot to restore and a boot where there is not, which is the
+ * difference between tens of milliseconds and a second or so. Which one happened is
+ * `resumeInstance`'s to decide; what is decided here is whether it may happen at all.
  *
  * One wake per app at a time. A cold page load is a burst of requests, and every one of them
- * arrives to find no microVM: without this the first would boot it and the rest would each spend
- * the app's restart budget racing that boot.
+ * arrives to find no microVM: without this the first would bring it up and the rest would each
+ * spend the app's restart budget racing it.
  */
 export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
   effect: Effect.gen(function* () {
     const cache = yield* DesiredStateCache;
     const context = yield* Effect.context<WakeContext>();
-    const inFlight = yield* Ref.make(new Map<AppId, Deferred.Deferred<void, WakeFailed>>());
+    const inFlight = yield* Ref.make(
+      new Map<AppId, Deferred.Deferred<void, WakeFailed | HostHasNoRoom>>(),
+    );
 
     /**
      * The grace period is the deadline: past it the health loop would call the instance failed
@@ -77,6 +105,25 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
         Effect.asVoid,
       );
 
+    /**
+     * Whether this host can find the memory for one more microVM, asked of everything *else* it
+     * is holding: the app being woken is `idle`, so it commits nothing until it is up, and one
+     * that is somehow already running would otherwise be counted twice and refused its own room.
+     */
+    const refusalForRoom = Effect.fn('AppWaker.refusalForRoom')(function* (
+      wanted: DesiredInstance,
+    ) {
+      const others = (yield* AgentState.records).filter((record) => record.appId !== wanted.appId);
+      const shortfallMib = memoryShortfallMib({
+        hostMemoryMib: readHostMemoryMib(),
+        committed: committedResources(others),
+        wanted: wanted.config.resources,
+      });
+      return shortfallMib > NO_SHORTFALL
+        ? new HostHasNoRoom({ appId: wanted.appId, shortfallMib })
+        : undefined;
+    });
+
     const boot = Effect.fn('AppWaker.boot')(function* (appId: AppId) {
       const desired = yield* cache.latest;
       const wanted = Option.getOrUndefined(desired)?.instances.find(
@@ -94,17 +141,28 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
         return yield* new WakeFailed({ appId, reason: 'the isolation ruleset is not applied' });
       }
 
+      const noRoom = yield* refusalForRoom(wanted);
+      if (noRoom) {
+        // The record is the only account of this its owner will ever see, and left to say nothing
+        // it reads as an app asleep between requests — which is the one thing it is not.
+        yield* AgentState.updateRecord({
+          appId,
+          change: (record) => ({ ...record, message: noRoom.message }),
+        });
+        return yield* noRoom;
+      }
+
       // A slot table with nothing free is the one start failure a request can cause, and it is
       // this host's problem rather than this app's — so it is said in the same breath as any
       // other reason the microVM is not there.
-      yield* startInstance(wanted).pipe(
+      yield* resumeInstance(wanted).pipe(
         Effect.catchAll((error) => new WakeFailed({ appId, reason: reportedMessage(error) })),
       );
 
       const record = (yield* AgentState.snapshot).records.get(appId);
       if (!record?.startedAt) {
-        // A start that wrote no time never reached the VMM: the artifact would not fetch, or the
-        // restart budget was spent on boots that already failed.
+        // Neither half wrote a time, so neither reached the VMM: the artifact would not fetch,
+        // the restore was refused, or the restart budget was spent on boots that already failed.
         return yield* new WakeFailed({
           appId,
           reason: record?.message ?? 'the microVM would not start',
@@ -116,13 +174,13 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
 
     return {
       wake: Effect.fn('AppWaker.wake')(function* (appId: AppId) {
-        const claim = yield* Deferred.make<void, WakeFailed>();
+        const claim = yield* Deferred.make<void, WakeFailed | HostHasNoRoom>();
         const held = yield* Ref.modify(inFlight, (current) => {
           const existing = current.get(appId);
           return existing
             ? ([Option.some(existing), current] as const)
             : ([
-                Option.none<Deferred.Deferred<void, WakeFailed>>(),
+                Option.none<Deferred.Deferred<void, WakeFailed | HostHasNoRoom>>(),
                 new Map(current).set(appId, claim),
               ] as const);
         });

--- a/apps/agent/src/services/reconciler.service.ts
+++ b/apps/agent/src/services/reconciler.service.ts
@@ -8,6 +8,7 @@ import { applyExports } from '#lib/reconcile/exports.ts';
 import {
   prefetchArtifacts,
   refreshStates,
+  sleepInstance,
   startInstance,
   stopInstance,
 } from '#lib/reconcile/instances.ts';
@@ -154,7 +155,8 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
               hostnames: wanted.hostnames,
               healthCheck: wanted.config.healthCheck,
               resources: wanted.config.resources,
-              desiredRunning: wanted.desiredState === 'running',
+              desiredRunning: wanted.desiredState !== 'stopped',
+              onRequest: wanted.desiredState === 'on-request',
               httpPort: wanted.config.httpPort,
               hasExtraPublicPort: wanted.config.hasExtraPublicPort,
             }),
@@ -185,6 +187,18 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
           }
           return Effect.void;
         },
+        { discard: true },
+      );
+
+    /**
+     * The apps this host answers for without running anything. Nothing boots here — that is what
+     * makes them cheap — but the slot and the record are what a request has to arrive to, so
+     * they are made before the activators bind and before routing is rendered.
+     */
+    const applySleeps = (plan: ReturnType<typeof planReconcile>) =>
+      Effect.forEach(
+        plan.instances,
+        (action) => (action.action === 'sleep' ? sleepInstance(action.desired) : Effect.void),
         { discard: true },
       );
 
@@ -229,6 +243,8 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
         { concurrency: 'unbounded', discard: true },
       );
       yield* applyVolumes({ plan, observed, desired }).pipe(Effect.withSpan('reconcile.volumes'));
+      // Before the activators below, because the slot one binds on is allocated here.
+      yield* applySleeps(plan).pipe(Effect.withSpan('reconcile.sleeps'));
       // Before the forwards below are withdrawn from a tenant that has just stopped, so the port
       // it was reached on is answered rather than closed.
       yield* applyActivators.pipe(Effect.withSpan('reconcile.activators'));

--- a/apps/agent/tests/lib/agent/usage.test.ts
+++ b/apps/agent/tests/lib/agent/usage.test.ts
@@ -18,6 +18,7 @@ import {
 } from '#services/filesystem-reader.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { agentConfig } from '#tests/support/config.ts';
+import { instanceRecord } from '#tests/support/fixtures.ts';
 import { platform } from '#tests/support/run.ts';
 
 const BUSY = Value.Parse(AppIdSchema, 'app-pocketbase');
@@ -142,6 +143,36 @@ describe('every guest this host holds is measured on a pass of its own', () => {
 
     expect(snapshot.volumeUsage.get(BUSY)).toEqual(filesystem(FILLED_BYTES));
     expect(snapshot.computeUsage.get(BUSY)?.memoryUsedBytes).toBe(MEMORY_USED_BYTES);
+  });
+
+  /**
+   * The exception, and the difference is whether there is a microVM at all. A suspended app was
+   * taken offline by an owner who may want to know what it was doing; an `on-request` app sleeps
+   * and wakes on its own, and a figure carried across every sleep would have one holding nothing
+   * go on reporting what it held when it last ran.
+   */
+  test('an app asleep between requests forgets what it was spending', async () => {
+    const snapshot = await run({
+      readings: new Map([
+        [BUSY, reading({ filesystem: filesystem(FILLED_BYTES), compute: FIRST_PASS })],
+      ]),
+      program: Effect.gen(function* () {
+        const allocator = yield* SlotAllocator;
+        yield* allocator.allocate(BUSY);
+        yield* measureUsage;
+        yield* AgentState.putRecord(
+          instanceRecord({ appId: BUSY, onRequest: true, state: 'idle' }),
+        );
+        // The same pass again, with the guest gone the way a sleeping app's is.
+        yield* Effect.provide(measureUsage, measuring(new Map()));
+        return yield* AgentState.snapshot;
+      }),
+    });
+
+    expect(snapshot.computeUsage.has(BUSY)).toBe(false);
+    expect(snapshot.computeTicks.has(BUSY)).toBe(false);
+    // The volume is untouched: a filesystem is still there when the microVM holding it is not.
+    expect(snapshot.volumeUsage.get(BUSY)).toEqual(filesystem(FILLED_BYTES));
   });
 
   // The slot goes when the control plane says the volume is absent, which is the one moment the

--- a/apps/agent/tests/lib/health/state.test.ts
+++ b/apps/agent/tests/lib/health/state.test.ts
@@ -83,6 +83,7 @@ function evaluate({
   healthCheck = check(),
   stopRequested = false,
   desiredRunning = true,
+  onRequest = false,
   startedAtMs = STARTED_AT_MS as number | undefined,
 }: {
   unit: UnitStatus;
@@ -91,6 +92,7 @@ function evaluate({
   healthCheck?: HealthCheck;
   stopRequested?: boolean;
   desiredRunning?: boolean;
+  onRequest?: boolean;
   startedAtMs?: number | undefined;
 }) {
   return evaluateInstanceState({
@@ -98,6 +100,7 @@ function evaluate({
     tracker,
     healthCheck,
     desiredRunning,
+    onRequest,
     stopRequested,
     ...(startedAtMs === undefined ? {} : { startedAtMs }),
     nowMs,
@@ -252,6 +255,7 @@ describe('what the VM itself is doing', () => {
         tracker: initialTracker(),
         healthCheck: check(),
         desiredRunning: true,
+        onRequest: false,
         stopRequested: false,
         nowMs: STARTED_AT_MS,
       }),
@@ -265,10 +269,67 @@ describe('what the VM itself is doing', () => {
         tracker: initialTracker(),
         healthCheck: check(),
         desiredRunning: true,
+        onRequest: false,
         stopRequested: false,
         nowMs: STARTED_AT_MS,
       }),
     ).toBe('pending');
+  });
+
+  /**
+   * The two states a microVM can be absent in, and they are not the same news. One says the
+   * release is over; the other says it is between requests. An owner reading `stopped` for an app
+   * working exactly as configured would have nothing to tell it from a broken one.
+   */
+  describe('an app that runs on request is idle rather than stopped', () => {
+    test('one nobody has ever asked for is idle, not pending', () => {
+      expect(
+        evaluateInstanceState({
+          unit: absent,
+          tracker: initialTracker(),
+          healthCheck: check(),
+          desiredRunning: true,
+          onRequest: true,
+          stopRequested: false,
+          nowMs: STARTED_AT_MS,
+        }),
+      ).toBe('idle');
+    });
+
+    test('one stopped for being quiet is idle', () => {
+      expect(
+        evaluate({
+          unit: exited,
+          tracker: initialTracker(),
+          onRequest: true,
+          stopRequested: true,
+          nowMs: PAST_GRACE_MS,
+        }),
+      ).toBe('idle');
+    });
+
+    test('but a microVM that went down unasked is failed, whatever the policy', () => {
+      expect(
+        evaluate({
+          unit: exited,
+          tracker: initialTracker(),
+          onRequest: true,
+          nowMs: PAST_GRACE_MS,
+        }),
+      ).toBe('failed');
+    });
+
+    test('and a suspended one is stopped: the owner asked for that, not the request pattern', () => {
+      expect(
+        evaluate({
+          unit: absent,
+          tracker: initialTracker(),
+          onRequest: true,
+          desiredRunning: false,
+          nowMs: PAST_GRACE_MS,
+        }),
+      ).toBe('stopped');
+    });
   });
 
   test('an instance the control plane wants stopped reads as stopped once the unit is down', () => {

--- a/apps/agent/tests/lib/reconcile/idle.test.ts
+++ b/apps/agent/tests/lib/reconcile/idle.test.ts
@@ -8,8 +8,11 @@ const NOW_MS = 10_000_000;
 const QUIET_SINCE_MS = NOW_MS - TIMEOUT_MS;
 const BUSY_SINCE_MS = NOW_MS - TIMEOUT_MS + 1;
 
-/** The two an app can be stopped from: up and serving, or up and not answering. */
-const AWAKE_STATES: InstanceState[] = ['running', 'unhealthy'];
+/** The one an app can be let go to sleep from: up, and answering the probes that say so. */
+const SLEEPABLE: InstanceState = 'running';
+
+/** Up, so there is a microVM to stop — and not one this may stop. */
+const UNHEALTHY: InstanceState = 'unhealthy';
 
 function quiet(overrides: Partial<Parameters<typeof hasGoneQuiet>[0]>) {
   return hasGoneQuiet({
@@ -22,8 +25,17 @@ function quiet(overrides: Partial<Parameters<typeof hasGoneQuiet>[0]>) {
 }
 
 describe('an app is only let go to sleep once it is certain nobody wants it', () => {
-  test.each(AWAKE_STATES)('a quiet %s app has gone quiet', (state) => {
-    expect(quiet({ record: instanceRecord({ onRequest: true, state }) })).toBe(true);
+  test('a quiet serving app has gone quiet', () => {
+    expect(quiet({ record: instanceRecord({ onRequest: true, state: SLEEPABLE }) })).toBe(true);
+  });
+
+  /**
+   * An app failing its probes has gone quiet because it is broken, so the silence is a symptom of
+   * the fault rather than evidence nobody wants it. Sleeping it would turn a failure its owner can
+   * see into one they cannot, and take it out of the machinery that exists to answer this.
+   */
+  test('but an unhealthy app is not a quiet one, however long nobody has asked for it', () => {
+    expect(quiet({ record: instanceRecord({ onRequest: true, state: UNHEALTHY }) })).toBe(false);
   });
 
   test('one asked for a moment ago has not', () => {
@@ -42,7 +54,7 @@ describe('an app is only let go to sleep once it is certain nobody wants it', ()
     ).toBe(false);
   });
 
-  test.each(INSTANCE_STATES.filter((state) => !AWAKE_STATES.includes(state)))(
+  test.each(INSTANCE_STATES.filter((state) => state !== SLEEPABLE && state !== UNHEALTHY))(
     'a %s app has no microVM to stop',
     (state) => {
       expect(quiet({ record: instanceRecord({ onRequest: true, state }) })).toBe(false);

--- a/apps/agent/tests/lib/reconcile/idle.test.ts
+++ b/apps/agent/tests/lib/reconcile/idle.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+import { INSTANCE_STATES, type InstanceState } from '@repo/protocol';
+import { hasGoneQuiet } from '#lib/reconcile/idle.ts';
+import { instanceRecord } from '#tests/support/fixtures.ts';
+
+const TIMEOUT_MS = 900_000;
+const NOW_MS = 10_000_000;
+const QUIET_SINCE_MS = NOW_MS - TIMEOUT_MS;
+const BUSY_SINCE_MS = NOW_MS - TIMEOUT_MS + 1;
+
+/** The two an app can be stopped from: up and serving, or up and not answering. */
+const AWAKE_STATES: InstanceState[] = ['running', 'unhealthy'];
+
+function quiet(overrides: Partial<Parameters<typeof hasGoneQuiet>[0]>) {
+  return hasGoneQuiet({
+    record: instanceRecord({ onRequest: true, state: 'running' }),
+    timeoutMs: TIMEOUT_MS,
+    lastActiveAtMs: QUIET_SINCE_MS,
+    nowMs: NOW_MS,
+    ...overrides,
+  });
+}
+
+describe('an app is only let go to sleep once it is certain nobody wants it', () => {
+  test.each(AWAKE_STATES)('a quiet %s app has gone quiet', (state) => {
+    expect(quiet({ record: instanceRecord({ onRequest: true, state }) })).toBe(true);
+  });
+
+  test('one asked for a moment ago has not', () => {
+    expect(quiet({ lastActiveAtMs: BUSY_SINCE_MS })).toBe(false);
+  });
+
+  test('an app that is kept up is never let go, however quiet it is', () => {
+    expect(quiet({ record: instanceRecord({ onRequest: false, state: 'running' }) })).toBe(false);
+  });
+
+  test('nor is a suspended one: it is already going down for another reason', () => {
+    expect(
+      quiet({
+        record: instanceRecord({ onRequest: true, state: 'running', desiredRunning: false }),
+      }),
+    ).toBe(false);
+  });
+
+  test.each(INSTANCE_STATES.filter((state) => !AWAKE_STATES.includes(state)))(
+    'a %s app has no microVM to stop',
+    (state) => {
+      expect(quiet({ record: instanceRecord({ onRequest: true, state }) })).toBe(false);
+    },
+  );
+
+  /**
+   * The two ways of knowing nothing. A restarted agent has watched no traffic yet, and an app
+   * desired state no longer calls `on-request` has no timeout to be measured against — both are
+   * questions this cannot answer, and answering them by stopping a tenant is the wrong guess.
+   */
+  test('an app nothing has been observed about is left alone', () => {
+    expect(quiet({ lastActiveAtMs: undefined })).toBe(false);
+  });
+
+  test('so is one with no timeout to have run out', () => {
+    expect(quiet({ timeoutMs: undefined })).toBe(false);
+  });
+});

--- a/apps/agent/tests/lib/reconcile/instances.test.ts
+++ b/apps/agent/tests/lib/reconcile/instances.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, test } from 'bun:test';
 import { FetchHttpClient } from '@effect/platform';
 import { Deferred, Effect, Fiber, Layer } from 'effect';
-import { refreshStates } from '#lib/reconcile/instances.ts';
+import { refreshStates, resumeInstance, suspendInstance } from '#lib/reconcile/instances.ts';
+import { SleepRefused, SnapshotUnusable } from '#lib/vm/snapshot.ts';
 import { AgentState } from '#services/agent-state.service.ts';
+import { ArtifactStore, ArtifactTransferError } from '#services/artifact-store.service.ts';
 import { CommandRunner } from '#services/command-runner.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
+import { SlotAllocator } from '#services/slot-allocator.service.ts';
+import { VmManager } from '#services/vm-manager.service.ts';
+import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
 import { succeeding } from '#tests/support/commands.ts';
-import { APP_ID, instanceRecord } from '#tests/support/fixtures.ts';
+import { agentConfig } from '#tests/support/config.ts';
+import { APP_ID, DEPLOYMENT_ID, desiredInstance, instanceRecord } from '#tests/support/fixtures.ts';
 import { platform, provided } from '#tests/support/run.ts';
 
 /** What `systemctl show` says about a microVM that is up, which is all a pass reads off it. */
@@ -98,4 +104,222 @@ describe('a settle writes back only what it measured', () => {
         expect(yield* recordOf).toBeUndefined();
       }),
     ));
+});
+
+/** What `systemctl show` says about a microVM that is down, which is what a wake has to find. */
+const INACTIVE_UNIT = [
+  'LoadState=loaded',
+  'ActiveState=inactive',
+  'SubState=dead',
+  'Result=success',
+  'ExecMainStatus=0',
+  'InactiveExitTimestampMonotonic=1',
+].join('\n');
+
+const VM_DIR = '/nonexistent/nibrun-test/vm';
+
+/** Enough that a wake counting one more would be visible, and few enough to leave budget. */
+const RESTARTS_SO_FAR = 4;
+const NO_ATTEMPTS = 0;
+
+type VmCall = 'boot' | 'sleep' | 'wake' | 'stop' | 'discard';
+
+/**
+ * Every way the agent can act on a microVM, recorded rather than performed. Which of them a wake
+ * reached is the whole assertion: a restore and a cold boot leave the same app serving, and the
+ * only thing that tells them apart from the outside is how long the visitor waited.
+ */
+function recordingVms({
+  onSleep = Effect.succeed(undefined),
+  onWake = Effect.void,
+}: {
+  onSleep?: Effect.Effect<undefined, SleepRefused>;
+  onWake?: Effect.Effect<void, SnapshotUnusable>;
+} = {}) {
+  const calls: VmCall[] = [];
+  function taking<A, E>({ call, outcome }: { call: VmCall; outcome: Effect.Effect<A, E> }) {
+    return Effect.suspend(() => {
+      calls.push(call);
+      return outcome;
+    });
+  }
+  return {
+    calls,
+    layer: Layer.succeed(
+      VmManager,
+      VmManager.make({
+        workingDir: () => VM_DIR,
+        boot: () => taking({ call: 'boot', outcome: Effect.void }),
+        sleep: () => taking({ call: 'sleep', outcome: onSleep }),
+        wake: () => taking({ call: 'wake', outcome: onWake }),
+        stop: () => taking({ call: 'stop', outcome: Effect.void }),
+        discard: () => taking({ call: 'discard', outcome: Effect.void }),
+      }),
+    ),
+  };
+}
+
+/**
+ * A stubbed `VmManager` still asks for what a real boot would fetch, so this stands in for the
+ * bucket the artifact would come from. Reaching it is the failure: nothing here boots anything.
+ */
+const noArtifacts = Layer.succeed(
+  ArtifactStore,
+  ArtifactStore.make({
+    open: () => new ArtifactTransferError({ cause: 'no artifact store in a test' }),
+  }),
+);
+
+function onHost({ vms, unit }: { vms: ReturnType<typeof recordingVms>; unit: string }) {
+  const host = Layer.mergeAll(
+    agentConfig({ vmDir: VM_DIR }),
+    Layer.succeed(CommandRunner, CommandRunner.make({ run: () => succeeding({ stdout: unit }) })),
+  );
+  return provided(
+    Layer.mergeAll(
+      AgentState.Default,
+      ReportSignal.Default,
+      SlotAllocator.DefaultWithoutDependencies,
+      ZerofsTopology.DefaultWithoutDependencies,
+      noArtifacts,
+      vms.layer,
+    ).pipe(Layer.provideMerge(host), Layer.provideMerge(platform)),
+  );
+}
+
+function withMicroVmDown(vms: ReturnType<typeof recordingVms>) {
+  return onHost({ vms, unit: INACTIVE_UNIT });
+}
+
+/**
+ * A wake is a restore, and a cold boot is only what is left when there is nothing to restore.
+ * Both halves are checked against the same stub, because which one ran is the difference between
+ * a visitor waiting thirty milliseconds and one waiting a second.
+ */
+describe('an app is woken by putting back the microVM it had', () => {
+  test('a snapshot that loads is restored rather than booted', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'idle' }));
+
+        yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }));
+
+        expect(vms.calls).toEqual(['wake']);
+        expect((yield* recordOf)?.startedAt).toBeDefined();
+      }),
+    );
+  });
+
+  // The one path that may cold-boot: a first sleep, a redeploy, a host that rebooted, a guest
+  // image that moved. Every other failure leaves the app down and says why.
+  test('a snapshot nothing can load is a cold boot instead', () => {
+    const vms = recordingVms({
+      onWake: new SnapshotUnusable({ reason: 'the host has rebooted' }),
+    });
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'idle' }));
+
+        yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }));
+
+        expect(vms.calls).toEqual(['wake', 'boot']);
+      }),
+    );
+  });
+
+  /**
+   * An app woken every morning for a year is not an app that crashed three hundred times. The
+   * budget still bounds the damage, because the cold boot above is what spends it.
+   */
+  test('a restore is not a restart, so it costs the app nothing', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(
+          instanceRecord({ onRequest: true, state: 'idle', restartCount: RESTARTS_SO_FAR }),
+        );
+
+        yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }));
+
+        const record = yield* recordOf;
+        expect(record?.restartCount).toBe(RESTARTS_SO_FAR);
+        expect(record?.startAttempts.attempts).toBe(NO_ATTEMPTS);
+      }),
+    );
+  });
+
+  // Firecracker takes a snapshot load only from a process that has configured nothing, and
+  // `systemctl start` on a unit already up is the no-op that would have hidden it.
+  test('a microVM that is already up is left alone rather than restored onto', () => {
+    const vms = recordingVms();
+    return onHost({ vms, unit: ACTIVE_UNIT })(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }));
+
+        expect(vms.calls).toEqual([]);
+      }),
+    );
+  });
+});
+
+describe('an app that has gone quiet is put down where it can be picked up', () => {
+  const suspend = suspendInstance({ appId: APP_ID, deploymentId: DEPLOYMENT_ID, reason: 'idle' });
+
+  test('it is snapshotted rather than stopped, and reads as asleep after', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* (yield* SlotAllocator).allocate(APP_ID);
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* suspend;
+
+        expect(vms.calls).toEqual(['sleep']);
+        const record = yield* recordOf;
+        expect(record?.state).toBe('idle');
+        // What tells the health loop a microVM that is gone is asleep rather than crashed, and
+        // what keeps the boot after a discarded snapshot from counting as a restart.
+        expect(record?.stopRequested).toBe(true);
+      }),
+    );
+  });
+
+  /**
+   * A refusal is an outcome, not a failure. `VmManager.sleep` leaves the microVM running, so the
+   * app goes on serving and the next measurement tick asks again — and nothing here may mark it
+   * failed for having been asked at a moment it could not answer.
+   */
+  test('one that may not be snapshotted is left up rather than called broken', () => {
+    const vms = recordingVms({
+      onSleep: new SleepRefused({ reason: 'it has already been asked to stop' }),
+    });
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* (yield* SlotAllocator).allocate(APP_ID);
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* suspend;
+
+        expect((yield* recordOf)?.state).toBe('running');
+      }),
+    );
+  });
+
+  // No slot is no tap, no address and no NBD minor for a restore to land on. Stopping still
+  // reclaims the memory, which is what the sleep was for.
+  test('one with no slot to come back to is stopped', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* suspend;
+
+        expect(vms.calls).toEqual(['stop']);
+      }),
+    );
+  });
 });

--- a/apps/agent/tests/lib/reconcile/plan.test.ts
+++ b/apps/agent/tests/lib/reconcile/plan.test.ts
@@ -119,6 +119,52 @@ describe('instances are authoritative', () => {
   });
 });
 
+/**
+ * Nothing here boots. What the plan has to produce for an app that runs on request is the part a
+ * request arrives to — the slot and the record — and the microVM is left to whoever visits.
+ */
+describe('an app that runs on request is prepared rather than started', () => {
+  const onRequest = desiredInstance({ desiredState: 'on-request' });
+
+  test('one nothing is running is put to sleep rather than started', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [onRequest] }),
+      observed: observedState(),
+    });
+    expect(plan.instances).toEqual([{ action: 'sleep', desired: onRequest }]);
+  });
+
+  test('one already sleeping stays that way, however many times this runs', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [onRequest] }),
+      observed: observedState({
+        instances: [observedInstance({ running: false, exited: false })],
+      }),
+    });
+    expect(plan.instances).toEqual([{ action: 'sleep', desired: onRequest }]);
+  });
+
+  test('one that is up and serving the release it should be is left alone', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [onRequest] }),
+      observed: observedState({ instances: [observedInstance()] }),
+    });
+    expect(plan.instances).toEqual([{ action: 'none', appId: APP_ID }]);
+  });
+
+  // New bytes must not go on being served by the release they replaced, and a deploy is the one
+  // moment somebody is watching — so the replacement comes up rather than waiting to be asked for.
+  test('one that is up on an older release is replaced', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [onRequest] }),
+      observed: observedState({
+        instances: [observedInstance({ deploymentId: Value.Parse(DeploymentIdSchema, 'dep-0') })],
+      }),
+    });
+    expect(plan.instances).toEqual([{ action: 'replace', desired: onRequest }]);
+  });
+});
+
 describe('volumes are not authoritative', () => {
   const absent = desiredVolume({ desiredState: 'absent' });
 

--- a/apps/agent/tests/lib/report/build-report.test.ts
+++ b/apps/agent/tests/lib/report/build-report.test.ts
@@ -15,7 +15,7 @@ import {
   Value,
 } from '@repo/protocol';
 import { buildReportedState, toReportedInstance } from '#lib/report/build-report.ts';
-import { allocatableCapacity } from '#lib/report/capacity.ts';
+import { allocatableCapacity, committedResources } from '#lib/report/capacity.ts';
 import type { InstanceRecord } from '#lib/report/instance-record.ts';
 import {
   APP_ID,
@@ -40,6 +40,13 @@ const HOST_CAPACITY = {
   cacheBytes: HOST_CACHE_BYTES,
 };
 const BOOTED = [DEFAULT_INSTANCE_RESOURCES, DEFAULT_INSTANCE_RESOURCES];
+/** The four states below with a microVM behind them, which is what the four of them hold. */
+const BOOTED_AND_SETTLING = [
+  DEFAULT_INSTANCE_RESOURCES,
+  DEFAULT_INSTANCE_RESOURCES,
+  DEFAULT_INSTANCE_RESOURCES,
+  DEFAULT_INSTANCE_RESOURCES,
+];
 const DEFAULT_INSTANCE_RESOURCES_AS_CAPACITY = {
   ...DEFAULT_INSTANCE_RESOURCES,
   cacheBytes: HOST_CACHE_BYTES,
@@ -226,6 +233,26 @@ describe('allocatable capacity', () => {
       memoryMib: HOST_MEMORY_MIB - DEFAULT_INSTANCE_RESOURCES.memoryMib * BOOTED.length,
       cacheBytes: FREE_CACHE_BYTES,
     });
+  });
+
+  // The whole of what `on-request` saves: a host still reserving a sleeping app's memory would
+  // pay for every sleep and collect on none of them.
+  test('an idle app is holding none of the host', () => {
+    expect(committedResources([instanceRecord({ state: 'idle', onRequest: true })])).toEqual([]);
+  });
+
+  test('every state with a microVM behind it still holds what it was given', () => {
+    expect(
+      committedResources([
+        instanceRecord({ state: 'running' }),
+        instanceRecord({ state: 'starting' }),
+        instanceRecord({ state: 'unhealthy' }),
+        instanceRecord({ state: 'stopping' }),
+        instanceRecord({ state: 'idle' }),
+        instanceRecord({ state: 'stopped' }),
+        instanceRecord({ state: 'failed' }),
+      ]),
+    ).toEqual(BOOTED_AND_SETTLING);
   });
 
   test('an oversubscribed host reports zero rather than a negative', () => {

--- a/apps/agent/tests/lib/report/capacity.test.ts
+++ b/apps/agent/tests/lib/report/capacity.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { AppIdSchema, DEFAULT_INSTANCE_RESOURCES, type InstanceState, Value } from '@repo/protocol';
+import { committedResources, memoryShortfallMib } from '#lib/report/capacity.ts';
+import { instanceRecord } from '#tests/support/fixtures.ts';
+
+const APP_MEMORY_MIB = DEFAULT_INSTANCE_RESOURCES.memoryMib;
+const NEIGHBOURS_THAT_FIT = 3;
+const HOST_MEMORY_MIB = APP_MEMORY_MIB * (NEIGHBOURS_THAT_FIT + 1);
+
+function neighbours({ count, state }: { count: number; state: InstanceState }) {
+  const records = [];
+  for (let index = 0; index < count; index += 1) {
+    records.push(instanceRecord({ appId: Value.Parse(AppIdSchema, `neighbour-${index}`), state }));
+  }
+  return records;
+}
+
+/** What one more of the default-sized apps would cost this host beyond what it has. */
+function shortfall({ count, state }: { count: number; state: InstanceState }) {
+  return memoryShortfallMib({
+    hostMemoryMib: HOST_MEMORY_MIB,
+    committed: committedResources(neighbours({ count, state })),
+    wanted: DEFAULT_INSTANCE_RESOURCES,
+  });
+}
+
+/**
+ * The refusal a wake is made on. Memory is counted against what the host has rather than against
+ * what the control plane placed here, because a sleeping app gave its share back and the whole
+ * point of `on-request` is that somebody else may have taken it.
+ */
+describe('a host has room for one more microVM until it does not', () => {
+  test('an empty host has room', () => {
+    expect(shortfall({ count: 0, state: 'running' })).toBe(0);
+  });
+
+  test('so has one filled to exactly the last app it fits', () => {
+    expect(shortfall({ count: NEIGHBOURS_THAT_FIT, state: 'running' })).toBe(0);
+  });
+
+  test('one app past that is short by exactly what the app asked for', () => {
+    expect(shortfall({ count: NEIGHBOURS_THAT_FIT + 1, state: 'running' })).toBe(APP_MEMORY_MIB);
+  });
+
+  // The saving and the failure mode are the same fact: a host packed with sleeping apps has all
+  // its memory free, and every one of them can be woken until the memory runs out.
+  test('a neighbour asleep between requests is holding none of it', () => {
+    expect(shortfall({ count: NEIGHBOURS_THAT_FIT * 2, state: 'idle' })).toBe(0);
+  });
+});

--- a/apps/agent/tests/services/app-activator.test.ts
+++ b/apps/agent/tests/services/app-activator.test.ts
@@ -12,12 +12,13 @@ import {
 import { Duration, Effect, Either, Layer } from 'effect';
 import { AgentState } from '#services/agent-state.service.ts';
 import { AppActivator } from '#services/app-activator.service.ts';
-import { AppWaker, WakeFailed } from '#services/app-waker.service.ts';
+import { AppWaker, HostHasNoRoom, WakeFailed } from '#services/app-waker.service.ts';
 import { APP_ID, instanceRecord } from '#tests/support/fixtures.ts';
 import { provided } from '#tests/support/run.ts';
 import { HTTP_OK, HTTP_UNAVAILABLE, serving } from '#tests/support/server.ts';
 
 const OTHER_APP_ID = Value.Parse(AppIdSchema, 'app-2');
+const SHORT_BY_MIB = 256;
 const LOOPBACK = '127.0.0.1';
 
 /** Nothing here has a microVM to be woken, so a waker that would boot one is not the subject. */
@@ -219,6 +220,33 @@ describe('an app that runs on request is started by the request that wanted it',
 
         expect(response.status).toBe(HTTP_UNAVAILABLE);
         expect(yield* Effect.promise(() => response.text())).toContain('could not be started');
+      }),
+    );
+  });
+
+  /**
+   * A host with no memory left is not a broken app, and the visitor is not told it is one: an
+   * owner sent to read a binary that is fine would find nothing, because the repair is to move
+   * the app and neither of them can bring that about by asking again.
+   */
+  test('a wake refused for want of memory says so rather than blaming the app', () => {
+    const full = Layer.succeed(
+      AppWaker,
+      AppWaker.make({
+        wake: (appId: AppId) => new HostHasNoRoom({ appId, shortfallMib: SHORT_BY_MIB }),
+      }),
+    );
+    return activator(full)(
+      Effect.gen(function* () {
+        const app = yield* AppActivator;
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'idle' }));
+        const hostPort = unusedPort();
+        yield* app.serve([{ appId: APP_ID, hostPort }]);
+
+        const response = yield* get(hostPort);
+
+        expect(response.status).toBe(HTTP_UNAVAILABLE);
+        expect(yield* Effect.promise(() => response.text())).toContain('out of memory');
       }),
     );
   });

--- a/apps/agent/tests/services/app-activator.test.ts
+++ b/apps/agent/tests/services/app-activator.test.ts
@@ -1,16 +1,37 @@
 import { describe, expect, test } from 'bun:test';
 import { connect } from 'node:net';
-import { AppIdSchema, type HostPort, HostPortSchema, Value } from '@repo/protocol';
-import { Duration, Effect, Either } from 'effect';
+import {
+  type AppId,
+  AppIdSchema,
+  type HostPort,
+  HostPortSchema,
+  HttpPortSchema,
+  Ipv4AddressSchema,
+  Value,
+} from '@repo/protocol';
+import { Duration, Effect, Either, Layer } from 'effect';
+import { AgentState } from '#services/agent-state.service.ts';
 import { AppActivator } from '#services/app-activator.service.ts';
-import { APP_ID } from '#tests/support/fixtures.ts';
+import { AppWaker, WakeFailed } from '#services/app-waker.service.ts';
+import { APP_ID, instanceRecord } from '#tests/support/fixtures.ts';
 import { provided } from '#tests/support/run.ts';
-import { HTTP_UNAVAILABLE } from '#tests/support/server.ts';
+import { HTTP_OK, HTTP_UNAVAILABLE, serving } from '#tests/support/server.ts';
 
 const OTHER_APP_ID = Value.Parse(AppIdSchema, 'app-2');
 const LOOPBACK = '127.0.0.1';
 
-const run = provided(AppActivator.Default);
+/** Nothing here has a microVM to be woken, so a waker that would boot one is not the subject. */
+const neverWoken = Layer.succeed(AppWaker, AppWaker.make({ wake: () => Effect.void }));
+
+const activator = (waker: Layer.Layer<AppWaker>) =>
+  provided(
+    Layer.mergeAll(
+      AppActivator.DefaultWithoutDependencies.pipe(Layer.provide(waker)),
+      AgentState.Default,
+    ),
+  );
+
+const run = activator(neverWoken);
 
 /**
  * A port the kernel has just handed out and taken back, rather than the one an app's slot really
@@ -105,4 +126,119 @@ describe('an app that is down answers for itself', () => {
         expect(answer.toLowerCase()).toContain('connection: close');
       }),
     ));
+});
+
+/**
+ * The half of this that only an app running on request has: the request is not refused, it is
+ * what starts the microVM, and it is answered from that microVM once it is up. What stands in
+ * for the guest here is a real listener on the address the record names, because the thing being
+ * checked is that a request came out of the far side.
+ */
+describe('an app that runs on request is started by the request that wanted it', () => {
+  function guest(handler: (request: Request) => Response | Promise<Response>) {
+    return Effect.flatMap(serving(handler), ({ port }) =>
+      Effect.gen(function* () {
+        const record = instanceRecord({
+          onRequest: true,
+          state: 'idle',
+          guestIpv4: Value.Parse(Ipv4AddressSchema, LOOPBACK),
+          httpPort: Value.Parse(HttpPortSchema, port),
+        });
+        yield* AgentState.putRecord(record);
+        return record;
+      }),
+    );
+  }
+
+  /** Records who was asked to wake, so a request that reached a guest without one is visible. */
+  function wakes() {
+    const woken: AppId[] = [];
+    return {
+      woken,
+      layer: Layer.succeed(
+        AppWaker,
+        AppWaker.make({
+          wake: (appId: AppId) => Effect.sync(() => void woken.push(appId)),
+        }),
+      ),
+    };
+  }
+
+  test('the request waits for the wake and is answered by the guest that comes up', () => {
+    const waker = wakes();
+    return activator(waker.layer)(
+      Effect.gen(function* () {
+        const app = yield* AppActivator;
+        yield* guest(() => new Response('served by the tenant', { status: HTTP_OK }));
+        const hostPort = unusedPort();
+        yield* app.serve([{ appId: APP_ID, hostPort }]);
+
+        const response = yield* get(hostPort);
+
+        expect(response.status).toBe(HTTP_OK);
+        expect(yield* Effect.promise(() => response.text())).toBe('served by the tenant');
+        expect(waker.woken).toEqual([APP_ID]);
+      }),
+    );
+  });
+
+  // The forward rule takes over the moment the microVM is up, and a connection the proxy keeps
+  // open to here would go on being answered here instead — the same reuse that had a resumed app
+  // still reading as down.
+  test('the answer is not reusable, so the proxy takes the forward rule instead', () =>
+    activator(wakes().layer)(
+      Effect.gen(function* () {
+        const app = yield* AppActivator;
+        yield* guest(() => new Response('served by the tenant'));
+        const hostPort = unusedPort();
+        yield* app.serve([{ appId: APP_ID, hostPort }]);
+
+        const answer = yield* untilServerHangsUp(hostPort).pipe(
+          Effect.timeout(Duration.seconds(REUSE_TIMEOUT_SECONDS)),
+        );
+
+        expect(answer.toLowerCase()).toContain('connection: close');
+      }),
+    ));
+
+  test('a microVM that would not start is said to have not started', () => {
+    const refusing = Layer.succeed(
+      AppWaker,
+      AppWaker.make({
+        wake: (appId: AppId) => new WakeFailed({ appId, reason: 'no slots left on this host' }),
+      }),
+    );
+    return activator(refusing)(
+      Effect.gen(function* () {
+        const app = yield* AppActivator;
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'idle' }));
+        const hostPort = unusedPort();
+        yield* app.serve([{ appId: APP_ID, hostPort }]);
+
+        const response = yield* get(hostPort);
+
+        expect(response.status).toBe(HTTP_UNAVAILABLE);
+        expect(yield* Effect.promise(() => response.text())).toContain('could not be started');
+      }),
+    );
+  });
+
+  // Suspending is an answer, not a question. A request is not the thing that reverses it, so the
+  // one that arrives is told the app is down rather than quietly starting it again.
+  test('a suspended app is not woken by somebody finding its hostname', () => {
+    const waker = wakes();
+    return activator(waker.layer)(
+      Effect.gen(function* () {
+        const app = yield* AppActivator;
+        yield* AgentState.putRecord(
+          instanceRecord({ onRequest: true, state: 'stopped', desiredRunning: false }),
+        );
+        const hostPort = unusedPort();
+        yield* app.serve([{ appId: APP_ID, hostPort }]);
+
+        expect((yield* get(hostPort)).status).toBe(HTTP_UNAVAILABLE);
+        expect(waker.woken).toEqual([]);
+      }),
+    );
+  });
 });

--- a/apps/agent/tests/support/fixtures.ts
+++ b/apps/agent/tests/support/fixtures.ts
@@ -143,6 +143,7 @@ export function instanceRecord(overrides: Partial<InstanceRecord> = {}): Instanc
       guestIpv4: describeSlot({ slot: FIRST_SLOT, appId: APP_ID }).guestIpv4,
       artifactDigest: ARTIFACT_DIGEST,
       state: 'running',
+      onRequest: false,
       health: initialTracker(),
       healthCheck: DEFAULT_HEALTH_CHECK,
       resources: DEFAULT_INSTANCE_RESOURCES,

--- a/apps/api/src/db/migrations/0035_apps_choose_how_they_start.sql
+++ b/apps/api/src/db/migrations/0035_apps_choose_how_they_start.sql
@@ -1,0 +1,49 @@
+-- How an app is brought up, beside the state that says whether it should be up at all. The two
+-- are the same kind of fact — what the owner wants of the app, rather than what a release runs —
+-- which is why this is here and not on `app_configs`: a config version is pinned by a deployment
+-- and never rewritten, so a policy stored there could only be changed by deploying, and a
+-- rollback would replay whichever policy was in force months ago.
+--
+-- The CHECK repeats APP_ACTIVATIONS from @repo/protocol and nothing compares the two, so adding
+-- an activation there is also a migration here.
+--
+-- `always` is the default and every existing app takes it, which is what they have always done.
+-- `idle_timeout_ms` is what an `on-request` app's saving is actually made of: it is the memory
+-- a sleeping app is not holding, so the shorter this is the more of the day is reclaimed. The
+-- default is minutes rather than an hour because an app visited a few times a day sleeps through
+-- almost none of it at an hour, and rather than seconds because whoever arrives after the gap
+-- pays a cold boot for it. It is read only for `on-request`, and kept for every app so that
+-- flipping the activation is one column rather than two. The floor repeats MIN_IDLE_TIMEOUT_MS
+-- from @repo/protocol, which is the cadence the host measures traffic on.
+ALTER TABLE nibrun.apps
+  ADD COLUMN activation text NOT NULL DEFAULT 'always',
+  ADD COLUMN idle_timeout_ms integer NOT NULL DEFAULT 900000,
+  ADD CONSTRAINT apps_activation_check CHECK (activation IN ('always', 'on-request')),
+  ADD CONSTRAINT apps_idle_timeout_ms_check CHECK (idle_timeout_ms >= 60000);
+
+COMMENT ON COLUMN nibrun.apps.activation IS $c$@type import('@repo/protocol').AppActivation$c$;
+
+-- A suspended app is stopped whatever its activation says, so the two collapse into the one
+-- answer a host acts on. `on-request` reaches it only for an app that should be serving, which
+-- is what keeps the host from having to reason about a policy it cannot act on.
+--
+-- Appended last, because CREATE OR REPLACE VIEW may only add columns at the end.
+CREATE OR REPLACE VIEW nibrun.desired_deployments AS
+  SELECT d.id,
+         d.app_id,
+         a.state,
+         ar.digest, ar.size_bytes, ar.object_key, ar.original_file_name,
+         c.http_port, c.args, c.vcpu_count, c.memory_mib,
+         c.health_check_path, c.health_check_interval_ms, c.health_check_timeout_ms,
+         c.health_check_grace_period_ms, c.health_check_healthy_threshold,
+         c.health_check_unhealthy_threshold,
+         c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
+         c.restart_backoff_factor, c.restart_reset_after_ms,
+         d.config_id,
+         c.has_extra_public_port,
+         a.activation, a.idle_timeout_ms
+  FROM nibrun.deployments d
+  JOIN nibrun.apps a ON a.id = d.app_id
+  JOIN nibrun.artifacts ar ON ar.id = d.artifact_id
+  JOIN nibrun.app_configs c ON c.id = d.config_id
+  WHERE d.state NOT IN ('superseded', 'failed') AND a.state IN ('active', 'suspended');

--- a/apps/api/src/db/migrations/0035_apps_choose_how_they_start.sql
+++ b/apps/api/src/db/migrations/0035_apps_choose_how_they_start.sql
@@ -14,12 +14,17 @@
 -- almost none of it at an hour, and rather than seconds because whoever arrives after the gap
 -- pays a cold boot for it. It is read only for `on-request`, and kept for every app so that
 -- flipping the activation is one column rather than two. The floor repeats MIN_IDLE_TIMEOUT_MS
--- from @repo/protocol, which is the cadence the host measures traffic on.
+-- from @repo/protocol, which is the cadence the host measures traffic on: a shorter timeout
+-- would be one the host accepts and cannot keep. The ceiling is a different kind of rule and
+-- deliberately loose — `always` is how an owner says never sleep, so a long wait is a legal
+-- preference rather than a wrong one. A day only ever refuses the slipped zero that turns
+-- fifteen minutes into two and a half hours and stops the saving without saying so.
 ALTER TABLE nibrun.apps
   ADD COLUMN activation text NOT NULL DEFAULT 'always',
   ADD COLUMN idle_timeout_ms integer NOT NULL DEFAULT 900000,
   ADD CONSTRAINT apps_activation_check CHECK (activation IN ('always', 'on-request')),
-  ADD CONSTRAINT apps_idle_timeout_ms_check CHECK (idle_timeout_ms >= 60000);
+  ADD CONSTRAINT apps_idle_timeout_ms_check
+    CHECK (idle_timeout_ms >= 60000 AND idle_timeout_ms <= 86400000);
 
 COMMENT ON COLUMN nibrun.apps.activation IS $c$@type import('@repo/protocol').AppActivation$c$;
 

--- a/apps/api/src/db/migrations/0036_deployments_say_what_the_microvm_is_doing.sql
+++ b/apps/api/src/db/migrations/0036_deployments_say_what_the_microvm_is_doing.sql
@@ -8,6 +8,11 @@
 --
 -- The CHECK repeats INSTANCE_STATES from @repo/protocol and nothing compares the two, so adding
 -- a state there is also a migration here.
+--
+-- This release adds `idle` to that enum, which makes it one the api has to be deployed *before*
+-- the agents. An unknown value in a known field fails the schema check and rejects the whole
+-- report, so an agent that has put one app to sleep against an api that predates this loses
+-- everything it was saying about every app on that host — not just the sleeping one.
 
 ALTER TABLE nibrun.deployments
   ADD COLUMN instance_state text,

--- a/apps/api/src/db/migrations/0036_deployments_say_what_the_microvm_is_doing.sql
+++ b/apps/api/src/db/migrations/0036_deployments_say_what_the_microvm_is_doing.sql
@@ -1,0 +1,18 @@
+-- What the host last said about the microVM, beside the state of the release it belongs to. The
+-- two were one sentence until `on-request` separated them: a release whose app sleeps between
+-- requests is still the release the next visitor reaches, so it stays `running` with no microVM
+-- behind it at all. Without somewhere to keep the other half, the owner of an app that is asleep
+-- because nobody has visited it is shown one that is running and no reading of anything.
+--
+-- Null for a row written before hosts said it, and for a deployment no host has reported on yet.
+--
+-- The CHECK repeats INSTANCE_STATES from @repo/protocol and nothing compares the two, so adding
+-- a state there is also a migration here.
+
+ALTER TABLE nibrun.deployments
+  ADD COLUMN instance_state text,
+  ADD CONSTRAINT deployments_instance_state_check
+    CHECK (instance_state IN ('pending', 'starting', 'running', 'unhealthy', 'stopping',
+                              'stopped', 'idle', 'failed'));
+
+COMMENT ON COLUMN nibrun.deployments.instance_state IS $c$@type import('@repo/protocol').InstanceState$c$;

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -581,6 +581,7 @@ export interface ISelectDeploymentsByAppResult {
     app_id: IDeploymentsColumns["app_id"];
     artifact_id: IDeploymentsColumns["artifact_id"];
     state: IDeploymentsColumns["state"];
+    instance_state: IDeploymentsColumns["instance_state"];
     activated_at: IDeploymentsColumns["activated_at"];
     /** The deployment this one replays, when it was made to go back to one. */
     rollback_of_deployment_id: IDeploymentsColumns["rollback_of_deployment_id"];
@@ -618,6 +619,7 @@ export interface ISelectDeploymentByIdResult {
     app_id: IDeploymentsColumns["app_id"];
     artifact_id: IDeploymentsColumns["artifact_id"];
     state: IDeploymentsColumns["state"];
+    instance_state: IDeploymentsColumns["instance_state"];
     activated_at: IDeploymentsColumns["activated_at"];
     /** The deployment this one replays, when it was made to go back to one. */
     rollback_of_deployment_id: IDeploymentsColumns["rollback_of_deployment_id"];
@@ -681,6 +683,7 @@ export interface ISelectInsertedDeploymentResult {
     app_id: IDeploymentsColumns["app_id"];
     artifact_id: IDeploymentsColumns["artifact_id"];
     state: IDeploymentsColumns["state"];
+    instance_state: IDeploymentsColumns["instance_state"];
     activated_at: IDeploymentsColumns["activated_at"];
     /** The deployment this one replays, when it was made to go back to one. */
     rollback_of_deployment_id: IDeploymentsColumns["rollback_of_deployment_id"];
@@ -1171,6 +1174,7 @@ export interface IDeploymentsColumns {
     updated_at: Date;
     public_ipv4: import("@repo/protocol").Ipv4Address | null;
     extra_public_port: import("@repo/protocol").HostPort | null;
+    instance_state: import("@repo/protocol").InstanceState | null;
 }
 
 /** Schema of `deployments`. */
@@ -1722,7 +1726,8 @@ export const schema = {
             created_at: { _columnName: "created_at", _foreignKeys: {} },
             updated_at: { _columnName: "updated_at", _foreignKeys: {} },
             public_ipv4: { _columnName: "public_ipv4", _foreignKeys: {} },
-            extra_public_port: { _columnName: "extra_public_port", _foreignKeys: {} }
+            extra_public_port: { _columnName: "extra_public_port", _foreignKeys: {} },
+            instance_state: { _columnName: "instance_state", _foreignKeys: {} }
         },
         _indexes: {
             deployments_app_id_idx: { _indexName: "deployments_app_id_idx" },
@@ -1737,6 +1742,7 @@ export const schema = {
             deployments_artifact_id_fkey: { _constraintName: "deployments_artifact_id_fkey" },
             deployments_config_id_fkey: { _constraintName: "deployments_config_id_fkey" },
             deployments_extra_public_port_check: { _constraintName: "deployments_extra_public_port_check" },
+            deployments_instance_state_check: { _constraintName: "deployments_instance_state_check" },
             deployments_pkey: { _constraintName: "deployments_pkey" },
             deployments_rollback_of_deployment_id_fkey: { _constraintName: "deployments_rollback_of_deployment_id_fkey" },
             deployments_state_check: { _constraintName: "deployments_state_check" }

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -32,6 +32,8 @@ export interface ISelectDesiredDeploymentsResult {
     restart_reset_after_ms: IAppConfigsColumns["restart_reset_after_ms"];
     /** The app config version this deployment was launched with. */
     config_id: IDeploymentsColumns["config_id"];
+    activation: IAppsColumns["activation"];
+    idle_timeout_ms: IAppsColumns["idle_timeout_ms"];
 }
 
 /** Result of query `SelectDesiredVolumes`. */
@@ -1108,6 +1110,8 @@ export interface IAppsColumns {
     /** Derived from the uuidv7 id; the moment the row was created. */
     created_at: Date;
     updated_at: Date;
+    activation: import("@repo/protocol").AppActivation;
+    idle_timeout_ms: number;
 }
 
 /** Schema of `apps`. */
@@ -1203,6 +1207,8 @@ export interface IDesiredDeploymentsColumns {
     restart_reset_after_ms: number | null;
     config_id: string | null;
     has_extra_public_port: boolean | null;
+    activation: string | null;
+    idle_timeout_ms: number | null;
 }
 
 /** Schema of `desired_deployments`. */
@@ -1653,7 +1659,9 @@ export const schema = {
             slug: { _columnName: "slug", _foreignKeys: {} },
             state: { _columnName: "state", _foreignKeys: {} },
             created_at: { _columnName: "created_at", _foreignKeys: {} },
-            updated_at: { _columnName: "updated_at", _foreignKeys: {} }
+            updated_at: { _columnName: "updated_at", _foreignKeys: {} },
+            activation: { _columnName: "activation", _foreignKeys: {} },
+            idle_timeout_ms: { _columnName: "idle_timeout_ms", _foreignKeys: {} }
         },
         _indexes: {
             apps_deleted_idx: { _indexName: "apps_deleted_idx" },
@@ -1662,6 +1670,8 @@ export const schema = {
             apps_slug_key: { _indexName: "apps_slug_key" }
         },
         _constraints: {
+            apps_activation_check: { _constraintName: "apps_activation_check" },
+            apps_idle_timeout_ms_check: { _constraintName: "apps_idle_timeout_ms_check" },
             apps_owner_id_fkey: { _constraintName: "apps_owner_id_fkey" },
             apps_pkey: { _constraintName: "apps_pkey" },
             apps_slug_key: { _constraintName: "apps_slug_key" },
@@ -1759,7 +1769,9 @@ export const schema = {
             restart_backoff_factor: { _columnName: "restart_backoff_factor", _foreignKeys: {} },
             restart_reset_after_ms: { _columnName: "restart_reset_after_ms", _foreignKeys: {} },
             config_id: { _columnName: "config_id", _foreignKeys: {} },
-            has_extra_public_port: { _columnName: "has_extra_public_port", _foreignKeys: {} }
+            has_extra_public_port: { _columnName: "has_extra_public_port", _foreignKeys: {} },
+            activation: { _columnName: "activation", _foreignKeys: {} },
+            idle_timeout_ms: { _columnName: "idle_timeout_ms", _foreignKeys: {} }
         },
         _indexes: {},
         _constraints: {}

--- a/apps/api/src/lib/deployments/desired-state.ts
+++ b/apps/api/src/lib/deployments/desired-state.ts
@@ -4,6 +4,7 @@ import {
   type AppId,
   DEFAULT_VOLUME_SIZE_BYTES,
   type DesiredInstance,
+  type DesiredInstanceState,
   type DesiredVolume,
   Value,
   type VolumeId,
@@ -64,11 +65,15 @@ export function toDesiredInstance({
   environments: Map<string, SealedEnvironment>;
   secretsKey: TenantSecretsKey;
 }): DesiredInstance {
+  const desiredState = desiredInstanceState(row);
   return {
     appId: row.app_id,
     deploymentId: row.id,
     volumeId: volumeIdOf(row.app_id),
-    desiredState: row.state === 'active' ? 'running' : 'stopped',
+    desiredState,
+    // Left out for an app whose microVM is kept up either way, so a host is never handed a
+    // timeout it would be wrong to act on.
+    ...(desiredState === 'on-request' ? { idleTimeoutMs: row.idle_timeout_ms } : {}),
     artifact: {
       digest: row.digest,
       sizeBytes: Number(row.size_bytes),
@@ -82,6 +87,18 @@ export function toDesiredInstance({
     }),
     hostnames: hostnames.get(row.app_id) ?? [],
   };
+}
+
+/**
+ * Suspended wins over any activation policy: an owner who has stopped their app has said the
+ * microVM should be down, and `on-request` would have the next stranger to find the hostname
+ * start it again.
+ */
+function desiredInstanceState(row: DesiredDeploymentRow): DesiredInstanceState {
+  if (row.state !== 'active') {
+    return 'stopped';
+  }
+  return row.activation === 'on-request' ? 'on-request' : 'running';
 }
 
 export type DesiredEnvironmentRow = Queries['SelectDesiredEnvironment'];

--- a/apps/api/src/lib/deployments/lifecycle.ts
+++ b/apps/api/src/lib/deployments/lifecycle.ts
@@ -95,6 +95,10 @@ export class DeploymentLifecycle {
   #whileStopped(reported: ReportedInstance | undefined): DeploymentState {
     switch (reported?.state) {
       case 'running':
+      // An on-request app that has been resumed: no microVM yet, and the release is nonetheless
+      // the one the next request reaches. Waiting for a boot that only a visitor can cause would
+      // leave it reading as stopped until someone happened to load it.
+      case 'idle':
         return 'running';
       case 'failed':
         return 'failed';
@@ -121,6 +125,10 @@ export class DeploymentLifecycle {
       case 'starting':
         return 'starting';
       case 'running':
+      // The host has taken the release on and is waiting to be asked for a microVM, which is as
+      // far as an on-request app comes up on its own. Nothing is late, so this is where it stops
+      // being measured against the startup deadline.
+      case 'idle':
         return 'running';
       case 'failed':
         return 'failed';

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -108,7 +108,8 @@ export class AgentRepository extends Repository implements AgentRepositoryContra
                  health_check_grace_period_ms, health_check_healthy_threshold,
                  health_check_unhealthy_threshold,
                  restart_max_restarts, restart_initial_backoff_ms, restart_max_backoff_ms,
-                 restart_backoff_factor, restart_reset_after_ms, config_id
+                 restart_backoff_factor, restart_reset_after_ms, config_id,
+                 activation, idle_timeout_ms
           FROM nibrun.desired_deployments
         `,
         this.sql.SelectDesiredVolumes`

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -68,6 +68,7 @@ export abstract class AppsRepositoryContract {
     readings: ReadonlyMap<AppId, FilesystemUsage>;
   }): Promise<void>;
   abstract recordComputeUsage(input: { readings: ReadonlyMap<AppId, ComputeUsage> }): Promise<void>;
+  abstract clearComputeUsage(input: { appIds: readonly AppId[] }): Promise<void>;
   abstract updateConfig(input: OwnedApp & { patch: SealedConfigPatch }): Promise<AppRow | null>;
   abstract updateState(input: StateChange): Promise<AppRow | null>;
   abstract finishDeleting(input: { appId: AppId }): Promise<boolean>;
@@ -315,6 +316,25 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
             compute_measured_at = EXCLUDED.compute_measured_at
         WHERE nibrun.app_usage.compute_measured_at IS NULL
            OR EXCLUDED.compute_measured_at > nibrun.app_usage.compute_measured_at
+    `;
+  }
+
+  /**
+   * Forgets what an app was last measured spending, for one whose microVM has gone on purpose.
+   *
+   * Not the same as a reading that failed to arrive, which is why it is a statement of its own:
+   * a guest that could not be asked this minute still has a last known figure worth keeping, and
+   * one that is not there has nothing left to be the answer about. Cleared rather than zeroed —
+   * nought is a reading somebody would act on, and absent is how this end writes unknown.
+   *
+   * The volume half is untouched: a filesystem is still there when the microVM holding it is not.
+   */
+  async clearComputeUsage({ appIds }: { appIds: readonly AppId[] }): Promise<void> {
+    await this.sql`
+      UPDATE nibrun.app_usage
+      SET memory_total_bytes = NULL, memory_used_bytes = NULL, cpu_share = NULL,
+          compute_measured_at = NULL
+      WHERE app_id = ANY(${this.sql.array([...appIds], TEXT_ARRAY)}::uuid[])
     `;
   }
 

--- a/apps/api/src/repositories/deployments.repository.ts
+++ b/apps/api/src/repositories/deployments.repository.ts
@@ -5,6 +5,7 @@ import type {
   DeploymentId,
   DeploymentState,
   HostPort,
+  InstanceState,
   Ipv4Address,
   OwnerId,
 } from '@repo/protocol';
@@ -42,6 +43,8 @@ export type LiveDeploymentRow = Queries['SelectLiveDeployments'];
 export type ReportedDeployment = {
   deploymentId: DeploymentId;
   state: DeploymentState;
+  /** The microVM's own state, which the release's no longer answers: a running one can be asleep. */
+  instanceState: InstanceState;
   hostPort: HostPort | null;
   guestIpv4: Ipv4Address | null;
   publicIpv4: Ipv4Address | null;
@@ -158,7 +161,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
   listByApp({ appId, ownerId }: DeploymentsByAppInput): Promise<DeploymentRow[]> {
     return this.sql.SelectDeploymentsByApp`
       /* @notNull environment_names */
-      SELECT d.id, d.app_id, d.artifact_id, d.state, d.activated_at,
+      SELECT d.id, d.app_id, d.artifact_id, d.state, d.instance_state, d.activated_at,
              d.rollback_of_deployment_id, d.created_at, d.message,
              d.started_at, d.last_healthy_at, d.restart_count,
              d.public_ipv4, d.extra_public_port,
@@ -183,7 +186,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
   }: DeploymentByIdInput): Promise<DeploymentRow | null> {
     const [row] = await this.sql.SelectDeploymentById`
       /* @notNull environment_names */
-      SELECT d.id, d.app_id, d.artifact_id, d.state, d.activated_at,
+      SELECT d.id, d.app_id, d.artifact_id, d.state, d.instance_state, d.activated_at,
              d.rollback_of_deployment_id, d.created_at, d.message,
              d.started_at, d.last_healthy_at, d.restart_count,
              d.public_ipv4, d.extra_public_port,
@@ -234,6 +237,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
         await tx.ApplyReportedDeployment`
           UPDATE nibrun.deployments SET
             state = ${instance.state},
+            instance_state = ${instance.instanceState},
             host_port = ${instance.hostPort},
             guest_ipv4 = ${instance.guestIpv4},
             public_ipv4 = ${instance.publicIpv4},
@@ -307,7 +311,7 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
   }): Promise<DeploymentRow | null> {
     const [row] = await tx.SelectInsertedDeployment`
       /* @notNull environment_names */
-      SELECT d.id, d.app_id, d.artifact_id, d.state, d.activated_at,
+      SELECT d.id, d.app_id, d.artifact_id, d.state, d.instance_state, d.activated_at,
              d.rollback_of_deployment_id, d.created_at, d.message,
              d.started_at, d.last_healthy_at, d.restart_count,
              d.public_ipv4, d.extra_public_port,

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -336,6 +336,11 @@ export class AppsService extends Service {
    *
    * Deduplicated for the same reason, and by the same rule — an app has one instance on a host,
    * and a report naming it twice must not take the whole report down with it.
+   *
+   * An app reported asleep is cleared rather than left alone. A host stops sending a reading for
+   * one, and doing nothing about that would leave the last figure standing — so an app that is
+   * holding nothing would go on being shown spending what it spent before it went to sleep, for
+   * as long as it slept.
    */
   async recordComputeUsage({
     instances,
@@ -343,13 +348,19 @@ export class AppsService extends Service {
     instances: readonly ReportedInstance[];
   }): Promise<void> {
     const readings = new Map<AppId, ComputeUsage>();
+    const asleep = new Set<AppId>();
     for (const instance of instances) {
       if (instance.compute) {
         readings.set(instance.appId, instance.compute);
+      } else if (instance.state === 'idle') {
+        asleep.add(instance.appId);
       }
     }
     if (readings.size > 0) {
       await this.appsRepo.recordComputeUsage({ readings });
+    }
+    if (asleep.size > 0) {
+      await this.appsRepo.clearComputeUsage({ appIds: [...asleep] });
     }
   }
 

--- a/apps/api/src/services/deployments.service.ts
+++ b/apps/api/src/services/deployments.service.ts
@@ -179,6 +179,7 @@ function toReportedDeployment({
   return {
     deploymentId: instance.deploymentId,
     state,
+    instanceState: instance.state,
     hostPort: instance.hostPort ?? null,
     guestIpv4: instance.guestIpv4 ?? null,
     publicIpv4: instance.publicIpv4 ?? null,
@@ -199,6 +200,7 @@ function toPublicDeployment(row: DeploymentRow): PublicDeployment {
     state: row.state,
     createdAt: toTimestamp(row.created_at),
     restartCount: row.restart_count,
+    ...(row.instance_state && { instanceState: row.instance_state }),
     ...(row.public_ipv4 && { publicIpv4: row.public_ipv4 }),
     ...(row.extra_public_port && { extraPublicPort: row.extra_public_port }),
     ...(row.started_at && { startedAt: toTimestamp(row.started_at) }),

--- a/apps/api/tests/lib/deployments/desired-state.test.ts
+++ b/apps/api/tests/lib/deployments/desired-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { AppState } from '@repo/protocol';
+import type { AppActivation, AppState } from '@repo/protocol';
 import type { Queries } from '#db/queries.gen.ts';
 import { environmentByDeployment, toDesiredInstance } from '#lib/deployments/desired-state.ts';
 import { sealEnvironment, sealedFromStore } from '#lib/tenant-secrets.ts';
@@ -10,6 +10,7 @@ type EnvironmentRow = Queries['SelectDesiredEnvironment'];
 const DEPLOYMENT = 'deployment-1';
 const OTHER_DEPLOYMENT = 'deployment-2';
 const SECRET = '/app/data/.openclaw';
+const IDLE_TIMEOUT_MS = 900_000;
 
 function rowsFor(entries: Array<[string, string, string]>): EnvironmentRow[] {
   return entries.map(
@@ -91,19 +92,56 @@ describe('what a host is told to run with', () => {
  */
 describe('whether a host runs it is the state of the app, not of the release', () => {
   test('an active app is the one that runs', () => {
-    expect(desiredInstance('active').desiredState).toBe('running');
+    expect(desiredInstance({ state: 'active' }).desiredState).toBe('running');
   });
 
   // `deleting` is here because the app stays in desired state until its filesystem is gone, and
   // a microVM still serving out of one being torn down is the thing that must not happen.
   test.each(['suspended', 'deleting'] as const)('a %s app is one the host stops', (state) => {
-    expect(desiredInstance(state).desiredState).toBe('stopped');
+    expect(desiredInstance({ state }).desiredState).toBe('stopped');
   });
 });
 
-function desiredInstance(state: AppState) {
+/**
+ * Two columns, one answer. A host is told what should be true of the app rather than the policy
+ * behind it, which is why suspending an `on-request` app produces the same `stopped` as
+ * suspending any other: whichever is stricter is what the host has to act on.
+ */
+describe('how the app comes up is folded into the same answer', () => {
+  test('an active app that runs on request is neither running nor stopped', () => {
+    expect(desiredInstance({ state: 'active', activation: 'on-request' }).desiredState).toBe(
+      'on-request',
+    );
+  });
+
+  test('suspending it wins over its activation policy', () => {
+    expect(desiredInstance({ state: 'suspended', activation: 'on-request' }).desiredState).toBe(
+      'stopped',
+    );
+  });
+
+  test('the timeout rides along only where there is something to time', () => {
+    expect(desiredInstance({ state: 'active', activation: 'on-request' }).idleTimeoutMs).toBe(
+      IDLE_TIMEOUT_MS,
+    );
+    expect(
+      desiredInstance({ state: 'active', activation: 'always' }).idleTimeoutMs,
+    ).toBeUndefined();
+    expect(
+      desiredInstance({ state: 'suspended', activation: 'on-request' }).idleTimeoutMs,
+    ).toBeUndefined();
+  });
+});
+
+function desiredInstance({
+  state,
+  activation = 'always',
+}: {
+  state: AppState;
+  activation?: AppActivation;
+}) {
   return toDesiredInstance({
-    row: { ...deploymentRow(), state },
+    row: { ...deploymentRow(), state, activation },
     hostnames: new Map(),
     environments: new Map(),
     secretsKey: TEST_SECRETS_KEY,
@@ -135,5 +173,7 @@ function deploymentRow() {
     restart_backoff_factor: 2,
     restart_reset_after_ms: 1000,
     config_id: 'config-1',
+    activation: 'always',
+    idle_timeout_ms: IDLE_TIMEOUT_MS,
   } as unknown as Parameters<typeof toDesiredInstance>[0]['row'];
 }

--- a/apps/api/tests/lib/deployments/lifecycle.test.ts
+++ b/apps/api/tests/lib/deployments/lifecycle.test.ts
@@ -47,6 +47,11 @@ describe('a release follows the microVM running it', () => {
     ['pending', 'starting'],
     ['starting', 'starting'],
     ['running', 'running'],
+    // An app that runs on request comes up no further than this on its own, so an `idle` report
+    // is the host saying it has the release and is waiting to be asked. Anything short of running
+    // would leave it reading as mid-deploy until a stranger happened to load it — and, past the
+    // startup deadline, as one that failed to come up.
+    ['idle', 'running'],
     ['failed', 'failed'],
   ];
 
@@ -212,4 +217,14 @@ describe('a terminal deployment is not something a report can reopen', () => {
       expect(advance({ from, instance: 'running' })).toBe(from);
     });
   }
+});
+
+describe('a release that runs on request is live between requests', () => {
+  test('an idle report past the startup deadline is not a release that never came up', () => {
+    expect(advance({ instance: 'idle', afterMs: STARTUP_DEADLINE_MS + 1 })).toBe('running');
+  });
+
+  test('resuming a suspended one is live again before anything has visited it', () => {
+    expect(advance({ from: 'stopped', instance: 'idle' })).toBe('running');
+  });
 });

--- a/apps/api/tests/repositories/desired-activation.test.ts
+++ b/apps/api/tests/repositories/desired-activation.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { SQL } from 'bun';
+import { startTestDatabase, stopTestDatabase } from '#tests/support/database.ts';
+
+const DATABASE_START_TIMEOUT_MS = 180_000;
+
+const APP_SLUG = 'lazy';
+const SHORT_IDLE_MS = 60_000;
+
+type DesiredRow = { state: string; activation: string; idle_timeout_ms: number };
+
+/**
+ * `nibrun.desired_deployments` is what a host is told to run, and how an app comes up now reaches
+ * it from a column on the app rather than from the config a deployment pinned. That is the whole
+ * point of it living there — an owner changes how their app runs without deploying — and nothing
+ * short of the real view and the real constraint can say whether it does.
+ */
+describe('how an app comes up travels with what it should be doing', () => {
+  let sql: SQL;
+
+  beforeAll(async () => {
+    sql = await startTestDatabase();
+    await seedDeployedApp(sql);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await stopTestDatabase(sql);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  async function desired(): Promise<DesiredRow> {
+    const [row] = (await sql.unsafe(
+      'SELECT state, activation, idle_timeout_ms FROM nibrun.desired_deployments',
+    )) as DesiredRow[];
+    if (!row) {
+      throw new Error('the seeded app is not in desired state');
+    }
+    return row;
+  }
+
+  test('an app nobody has said anything about is kept up, as every app was before', async () => {
+    expect(await desired()).toMatchObject({ state: 'active', activation: 'always' });
+  });
+
+  test('one column is the whole of turning it on', async () => {
+    await sql.unsafe('UPDATE nibrun.apps SET activation = $1 WHERE slug = $2', [
+      'on-request',
+      APP_SLUG,
+    ]);
+
+    expect(await desired()).toMatchObject({ state: 'active', activation: 'on-request' });
+  });
+
+  test('and how long it may go unasked-for rides beside it', async () => {
+    await sql.unsafe('UPDATE nibrun.apps SET idle_timeout_ms = $1 WHERE slug = $2', [
+      SHORT_IDLE_MS,
+      APP_SLUG,
+    ]);
+
+    expect((await desired()).idle_timeout_ms).toBe(SHORT_IDLE_MS);
+  });
+
+  // Both columns repeat something @repo/protocol states and nothing compares the two, so the
+  // check is the only thing standing between a typo and a host being told a policy it cannot act
+  // on — which it would read as `always`, quietly keeping every such app up.
+  test('an activation nothing implements is refused rather than stored', async () => {
+    expect(
+      await refused(() =>
+        sql.unsafe('UPDATE nibrun.apps SET activation = $1 WHERE slug = $2', [
+          'sometimes',
+          APP_SLUG,
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  test('and so is a timeout too short to be anything but a mistake', async () => {
+    expect(
+      await refused(() =>
+        sql.unsafe('UPDATE nibrun.apps SET idle_timeout_ms = 1000 WHERE slug = $1', [APP_SLUG]),
+      ),
+    ).toBe(true);
+  });
+
+  // Suspending is the stricter answer and has to win: the host reads one field, and an app told
+  // it runs on request would be started again by whoever found its hostname next.
+  test('a suspended app keeps its policy and is stopped anyway', async () => {
+    await sql.unsafe('UPDATE nibrun.apps SET state = $1 WHERE slug = $2', ['suspended', APP_SLUG]);
+
+    expect(await desired()).toMatchObject({ state: 'suspended', activation: 'on-request' });
+  });
+});
+
+/** Whether the database turned the statement down, without the failure ending the test. */
+async function refused(statement: () => Promise<unknown>): Promise<boolean> {
+  try {
+    await statement();
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/** An app a host would be told to run: one live deployment, one config version. */
+async function seedDeployedApp(sql: SQL): Promise<void> {
+  await sql.unsafe(
+    `INSERT INTO auth."user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+     VALUES ('owner', 'owner', 'owner@example.com', true, now(), now())`,
+  );
+  await sql.unsafe(`INSERT INTO nibrun.apps (owner_id, slug) VALUES ('owner', $1)`, [APP_SLUG]);
+  await sql.unsafe(
+    `INSERT INTO nibrun.artifacts (app_id, digest, size_bytes, object_key, original_file_name)
+     SELECT id, 'sha256:a', 1, 'artifacts/a', 'app' FROM nibrun.apps WHERE slug = $1`,
+    [APP_SLUG],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.app_configs (
+       app_id, http_port, args, vcpu_count, memory_mib,
+       health_check_interval_ms, health_check_timeout_ms, health_check_grace_period_ms,
+       health_check_healthy_threshold, health_check_unhealthy_threshold,
+       restart_max_restarts, restart_initial_backoff_ms, restart_max_backoff_ms,
+       restart_backoff_factor, restart_reset_after_ms)
+     SELECT id, 8080, '{}'::text[], 1, 512, 1000, 1000, 1000, 1, 3, 5, 500, 5000, 2, 60000
+     FROM nibrun.apps WHERE slug = $1`,
+    [APP_SLUG],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.deployments (app_id, artifact_id, config_id, state)
+     SELECT a.id, ar.id, c.id, 'running'
+     FROM nibrun.apps a
+     JOIN nibrun.artifacts ar ON ar.app_id = a.id
+     JOIN nibrun.app_configs c ON c.app_id = a.id
+     WHERE a.slug = $1`,
+    [APP_SLUG],
+  );
+}

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -124,6 +124,7 @@ class StubAppsRepository implements AppsRepositoryContract {
   readonly leftovers = new Map<AppId, Leftovers>();
   readonly measured: ReadonlyMap<AppId, FilesystemUsage>[] = [];
   readonly spending: ReadonlyMap<AppId, ComputeUsage>[] = [];
+  readonly forgotten: AppId[][] = [];
   deleting: AppId[] = [];
   purgeable: AppId[] = [];
   deployedApps: AppId[] = [];
@@ -223,6 +224,11 @@ class StubAppsRepository implements AppsRepositoryContract {
 
   recordComputeUsage({ readings }: { readings: ReadonlyMap<AppId, ComputeUsage> }): Promise<void> {
     this.spending.push(new Map(readings));
+    return Promise.resolve();
+  }
+
+  clearComputeUsage({ appIds }: { appIds: readonly AppId[] }): Promise<void> {
+    this.forgotten.push([...appIds]);
     return Promise.resolve();
   }
 
@@ -957,6 +963,14 @@ describe('what a guest is spending, as the host running it last measured it', ()
     };
   }
 
+  /** An app asleep between requests, which is a host reporting no reading and saying why. */
+  const ASLEEP: ReportedInstance = {
+    appId: APP_ID,
+    deploymentId: DEPLOYMENT_ID,
+    state: 'idle',
+    restartCount: 0,
+  };
+
   test('a reading a host took is recorded against the app it is running', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
 
@@ -973,6 +987,28 @@ describe('what a guest is spending, as the host running it last measured it', ()
     await serviceWith({ appsRepo }).recordComputeUsage({ instances: [reportedInstance()] });
 
     expect(appsRepo.spending).toEqual([]);
+  });
+
+  /**
+   * The difference between a reading that did not arrive and a guest that is not there. Leaving
+   * the last figure standing would have an app holding nothing go on being shown spending what it
+   * spent before it slept, for as long as it slept.
+   */
+  test('an app reported asleep is forgotten rather than left as it was', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+
+    await serviceWith({ appsRepo }).recordComputeUsage({ instances: [ASLEEP] });
+
+    expect(appsRepo.forgotten).toEqual([[APP_ID]]);
+    expect(appsRepo.spending).toEqual([]);
+  });
+
+  test('and a running app that simply was not measured is left exactly as it was', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+
+    await serviceWith({ appsRepo }).recordComputeUsage({ instances: [reportedInstance()] });
+
+    expect(appsRepo.forgotten).toEqual([]);
   });
 
   test('two instances naming one app are written once, as the later reading', async () => {

--- a/apps/api/tests/services/deployments.test.ts
+++ b/apps/api/tests/services/deployments.test.ts
@@ -87,6 +87,7 @@ function deploymentRow(overrides: Partial<DeploymentRow> = {}): DeploymentRow {
     app_id: APP_ID,
     artifact_id: ARTIFACT_ID,
     state: 'pending',
+    instance_state: null,
     activated_at: null,
     rollback_of_deployment_id: null,
     created_at: CREATED_AT,

--- a/apps/dashboard/src/components/apps/app-status-badge.tsx
+++ b/apps/dashboard/src/components/apps/app-status-badge.tsx
@@ -29,6 +29,11 @@ export function AppStatusBadge({ app }: { app: AppSummary }) {
       return <AppStateBadge state={status.status.state} />;
     case 'deployment':
       return <DeploymentStateBadge state={status.status.state} />;
+    // Outline rather than destructive or muted: an app waiting for its first visitor is doing
+    // what it was configured to do, and a badge that reads as trouble would have owners
+    // switching the saving off to make it go away.
+    case 'instance':
+      return <Badge variant="outline">{APP_STATUS_LABELS[status.status.state]}</Badge>;
     case 'transition':
       return <Badge variant="outline">{status.status.label}</Badge>;
     case 'never-deployed':

--- a/apps/dashboard/src/lib/app-actions.ts
+++ b/apps/dashboard/src/lib/app-actions.ts
@@ -46,6 +46,10 @@ const AVAILABILITY: Record<AppStatusKey, AppActions> = {
   pending: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
   starting: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
   running: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
+  // Everything a running app offers: an app asleep between requests is one that is up as far as
+  // its owner is concerned, and suspend is still what takes it offline for good rather than
+  // until the next visitor.
+  idle: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
   // Nothing is serving under either of these, so there is nothing to take offline — and a bundle
   // is cut from the volume rather than from a running microVM, so exporting still works.
   failed: { deploy: ENABLED, export: ENABLED, suspend: HIDDEN, delete: ENABLED },

--- a/apps/dashboard/src/lib/hooks/use-app-status.ts
+++ b/apps/dashboard/src/lib/hooks/use-app-status.ts
@@ -31,7 +31,12 @@ function statusOf({
   app: AppSummary;
   deployments: DeploymentSummary[] | undefined;
 }): AppStatus {
-  return appStatus({ appState: app.state, deploymentState: deployments?.[0]?.state });
+  const newest = deployments?.[0];
+  return appStatus({
+    appState: app.state,
+    deploymentState: newest?.state,
+    instanceState: newest?.instanceState,
+  });
 }
 
 /**

--- a/packages/app-operations/src/apps.ts
+++ b/packages/app-operations/src/apps.ts
@@ -34,7 +34,11 @@ export async function appWithStatus({ api, slug }: { api: PublicApiClient; slug:
   return {
     app,
     newest,
-    status: appStatus({ appState: app.state, deploymentState: newest?.state }),
+    status: appStatus({
+      appState: app.state,
+      deploymentState: newest?.state,
+      instanceState: newest?.instanceState,
+    }),
   };
 }
 

--- a/packages/app-operations/src/operations.ts
+++ b/packages/app-operations/src/operations.ts
@@ -40,6 +40,14 @@ const STATE: Record<AppStatusKey, AppState> = {
   pending: { because: 'is staging a release', refuses: [] },
   starting: { because: 'is starting', refuses: [] },
   running: { because: 'is running', refuses: [] },
+  // Refuses only what has to reach inside a microVM: there is none until a visitor causes one,
+  // and a browse is not a visit. Everything else is asked of the app rather than of the guest,
+  // and an app waiting to be asked for is one an owner may still release, export or suspend.
+  idle: {
+    because: 'is asleep until something asks for it',
+    hint: 'Open it to wake it.',
+    refuses: ['files'],
+  },
   // The volume outlives the release that failed on it, so everything but reading it from inside
   // a microVM still works — including the export that is how you get at it instead.
   failed: { because: 'is on a release that failed', refuses: ['files'] },

--- a/packages/app-operations/src/status.ts
+++ b/packages/app-operations/src/status.ts
@@ -1,4 +1,4 @@
-import type { AppState, DeploymentState } from '@repo/protocol';
+import type { AppState, DeploymentState, InstanceState } from '@repo/protocol';
 
 /**
  * What an app is doing, from the two things that know: the app row, which is what its owner asked
@@ -19,6 +19,10 @@ export type AppStatus =
   // Never `stopped`: a release is only ever stopped because its app was suspended, which is the
   // suspended app above or one of the two transitions below.
   | { readonly kind: 'deployment'; readonly state: Exclude<DeploymentState, 'stopped'> }
+  // The one thing the release cannot say about itself. An `on-request` app between visitors has a
+  // running release and no microVM, and the two are not the same news: the release is serving, and
+  // the app is asleep until somebody asks for it.
+  | { readonly kind: 'instance'; readonly state: Extract<InstanceState, 'idle'> }
   | { readonly kind: 'transition'; readonly label: AppTransition }
   | { readonly kind: 'never-deployed' };
 
@@ -35,6 +39,7 @@ export function statusKey(status: AppStatus): AppStatusKey {
   switch (status.kind) {
     case 'app':
     case 'deployment':
+    case 'instance':
       return status.state;
     case 'transition':
       return status.label;
@@ -43,6 +48,7 @@ export function statusKey(status: AppStatus): AppStatusKey {
   }
 }
 
+const ASLEEP: AppStatus = { kind: 'instance', state: 'idle' };
 const SUSPENDED: AppStatus = { kind: 'app', state: 'suspended' };
 const SUSPENDING: AppStatus = { kind: 'transition', label: 'suspending' };
 const RESUMING: AppStatus = { kind: 'transition', label: 'resuming' };
@@ -54,10 +60,13 @@ const NOT_SERVING: readonly DeploymentState[] = ['stopped', 'failed', 'supersede
 export function appStatus({
   appState,
   deploymentState,
+  instanceState,
 }: {
   appState: AppState;
   /** Absent for an app nobody has deployed, which no release can say anything about. */
   deploymentState: DeploymentState | undefined;
+  /** Absent for a release no host has reported on, and for one reported by a host that predates it. */
+  instanceState?: InstanceState | undefined;
 }): AppStatus {
   if (appState === 'deleting' || appState === 'deleted') {
     return { kind: 'app', state: appState };
@@ -69,6 +78,12 @@ export function appStatus({
   }
   if (deploymentState === undefined) {
     return NEVER_DEPLOYED;
+  }
+  // Read only under a release that is serving, which is the only place it means anything: an app
+  // that sleeps between requests has a running release with no microVM behind it, and telling the
+  // owner it is running would have them reading a page about an app that is not there.
+  if (deploymentState === 'running' && instanceState === 'idle') {
+    return ASLEEP;
   }
   // The one state the release holds only because the app was suspended. Asking for the app back
   // is not the host having started it, so this is the gap between the two said out loud.
@@ -89,6 +104,9 @@ export const APP_STATUS_LABELS: Record<AppStatusKey, string> = {
   pending: 'pending',
   starting: 'starting',
   running: 'running',
+  // Not the key: `idle` is a word for a machine doing nothing, and this is an app doing exactly
+  // what its owner configured — waiting to be asked, at no cost, until somebody visits it.
+  idle: 'asleep',
   failed: 'failed',
   superseded: 'superseded',
   suspended: 'suspended',
@@ -108,6 +126,9 @@ const LIVE_OUTPUT: Record<AppStatusKey, boolean> = {
   pending: false,
   starting: true,
   running: true,
+  // There is no microVM to say anything until a request makes one, and the request that would is
+  // the tenant's own traffic rather than somebody opening a log stream.
+  idle: false,
   failed: false,
   superseded: false,
   suspended: false,

--- a/packages/app-operations/tests/operations.test.ts
+++ b/packages/app-operations/tests/operations.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import { APP_STATES, type AppState, DEPLOYMENT_STATES, type DeploymentState } from '@repo/protocol';
+import {
+  APP_STATES,
+  type AppState,
+  DEPLOYMENT_STATES,
+  type DeploymentState,
+  INSTANCE_STATES,
+  type InstanceState,
+} from '@repo/protocol';
 import { APP_OPERATIONS, type AppOperation, operationRefusal } from '#operations.ts';
 import { appStatus } from '#status.ts';
 
@@ -9,15 +16,17 @@ function refusal({
   operation,
   appState = 'active',
   deploymentState,
+  instanceState,
   message,
 }: {
   operation: AppOperation;
   appState?: AppState;
   deploymentState?: DeploymentState;
+  instanceState?: InstanceState;
   message?: string;
 }): string | undefined {
   return operationRefusal({
-    status: appStatus({ appState, deploymentState }),
+    status: appStatus({ appState, deploymentState, instanceState }),
     operation,
     slug: SLUG,
     release: deploymentState && { id: 'deployment-1', state: deploymentState, message },
@@ -106,6 +115,26 @@ describe('an app on its way out', () => {
   });
 });
 
+describe('an app asleep between requests', () => {
+  const asleep = { deploymentState: 'running', instanceState: 'idle' } as const;
+
+  // The one thing that has to reach inside a microVM, and there is none until a visitor causes
+  // one — which a browse is not.
+  test('has no microVM mounting its filesystem, and says what would make one', () => {
+    expect(refusal({ operation: 'files', ...asleep })).toBe(
+      'App quiet-otter is asleep until something asks for it, so nothing is mounting its filesystem to read. Open it to wake it.',
+    );
+  });
+
+  const still: AppOperation[] = ['release', 'logs', 'export', 'suspend', 'delete', 'domains'];
+
+  for (const operation of still) {
+    test(`is still an app to ${operation}`, () => {
+      expect(refusal({ operation, ...asleep })).toBeUndefined();
+    });
+  }
+});
+
 test('a serving app refuses nothing', () => {
   for (const operation of APP_OPERATIONS) {
     expect(refusal({ operation, deploymentState: 'running' })).toBeUndefined();
@@ -116,11 +145,16 @@ test('a serving app refuses nothing', () => {
 // command someone finds hanging on an app that was never going to answer.
 test('every app and release the api can report is answered for, command by command', () => {
   const releases: (DeploymentState | undefined)[] = [...DEPLOYMENT_STATES, undefined];
+  const microVms: (InstanceState | undefined)[] = [...INSTANCE_STATES, undefined];
 
   for (const appState of APP_STATES) {
     for (const deploymentState of releases) {
-      for (const operation of APP_OPERATIONS) {
-        expect(() => refusal({ operation, appState, deploymentState })).not.toThrow();
+      for (const instanceState of microVms) {
+        for (const operation of APP_OPERATIONS) {
+          expect(() =>
+            refusal({ operation, appState, deploymentState, instanceState }),
+          ).not.toThrow();
+        }
       }
     }
   }

--- a/packages/app-operations/tests/status.test.ts
+++ b/packages/app-operations/tests/status.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, test } from 'bun:test';
-import type { AppState, DeploymentState } from '@repo/protocol';
-import { type AppStatus, appStatus, hasLiveOutput, isSettling } from '#status.ts';
+import type { AppState, DeploymentState, InstanceState } from '@repo/protocol';
+import {
+  APP_STATUS_LABELS,
+  type AppStatus,
+  appStatus,
+  hasLiveOutput,
+  isSettling,
+  statusKey,
+} from '#status.ts';
 
 function status({
   appState = 'active',
   deploymentState,
+  instanceState,
 }: {
   appState?: AppState;
   deploymentState?: DeploymentState;
+  instanceState?: InstanceState;
 } = {}): AppStatus {
-  return appStatus({ appState, deploymentState });
+  return appStatus({ appState, deploymentState, instanceState });
 }
 
 describe('an app on its way out answers for itself', () => {
@@ -85,6 +94,53 @@ describe('resuming is not running until the host has started it', () => {
   });
 });
 
+/**
+ * An `on-request` app is the one case where the release and the microVM say different things: the
+ * release is running because the next visitor reaches it, and there is nothing running until one
+ * does. The owner is owed the second half — a page saying `running` about an app holding no memory
+ * and reporting no readings is a page they would read as broken.
+ */
+describe('an app asleep between requests says so', () => {
+  test('a running release with no microVM behind it is asleep', () => {
+    expect(status({ deploymentState: 'running', instanceState: 'idle' })).toEqual({
+      kind: 'instance',
+      state: 'idle',
+    });
+  });
+
+  test('and it is not an error: waiting to be asked is what it was configured for', () => {
+    expect(
+      APP_STATUS_LABELS[statusKey(status({ deploymentState: 'running', instanceState: 'idle' }))],
+    ).toBe('asleep');
+  });
+
+  // Read only under a release that is serving. Anything else is a host still catching up with a
+  // deploy or a suspend, and the release is the one being waited on there.
+  const elsewhere = [
+    'pending',
+    'starting',
+    'stopped',
+  ] as const satisfies readonly DeploymentState[];
+
+  for (const deploymentState of elsewhere) {
+    test(`a ${deploymentState} release is what the app is doing whatever its microVM says`, () => {
+      expect(status({ deploymentState, instanceState: 'idle' })).not.toEqual({
+        kind: 'instance',
+        state: 'idle',
+      });
+    });
+  }
+
+  test('a suspended app is suspending whatever its microVM says', () => {
+    expect(
+      status({ appState: 'suspended', deploymentState: 'running', instanceState: 'idle' }),
+    ).toEqual({
+      kind: 'transition',
+      label: 'suspending',
+    });
+  });
+});
+
 describe('what is worth asking about again', () => {
   const moving: [string, AppStatus][] = [
     ['suspending', { kind: 'transition', label: 'suspending' }],
@@ -106,6 +162,8 @@ describe('what is worth asking about again', () => {
     ['a failed release', { kind: 'deployment', state: 'failed' }],
     ['a suspended app', { kind: 'app', state: 'suspended' }],
     ['an app never deployed', { kind: 'never-deployed' }],
+    // Nothing is going to move it: only a visitor can, and no amount of asking is one.
+    ['an app asleep between requests', { kind: 'instance', state: 'idle' }],
   ];
 
   for (const [name, status] of settled) {
@@ -138,6 +196,7 @@ describe('what has something running to write output', () => {
     ['a suspended app', status({ appState: 'suspended', deploymentState: 'stopped' })],
     ['one nobody has deployed', status()],
     ['one being deleted', status({ appState: 'deleting' })],
+    ['one asleep between requests', status({ deploymentState: 'running', instanceState: 'idle' })],
   ];
 
   for (const [name, each] of silent) {

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -13,6 +13,11 @@ The model is desired state, never commands. Nothing here may be shaped like `sta
   TypeBox is the only dependency, and this package must acquire no side effects and no client.
 - Types derive from schemas (`typeof XSchema.static`), state enums from one `const` array. Never
   hand-write a type a schema already describes.
+- **Adding a value to a state enum decides the deploy order.** Unknown *properties* are tolerated
+  (see `parseMessage`), but an unknown *value* in a known field fails the check and rejects the
+  whole message — so one instance in a state the reader has not heard of loses that host's entire
+  report, not just that instance. The side that reads the enum ships first: a new value on a
+  report means the control plane before the agents, and one on desired state means the reverse.
 - Absent means unknown or not applicable. **No field is ever `null`.** The one exception is
   `TenantEnvironmentPatchSchema`, which is an owner editing their app rather than anything a host
   is sent: there absent means "leave this variable as it is", so removing one needs a word of its

--- a/packages/protocol/src/control/desired-state.ts
+++ b/packages/protocol/src/control/desired-state.ts
@@ -16,7 +16,17 @@ import { ByteSizeSchema, FilenameSchema, ObjectKeySchema, Sha256DigestSchema } f
 // message, an agent restart and a control-plane restart are all non-events — the next poll
 // re-reads the truth.
 
-export const DESIRED_INSTANCE_STATES = ['running', 'stopped'] as const;
+/**
+ * `on-request` is `running` with the microVM left out until something asks for it: the app is
+ * reachable, its host answers for its hostnames, and the guest is brought up by the first request
+ * that needs one. A world rather than a command, like the other two — what differs is only how
+ * much of it is standing at any moment.
+ *
+ * A third value rather than a flag beside these, because it is the same question: what should be
+ * true of this app. A suspended app is `stopped` whatever its activation policy says, which is
+ * why that policy never has to travel separately.
+ */
+export const DESIRED_INSTANCE_STATES = ['running', 'on-request', 'stopped'] as const;
 
 export const DesiredInstanceStateSchema = stringEnum(DESIRED_INSTANCE_STATES);
 
@@ -46,11 +56,31 @@ export const DesiredArtifactSchema = Type.Object({
 
 export type DesiredArtifact = typeof DesiredArtifactSchema.static;
 
+/**
+ * How long an `on-request` app goes unasked-for before its microVM is stopped.
+ *
+ * The whole of what scale-to-zero saves is memory a sleeping app is not holding, so this is the
+ * dial the saving is on: an app visited three times a day sleeps for most of it at fifteen
+ * minutes and for almost none of it at an hour. What it costs is a cold boot for whoever arrives
+ * after the gap, which is why it is not seconds.
+ *
+ * The floor is the cadence the decision is made on rather than a round number: whether an app has
+ * gone quiet is only asked when its traffic is measured, so a shorter timeout than that would be
+ * one the host accepts and cannot keep.
+ */
+export const MIN_IDLE_TIMEOUT_MS = 60_000;
+
+export const IdleTimeoutMsSchema = Type.Integer({ minimum: MIN_IDLE_TIMEOUT_MS });
+
 export const DesiredInstanceSchema = Type.Object({
   appId: AppIdSchema,
   deploymentId: DeploymentIdSchema,
   volumeId: VolumeIdSchema,
   desiredState: DesiredInstanceStateSchema,
+  // Only ever read for an `on-request` instance, and optional so a host is told nothing about
+  // one it cannot act on — and so an api that predates this leaves a host on its own default
+  // rather than stopping it converging.
+  idleTimeoutMs: Type.Optional(IdleTimeoutMsSchema),
   artifact: DesiredArtifactSchema,
   config: AppConfigSchema,
   // Carried down so the host can render its own routing config from the same state it boots

--- a/packages/protocol/src/control/desired-state.ts
+++ b/packages/protocol/src/control/desired-state.ts
@@ -70,7 +70,19 @@ export type DesiredArtifact = typeof DesiredArtifactSchema.static;
  */
 export const MIN_IDLE_TIMEOUT_MS = 60_000;
 
-export const IdleTimeoutMsSchema = Type.Integer({ minimum: MIN_IDLE_TIMEOUT_MS });
+/**
+ * A day, which is not a judgement about how long an app should wait — `always` is how an owner
+ * says never sleep, so any value here is a legal preference and an app visited twice a day may
+ * reasonably want hours. It is there to catch the slipped zero: fifteen minutes and two and a
+ * half hours are one keystroke apart, and the wrong one costs nothing visible, it just quietly
+ * stops saving. Generous enough that it can only ever refuse a typo.
+ */
+export const MAX_IDLE_TIMEOUT_MS = 86_400_000;
+
+export const IdleTimeoutMsSchema = Type.Integer({
+  minimum: MIN_IDLE_TIMEOUT_MS,
+  maximum: MAX_IDLE_TIMEOUT_MS,
+});
 
 export const DesiredInstanceSchema = Type.Object({
   appId: AppIdSchema,

--- a/packages/protocol/src/domain/app.ts
+++ b/packages/protocol/src/domain/app.ts
@@ -223,6 +223,20 @@ export const AppConfigSchema = Type.Object({
 
 export type AppConfig = typeof AppConfigSchema.static;
 
+// Whether the app's microVM is kept up or is brought up by a request for it. `always` is what
+// every app has had until now and what a new one gets: an owner who has said nothing about this
+// has said they want their app up.
+//
+// A property of the app rather than of a release, and so on `apps` beside `state` rather than on
+// the config a deployment pins: it is the same kind of fact as being suspended — how the app is
+// brought up, not what it runs — and a rollback replaying an activation policy from months ago
+// would be the wrong thing every time.
+export const APP_ACTIVATIONS = ['always', 'on-request'] as const;
+
+export const AppActivationSchema = stringEnum(APP_ACTIVATIONS);
+
+export type AppActivation = typeof AppActivationSchema.static;
+
 export const APP_STATES = ['active', 'suspended', 'deleting', 'deleted'] as const;
 
 export const AppStateSchema = stringEnum(APP_STATES);

--- a/packages/protocol/src/domain/deployment.ts
+++ b/packages/protocol/src/domain/deployment.ts
@@ -1,6 +1,7 @@
 import { Type } from '@sinclair/typebox';
 import { AppConfigSchema } from '#domain/app.ts';
 import { AppIdSchema, ArtifactIdSchema, DeploymentIdSchema } from '#domain/identifiers.ts';
+import { InstanceStateSchema } from '#domain/instance.ts';
 import { stringEnum } from '#lib/string-enum.ts';
 import {
   HostPortSchema,
@@ -32,6 +33,11 @@ export const DeploymentSchema = Type.Object({
   artifactId: ArtifactIdSchema,
   config: AppConfigSchema,
   state: DeploymentStateSchema,
+  // What the microVM is doing, which the release's own state stopped answering when an app could
+  // start waiting for a request: one that sleeps between visitors keeps a `running` release with
+  // nothing running behind it, and this is the half that says so. Absent until a host has
+  // reported on it, which is every release for as long as it takes the first report to arrive.
+  instanceState: Type.Optional(InstanceStateSchema),
   createdAt: TimestampSchema,
   // What a host observed of the microVM this release is, as against when the release was asked
   // for. Each is absent until the moment it names has happened: a release still being staged has

--- a/packages/protocol/src/domain/instance.ts
+++ b/packages/protocol/src/domain/instance.ts
@@ -92,6 +92,11 @@ export const DEFAULT_RESTART_POLICY: RestartPolicy = {
 // `starting` is a booted microVM whose tenant process has not yet accepted a connection, and
 // `running` is one that has. Collapsing the two would let a deploy swap traffic onto a
 // booted-but-dead VM, which is worse than a deploy that fails.
+//
+// `idle` is an on-request app with no microVM because nothing has asked for one. It is not
+// `stopped` and the difference is load-bearing: a stopped instance is one nobody wants running,
+// and one nobody wants running is a release that has finished serving. An idle one is serving —
+// the next request is what it is waiting for — so the two cannot share a name.
 export const INSTANCE_STATES = [
   'pending',
   'starting',
@@ -99,6 +104,7 @@ export const INSTANCE_STATES = [
   'unhealthy',
   'stopping',
   'stopped',
+  'idle',
   'failed',
 ] as const;
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -22,6 +22,8 @@ export {
   DesiredVolumeSchema,
   type HostDesiredState,
   HostDesiredStateSchema,
+  IdleTimeoutMsSchema,
+  MIN_IDLE_TIMEOUT_MS,
 } from '#control/desired-state.ts';
 export {
   type FilesystemQuery,
@@ -65,10 +67,13 @@ export {
   PROTOCOL_VERSION_HEADER,
 } from '#control/transport.ts';
 export {
+  APP_ACTIVATIONS,
   APP_HOSTNAME_KINDS,
   APP_HOSTNAME_STATES,
   APP_STATES,
   type App,
+  type AppActivation,
+  AppActivationSchema,
   type AppConfig,
   AppConfigSchema,
   type AppHostname,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -23,6 +23,7 @@ export {
   type HostDesiredState,
   HostDesiredStateSchema,
   IdleTimeoutMsSchema,
+  MAX_IDLE_TIMEOUT_MS,
   MIN_IDLE_TIMEOUT_MS,
 } from '#control/desired-state.ts';
 export {

--- a/packages/protocol/tests/protocol.test.ts
+++ b/packages/protocol/tests/protocol.test.ts
@@ -19,7 +19,10 @@ import {
   HostnameSchema,
   type HostPort,
   type HttpPort,
+  IdleTimeoutMsSchema,
   isValidMessage,
+  MAX_IDLE_TIMEOUT_MS,
+  MIN_IDLE_TIMEOUT_MS,
   namesExtraPublicPortValues,
   ObjectKeySchema,
   ProtocolValidationError,
@@ -595,5 +598,28 @@ describe('a record read twice is handed over once', () => {
     seen.admit(logRecord({ _time: A_LATER_INSTANT, sequence: 1 }));
 
     expect(seen.admit(logRecord({ _time: A_LATER_INSTANT, sequence: 1 }))).toBe(false);
+  });
+});
+
+describe('how long an app may wait before it sleeps', () => {
+  const accepts = (value: number) => isValidMessage({ schema: IdleTimeoutMsSchema, value });
+
+  // The floor is the cadence the host measures traffic on, so anything under it is a promise
+  // the host cannot keep rather than an aggressive setting.
+  test('below the measurement tick is refused', () => {
+    expect(accepts(MIN_IDLE_TIMEOUT_MS)).toBe(true);
+    expect(accepts(MIN_IDLE_TIMEOUT_MS - 1)).toBe(false);
+  });
+
+  // The ceiling is not a view about how long is sensible — `always` is how an owner says never
+  // sleep. It only catches the slipped zero, so it has to accept every wait somebody could mean.
+  test('a day is accepted and a typo past it is not', () => {
+    expect(accepts(MAX_IDLE_TIMEOUT_MS)).toBe(true);
+    expect(accepts(MAX_IDLE_TIMEOUT_MS + 1)).toBe(false);
+  });
+
+  test('the hours an app visited twice a day would want are legal', () => {
+    const sixHours = 21_600_000;
+    expect(accepts(sixHours)).toBe(true);
   });
 });


### PR DESCRIPTION
Adds `activation: 'always' | 'on-request'` on the app, defaulting to `always` so nothing existing
changes. An on-request app holds its slot and its hostnames with no microVM until a request
arrives, is started by that request, and is stopped again once it has gone quiet.

The flag is on `nibrun.apps` rather than on `app_configs`: that table refuses `UPDATE` and a
deployment pins one row, so a policy stored there could only be changed by deploying, and a
rollback would replay whichever policy was in force months ago. It reaches the host as a third
`desiredState` — suspended still wins over it.

## Rollout: the api goes out before the agents

`idle` is a new value in `INSTANCE_STATES`, which is the one kind of protocol change that is not
symmetric. Unknown *properties* are tolerated on both sides; an unknown *value* in a known field
fails the schema check and rejects the whole message — so an agent that has put one app to sleep,
talking to an api that predates this, loses everything it was saying about **every app on that
host**, not just the sleeping one. The reverse order is safe: an old agent never says `idle`,
`instance_state` stays null, and the app reads from its release as it does today.

In practice the window is latent rather than live — nothing sets `activation` to `on-request`
without the SQL below — but the ordering has to hold once that surface exists. Written down in
`packages/protocol/AGENTS.md` (the constraint on the enum) and in `0036`'s header (the deploy
order, beside the CHECK that repeats the same list).

Two things worth a look:

- **Freezing before every stop.** The microVM unit says a stop is abrupt from the guest's point of
  view, which was survivable while stopping was a rare deliberate act. On a timer it is not, so
  `stopInstance` now holds the guest's filesystem frozen across the ZeroFS flush.
- **Idle detection reuses the counters from #392/#398** rather than adding its own. This PR only
  decides: `hasGoneQuiet` reads `lastActiveAtMs`, and `applySleep` runs on the measurement tick
  right after `recordActivity`, because that is the only thing that moves the answer — and because
  a stop freezes a filesystem and waits on systemd, which is not work to put in front of every
  other app's health probes.

Waking is a Firecracker snapshot restore: `suspendInstance` pauses the microVM and captures
it, `resumeInstance` loads it back. Measured on a host, a restore is ~30ms against ~1s for a
cold boot. Cold boot survives only where there is no snapshot to load — the app has never
slept, it was redeployed, or the host rebooted and took the instance store with it.

Two limits stated plainly: a websocket that is the *first* connection to a sleeping app cannot be
carried across the wake (it wakes the app and asks the client to reconnect; once awake it works
normally), and an app doing only outbound work reads as idle.

One seam worth knowing about: `activityAfter` keeps the recorded moment on a first counter
reading, which is right for a newly deployed app and wrong for a woken one — a woken app's counter
is new, so it would fall back to the moment that had it sleeping and be stopped again immediately.
`markActive` on the wake path is what closes that, so it is not redundant with the counters.

The floor on `idle_timeout_ms` is 60s rather than a round number, because the decision is made on
the measurement tick — a shorter timeout would be one the host accepts and cannot keep.

## What sleeping costs, and what the owner sees

Three things followed from a sleeping app having no microVM, and none of them worked on their own:

- **It releases its memory.** It was still counted against `allocatable`, so a host reserved every
  on-request app's full memory for as long as it held the record — the saving was never collected.
  This makes a wake on a full host a real failure mode: nothing consumes `allocatable` for
  placement today, so the danger is latent, but it has to be closed before density is switched on.
- **It reports no compute.** The host kept the last reading for a guest it could not measure and
  the api only ever overwrites what it stored, so an app whose whole point is costing nothing
  while asleep was shown spending what it spent awake, indefinitely. The reading now goes with the
  microVM at both ends. A *suspended* app still keeps its last reading — that one answers a
  question its owner asked — and whether that distinction survives is a separate argument.
- **The owner is told it is asleep.** A sleeping app has a `running` release with nothing running
  behind it, and the release's state cannot say both, so the host's word about the microVM is kept
  beside it in `deployments.instance_state` and read where a person asks what the app is doing.
  It shows as **asleep**, not `idle`: an app waiting to be asked is doing what it was configured
  to do, and a badge reading as trouble would have owners switching the saving off.

Also: `unhealthy` is no longer a state an app can be slept from. An app failing its probes goes
quiet *because* it is broken, so the silence is a symptom of the fault rather than evidence nobody
wants it — sleeping it turned a visible failure into an invisible one and took the app out of the
restart and backoff machinery that exists to answer exactly this.

Verified against a real Postgres and a real kernel: the migration applies, and the rendered
ruleset loads into nftables 1.0.4.

To try it:

```sql
UPDATE nibrun.apps SET activation = 'on-request', idle_timeout_ms = 60000 WHERE slug = '<slug>';
```

The api, CLI and dashboard surface for setting `activation` is a follow-up.

