### PR TITLE
fix(agent): a volume is attached when it answers, not when it has a client

### DIFF
--- a/apps/agent/src/lib/volumes/nbd.ts
+++ b/apps/agent/src/lib/volumes/nbd.ts
@@ -1,5 +1,5 @@
 import type { VolumeId } from '@repo/protocol';
-import { Effect } from 'effect';
+import { Duration, Effect } from 'effect';
 import { run, stdoutOf } from '#services/command-runner.service.ts';
 
 const NBD_CLIENT = 'nbd-client';
@@ -11,10 +11,56 @@ const NBD_BLOCK_SIZE_BYTES = 4096;
  * remounting read-only. */
 const NBD_TIMEOUT_SECONDS = 600;
 
+/**
+ * Whether a device has a client, which is a different question from whether it has a working one.
+ * Kept because a detach is only worth attempting against a device somebody is holding.
+ */
 export const isAttached = (devicePath: string) =>
   Effect.map(
     run({ command: [NBD_CLIENT, '-check', devicePath] }),
     (result) => result.code === CONNECTED_EXIT_CODE,
+  );
+
+/** One block, at the offset every filesystem on the device keeps something at. */
+const PROBE_BYTES = 4096;
+
+/**
+ * A dead device answers instantly and a live one answers from cache, so this bounds the case
+ * neither covers: a server that is up but reaching S3 for the block. Shorter than the ceiling on
+ * the device itself, because a probe that waited that long would hold the reconcile behind it.
+ */
+const PROBE_TIMEOUT_SECONDS = 15;
+const PROBE_TIMEOUT = Duration.seconds(PROBE_TIMEOUT_SECONDS);
+
+/**
+ * Whether the device answers, which is what `-check` does not ask.
+ *
+ * A ZeroFS restart leaves the kernel holding a device that reports its size and names its client
+ * and fails every read: `-check` exits 0, `blockdev --getsize64` is right, and the guest's ext4
+ * cannot read its own superblock. Observed on a live host, on both ZeroFS versions, so it is the
+ * reconnect and not the release. Liveness has to be a read, because a read is the thing that is
+ * broken.
+ *
+ * `iflag=direct` is what makes it a read of the device rather than of the page cache. Without it
+ * the host answers out of memory for a device that has been dead for hours, which is the same
+ * false yes this replaces.
+ */
+export const isUsable = (devicePath: string) =>
+  run({
+    command: [
+      'dd',
+      `if=${devicePath}`,
+      'of=/dev/null',
+      `bs=${PROBE_BYTES}`,
+      'count=1',
+      'iflag=direct',
+    ],
+    timeout: PROBE_TIMEOUT,
+  }).pipe(
+    Effect.map((result) => result.code === CONNECTED_EXIT_CODE),
+    // A probe that could not be run is not evidence the device is well, and the repair it leads
+    // to costs a detach and an attach against a device nobody is using yet.
+    Effect.catchAll(() => Effect.succeed(false)),
   );
 
 const connect = ({
@@ -46,7 +92,13 @@ const connect = ({
     ],
   });
 
-/** `-persist` reconnects on its own, which keeps a ZeroFS restart a stall rather than an I/O error. */
+/**
+ * `-persist` reconnects on its own, and it is kept for the drops it does cover — a socket that
+ * goes and comes back while the kernel still has the device. It does not cover a ZeroFS restart:
+ * the kernel tears the device down first, and what reconnects onto it reads as attached and
+ * answers every read with an error. `isUsable` is what notices that, and `reattach` is what
+ * repairs it.
+ */
 export const attach = Effect.fn('nbd.attach')(
   (target: { socketPath: string; devicePath: string; volumeId: VolumeId }) =>
     connect({ ...target, extraArgs: ['-persist'] }),
@@ -72,3 +124,21 @@ export const attachCheckpoint = Effect.fn('nbd.attachCheckpoint')(
 export const detach = Effect.fn('nbd.detach')((devicePath: string) =>
   run({ command: [NBD_CLIENT, '-d', devicePath] }),
 );
+
+/**
+ * Takes the device down before bringing it up, because the failure this repairs is a device the
+ * kernel still holds. Attaching over it would find the minor busy; only a detach frees it.
+ *
+ * The detach is allowed to fail: the same call has to serve a device nobody has ever attached,
+ * where there is nothing to take down and `-d` says so.
+ */
+export const reattach = Effect.fn('nbd.reattach')(function* (target: {
+  socketPath: string;
+  devicePath: string;
+  volumeId: VolumeId;
+}) {
+  if (yield* isAttached(target.devicePath)) {
+    yield* Effect.ignore(detach(target.devicePath));
+  }
+  return yield* attach(target);
+});

--- a/apps/agent/src/services/volume-manager.service.ts
+++ b/apps/agent/src/services/volume-manager.service.ts
@@ -12,7 +12,7 @@ import type { AppSlot } from '#lib/network/slot.ts';
 import type { ObservedVolume } from '#lib/reconcile/plan.ts';
 import { devicePathFor, ensureDeviceFile, NBD_DIRECTORY } from '#lib/volumes/device-file.ts';
 import { formatOnce } from '#lib/volumes/ext4.ts';
-import { attach, detach, isAttached } from '#lib/volumes/nbd.ts';
+import { detach, isUsable, reattach } from '#lib/volumes/nbd.ts';
 import type { ZerofsFilesystem } from '#lib/volumes/topology.ts';
 import { flush } from '#lib/volumes/zerofs.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
@@ -63,7 +63,10 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
         if (Option.isNone(sizeBytes)) {
           return Option.none<ObservedVolume>();
         }
-        const attached = Option.isSome(slot) ? yield* isAttached(slot.value.nbdDevicePath) : false;
+        // Whether the device *works*, not whether it has a client: this is what `planVolumes`
+        // reads to decide a volume needs nothing done to it, so a device that lies here is one
+        // nothing ever repairs.
+        const attached = Option.isSome(slot) ? yield* isUsable(slot.value.nbdDevicePath) : false;
         return Option.some<ObservedVolume>({
           volumeId,
           appId,
@@ -119,8 +122,8 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
         sizeBytes: desired.sizeBytes,
       });
 
-      if (!(yield* isAttached(slot.nbdDevicePath))) {
-        yield* attach({
+      if (!(yield* isUsable(slot.nbdDevicePath))) {
+        yield* reattach({
           socketPath: filesystem.nbdSocketPath,
           devicePath: slot.nbdDevicePath,
           volumeId: desired.volumeId,

--- a/apps/agent/tests/lib/volumes/nbd.test.ts
+++ b/apps/agent/tests/lib/volumes/nbd.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { Value, VolumeIdSchema } from '@repo/protocol';
+import { Effect } from 'effect';
+import { isUsable, reattach } from '#lib/volumes/nbd.ts';
+import { recordingCommands, succeeding } from '#tests/support/commands.ts';
+
+const DEVICE = '/dev/nbd0';
+const SOCKET = '/run/zerofs/nbd.sock';
+const VOLUME_ID = Value.Parse(VolumeIdSchema, '0198f3aa-1c2d-7e4b-9f11-a0b1c2d3e4f5');
+
+const READ_FAILED = 1;
+const NOT_ATTACHED = 1;
+
+const target = { socketPath: SOCKET, devicePath: DEVICE, volumeId: VOLUME_ID };
+
+const isProbe = (command: readonly string[]) => command[0] === 'dd';
+const isCheck = (command: readonly string[]) => command.includes('-check');
+const isDetach = (command: readonly string[]) => command.includes('-d');
+
+function run<A>(effect: Effect.Effect<A, never, never>) {
+  return Effect.runPromise(effect);
+}
+
+describe('a device that answers is not the same as a device with a client', () => {
+  test('liveness is a read, because a read is what a dead device fails', async () => {
+    const { commands, layer } = recordingCommands(() => succeeding());
+    await run(Effect.provide(isUsable(DEVICE), layer));
+    expect(commands).toHaveLength(1);
+    expect(isProbe(commands[0]?.command ?? [])).toBe(true);
+    expect(commands[0]?.command).toContain(`if=${DEVICE}`);
+  });
+
+  // Without O_DIRECT the host answers out of its own page cache for a device that has been dead
+  // for hours, which is the same false yes this exists to replace.
+  test('the read bypasses the page cache', async () => {
+    const { commands, layer } = recordingCommands(() => succeeding());
+    await run(Effect.provide(isUsable(DEVICE), layer));
+    expect(commands[0]?.command).toContain('iflag=direct');
+  });
+
+  test('a probe that reads is usable', async () => {
+    const { layer } = recordingCommands(() => succeeding());
+    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(true);
+  });
+
+  test('a probe that cannot read is not usable, however healthy the device claims to be', async () => {
+    const { layer } = recordingCommands(() => succeeding({ code: READ_FAILED }));
+    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+  });
+
+  // The probe is bounded, so a device that never answers is a device this says no about rather
+  // than one it waits on — a reconcile held open behind it would stop every other app's.
+  test('a probe that could not be run at all is not evidence of health', async () => {
+    const { layer } = recordingCommands(() => Effect.fail(new Error('spawn failed') as never));
+    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+  });
+
+  test('the probe carries a timeout, so it cannot hold the reconcile open', async () => {
+    const { commands, layer } = recordingCommands(() => succeeding());
+    await run(Effect.provide(isUsable(DEVICE), layer));
+    expect(commands[0]?.timeout).toBeDefined();
+  });
+});
+
+describe('repairing a device the kernel still holds', () => {
+  test('a held device is taken down before it is brought up', async () => {
+    const { commands, layer } = recordingCommands(() => succeeding());
+    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
+    const shapes = commands.map(({ command }) => command);
+    expect(isCheck(shapes[0] ?? [])).toBe(true);
+    expect(isDetach(shapes[1] ?? [])).toBe(true);
+    expect(shapes[2]).toContain('-persist');
+  });
+
+  // Attaching over a device the kernel is holding finds the minor busy; only a detach frees it.
+  test('the detach is what makes the attach able to succeed', async () => {
+    const { commands, layer } = recordingCommands(() => succeeding());
+    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
+    const detachAt = commands.findIndex(({ command }) => isDetach(command));
+    const attachAt = commands.findIndex(({ command }) => command.includes('-persist'));
+    expect(detachAt).toBeGreaterThanOrEqual(0);
+    expect(attachAt).toBeGreaterThan(detachAt);
+  });
+
+  test('a device nobody has attached is attached without a detach first', async () => {
+    const { commands, layer } = recordingCommands((request) =>
+      isCheck(request.command) ? succeeding({ code: NOT_ATTACHED }) : succeeding(),
+    );
+    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
+    expect(commands.some(({ command }) => isDetach(command))).toBe(false);
+    expect(commands.some(({ command }) => command.includes('-persist'))).toBe(true);
+  });
+
+  test('a detach that fails does not stop the attach', async () => {
+    const { commands, layer } = recordingCommands((request) =>
+      isDetach(request.command) ? Effect.fail(new Error('busy') as never) : succeeding(),
+    );
+    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
+    expect(commands.some(({ command }) => command.includes('-persist'))).toBe(true);
+  });
+
+  test('the volume is named on the way back up, so the device serves the right export', async () => {
+    const { commands, layer } = recordingCommands(() => succeeding());
+    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
+    const attached = commands.find(({ command }) => command.includes('-persist'));
+    expect(attached?.command).toContain(VOLUME_ID);
+    expect(attached?.command).toContain(SOCKET);
+  });
+});


### PR DESCRIPTION
The NBD reconnect defect #270 identified as "the thing that actually needs
fixing", and the one that makes Firecracker snapshots unsafe to build on.

**What happens.** A ZeroFS restart closes the socket, the kernel tears the device
down, and what `nbd-client -persist` reconnects onto is a device that reports its
size, names its pid, and fails every read.

**Why nothing repaired it.** `planVolumes` re-provisions only
`if (!current?.attached)`, and `attached` came from `isAttached`, which is
`nbd-client -check`. So the one device that needs repairing is the one the plan
reads as fine, and it stays broken until the host is rebuilt. The guest meets it
as `EXT4-fs (vdd): unable to read superblock`.

**The fix is the definition of "attached".** It becomes a read — because a read is
what is broken — and that one change propagates through observe → plan →
provision without touching either of the latter.

`iflag=direct` is load-bearing rather than decoration: without it the host answers
out of its own page cache for a device that has been dead for hours, which is the
same false yes this replaces. The probe is bounded so a device that never answers
is one this says no about rather than one it waits on, and a probe that cannot be
run at all counts as no evidence of health.

Repair is a detach and a fresh attach, not an attach over the top: the kernel is
still holding the minor. Safe where it runs — `nibrun-vm@.service` carries
`BindsTo=nibrun-zerofs.service`, so every guest is already stopped by the time a
ZeroFS restart has happened and nothing holds the device.

The comment on `attach` claiming `-persist` "keeps a ZeroFS restart a stall rather
than an I/O error" is corrected. It is a stall for the drops it does cover — a
socket that goes and comes back while the kernel still has the device — and not
for this one.

## Proven end to end

On a throwaway `m8id.large` running ZeroFS v2.3.1, an 8 GiB volume attached with
the production arguments, ext4 on it and a file written:

```
A. HEALTHY DEVICE        CHECK=attached(0)   PROBE=pass
B. AFTER ZEROFS RESTART  CHECK=attached(0)   PROBE=FAIL
   old isAttached() => true => planVolumes says 'none' => never repaired
C. AFTER DETACH+ATTACH   CHECK=attached(0)   PROBE=pass
D. THE FILE              test-data
```

**A is the one that mattered most.** A probe that false-negatived on a healthy
device would detach volumes under running guests on every reconcile — worse than
the bug it fixes. O_DIRECT reads a live ZeroFS-backed device without complaint.

**B reproduces the defect exactly**, including that `-check` keeps exiting 0
throughout, which is what made it invisible to the reconciler.

**D is what makes C a repair rather than a reset**: the file written before the
device was poisoned is still there afterwards.

The host held no mount of its own during B and C, matching production, where only
the guest opens the device and `BindsTo` has already stopped it.