### PR TITLE
feat(www): boop is a deploy already configured, but for its admin login

### DIFF
--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -4,6 +4,9 @@ import { interpolableRuntimeValue, RUNTIME_VALUES } from '@repo/protocol';
 export const DEPLOY_PRESETS = {
   boop: {
     name: 'boop',
+    binary:
+      'https://github.com/chrisgreg/boop/releases/download/v1.3.0/boop_1.3.0_linux_amd64.tar.gz',
+    sha256: 'e68ea6a7dec4bf6f8fe6133735b0b1db4ccb4089d5e6b76e9813a1a63f4797a8',
     port: 8080,
     env: [
       `BOOP_PORT=${interpolableRuntimeValue(RUNTIME_VALUES.HTTP_PORT.name)}`,

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -2,6 +2,20 @@ import type { DeployLink } from '@repo/deploy-link';
 import { interpolableRuntimeValue, RUNTIME_VALUES } from '@repo/protocol';
 
 export const DEPLOY_PRESETS = {
+  boop: {
+    name: 'boop',
+    port: 8080,
+    env: [
+      `BOOP_PORT=${interpolableRuntimeValue(RUNTIME_VALUES.HTTP_PORT.name)}`,
+      `BOOP_DATABASE_PATH=${interpolableRuntimeValue(RUNTIME_VALUES.DATA_DIR.name)}/boop.db`,
+      `BOOP_BASE_URL=https://${interpolableRuntimeValue(RUNTIME_VALUES.HOSTNAME.name)}`,
+      // Carried without values: the pair is what stands between the admin api and everyone who
+      // reaches the url, and a link is read by more people than the one who follows it.
+      'BOOP_ADMIN_USER',
+      'BOOP_ADMIN_PASSWORD',
+    ],
+    minimal: true,
+  },
   pocketbase: {
     name: 'pocketbase',
     binary:


### PR DESCRIPTION
[Boop](https://github.com/chrisgreg/boop) is a single Go binary with SQLite and its web UI embedded, which is the shape this fits. v1.3.0 is the first release to attach pre-built binaries, so there is now a url to deploy from.

The three variables bind Boop's own names to the guest's; `BOOP_ADMIN_USER` and `BOOP_ADMIN_PASSWORD` are carried without values, so the form opens on them and the owner supplies them — without both, the admin API is open to whoever has the URL.

`sha256` is the tarball's own digest, as published in the release's `checksums.txt`.