### PR TITLE
feat(api): a client an owner says yes to can act for them

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1105.0",
     "@aws-sdk/s3-request-presigner": "^3.1105.0",
+    "@better-auth/oauth-provider": "^1.7.2",
     "@ilbertt/better-auth-bun-sql": "^0.4.0",
     "@ilbertt/bun-sqlgen": "^0.5.0",
     "@repo/protocol": "workspace:*",

--- a/apps/api/src/db/migrations/0035_better_auth_oauth_provider.sql
+++ b/apps/api/src/db/migrations/0035_better_auth_oauth_provider.sql
@@ -1,0 +1,62 @@
+-- Used by better-auth's oauth-provider plugin, which is what lets a client
+-- nibrun has never seen — an MCP client, an agent — obtain a token for an owner
+-- who says yes to it.
+--
+-- The plugin's own tables, carried by their own migration rather than an edit to
+-- 0003, which is what that file's note asks for. Emitted verbatim by the
+-- adapter's `createSchema` for the same reason: it stays diffable against a
+-- regenerated schema.
+--
+-- `jwks` belongs to the jwt plugin, which is here because oauth-provider refuses
+-- to resolve a request without it: it signs through that plugin and keeps no
+-- keys of its own.
+--
+-- `oauthClient` is written by dynamic client registration, so rows appear here
+-- without anyone at nibrun having done anything. `oauthConsent` is what keeps an
+-- owner from being asked twice, and is the row they revoke to take access back.
+
+create table "auth"."jwks" ("id" text not null primary key, "publicKey" text not null, "privateKey" text not null, "createdAt" timestamptz not null, "expiresAt" timestamptz, "alg" text, "crv" text);
+
+create table "auth"."oauthClient" ("id" text not null primary key, "clientId" text not null unique, "clientSecret" text, "clientDiscoveryId" text, "disabled" boolean, "skipConsent" boolean, "enableEndSession" boolean, "subjectType" text, "scopes" text, "clientCredentialsScopes" text, "userId" text references "auth"."user" ("id") on delete cascade, "createdAt" timestamptz, "updatedAt" timestamptz, "name" text, "uri" text, "icon" text, "contacts" text, "tos" text, "policy" text, "softwareId" text, "softwareVersion" text, "softwareStatement" text, "redirectUris" text not null, "postLogoutRedirectUris" text, "backchannelLogoutUri" text, "backchannelLogoutSessionRequired" boolean, "tokenEndpointAuthMethod" text, "applicationType" text, "jwks" text, "jwksUri" text, "grantTypes" text, "responseTypes" text, "requirePKCE" boolean, "dpopBoundAccessTokens" boolean, "referenceId" text, "metadata" text);
+
+create table "auth"."oauthResource" ("id" text not null primary key, "identifier" text not null unique, "name" text not null, "accessTokenTtl" integer, "refreshTokenTtl" integer, "signingAlgorithm" text, "signingKeyId" text, "allowedScopes" text, "customClaims" text, "dpopBoundAccessTokensRequired" boolean, "disabled" boolean, "createdAt" timestamptz, "updatedAt" timestamptz, "policyVersion" integer, "metadata" text);
+
+create table "auth"."oauthClientResource" ("id" text not null primary key, "clientId" text not null references "auth"."oauthClient" ("clientId") on delete cascade, "resourceId" text not null references "auth"."oauthResource" ("identifier") on delete cascade, "metadata" text, "createdAt" timestamptz);
+
+create table "auth"."oauthRefreshToken" ("id" text not null primary key, "token" text not null unique, "clientId" text not null references "auth"."oauthClient" ("clientId") on delete cascade, "sessionId" text references "auth"."session" ("id") on delete set null, "userId" text not null references "auth"."user" ("id") on delete cascade, "referenceId" text, "authorizationCodeId" text, "resources" text, "requestedUserInfoClaims" text, "expiresAt" timestamptz not null, "createdAt" timestamptz not null, "revoked" timestamptz, "rotatedAt" timestamptz, "rotationReplayResponse" text, "rotationReplayExpiresAt" timestamptz, "authTime" timestamptz, "confirmation" text, "scopes" text not null);
+
+create table "auth"."oauthAccessToken" ("id" text not null primary key, "token" text not null unique, "clientId" text not null references "auth"."oauthClient" ("clientId") on delete cascade, "sessionId" text references "auth"."session" ("id") on delete set null, "userId" text references "auth"."user" ("id") on delete cascade, "referenceId" text, "authorizationCodeId" text, "resources" text, "requestedUserInfoClaims" text, "refreshId" text references "auth"."oauthRefreshToken" ("id") on delete cascade, "expiresAt" timestamptz not null, "createdAt" timestamptz not null, "revoked" timestamptz, "confirmation" text, "scopes" text not null);
+
+create table "auth"."oauthConsent" ("id" text not null primary key, "clientId" text not null references "auth"."oauthClient" ("clientId") on delete cascade, "userId" text references "auth"."user" ("id") on delete cascade, "referenceId" text, "resources" text, "requestedUserInfoClaims" text, "scopes" text not null, "createdAt" timestamptz not null, "updatedAt" timestamptz not null);
+
+create table "auth"."oauthClientAssertion" ("id" text not null primary key, "expiresAt" timestamptz not null);
+
+create index "oauthClient_userId_idx" on "auth"."oauthClient" ("userId");
+
+create index "oauthClientResource_clientId_idx" on "auth"."oauthClientResource" ("clientId");
+
+create index "oauthClientResource_resourceId_idx" on "auth"."oauthClientResource" ("resourceId");
+
+create index "oauthRefreshToken_clientId_idx" on "auth"."oauthRefreshToken" ("clientId");
+
+create index "oauthRefreshToken_sessionId_idx" on "auth"."oauthRefreshToken" ("sessionId");
+
+create index "oauthRefreshToken_userId_idx" on "auth"."oauthRefreshToken" ("userId");
+
+create index "oauthRefreshToken_authorizationCodeId_idx" on "auth"."oauthRefreshToken" ("authorizationCodeId");
+
+create index "oauthAccessToken_clientId_idx" on "auth"."oauthAccessToken" ("clientId");
+
+create index "oauthAccessToken_sessionId_idx" on "auth"."oauthAccessToken" ("sessionId");
+
+create index "oauthAccessToken_userId_idx" on "auth"."oauthAccessToken" ("userId");
+
+create index "oauthAccessToken_authorizationCodeId_idx" on "auth"."oauthAccessToken" ("authorizationCodeId");
+
+create index "oauthAccessToken_refreshId_idx" on "auth"."oauthAccessToken" ("refreshId");
+
+create index "oauthConsent_clientId_idx" on "auth"."oauthConsent" ("clientId");
+
+create index "oauthConsent_userId_idx" on "auth"."oauthConsent" ("userId");
+
+create unique index "oauthClientResource_clientId_resourceId_uidx" on "auth"."oauthClientResource" ("clientId", "resourceId");

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -903,6 +903,209 @@ export interface IDeviceCodeTable {
     constraints: keyof (typeof schema)["deviceCode"]["_constraints"];
 }
 
