### PR TITLE
fix(agent): an app is counted by its traffic, not by its connections

### DIFF
--- a/apps/agent/src/lib/network/firewall.ts
+++ b/apps/agent/src/lib/network/firewall.ts
@@ -10,6 +10,9 @@ export const INSTANCE_METADATA_ADDRESS_V6 = 'fd00:ec2::254';
 /** nft rejects the name `dstnat` on the output hook, and the whole ruleset with it. */
 const OUTPUT_NAT_PRIORITY = -100;
 
+/** After the isolation chain on the same hook, so only traffic that was allowed is counted. */
+const TRAFFIC_CHAIN_PRIORITY = 'filter + 10';
+
 const PRIVATE_DESTINATIONS_V4 = [
   '10.0.0.0/8',
   '172.16.0.0/12',
@@ -36,10 +39,9 @@ const RULE_INDENT = '    ';
 const DENY = 'reject';
 
 /**
- * A named counter per app rather than one inline on each rule: an app is reached through more than
- * one of them — the loopback port the proxy uses, the host port from outside, and any extra port
- * it asked for — and what an app being used means is all of them together. The name carries the
- * attribution, so reading one back needs no rule to be recognised by its shape.
+ * A named counter per app, referenced from every chain that sees traffic reaching its guest. The
+ * name carries the attribution, so reading one back needs no rule to be recognised by its shape
+ * and no two rules have to be summed to answer for one app.
  *
  * Bare, not quoted: nft takes a declaration name as an identifier and rejects a quoted string
  * there, hyphens in an app id notwithstanding.
@@ -68,6 +70,13 @@ const set = (values: readonly string[]) => `{ ${values.join(', ')} }`;
  * Zeroed whenever the ruleset changes, because the table is replaced rather than edited. Whoever
  * reads these has to treat a count standing below the one before it as a reset and not as an app
  * that has gone quiet — the same hazard a rebooted guest is to a cpu share.
+ *
+ * Deliberately not counted on the nat rules that forward to a guest. A nat hook is traversed for
+ * the packet that creates a conntrack entry and no other, so a count taken there is a count of
+ * connections: measured on a live host, twenty requests over one keep-alive connection moved it
+ * by one, against the tap's own forty-two thousand. An app being read through a pooled connection
+ * or holding a websocket open would have looked idle, and idle is the direction that puts a
+ * microVM down underneath somebody.
  */
 const counterObjects = ({ instances }: FirewallState) =>
   instances.flatMap((instance) => [
@@ -98,6 +107,8 @@ export function renderRuleset(state: FirewallState): string {
     ...inputChainV4(),
     '',
     ...natChainsV4(state),
+    '',
+    ...trafficChainsV4(state),
     '}',
     '',
     `table ip6 ${NFTABLES_TABLE}`,
@@ -109,6 +120,55 @@ export function renderRuleset(state: FirewallState): string {
     ...inputChainV6(),
     '}',
   ].join('\n')}\n`;
+}
+
+/**
+ * Counts, and decides nothing: every rule here is a bare `counter` with no verdict, so traffic
+ * passes through exactly as it would if the chains were absent.
+ *
+ * Two chains because there are two ways in and they meet different hooks. The proxy dials the
+ * loopback port, which is locally generated and reaches `output`; anything from off the box —
+ * which is how a public port an app asked for is served — is forwarded and reaches `forward`.
+ * One counter behind both is what makes "is anybody using this app" a single number rather than
+ * a sum somebody could forget to take.
+ *
+ * A loopback source is what makes the output chain only the proxy's traffic. The nat output hook
+ * has already rewritten the destination by the time this runs, and the postrouting snat that
+ * re-sources it onto the tap has not, so a packet from the proxy is still 127.0.0.1 here. The
+ * agent's own health probes dial the guest address directly and are sourced from the tap, so they
+ * are not counted — being kept awake by the probing of the process deciding to sleep it is the
+ * one way this measurement could be circular.
+ *
+ * The forward chain sits after the isolation rules rather than beside them: those end in a
+ * verdict, so what reaches this has already been allowed, and nothing rejected is counted as use.
+ */
+function trafficChainsV4({ instances }: FirewallState): string[] {
+  if (instances.length === 0) {
+    return [];
+  }
+  return [
+    ...chain({
+      header: 'traffic_output {',
+      rules: [
+        'type filter hook output priority filter; policy accept;',
+        ...instances.map(
+          (instance) =>
+            `ip saddr 127.0.0.0/8 ip daddr ${instance.guestIpv4} tcp dport ${instance.httpPort} counter name ${appCounterName(instance.appId)}`,
+        ),
+      ],
+    }),
+    '',
+    ...chain({
+      header: 'traffic_forward {',
+      rules: [
+        `type filter hook forward priority ${TRAFFIC_CHAIN_PRIORITY}; policy accept;`,
+        ...instances.map(
+          (instance) =>
+            `iifname != ${TAP_MATCH} oifname ${TAP_MATCH} ip daddr ${instance.guestIpv4} counter name ${appCounterName(instance.appId)}`,
+        ),
+      ],
+    }),
+  ];
 }
 
 function forwardChainV4({ controlPlaneCidrsV4 }: FirewallState): string[] {
@@ -176,7 +236,7 @@ function natChainsV4({ instances }: FirewallState): string[] {
         'type nat hook prerouting priority dstnat; policy accept;',
         ...instances.map(
           (instance) =>
-            `iifname != ${TAP_MATCH} tcp dport ${instance.hostPort} counter name ${appCounterName(instance.appId)} dnat to ${instance.guestIpv4}:${instance.httpPort}`,
+            `iifname != ${TAP_MATCH} tcp dport ${instance.hostPort} dnat to ${instance.guestIpv4}:${instance.httpPort}`,
         ),
         // The same port on both sides, and both protocols: what arrives here has already been
         // forwarded once without being renumbered, and rewriting it now would leave a binary
@@ -186,7 +246,7 @@ function natChainsV4({ instances }: FirewallState): string[] {
             ? []
             : (['tcp', 'udp'] as const).map(
                 (protocol) =>
-                  `iifname != ${TAP_MATCH} ${protocol} dport ${instance.extraPublicPort} counter name ${appCounterName(instance.appId)} dnat to ${instance.guestIpv4}:${instance.extraPublicPort}`,
+                  `iifname != ${TAP_MATCH} ${protocol} dport ${instance.extraPublicPort} dnat to ${instance.guestIpv4}:${instance.extraPublicPort}`,
               ),
         ),
       ],
@@ -198,7 +258,7 @@ function natChainsV4({ instances }: FirewallState): string[] {
         `type nat hook output priority ${OUTPUT_NAT_PRIORITY}; policy accept;`,
         ...instances.map(
           (instance) =>
-            `ip daddr 127.0.0.1 tcp dport ${instance.hostPort} counter name ${appCounterName(instance.appId)} dnat to ${instance.guestIpv4}:${instance.httpPort}`,
+            `ip daddr 127.0.0.1 tcp dport ${instance.hostPort} dnat to ${instance.guestIpv4}:${instance.httpPort}`,
         ),
       ],
     }),

--- a/apps/agent/tests/lib/network/firewall.test.ts
+++ b/apps/agent/tests/lib/network/firewall.test.ts
@@ -241,6 +241,12 @@ describe('the ruleset is a function of state, not a history of edits', () => {
 });
 
 describe('an app is counted wherever it is reached', () => {
+  const linesOf = ({ ruleset, match }: { ruleset: string; match: string }) =>
+    ruleset
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.includes(match));
+
   test('every forwarded app declares a counter of its own', () => {
     const ruleset = renderRuleset(state({ instances: [instance] }));
     expect(ruleset).toContain(`counter ${appCounterName(instance.appId)} {`);
@@ -251,29 +257,70 @@ describe('an app is counted wherever it is reached', () => {
     expect(ruleset).not.toContain(`counter "${appCounterName(instance.appId)}"`);
   });
 
-  test('both ways in are counted against the same app', () => {
-    const rules = renderRuleset(state({ instances: [instance] }))
-      .split('\n')
-      .filter((line) => line.includes('dnat to'));
-    expect(rules).toHaveLength(2);
-    for (const rule of rules) {
-      expect(rule).toContain(`counter name ${appCounterName(instance.appId)}`);
+  // The reason this file has a test about where a counter is *not*: a nat hook is traversed for
+  // the packet that opens a connection and no other, so counting there counts connections. An app
+  // read over a pooled connection would go quiet while it was being used, and quiet is what puts
+  // a microVM down underneath somebody.
+  test('no rule that forwards to a guest carries a counter', () => {
+    const ruleset = renderRuleset(state({ instances: [instance, askedForAPort] }));
+    for (const rule of linesOf({ ruleset, match: 'dnat to' })) {
+      expect(rule).not.toContain('counter');
     }
   });
 
-  test('an extra public port is the same app being used, on both protocols', () => {
-    const rules = renderRuleset(state({ instances: [askedForAPort] }))
-      .split('\n')
-      .filter(
-        (line) => line.includes(String(EXTRA_PUBLIC_PORT_NUMBER)) && line.includes('dnat to'),
-      );
-    expect(rules).toHaveLength(2);
-    for (const rule of rules) {
-      expect(rule).toContain(`counter name ${appCounterName(askedForAPort.appId)}`);
+  test('the proxy reaching a guest over loopback is counted', () => {
+    const rules = linesOf({
+      ruleset: renderRuleset(state({ instances: [instance] })),
+      match: 'ip saddr 127.0.0.0/8',
+    });
+    const counted = rules.filter((rule) => rule.includes('counter name'));
+    expect(counted).toHaveLength(1);
+    expect(counted[0]).toContain(`ip daddr ${instance.guestIpv4}`);
+    expect(counted[0]).toContain(appCounterName(instance.appId));
+  });
+
+  test('traffic arriving from off the box is counted against the same app', () => {
+    const ruleset = renderRuleset(state({ instances: [instance] }));
+    const forwarded = linesOf({ ruleset, match: 'oifname "nbr*" ip daddr' }).filter((rule) =>
+      rule.includes('counter name'),
+    );
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]).toContain(appCounterName(instance.appId));
+  });
+
+  test('both ways in name one counter, so nothing has to be summed to answer for an app', () => {
+    const counted = linesOf({
+      ruleset: renderRuleset(state({ instances: [instance] })),
+      match: 'counter name',
+    });
+    expect(counted).toHaveLength(2);
+    for (const rule of counted) {
+      expect(rule).toContain(appCounterName(instance.appId));
     }
   });
 
-  test('a host with no apps declares no counters', () => {
-    expect(renderRuleset(state())).not.toContain('counter ');
+  // A guest is reachable on a port it asked for without that port being in any rule here: the
+  // forward rule matches the address, so a protocol nobody thought about is counted anyway.
+  test('a port an app asked for needs no counting rule of its own', () => {
+    const withPort = linesOf({
+      ruleset: renderRuleset(state({ instances: [askedForAPort] })),
+      match: 'counter name',
+    });
+    const without = linesOf({
+      ruleset: renderRuleset(state({ instances: [instance] })),
+      match: 'counter name',
+    });
+    expect(withPort).toHaveLength(without.length);
+  });
+
+  test('counting runs after the rules that refuse, so nothing rejected reads as use', () => {
+    const ruleset = renderRuleset(state({ instances: [instance] }));
+    expect(ruleset).toContain('type filter hook forward priority filter + 10;');
+  });
+
+  test('a host with no apps declares no counters and adds no chains', () => {
+    const ruleset = renderRuleset(state());
+    expect(ruleset).not.toContain('counter ');
+    expect(ruleset).not.toContain('traffic_');
   });
 });


### PR DESCRIPTION
#392 put the counters on the nat rules that forward to a guest. A nat hook is
traversed for the packet that creates a conntrack entry and no other, so what
they measured was connections opened, not an app being used.

**Measured on the live host**, against `i-03738d79b4aae4939`:

```
counter before: 7 packets
http_code=200 tcp_connections_opened=0     <- reused the pooled connection
counter after:  8 packets
DELTA: 1 packets, for 20 HTTP requests
```

That app's tap had carried 42,292 packets at the time. Four of the five apps
running read exactly `0`. The agent's own log said as much every minute —
`measured: 5, moved: 0` — against a host plainly serving traffic.

An app read over a pooled connection, or holding a websocket open, would have
gone quiet while it was being used. That is the error that matters: the two
directions are not symmetric. Believing a busy app is idle stops a microVM under
somebody's request; believing an idle app is busy costs 256 MiB.

**What changes.** Counting moves off the nat rules and into two chains that see
every packet, both naming the same counter so nothing has to be summed:

- `traffic_output`, filter hook output — the proxy's loopback traffic. The nat
  output hook has already rewritten the destination by then, and the postrouting
  snat that re-sources it onto the tap has not, so a packet from the proxy is
  still `127.0.0.1` here.
- `traffic_forward`, filter hook forward at `priority filter + 10` — anything
  arriving from off the box, which is how a public port an app asked for is
  served. #392 did not count that path at all. It sits after the isolation
  chain, whose rules end in a verdict, so nothing rejected reads as use.

Every rule is a bare `counter` with no verdict: the chains decide nothing and
traffic passes exactly as it would if they were absent.

Health probes are still excluded, and still by construction rather than by
filtering: `probe.ts` dials the guest address directly, so its packets are
sourced from the tap and match neither chain. Being kept awake by the probing of
the process deciding to sleep it is the one way this measurement could be
circular.

The read path, the reset handling, the persistence and the log line are all
unchanged — those were right; only the hook was wrong.

**Verified against a real kernel**, not just rendered. The full ruleset loads
into nftables 1.0.4, `priority filter + 10` and two chains on one hook included,
and the production rule shape counts as intended:

```
20 HTTP requests over ONE keep-alive connection, identical match:
  filter hook (this PR):  ~37 packets
  nat hook    (#392):     ~1.5 packets
```

A test now asserts that no rule carrying `dnat to` also carries a counter, so
this cannot drift back.