+/** Columns of `jwks`. */
+export interface IJwksColumns {
+    id: string;
+    publicKey: string;
+    privateKey: string;
+    createdAt: Date;
+    expiresAt: Date | null;
+    alg: string | null;
+    crv: string | null;
+}
+
+/** Schema of `jwks`. */
+export interface IJwksTable {
+    columns: IJwksColumns;
+    relationType: (typeof schema)["jwks"]["_relationType"];
+    indexes: keyof (typeof schema)["jwks"]["_indexes"];
+    constraints: keyof (typeof schema)["jwks"]["_constraints"];
+}
+
+/** Columns of `oauthAccessToken`. */
+export interface IOauthAccessTokenColumns {
+    id: string;
+    token: string;
+    clientId: string;
+    sessionId: string | null;
+    userId: string | null;
+    referenceId: string | null;
+    authorizationCodeId: string | null;
+    resources: string | null;
+    requestedUserInfoClaims: string | null;
+    refreshId: string | null;
+    expiresAt: Date;
+    createdAt: Date;
+    revoked: Date | null;
+    confirmation: string | null;
+    scopes: string;
+}
+
+/** Schema of `oauthAccessToken`. */
+export interface IOauthAccessTokenTable {
+    columns: IOauthAccessTokenColumns;
+    relationType: (typeof schema)["oauthAccessToken"]["_relationType"];
+    indexes: keyof (typeof schema)["oauthAccessToken"]["_indexes"];
+    constraints: keyof (typeof schema)["oauthAccessToken"]["_constraints"];
+}
+
+/** Columns of `oauthClient`. */
+export interface IOauthClientColumns {
+    id: string;
+    clientId: string;
+    clientSecret: string | null;
+    clientDiscoveryId: string | null;
+    disabled: boolean | null;
+    skipConsent: boolean | null;
+    enableEndSession: boolean | null;
+    subjectType: string | null;
+    scopes: string | null;
+    clientCredentialsScopes: string | null;
+    userId: string | null;
+    createdAt: Date | null;
+    updatedAt: Date | null;
+    name: string | null;
+    uri: string | null;
+    icon: string | null;
+    contacts: string | null;
+    tos: string | null;
+    policy: string | null;
+    softwareId: string | null;
+    softwareVersion: string | null;
+    softwareStatement: string | null;
+    redirectUris: string;
+    postLogoutRedirectUris: string | null;
+    backchannelLogoutUri: string | null;
+    backchannelLogoutSessionRequired: boolean | null;
+    tokenEndpointAuthMethod: string | null;
+    applicationType: string | null;
+    jwks: string | null;
+    jwksUri: string | null;
+    grantTypes: string | null;
+    responseTypes: string | null;
+    requirePKCE: boolean | null;
+    dpopBoundAccessTokens: boolean | null;
+    referenceId: string | null;
+    metadata: string | null;
+}
+
+/** Schema of `oauthClient`. */
+export interface IOauthClientTable {
+    columns: IOauthClientColumns;
+    relationType: (typeof schema)["oauthClient"]["_relationType"];
+    indexes: keyof (typeof schema)["oauthClient"]["_indexes"];
+    constraints: keyof (typeof schema)["oauthClient"]["_constraints"];
+}
+
+/** Columns of `oauthClientAssertion`. */
+export interface IOauthClientAssertionColumns {
+    id: string;
+    expiresAt: Date;
+}
+
+/** Schema of `oauthClientAssertion`. */
+export interface IOauthClientAssertionTable {
+    columns: IOauthClientAssertionColumns;
+    relationType: (typeof schema)["oauthClientAssertion"]["_relationType"];
+    indexes: keyof (typeof schema)["oauthClientAssertion"]["_indexes"];
+    constraints: keyof (typeof schema)["oauthClientAssertion"]["_constraints"];
+}
+
+/** Columns of `oauthClientResource`. */
+export interface IOauthClientResourceColumns {
+    id: string;
+    clientId: string;
+    resourceId: string;
+    metadata: string | null;
+    createdAt: Date | null;
+}
+
+/** Schema of `oauthClientResource`. */
+export interface IOauthClientResourceTable {
+    columns: IOauthClientResourceColumns;
+    relationType: (typeof schema)["oauthClientResource"]["_relationType"];
+    indexes: keyof (typeof schema)["oauthClientResource"]["_indexes"];
+    constraints: keyof (typeof schema)["oauthClientResource"]["_constraints"];
+}
+
+/** Columns of `oauthConsent`. */
+export interface IOauthConsentColumns {
+    id: string;
+    clientId: string;
+    userId: string | null;
+    referenceId: string | null;
+    resources: string | null;
+    requestedUserInfoClaims: string | null;
+    scopes: string;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+/** Schema of `oauthConsent`. */
+export interface IOauthConsentTable {
+    columns: IOauthConsentColumns;
+    relationType: (typeof schema)["oauthConsent"]["_relationType"];
+    indexes: keyof (typeof schema)["oauthConsent"]["_indexes"];
+    constraints: keyof (typeof schema)["oauthConsent"]["_constraints"];
+}
+
+/** Columns of `oauthRefreshToken`. */
+export interface IOauthRefreshTokenColumns {
+    id: string;
+    token: string;
+    clientId: string;
+    sessionId: string | null;
+    userId: string;
+    referenceId: string | null;
+    authorizationCodeId: string | null;
+    resources: string | null;
+    requestedUserInfoClaims: string | null;
+    expiresAt: Date;
+    createdAt: Date;
+    revoked: Date | null;
+    rotatedAt: Date | null;
+    rotationReplayResponse: string | null;
+    rotationReplayExpiresAt: Date | null;
+    authTime: Date | null;
+    confirmation: string | null;
+    scopes: string;
+}
+
+/** Schema of `oauthRefreshToken`. */
+export interface IOauthRefreshTokenTable {
+    columns: IOauthRefreshTokenColumns;
+    relationType: (typeof schema)["oauthRefreshToken"]["_relationType"];
+    indexes: keyof (typeof schema)["oauthRefreshToken"]["_indexes"];
+    constraints: keyof (typeof schema)["oauthRefreshToken"]["_constraints"];
+}
+
+/** Columns of `oauthResource`. */
+export interface IOauthResourceColumns {
+    id: string;
+    identifier: string;
+    name: string;
+    accessTokenTtl: number | null;
+    refreshTokenTtl: number | null;
+    signingAlgorithm: string | null;
+    signingKeyId: string | null;
+    allowedScopes: string | null;
+    customClaims: string | null;
+    dpopBoundAccessTokensRequired: boolean | null;
+    disabled: boolean | null;
+    createdAt: Date | null;
+    updatedAt: Date | null;
+    policyVersion: number | null;
+    metadata: string | null;
+}
+
+/** Schema of `oauthResource`. */
+export interface IOauthResourceTable {
+    columns: IOauthResourceColumns;
+    relationType: (typeof schema)["oauthResource"]["_relationType"];
+    indexes: keyof (typeof schema)["oauthResource"]["_indexes"];
+    constraints: keyof (typeof schema)["oauthResource"]["_constraints"];
+}
+
 /** Columns of `session`. */
 export interface ISessionColumns {
     id: string;
@@ -1422,6 +1625,244 @@ export const schema = {
             deviceCode_pkey: { _constraintName: "deviceCode_pkey" }
         }
     },
+    jwks: {
+        _relationName: "jwks",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            publicKey: { _columnName: "publicKey", _foreignKeys: {} },
+            privateKey: { _columnName: "privateKey", _foreignKeys: {} },
+            createdAt: { _columnName: "createdAt", _foreignKeys: {} },
+            expiresAt: { _columnName: "expiresAt", _foreignKeys: {} },
+            alg: { _columnName: "alg", _foreignKeys: {} },
+            crv: { _columnName: "crv", _foreignKeys: {} }
+        },
+        _indexes: {
+            jwks_pkey: { _indexName: "jwks_pkey" }
+        },
+        _constraints: {
+            jwks_pkey: { _constraintName: "jwks_pkey" }
+        }
+    },
+    oauthAccessToken: {
+        _relationName: "oauthAccessToken",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            token: { _columnName: "token", _foreignKeys: {} },
+            clientId: { _columnName: "clientId", _foreignKeys: { oauthAccessToken_clientId_fkey: { _constraintName: "oauthAccessToken_clientId_fkey", _references: { _relationName: "oauthClient", _columnName: "clientId" } } } },
+            sessionId: { _columnName: "sessionId", _foreignKeys: { oauthAccessToken_sessionId_fkey: { _constraintName: "oauthAccessToken_sessionId_fkey", _references: { _relationName: "session", _columnName: "id" } } } },
+            userId: { _columnName: "userId", _foreignKeys: { oauthAccessToken_userId_fkey: { _constraintName: "oauthAccessToken_userId_fkey", _references: { _relationName: "user", _columnName: "id" } } } },
+            referenceId: { _columnName: "referenceId", _foreignKeys: {} },
+            authorizationCodeId: { _columnName: "authorizationCodeId", _foreignKeys: {} },
+            resources: { _columnName: "resources", _foreignKeys: {} },
+            requestedUserInfoClaims: { _columnName: "requestedUserInfoClaims", _foreignKeys: {} },
+            refreshId: { _columnName: "refreshId", _foreignKeys: { oauthAccessToken_refreshId_fkey: { _constraintName: "oauthAccessToken_refreshId_fkey", _references: { _relationName: "oauthRefreshToken", _columnName: "id" } } } },
+            expiresAt: { _columnName: "expiresAt", _foreignKeys: {} },
+            createdAt: { _columnName: "createdAt", _foreignKeys: {} },
+            revoked: { _columnName: "revoked", _foreignKeys: {} },
+            confirmation: { _columnName: "confirmation", _foreignKeys: {} },
+            scopes: { _columnName: "scopes", _foreignKeys: {} }
+        },
+        _indexes: {
+            oauthAccessToken_authorizationCodeId_idx: { _indexName: "oauthAccessToken_authorizationCodeId_idx" },
+            oauthAccessToken_clientId_idx: { _indexName: "oauthAccessToken_clientId_idx" },
+            oauthAccessToken_pkey: { _indexName: "oauthAccessToken_pkey" },
+            oauthAccessToken_refreshId_idx: { _indexName: "oauthAccessToken_refreshId_idx" },
+            oauthAccessToken_sessionId_idx: { _indexName: "oauthAccessToken_sessionId_idx" },
+            oauthAccessToken_token_key: { _indexName: "oauthAccessToken_token_key" },
+            oauthAccessToken_userId_idx: { _indexName: "oauthAccessToken_userId_idx" }
+        },
+        _constraints: {
+            oauthAccessToken_clientId_fkey: { _constraintName: "oauthAccessToken_clientId_fkey" },
+            oauthAccessToken_pkey: { _constraintName: "oauthAccessToken_pkey" },
+            oauthAccessToken_refreshId_fkey: { _constraintName: "oauthAccessToken_refreshId_fkey" },
+            oauthAccessToken_sessionId_fkey: { _constraintName: "oauthAccessToken_sessionId_fkey" },
+            oauthAccessToken_token_key: { _constraintName: "oauthAccessToken_token_key" },
+            oauthAccessToken_userId_fkey: { _constraintName: "oauthAccessToken_userId_fkey" }
+        }
+    },
+    oauthClient: {
+        _relationName: "oauthClient",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            clientId: { _columnName: "clientId", _foreignKeys: {} },
+            clientSecret: { _columnName: "clientSecret", _foreignKeys: {} },
+            clientDiscoveryId: { _columnName: "clientDiscoveryId", _foreignKeys: {} },
+            disabled: { _columnName: "disabled", _foreignKeys: {} },
+            skipConsent: { _columnName: "skipConsent", _foreignKeys: {} },
+            enableEndSession: { _columnName: "enableEndSession", _foreignKeys: {} },
+            subjectType: { _columnName: "subjectType", _foreignKeys: {} },
+            scopes: { _columnName: "scopes", _foreignKeys: {} },
+            clientCredentialsScopes: { _columnName: "clientCredentialsScopes", _foreignKeys: {} },
+            userId: { _columnName: "userId", _foreignKeys: { oauthClient_userId_fkey: { _constraintName: "oauthClient_userId_fkey", _references: { _relationName: "user", _columnName: "id" } } } },
+            createdAt: { _columnName: "createdAt", _foreignKeys: {} },
+            updatedAt: { _columnName: "updatedAt", _foreignKeys: {} },
+            name: { _columnName: "name", _foreignKeys: {} },
+            uri: { _columnName: "uri", _foreignKeys: {} },
+            icon: { _columnName: "icon", _foreignKeys: {} },
+            contacts: { _columnName: "contacts", _foreignKeys: {} },
+            tos: { _columnName: "tos", _foreignKeys: {} },
+            policy: { _columnName: "policy", _foreignKeys: {} },
+            softwareId: { _columnName: "softwareId", _foreignKeys: {} },
+            softwareVersion: { _columnName: "softwareVersion", _foreignKeys: {} },
+            softwareStatement: { _columnName: "softwareStatement", _foreignKeys: {} },
+            redirectUris: { _columnName: "redirectUris", _foreignKeys: {} },
+            postLogoutRedirectUris: { _columnName: "postLogoutRedirectUris", _foreignKeys: {} },
+            backchannelLogoutUri: { _columnName: "backchannelLogoutUri", _foreignKeys: {} },
+            backchannelLogoutSessionRequired: { _columnName: "backchannelLogoutSessionRequired", _foreignKeys: {} },
+            tokenEndpointAuthMethod: { _columnName: "tokenEndpointAuthMethod", _foreignKeys: {} },
+            applicationType: { _columnName: "applicationType", _foreignKeys: {} },
+            jwks: { _columnName: "jwks", _foreignKeys: {} },
+            jwksUri: { _columnName: "jwksUri", _foreignKeys: {} },
+            grantTypes: { _columnName: "grantTypes", _foreignKeys: {} },
+            responseTypes: { _columnName: "responseTypes", _foreignKeys: {} },
+            requirePKCE: { _columnName: "requirePKCE", _foreignKeys: {} },
+            dpopBoundAccessTokens: { _columnName: "dpopBoundAccessTokens", _foreignKeys: {} },
+            referenceId: { _columnName: "referenceId", _foreignKeys: {} },
+            metadata: { _columnName: "metadata", _foreignKeys: {} }
+        },
+        _indexes: {
+            oauthClient_clientId_key: { _indexName: "oauthClient_clientId_key" },
+            oauthClient_pkey: { _indexName: "oauthClient_pkey" },
+            oauthClient_userId_idx: { _indexName: "oauthClient_userId_idx" }
+        },
+        _constraints: {
+            oauthClient_clientId_key: { _constraintName: "oauthClient_clientId_key" },
+            oauthClient_pkey: { _constraintName: "oauthClient_pkey" },
+            oauthClient_userId_fkey: { _constraintName: "oauthClient_userId_fkey" }
+        }
+    },
+    oauthClientAssertion: {
+        _relationName: "oauthClientAssertion",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            expiresAt: { _columnName: "expiresAt", _foreignKeys: {} }
+        },
+        _indexes: {
+            oauthClientAssertion_pkey: { _indexName: "oauthClientAssertion_pkey" }
+        },
+        _constraints: {
+            oauthClientAssertion_pkey: { _constraintName: "oauthClientAssertion_pkey" }
+        }
+    },
+    oauthClientResource: {
+        _relationName: "oauthClientResource",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            clientId: { _columnName: "clientId", _foreignKeys: { oauthClientResource_clientId_fkey: { _constraintName: "oauthClientResource_clientId_fkey", _references: { _relationName: "oauthClient", _columnName: "clientId" } } } },
+            resourceId: { _columnName: "resourceId", _foreignKeys: { oauthClientResource_resourceId_fkey: { _constraintName: "oauthClientResource_resourceId_fkey", _references: { _relationName: "oauthResource", _columnName: "identifier" } } } },
+            metadata: { _columnName: "metadata", _foreignKeys: {} },
+            createdAt: { _columnName: "createdAt", _foreignKeys: {} }
+        },
+        _indexes: {
+            oauthClientResource_clientId_idx: { _indexName: "oauthClientResource_clientId_idx" },
+            oauthClientResource_clientId_resourceId_uidx: { _indexName: "oauthClientResource_clientId_resourceId_uidx" },
+            oauthClientResource_pkey: { _indexName: "oauthClientResource_pkey" },
+            oauthClientResource_resourceId_idx: { _indexName: "oauthClientResource_resourceId_idx" }
+        },
+        _constraints: {
+            oauthClientResource_clientId_fkey: { _constraintName: "oauthClientResource_clientId_fkey" },
+            oauthClientResource_pkey: { _constraintName: "oauthClientResource_pkey" },
+            oauthClientResource_resourceId_fkey: { _constraintName: "oauthClientResource_resourceId_fkey" }
+        }
+    },
+    oauthConsent: {
+        _relationName: "oauthConsent",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            clientId: { _columnName: "clientId", _foreignKeys: { oauthConsent_clientId_fkey: { _constraintName: "oauthConsent_clientId_fkey", _references: { _relationName: "oauthClient", _columnName: "clientId" } } } },
+            userId: { _columnName: "userId", _foreignKeys: { oauthConsent_userId_fkey: { _constraintName: "oauthConsent_userId_fkey", _references: { _relationName: "user", _columnName: "id" } } } },
+            referenceId: { _columnName: "referenceId", _foreignKeys: {} },
+            resources: { _columnName: "resources", _foreignKeys: {} },
+            requestedUserInfoClaims: { _columnName: "requestedUserInfoClaims", _foreignKeys: {} },
+            scopes: { _columnName: "scopes", _foreignKeys: {} },
+            createdAt: { _columnName: "createdAt", _foreignKeys: {} },
+            updatedAt: { _columnName: "updatedAt", _foreignKeys: {} }
+        },
+        _indexes: {
+            oauthConsent_clientId_idx: { _indexName: "oauthConsent_clientId_idx" },
+            oauthConsent_pkey: { _indexName: "oauthConsent_pkey" },
+            oauthConsent_userId_idx: { _indexName: "oauthConsent_userId_idx" }
+        },
+        _constraints: {
+            oauthConsent_clientId_fkey: { _constraintName: "oauthConsent_clientId_fkey" },
+            oauthConsent_pkey: { _constraintName: "oauthConsent_pkey" },
+            oauthConsent_userId_fkey: { _constraintName: "oauthConsent_userId_fkey" }
+        }
+    },
+    oauthRefreshToken: {
+        _relationName: "oauthRefreshToken",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            token: { _columnName: "token", _foreignKeys: {} },
+            clientId: { _columnName: "clientId", _foreignKeys: { oauthRefreshToken_clientId_fkey: { _constraintName: "oauthRefreshToken_clientId_fkey", _references: { _relationName: "oauthClient", _columnName: "clientId" } } } },
+            sessionId: { _columnName: "sessionId", _foreignKeys: { oauthRefreshToken_sessionId_fkey: { _constraintName: "oauthRefreshToken_sessionId_fkey", _references: { _relationName: "session", _columnName: "id" } } } },
+            userId: { _columnName: "userId", _foreignKeys: { oauthRefreshToken_userId_fkey: { _constraintName: "oauthRefreshToken_userId_fkey", _references: { _relationName: "user", _columnName: "id" } } } },
+            referenceId: { _columnName: "referenceId", _foreignKeys: {} },
+            authorizationCodeId: { _columnName: "authorizationCodeId", _foreignKeys: {} },
+            resources: { _columnName: "resources", _foreignKeys: {} },
+            requestedUserInfoClaims: { _columnName: "requestedUserInfoClaims", _foreignKeys: {} },
+            expiresAt: { _columnName: "expiresAt", _foreignKeys: {} },
+            createdAt: { _columnName: "createdAt", _foreignKeys: {} },
+            revoked: { _columnName: "revoked", _foreignKeys: {} },
+            rotatedAt: { _columnName: "rotatedAt", _foreignKeys: {} },
+            rotationReplayResponse: { _columnName: "rotationReplayResponse", _foreignKeys: {} },
+            rotationReplayExpiresAt: { _columnName: "rotationReplayExpiresAt", _foreignKeys: {} },
+            authTime: { _columnName: "authTime", _foreignKeys: {} },
+            confirmation: { _columnName: "confirmation", _foreignKeys: {} },
+            scopes: { _columnName: "scopes", _foreignKeys: {} }
+        },
+        _indexes: {
+            oauthRefreshToken_authorizationCodeId_idx: { _indexName: "oauthRefreshToken_authorizationCodeId_idx" },
+            oauthRefreshToken_clientId_idx: { _indexName: "oauthRefreshToken_clientId_idx" },
+            oauthRefreshToken_pkey: { _indexName: "oauthRefreshToken_pkey" },
+            oauthRefreshToken_sessionId_idx: { _indexName: "oauthRefreshToken_sessionId_idx" },
+            oauthRefreshToken_token_key: { _indexName: "oauthRefreshToken_token_key" },
+            oauthRefreshToken_userId_idx: { _indexName: "oauthRefreshToken_userId_idx" }
+        },
+        _constraints: {
+            oauthRefreshToken_clientId_fkey: { _constraintName: "oauthRefreshToken_clientId_fkey" },
+            oauthRefreshToken_pkey: { _constraintName: "oauthRefreshToken_pkey" },
+            oauthRefreshToken_sessionId_fkey: { _constraintName: "oauthRefreshToken_sessionId_fkey" },
+            oauthRefreshToken_token_key: { _constraintName: "oauthRefreshToken_token_key" },
+            oauthRefreshToken_userId_fkey: { _constraintName: "oauthRefreshToken_userId_fkey" }
+        }
+    },
+    oauthResource: {
+        _relationName: "oauthResource",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            identifier: { _columnName: "identifier", _foreignKeys: {} },
+            name: { _columnName: "name", _foreignKeys: {} },
+            accessTokenTtl: { _columnName: "accessTokenTtl", _foreignKeys: {} },
+            refreshTokenTtl: { _columnName: "refreshTokenTtl", _foreignKeys: {} },
+            signingAlgorithm: { _columnName: "signingAlgorithm", _foreignKeys: {} },
+            signingKeyId: { _columnName: "signingKeyId", _foreignKeys: {} },
+            allowedScopes: { _columnName: "allowedScopes", _foreignKeys: {} },
+            customClaims: { _columnName: "customClaims", _foreignKeys: {} },
+            dpopBoundAccessTokensRequired: { _columnName: "dpopBoundAccessTokensRequired", _foreignKeys: {} },
+            disabled: { _columnName: "disabled", _foreignKeys: {} },
+            createdAt: { _columnName: "createdAt", _foreignKeys: {} },
+            updatedAt: { _columnName: "updatedAt", _foreignKeys: {} },
+            policyVersion: { _columnName: "policyVersion", _foreignKeys: {} },
+            metadata: { _columnName: "metadata", _foreignKeys: {} }
+        },
+        _indexes: {
+            oauthResource_identifier_key: { _indexName: "oauthResource_identifier_key" },
+            oauthResource_pkey: { _indexName: "oauthResource_pkey" }
+        },
+        _constraints: {
+            oauthResource_identifier_key: { _constraintName: "oauthResource_identifier_key" },
+            oauthResource_pkey: { _constraintName: "oauthResource_pkey" }
+        }
+    },
     session: {
         _relationName: "session",
         _relationType: "table",
@@ -1893,6 +2334,14 @@ export const schema = {
 export interface Tables {
     account: IAccountTable;
     deviceCode: IDeviceCodeTable;
+    jwks: IJwksTable;
+    oauthAccessToken: IOauthAccessTokenTable;
+    oauthClient: IOauthClientTable;
+    oauthClientAssertion: IOauthClientAssertionTable;
+    oauthClientResource: IOauthClientResourceTable;
+    oauthConsent: IOauthConsentTable;
+    oauthRefreshToken: IOauthRefreshTokenTable;
+    oauthResource: IOauthResourceTable;
     session: ISessionTable;
     user: IUserTable;
     verification: IVerificationTable;

--- a/apps/api/src/lib/auth/better-auth.ts
+++ b/apps/api/src/lib/auth/better-auth.ts
@@ -1,6 +1,7 @@
+import { oauthProvider } from '@better-auth/oauth-provider';
 import { bunSqlAdapter } from '@ilbertt/better-auth-bun-sql';
 import { betterAuth } from 'better-auth';
-import { bearer, deviceAuthorization } from 'better-auth/plugins';
+import { bearer, deviceAuthorization, jwt } from 'better-auth/plugins';
 import { sql } from '#db/client.ts';
 import { env } from '#lib/env.ts';
 import { RoutePrefix } from '#lib/routes/prefixes.ts';
@@ -13,16 +14,65 @@ const AUTH_BASE_PATH = `${RoutePrefix.Api}${AUTH_ROUTE_PATH}`;
 
 const DEVICE_VERIFICATION_PATH = '/device';
 
+// Routes of the dashboard, which is served at the root origin: better-auth sends the owner to
+// these and they read the authorize query it appends. Both are the paths the dashboard's own
+// router declares, so renaming a route there means renaming it here.
+const SIGN_IN_PATH = '/login';
+const CONSENT_PATH = '/consent';
+
+/**
+ * What a token is issued for, per RFC 8707. The endpoint's own url, because that is what a client
+ * asks for and what the endpoint has to recognise as itself — taken from the prefix the api serves
+ * it at rather than written out again, so the two cannot drift.
+ */
+const MCP_RESOURCE = new URL(RoutePrefix.Mcp, env.BASE_URL).href;
+
+/**
+ * The one scope worth naming, and it is coarse on purpose: every tool the MCP server offers acts
+ * as the owner, up to and including deleting an app. Splitting it into read and write would be a
+ * promise nothing enforces yet, which is worse than a scope that says plainly what it grants.
+ *
+ * No `openid`. This is an OAuth 2.1 authorization server and not an OIDC provider — MCP asks for
+ * an access token and never for an identity token, and advertising `openid` would commit us to
+ * claims nothing reads.
+ */
+export const MCP_SCOPE = 'mcp';
+
+const OAUTH_SCOPES = ['offline_access', MCP_SCOPE];
+
 export const auth = betterAuth({
   database: bunSqlAdapter({ sql, pgSchema: AUTH_SCHEMA }),
   baseURL: env.BASE_URL.origin,
   basePath: AUTH_BASE_PATH,
   secret: env.BETTER_AUTH_SECRET,
+  trustedOrigins: [env.BASE_URL.origin],
   socialProviders: {
     github: {
       clientId: env.GITHUB_CLIENT_ID,
       clientSecret: env.GITHUB_CLIENT_SECRET,
     },
   },
-  plugins: [deviceAuthorization({ verificationUri: DEVICE_VERIFICATION_PATH }), bearer()],
+  plugins: [
+    deviceAuthorization({ verificationUri: DEVICE_VERIFICATION_PATH }),
+    bearer(),
+    // Required by `oauthProvider`, which refuses to resolve a request without it: the keys it
+    // signs with live in `jwks`, and it reads them through this plugin rather than holding any of
+    // its own. Not here for identity tokens — see the note on scopes above.
+    jwt({ jwt: { issuer: env.BASE_URL.origin, audience: MCP_RESOURCE } }),
+    oauthProvider({
+      loginPage: SIGN_IN_PATH,
+      consentPage: CONSENT_PATH,
+      scopes: OAUTH_SCOPES,
+      // An MCP client is one nobody at nibrun has ever heard of, so there is no one to register it
+      // by hand and nothing it could authenticate as beforehand. What stands in for that is the
+      // consent page: a client is only ever a client, and access begins when an owner says yes.
+      allowDynamicClientRegistration: true,
+      allowUnauthenticatedClientRegistration: true,
+      resources: [MCP_RESOURCE],
+      // `enforcePerClientResources` defaults on, which means a client is refused a token for a
+      // resource it is not linked to — and a client that registered itself is linked to nothing.
+      // This is what links each one as it registers.
+      clientRegistrationDefaultResources: [MCP_RESOURCE],
+    }),
+  ],
 });

--- a/apps/api/src/lib/auth/plugin.ts
+++ b/apps/api/src/lib/auth/plugin.ts
@@ -2,13 +2,16 @@ import Elysia from 'elysia';
 import { auth } from '#lib/auth/better-auth.ts';
 import { UnauthorizedError } from '#lib/errors.ts';
 
+/** The two places better-auth reads a caller from, and so the whole of what could name one. */
+const CREDENTIAL_HEADERS = ['cookie', 'authorization'];
+
 /**
  * Use this plugin in with any controller. Elysia will deduplicate it across all routes.
  */
 export const authPlugin = new Elysia({ name: 'auth' }).macro({
   auth: {
     async resolve({ request }) {
-      const session = await auth.api.getSession({ headers: request.headers });
+      const session = await sessionFor(request);
       if (!session) {
         throw new UnauthorizedError();
       }
@@ -16,3 +19,16 @@ export const authPlugin = new Elysia({ name: 'auth' }).macro({
     },
   },
 });
+
+/**
+ * Who is asking, where the request says anything about that at all.
+ *
+ * A request carrying neither a cookie nor a bearer token is answered without asking better-auth:
+ * a session is looked up by one or the other, so there is nothing for a lookup to find, and since
+ * the oauth provider a lookup reaches the database. That makes an anonymous request cost a round
+ * trip to be told what its own headers already said.
+ */
+function sessionFor(request: Request) {
+  const named = CREDENTIAL_HEADERS.some((header) => request.headers.has(header));
+  return named ? auth.api.getSession({ headers: request.headers }) : null;
+}

--- a/apps/api/src/lib/routes/prefixes.ts
+++ b/apps/api/src/lib/routes/prefixes.ts
@@ -5,6 +5,10 @@ export enum RoutePrefix {
   // Answered by the edge with 404 and reached by agents over the VPC, so a
   // route added here is unreachable from the internet the moment it is written.
   Internal = '/internal',
+  // The MCP endpoint, and the RFC 8707 resource an access token is issued for.
+  // Listed here before anything answers it so that a client reaching for it is
+  // told 404 rather than handed the dashboard's index.
+  Mcp = '/mcp',
 }
 
 type PathBelow<

--- a/apps/api/src/routes/controller.ts
+++ b/apps/api/src/routes/controller.ts
@@ -31,7 +31,7 @@ function createRootController() {
 // Every prefix the server answers. A path missing from here falls through to the
 // dashboard's index, so an agent calling a route that does not exist would be
 // handed HTML and a 200 instead of the 404 that would tell it what is wrong.
-const SERVED_PREFIXES = [RoutePrefix.Api, RoutePrefix.Internal];
+const SERVED_PREFIXES = [RoutePrefix.Api, RoutePrefix.Internal, RoutePrefix.Mcp];
 
 function isClientRoutePath(pathname: string): boolean {
   return !SERVED_PREFIXES.some((prefix) => pathname.startsWith(prefix));

--- a/apps/api/tests/controllers/agent.test.ts
+++ b/apps/api/tests/controllers/agent.test.ts
@@ -15,7 +15,10 @@ import {
   Value,
 } from '@repo/protocol';
 import { StatusMap } from 'elysia';
-import { ORIGIN, sendJson } from '#tests/controllers/support/api.ts';
+import { ORIGIN, sendJson, useTestDatabase } from '#tests/controllers/support/api.ts';
+
+// An agent names itself with a session token, which better-auth resolves against the database.
+useTestDatabase();
 
 const A_SERVED_APP_ID = Value.Parse(AppIdSchema, 'app-pocketbase');
 

--- a/apps/api/tests/controllers/support/api.ts
+++ b/apps/api/tests/controllers/support/api.ts
@@ -1,12 +1,21 @@
+import { afterAll } from 'bun:test';
+import { startTestDatabase, stopTestDatabase, TEST_DATABASE_URL } from '#tests/support/database.ts';
 import { TEST_SECRETS_KEY_BASE64 } from '#tests/support/secrets.ts';
 
 const BETTER_AUTH_SECRET_LENGTH = 32;
 
+const DATABASE_START_TIMEOUT_MS = 180_000;
+
 // The api reads its configuration when the service graph is constructed, so the environment has
-// to exist before the app module is imported — hence the dynamic import below. Postgres and the
-// object store are pointed at closed ports: no route reached from here gets that far.
+// to exist before the app module is imported — hence the dynamic import below. The object store is
+// pointed at a closed port: no route reached from here gets that far.
+//
+// Postgres is the suite's own database, brought up below before the api is imported rather than by
+// a test hook. Constructing better-auth with the oauth provider starts the plugin seeding its
+// resource row, and that lands as an unhandled rejection during module evaluation — before any
+// `beforeAll` could have started anything — which takes the whole file down with it.
 Object.assign(process.env, {
-  DATABASE_URL: 'postgres://nobody@127.0.0.1:1/none',
+  DATABASE_URL: TEST_DATABASE_URL,
   BETTER_AUTH_SECRET: 'x'.repeat(BETTER_AUTH_SECRET_LENGTH),
   GITHUB_CLIENT_ID: 'test',
   GITHUB_CLIENT_SECRET: 'test',
@@ -20,6 +29,8 @@ Object.assign(process.env, {
   APP_HOST_DOMAIN: 'apps.test',
   TENANT_SECRETS_KEY: TEST_SECRETS_KEY_BASE64,
 });
+
+const sql = await startTestDatabase();
 
 const { createApp } = await import('#app.ts');
 
@@ -66,4 +77,17 @@ export function sendJson({
     body: body === undefined ? undefined : JSON.stringify(body),
     signal,
   });
+}
+
+/**
+ * Take the suite's database down once this file is done with it.
+ *
+ * Called by the one file that reaches the database, which is what makes it the file that owns
+ * putting it away. Everything else here is answered before a query is reached, so a container
+ * already stopped costs those files nothing.
+ */
+export function useTestDatabase(): void {
+  afterAll(async () => {
+    await stopTestDatabase(sql);
+  }, DATABASE_START_TIMEOUT_MS);
 }

--- a/apps/api/tests/support/database.ts
+++ b/apps/api/tests/support/database.ts
@@ -6,7 +6,11 @@ const COMPOSE_FILE = resolve(import.meta.dir, '..', '..', '..', '..', 'docker-co
 
 // Fixed rather than discovered, because the compose file publishes it: a test that asked Docker
 // which port it got would be reading back what it already said.
-const DATABASE_URL = 'postgres://nibrun:nibrun@127.0.0.1:55432/nibrun_test';
+//
+// Exported because the controller suite has to name it before it imports the api — the service
+// graph reads its configuration as it is constructed — and a second copy of this string is a
+// second thing to keep in step with the compose file.
+export const TEST_DATABASE_URL = 'postgres://nibrun:nibrun@127.0.0.1:55432/nibrun_test';
 
 // The two the migrations own. Dropped before applying so a run finds the same empty database as
 // the one before it, including after a run that was killed before it could tear anything down.
@@ -22,7 +26,7 @@ const OWNED_SCHEMAS = ['nibrun', 'auth'];
 export async function startTestDatabase(): Promise<SQL> {
   await compose(['up', '-d', '--wait']);
 
-  const sql = new SQL(DATABASE_URL);
+  const sql = new SQL(TEST_DATABASE_URL);
   for (const schema of OWNED_SCHEMAS) {
     await sql.unsafe(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
   }

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,6 +12,7 @@
     "check:types": "bun run --bun tsc"
   },
   "dependencies": {
+    "@better-auth/oauth-provider": "^1.7.2",
     "@repo/api-client": "workspace:*",
     "@repo/app-operations": "workspace:*",
     "@repo/binary-handoff": "workspace:*",

--- a/apps/dashboard/src/components/auth/auth-card.tsx
+++ b/apps/dashboard/src/components/auth/auth-card.tsx
@@ -8,7 +8,7 @@ import {
 import { cn } from '@repo/ui/lib/utils';
 import type { ReactNode } from 'react';
 
-export function DeviceCard({
+export function AuthCard({
   title,
   description,
   failed,

--- a/apps/dashboard/src/components/consent/consent-approval.tsx
+++ b/apps/dashboard/src/components/consent/consent-approval.tsx
@@ -1,0 +1,62 @@
+import { Button } from '@repo/ui/components/button';
+import { Field, FieldError } from '@repo/ui/components/field';
+import { AuthCard } from '#components/auth/auth-card.tsx';
+import { ConsentScopes } from '#components/consent/consent-scopes.tsx';
+import { useConsentDecision } from '#lib/hooks/use-consent-decision.ts';
+import { useOauthClient } from '#lib/hooks/use-oauth-client.ts';
+import { useSession } from '#lib/hooks/use-session.ts';
+
+export function ConsentApproval({ clientId, scopes }: { clientId: string; scopes: string[] }) {
+  const session = useSession();
+  const client = useOauthClient(clientId);
+  const decide = useConsentDecision();
+
+  if (client.status === 'checking') {
+    return <AuthCard title="Authorize an application" description="Checking that application…" />;
+  }
+
+  if (client.status === 'refused') {
+    return <AuthCard failed title="Authorization failed" description={client.reason} />;
+  }
+
+  return (
+    <AuthCard
+      title="Authorize an application"
+      description="Allow only if you just started this yourself."
+    >
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-1">
+          <p className="text-muted-foreground text-sm">
+            <span className="font-semibold text-foreground">{client.name}</span> is asking to act as
+          </p>
+          <p className="truncate font-semibold">{session?.user.email}</p>
+        </div>
+        <ConsentScopes scopes={scopes} />
+        <p className="text-muted-foreground text-sm">
+          Anyone can register an application, and this one named itself. Allow it only if you
+          recognise it — what it is granted, it can do without asking you again.
+        </p>
+        <Field data-invalid={decide.isError || undefined}>
+          <div className="flex gap-3">
+            <Button
+              variant="outline"
+              className="flex-1"
+              disabled={decide.isPending}
+              onClick={() => decide.mutate('refuse')}
+            >
+              Refuse
+            </Button>
+            <Button
+              className="flex-1"
+              disabled={decide.isPending}
+              onClick={() => decide.mutate('allow')}
+            >
+              {decide.isPending ? 'Working…' : 'Allow'}
+            </Button>
+          </div>
+          {decide.isError && <FieldError>{decide.error.message}</FieldError>}
+        </Field>
+      </div>
+    </AuthCard>
+  );
+}

--- a/apps/dashboard/src/components/consent/consent-scopes.tsx
+++ b/apps/dashboard/src/components/consent/consent-scopes.tsx
@@ -1,0 +1,22 @@
+// What each scope lets the client do, in the owner's terms. A scope with no line here is shown as
+// the authorization server named it: this is the wording for scopes we know, not the list of
+// scopes that exist, and one added on the api should read as itself until it is given a sentence.
+const GRANTS: Record<string, string> = {
+  mcp: 'Deploy, suspend and delete your apps, and read their logs and files',
+  offline_access: 'Stay connected without asking you again',
+};
+
+export function ConsentScopes({ scopes }: { scopes: string[] }) {
+  return (
+    <ul className="flex flex-col gap-2">
+      {scopes.map((scope) => (
+        <li className="flex gap-2 text-sm" key={scope}>
+          <span aria-hidden className="text-muted-foreground">
+            •
+          </span>
+          <span>{GRANTS[scope] ?? scope}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/dashboard/src/components/device/device-approval.tsx
+++ b/apps/dashboard/src/components/device/device-approval.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@repo/ui/components/button';
 import { Field, FieldError } from '@repo/ui/components/field';
-import { DeviceCard } from '#components/device/device-card.tsx';
+import { AuthCard } from '#components/auth/auth-card.tsx';
 import { useDeviceCode } from '#lib/hooks/use-device-code.ts';
 import { useDeviceDecision } from '#lib/hooks/use-device-decision.ts';
 import { useSession } from '#lib/hooks/use-session.ts';
@@ -11,18 +11,18 @@ export function DeviceApproval({ userCode }: { userCode: string }) {
   const decide = useDeviceDecision(userCode);
 
   if (code.status === 'checking') {
-    return <DeviceCard title="Sign in a terminal" description="Checking that code…" />;
+    return <AuthCard title="Sign in a terminal" description="Checking that code…" />;
   }
 
   if (code.status === 'refused') {
-    return <DeviceCard failed title="Sign in failed" description={code.reason} />;
+    return <AuthCard failed title="Sign in failed" description={code.reason} />;
   }
 
   if (decide.isSuccess) {
     return decide.variables === 'approve' ? (
-      <DeviceCard title="Signed in" description="You can close this page." />
+      <AuthCard title="Signed in" description="You can close this page." />
     ) : (
-      <DeviceCard
+      <AuthCard
         title="Sign in refused"
         description="Nothing was signed in. You can close this page."
       />
@@ -30,7 +30,7 @@ export function DeviceApproval({ userCode }: { userCode: string }) {
   }
 
   return (
-    <DeviceCard
+    <AuthCard
       title="Sign in a terminal"
       description="Check the code matches the one it showed you."
     >
@@ -67,6 +67,6 @@ export function DeviceApproval({ userCode }: { userCode: string }) {
           {decide.isError && <FieldError>{decide.error.message}</FieldError>}
         </Field>
       </div>
-    </DeviceCard>
+    </AuthCard>
   );
 }

--- a/apps/dashboard/src/components/device/device-code-form.tsx
+++ b/apps/dashboard/src/components/device/device-code-form.tsx
@@ -3,7 +3,7 @@ import { Field, FieldLabel } from '@repo/ui/components/field';
 import { Input } from '@repo/ui/components/input';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
-import { DeviceCard } from '#components/device/device-card.tsx';
+import { AuthCard } from '#components/auth/auth-card.tsx';
 
 /** Shown when nobody followed the link the CLI printed and typed the address themselves. */
 export function DeviceCodeForm() {
@@ -11,7 +11,7 @@ export function DeviceCodeForm() {
   const [code, setCode] = useState('');
 
   return (
-    <DeviceCard title="Sign in a terminal" description="Enter the code it showed you.">
+    <AuthCard title="Sign in a terminal" description="Enter the code it showed you.">
       <form
         onSubmit={(event) => {
           event.preventDefault();
@@ -35,6 +35,6 @@ export function DeviceCodeForm() {
           Continue
         </Button>
       </form>
-    </DeviceCard>
+    </AuthCard>
   );
 }

--- a/apps/dashboard/src/components/login/github-sign-in-button.tsx
+++ b/apps/dashboard/src/components/login/github-sign-in-button.tsx
@@ -2,12 +2,21 @@ import { Button } from '@repo/ui/components/button';
 import { Field, FieldError } from '@repo/ui/components/field';
 import { GithubIcon } from '#icons/github-icon.tsx';
 import { useSignIn } from '#lib/hooks/use-sign-in.ts';
+import { resolveSignInTarget } from '#lib/oauth.ts';
 import { Route as LoginRoute } from '#routes/(auth)/login.tsx';
 import { Route as IndexRoute } from '#routes/(dashboard)/index.tsx';
 
 export function GithubSignInButton() {
   const { redirect } = LoginRoute.useSearch();
-  const signIn = useSignIn(redirect ?? IndexRoute.to);
+  // The location rather than the parsed search: an authorize request arrives here signed, and
+  // where it resumes has to be built from the query as it was signed. `redirect` is the
+  // dashboard's own way back, and only decides where an ordinary sign-in lands.
+  const signIn = useSignIn(
+    resolveSignInTarget({
+      search: window.location.search,
+      fallback: redirect ?? IndexRoute.to,
+    }),
+  );
 
   return (
     <Field data-invalid={signIn.isError || undefined}>

--- a/apps/dashboard/src/lib/auth.ts
+++ b/apps/dashboard/src/lib/auth.ts
@@ -1,12 +1,14 @@
+import { oauthProviderClient } from '@better-auth/oauth-provider/client';
 import { deviceAuthorizationClient } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
 
 // Same origin in both environments, for the same reason as the api client.
 export const authClient = createAuthClient({
   baseURL: window.location.origin,
-  // Types `authClient.device.*`. The request methods it declares are inferred correctly without
-  // it, so removing it costs no requests — only the accessors the device page is written against.
-  plugins: [deviceAuthorizationClient()],
+  // Types `authClient.device.*` and `authClient.oauth2.*`. The request methods they declare are
+  // inferred correctly without them, so removing one costs no requests — only the accessors the
+  // device and consent pages are written against.
+  plugins: [deviceAuthorizationClient(), oauthProviderClient()],
 });
 
 export type Session = typeof authClient.$Infer.Session;

--- a/apps/dashboard/src/lib/hooks/use-consent-decision.ts
+++ b/apps/dashboard/src/lib/hooks/use-consent-decision.ts
@@ -1,0 +1,33 @@
+import { type UseMutationResult, useMutation } from '@tanstack/react-query';
+import { authClient } from '#lib/auth.ts';
+import { signedQuery } from '#lib/oauth.ts';
+
+export type ConsentDecision = 'allow' | 'refuse';
+
+/**
+ * Answer the authorize request the owner was sent here by.
+ *
+ * The whole query string goes back rather than the code alone: better-auth signed every parameter
+ * of the request onto this url and verifies them back off it, so anything picked out and rebuilt
+ * here would be a query whose signature no longer matches.
+ *
+ * Both answers end at the client's `redirect_uri` — a refusal is an answer the client is owed, not
+ * a page the owner is left on — so this navigates rather than returning.
+ */
+export function useConsentDecision(): UseMutationResult<void, Error, ConsentDecision> {
+  return useMutation({
+    mutationFn: async (decision: ConsentDecision) => {
+      const { data, error } = await authClient.oauth2.consent({
+        accept: decision === 'allow',
+        oauth_query: signedQuery(),
+      });
+      if (error) {
+        throw new Error(error.message ?? 'That decision could not be recorded.');
+      }
+      if (!data?.url) {
+        throw new Error('The authorization was recorded without saying where to send you back to.');
+      }
+      window.location.href = data.url;
+    },
+  });
+}

--- a/apps/dashboard/src/lib/hooks/use-oauth-client.ts
+++ b/apps/dashboard/src/lib/hooks/use-oauth-client.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { oauthClientQueryOptions } from '#queries/oauth-client.ts';
+
+export type OauthClientState =
+  | { status: 'checking'; name?: undefined; reason?: undefined }
+  | { status: 'known'; name: string; reason?: undefined }
+  | { status: 'refused'; name?: undefined; reason: string };
+
+/**
+ * A name to put in the sentence the owner is answering. A client that registered itself may have
+ * given none, and the id it registered under says more than an empty line would.
+ */
+export function useOauthClient(clientId: string): OauthClientState {
+  const { isPending, isError, error, data } = useQuery(oauthClientQueryOptions(clientId));
+
+  if (isPending) {
+    return { status: 'checking' };
+  }
+  if (isError) {
+    return { status: 'refused', reason: error.message };
+  }
+  return { status: 'known', name: data?.client_name || clientId };
+}

--- a/apps/dashboard/src/lib/oauth.ts
+++ b/apps/dashboard/src/lib/oauth.ts
@@ -1,0 +1,37 @@
+const AUTHORIZE_PATH = '/api/auth/oauth2/authorize';
+
+/** better-auth's own parameter on the sign-in redirect, and the only one that is not the request. */
+const CALLBACK_PARAM = 'callbackURL';
+
+/**
+ * Where signing in should land, given the query better-auth sent the owner here with.
+ *
+ * An authorize request that has no session is redirected to the sign-in page carrying the whole of
+ * itself, so replaying that query against `authorize` is what resumes it. Anything else is the
+ * dashboard's own sign-in, and lands wherever it was going.
+ */
+export function resolveSignInTarget({
+  search,
+  fallback,
+}: {
+  search: string;
+  fallback: string;
+}): string {
+  const params = new URLSearchParams(search);
+  params.delete(CALLBACK_PARAM);
+  const authorizeQuery = params.toString();
+  return authorizeQuery === '' ? fallback : `${AUTHORIZE_PATH}?${authorizeQuery}`;
+}
+
+/**
+ * The query exactly as it arrived.
+ *
+ * Read off the location rather than the router, and this is load-bearing: better-auth signs the
+ * authorize request with repeated `ba_param` keys, and the router's search parser collapses
+ * repeated keys into one array-valued entry — which re-serialises into a query whose signature no
+ * longer matches. better-auth only ever reaches these pages by a full-document redirect, so what
+ * the browser holds is the verbatim signed query.
+ */
+export function signedQuery(): string {
+  return window.location.search.replace(/^\?/, '');
+}

--- a/apps/dashboard/src/queries/oauth-client.ts
+++ b/apps/dashboard/src/queries/oauth-client.ts
@@ -1,0 +1,26 @@
+import { queryOptions } from '@tanstack/react-query';
+import { authClient } from '#lib/auth.ts';
+
+export const OAUTH_CLIENT_QUERY_KEY = 'oauth-client';
+
+/**
+ * The client's own account of itself, which is all a consent page has to show for it.
+ *
+ * Everything here was written by whoever registered the client, and anyone may register one — so
+ * it names what is asking without vouching for it. That is what the warning beside it is for.
+ */
+export function oauthClientQueryOptions(clientId: string) {
+  return queryOptions({
+    queryKey: [OAUTH_CLIENT_QUERY_KEY, clientId],
+    queryFn: async () => {
+      const { data, error } = await authClient.oauth2.publicClient({
+        query: { client_id: clientId },
+      });
+      if (error) {
+        throw new Error(error.message ?? 'That application is not one we know.');
+      }
+      return data;
+    },
+    retry: false,
+  });
+}

--- a/apps/dashboard/src/routeTree.gen.ts
+++ b/apps/dashboard/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as authRouteRouteImport } from './routes/(auth)/route'
 import { Route as dashboardRouteRouteImport } from './routes/(dashboard)/route'
 import { Route as DeployRouteImport } from './routes/deploy'
+import { Route as authConsentRouteImport } from './routes/(auth)/consent'
 import { Route as authDeviceRouteImport } from './routes/(auth)/device'
 import { Route as authLoginRouteImport } from './routes/(auth)/login'
 import { Route as dashboardIndexRouteImport } from './routes/(dashboard)/index'
@@ -34,6 +35,11 @@ const DeployRoute = DeployRouteImport.update({
   id: '/deploy',
   path: '/deploy',
   getParentRoute: () => rootRouteImport,
+} as any)
+const authConsentRoute = authConsentRouteImport.update({
+  id: '/consent',
+  path: '/consent',
+  getParentRoute: () => authRouteRoute,
 } as any)
 const authDeviceRoute = authDeviceRouteImport.update({
   id: '/device',
@@ -84,6 +90,7 @@ const dashboardAppsAppIdLogsRoute = dashboardAppsAppIdLogsRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/deploy': typeof DeployRoute
+  '/consent': typeof authConsentRoute
   '/device': typeof authDeviceRoute
   '/login': typeof authLoginRoute
   '/': typeof dashboardIndexRoute
@@ -96,6 +103,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/deploy': typeof DeployRoute
+  '/consent': typeof authConsentRoute
   '/device': typeof authDeviceRoute
   '/login': typeof authLoginRoute
   '/': typeof dashboardIndexRoute
@@ -110,6 +118,7 @@ export interface FileRoutesById {
   '/(auth)': typeof authRouteRouteWithChildren
   '/(dashboard)': typeof dashboardRouteRouteWithChildren
   '/deploy': typeof DeployRoute
+  '/(auth)/consent': typeof authConsentRoute
   '/(auth)/device': typeof authDeviceRoute
   '/(auth)/login': typeof authLoginRoute
   '/(dashboard)/': typeof dashboardIndexRoute
@@ -124,6 +133,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/deploy'
+    | '/consent'
     | '/device'
     | '/login'
     | '/'
@@ -136,6 +146,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/deploy'
+    | '/consent'
     | '/device'
     | '/login'
     | '/'
@@ -149,6 +160,7 @@ export interface FileRouteTypes {
     | '/(auth)'
     | '/(dashboard)'
     | '/deploy'
+    | '/(auth)/consent'
     | '/(auth)/device'
     | '/(auth)/login'
     | '/(dashboard)/'
@@ -188,6 +200,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/deploy'
       preLoaderRoute: typeof DeployRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/(auth)/consent': {
+      id: '/(auth)/consent'
+      path: '/consent'
+      fullPath: '/consent'
+      preLoaderRoute: typeof authConsentRouteImport
+      parentRoute: typeof authRouteRoute
     }
     '/(auth)/device': {
       id: '/(auth)/device'
@@ -256,11 +275,13 @@ declare module '@tanstack/react-router' {
 }
 
 interface authRouteRouteChildren {
+  authConsentRoute: typeof authConsentRoute
   authDeviceRoute: typeof authDeviceRoute
   authLoginRoute: typeof authLoginRoute
 }
 
 const authRouteRouteChildren: authRouteRouteChildren = {
+  authConsentRoute: authConsentRoute,
   authDeviceRoute: authDeviceRoute,
   authLoginRoute: authLoginRoute,
 }

--- a/apps/dashboard/src/routes/(auth)/consent.tsx
+++ b/apps/dashboard/src/routes/(auth)/consent.tsx
@@ -1,0 +1,36 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AuthCard } from '#components/auth/auth-card.tsx';
+import { ConsentApproval } from '#components/consent/consent-approval.tsx';
+import { signedQuery } from '#lib/oauth.ts';
+
+const SCOPE_SEPARATOR = ' ';
+
+/**
+ * No `validateSearch`, unlike every other route here, and deliberately: better-auth signs the
+ * authorize request with repeated `ba_param` keys, and the router's search parser collapses
+ * repeated keys into one array-valued entry. What is answered has to be the query as it was
+ * signed, so this page reads the location and leaves the router out of it.
+ */
+export const Route = createFileRoute('/(auth)/consent')({ component: RouteComponent });
+
+function RouteComponent() {
+  const asked = new URLSearchParams(signedQuery());
+  const clientId = asked.get('client_id');
+
+  if (!clientId) {
+    return (
+      <AuthCard
+        failed
+        title="Authorization failed"
+        description="This link is missing the application it was asking about. Start again from the application."
+      />
+    );
+  }
+
+  return (
+    <ConsentApproval
+      clientId={clientId}
+      scopes={asked.get('scope')?.split(SCOPE_SEPARATOR).filter(Boolean) ?? []}
+    />
+  );
+}

--- a/apps/dashboard/tests/lib/oauth.test.ts
+++ b/apps/dashboard/tests/lib/oauth.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveSignInTarget } from '#lib/oauth.ts';
+
+const FALLBACK = '/apps';
+
+describe('resolveSignInTarget', () => {
+  test('resumes the authorize request the owner was sent here by', () => {
+    const target = resolveSignInTarget({
+      search: '?client_id=abc&scope=mcp&callbackURL=%2Flogin',
+      fallback: FALLBACK,
+    });
+
+    expect(target).toBe('/api/auth/oauth2/authorize?client_id=abc&scope=mcp');
+  });
+
+  // The signature is over the parameters better-auth put on the request, and `callbackURL` is not
+  // one of them — it is how it asked to be sent back here.
+  test('drops only better-auth own way back to this page', () => {
+    const target = resolveSignInTarget({ search: '?callbackURL=%2Flogin', fallback: FALLBACK });
+
+    expect(target).toBe(FALLBACK);
+  });
+
+  // Repeated keys are how the request is signed, so both copies have to survive in the order they
+  // arrived — a parser that collapsed them would hand back a query that no longer verifies.
+  test('keeps a repeated parameter as the two it arrived as', () => {
+    const target = resolveSignInTarget({
+      search: '?ba_param=one&ba_param=two',
+      fallback: FALLBACK,
+    });
+
+    expect(target).toBe('/api/auth/oauth2/authorize?ba_param=one&ba_param=two');
+  });
+
+  test('signing in with nothing to resume lands where it was going', () => {
+    expect(resolveSignInTarget({ search: '', fallback: FALLBACK })).toBe(FALLBACK);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1105.0",
         "@aws-sdk/s3-request-presigner": "^3.1105.0",
+        "@better-auth/oauth-provider": "^1.7.2",
         "@ilbertt/better-auth-bun-sql": "^0.4.0",
         "@ilbertt/bun-sqlgen": "^0.5.0",
         "@repo/protocol": "workspace:*",
@@ -49,6 +50,7 @@
     "apps/dashboard": {
       "name": "@repo/dashboard",
       "dependencies": {
+        "@better-auth/oauth-provider": "^1.7.2",
         "@repo/api-client": "workspace:*",
         "@repo/app-operations": "workspace:*",
         "@repo/binary-handoff": "workspace:*",
@@ -378,6 +380,8 @@
     "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2" } }, "sha512-0q1SXMzm5esH9L0xVuM6IxCk59E4G+3HySX4My9gvEwqtmUobykn+iuc/si3Y4xwUO7JODqQ5o+/pPcLDDMIrA=="],
 
     "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-4879SmUWHUs0OYlvHoCFbycZ7i1bqytkcgAUdt9RLQMvZ5H3LRMTgax2YVlGZEXgwNjY/X7xAoXOecWLhlQWeA=="],
+
+    "@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.7.2", "", { "dependencies": { "jose": "^6.2.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "better-auth": "^1.7.2", "better-call": "1.4.0" } }, "sha512-td7FnUz3lLKXFXN+0RbZe3ygaHqxpRqDG+gxbfSZbztbVfG7vuZtR4ba3uccsodAw7anchhIg2xwVP1/zlcxcw=="],
 
     "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-mXTr/83WrNWLrvzIjtgDgdu9iXhOcSG1+qBQOAKlbGSFiOB+z4IMRneQ2wmMOiB8mKY9qGkClVUjKRFXqtHnFQ=="],
 


### PR DESCRIPTION
Stacked on #389.

better-auth becomes an OAuth 2.1 authorization server, so an MCP client can register itself and ask for a token. What stands in for knowing the client beforehand is the consent page — anyone may register one, so nothing is granted until the owner reads who is asking.

Not an OIDC provider: MCP wants an access token, never an identity, so `openid` is not advertised. The `jwt` plugin is here only because `oauth-provider` refuses to resolve a request without one to sign through.

Three things worth a reviewer's attention:

- **The signed query is answered verbatim, off `window.location`, not the router.** better-auth signs the authorize request with repeated keys and TanStack's search parser collapses those into one array-valued entry, which re-serialises into a query whose signature no longer verifies. `/consent` therefore has no `validateSearch`. Learned from `company-brain`, which documents the same trap.
- **1.7 keys resources on a row, not on config.** 1.6's `validAudiences` is gone, replaced by a DB-backed `resources` model that seeds lazily. So the api now reaches the database to resolve a caller — which is why the controller suite brings up the Postgres it had been able to do without, and why a request naming nobody is now refused without asking (a round trip whose answer its own headers already gave).
- **The migration is emitted by the adapter's `createSchema`**, diffed against the plugin-less schema, as 0003 and 0014 ask for — not hand-written.

`/mcp` is declared as the resource and added to the served prefixes so it 404s rather than returning the dashboard's index. Nothing serves it yet; that is the next PR.