### PR TITLE
feat(infra): an app host keeps its cache on the disk it came with

### DIFF
--- a/infra/app-host/deploy/ensure_ephemeral_data.sh
+++ b/infra/app-host/deploy/ensure_ephemeral_data.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Puts /data on the instance store, and is the only thing that may.
+#
+# An app host's /data holds nothing but caches: ZeroFS's, and a checkpoint
+# server's while an export reads. S3 is the source of truth for every byte of it,
+# which is what makes an ephemeral disk the right medium rather than a tolerable
+# one — the EBS volume it replaces was paying for durability nothing here wants.
+#
+# Run from a unit at boot rather than from the deploy, because the disk is blank
+# every time the instance starts. A spot reclaim stops the host and AWS hands the
+# replacement a fresh, unformatted device, so a filesystem made once at deploy
+# time would be gone by the time anything looked for it.
+set -euo pipefail
+
+log() { echo "=== [ensure_ephemeral_data $(date -u +%H:%M:%S)] $* ==="; }
+
+MOUNT_POINT=/data
+# Every instance-store namespace answers to this, and only those do: an EBS volume
+# is `nvme-Amazon_Elastic_Block_Store_*` under the same directory. Matching the
+# model rather than a device number is what keeps this right when the kernel
+# enumerates the NVMe controllers in a different order.
+STORE_GLOB='/dev/disk/by-id/nvme-Amazon_EC2_NVMe_Instance_Storage_*'
+
+device=""
+for candidate in $STORE_GLOB; do
+  # A namespace and its partitions both match; the partitions carry a -partN
+  # suffix and are not what this formats.
+  case "$candidate" in
+    *-part[0-9]*) continue ;;
+  esac
+  [ -e "$candidate" ] || continue
+  device="$candidate"
+  break
+done
+
+# Louder than falling back to the root volume: ZeroFS is configured for a 70 GB
+# cache and the root disk is 50 GB, so a /data that is quietly a directory fills
+# the disk the host itself runs from. The unit that calls this is required by
+# nibrun-zerofs.service, so failing here is what stops that.
+if [ -z "$device" ]; then
+  log "no instance store found — this host cannot serve /data"
+  exit 1
+fi
+log "instance store is $device"
+
+# The EBS volume's entry, written by ensure_data_volume.sh on a host deployed
+# before this existed. Left in place it would win the race at boot and take the
+# mount point this needs, so it goes — the volume itself is left attached and
+# untouched, which is what makes rolling back a matter of putting the line back.
+if grep -q "[[:space:]]${MOUNT_POINT}[[:space:]]" /etc/fstab 2>/dev/null; then
+  log "removing the legacy ${MOUNT_POINT} entry from /etc/fstab"
+  sed -i "\\#[[:space:]]${MOUNT_POINT}[[:space:]]#d" /etc/fstab
+fi
+
+mkdir -p "$MOUNT_POINT"
+
+# A host being migrated comes up with the EBS volume already mounted here. At
+# boot nothing has opened it yet, so it can simply be taken back; if something
+# has — a deploy re-running this while ZeroFS holds its cache — the unmount fails
+# and the host keeps the disk it is using until it next boots.
+if mountpoint -q "$MOUNT_POINT"; then
+  current=$(findmnt -no SOURCE "$MOUNT_POINT")
+  if [ "$(readlink -f "$current")" = "$(readlink -f "$device")" ]; then
+    log "already mounted from the instance store"
+    exit 0
+  fi
+  log "${MOUNT_POINT} is mounted from ${current}, taking it back"
+  if ! umount "$MOUNT_POINT"; then
+    log "could not unmount ${current} — it is in use, so ${MOUNT_POINT} stays where it is"
+    exit 0
+  fi
+fi
+
+# Blank on every start, so this is the ordinary path rather than the first-run
+# one. `blkid` answering means a filesystem survived, which happens on a reboot
+# that kept the instance rather than stopping it.
+if ! blkid "$device" >/dev/null 2>&1; then
+  log "formatting a blank instance store"
+  mkfs.xfs -f "$device"
+fi
+
+mount "$device" "$MOUNT_POINT"
+log "mounted $device at $MOUNT_POINT"
+
+# Recreated on every boot because the disk they were on did not survive. The
+# owner exists already — it is made by the deploy, on the root volume — but on a
+# host whose first boot precedes its first deploy it does not, and a directory
+# left owned by root is corrected by the deploy that creates the user.
+owner=$1
+shift
+for directory in "$@"; do
+  mkdir -p "${MOUNT_POINT}/${directory}"
+  if id -u "$owner" >/dev/null 2>&1; then
+    chown "${owner}:${owner}" "${MOUNT_POINT}/${directory}"
+  fi
+done

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -75,10 +75,13 @@ if [ ! -f /usr/lib/systemd/system/systemd-journal-upload.service ]; then
   dnf install -y systemd-journal-remote
 fi
 
-log "Ensuring the data volume is mounted"
-bash ensure_data_volume.sh zerofs
-
 id -u zerofs >/dev/null 2>&1 || useradd --system --no-create-home --shell /sbin/nologin zerofs
+
+# Before the mount, because the mount is what chowns the directories on it and it
+# can only do that once the user exists.
+log "Ensuring /data is the instance store"
+bash ensure_ephemeral_data.sh zerofs zerofs zerofs-checkpoint
+
 chown -R zerofs:zerofs /data/zerofs
 
 # Where a checkpoint server keeps its own cache, one directory per checkpoint,
@@ -432,7 +435,7 @@ if [ "$units_changed" = "1" ]; then
   systemctl daemon-reload
 fi
 
-systemctl enable nibrun-zerofs.service nibrun-zerofs-mount.service \
+systemctl enable nibrun-data.service nibrun-zerofs.service nibrun-zerofs-mount.service \
   nibrun-caddy.service nibrun-agent.service systemd-journal-upload.service >/dev/null
 
 # --- Restarting --------------------------------------------------------------

--- a/infra/app-host/systemd/nibrun-data.service
+++ b/infra/app-host/systemd/nibrun-data.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=nibrun ephemeral /data
+# The disk is blank every time the instance starts, so this is boot-time work
+# rather than deploy-time work: a filesystem made once by a deploy is gone by the
+# next start, and a spot reclaim is a stop.
+DefaultDependencies=no
+After=local-fs.target systemd-udev-settle.service
+Wants=systemd-udev-settle.service
+Before=nibrun-zerofs.service
+
+[Service]
+Type=oneshot
+# The mount is the result, and it outlives the process that made it. Without this
+# systemd would call the unit inactive the moment the script exits, and anything
+# ordered after it would be ordered after nothing.
+RemainAfterExit=yes
+# The owner first, then every directory on the disk. Both belong to ZeroFS: the
+# live server's cache, and the one a checkpoint server keeps while an export reads.
+ExecStart=/opt/nibrun/bundle/ensure_ephemeral_data.sh zerofs zerofs zerofs-checkpoint
+
+# No Restart=. A host that cannot find its instance store is not one a retry
+# fixes, and failing is what keeps ZeroFS from starting and writing a 70 GB cache
+# onto the 50 GB root volume.
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/app-host/systemd/nibrun-zerofs-checkpoint@.service
+++ b/infra/app-host/systemd/nibrun-zerofs-checkpoint@.service
@@ -29,7 +29,7 @@ EnvironmentFile=/etc/zerofs/zerofs.env
 
 # Scratch for one pass over one filesystem, not a working set to keep warm, so it is
 # made on the way in and removed on the way out rather than accumulating a directory
-# per export on the data volume.
+# per export on /data.
 ExecStartPre=/usr/bin/mkdir -p /data/zerofs-checkpoint/%i
 ExecStart=/opt/nibrun/bin/zerofs/zerofs run --config /etc/zerofs/checkpoint.toml --checkpoint %i
 # Type=exec calls the unit started the moment the process execs, which for ZeroFS is
@@ -60,8 +60,8 @@ ProtectControlGroups=true
 RestrictRealtime=true
 RestrictSUIDSGID=true
 LockPersonality=true
-# ProtectSystem=strict makes everything else read-only, and the cache lives on the
-# data volume rather than under CacheDirectory. Its own directory, never
+# ProtectSystem=strict makes everything else read-only, and the cache lives on
+# /data rather than under CacheDirectory. Its own directory, never
 # /data/zerofs: that one belongs to the live server, which is its only writer.
 ReadWritePaths=/data/zerofs-checkpoint
 

--- a/infra/app-host/systemd/nibrun-zerofs.service
+++ b/infra/app-host/systemd/nibrun-zerofs.service
@@ -46,7 +46,7 @@ RestrictRealtime=true
 RestrictSUIDSGID=true
 LockPersonality=true
 # ProtectSystem=strict makes everything else read-only, and the cache lives on
-# the data volume rather than under CacheDirectory.
+# /data rather than under CacheDirectory.
 ReadWritePaths=/data/zerofs
 
 # What this unit is called in the log store. journald attaches this to every

--- a/infra/app-host/systemd/nibrun-zerofs.service
+++ b/infra/app-host/systemd/nibrun-zerofs.service
@@ -3,6 +3,11 @@ Description=ZeroFS, backing every tenant disk on this host
 Documentation=https://www.zerofs.net
 After=network-online.target
 Wants=network-online.target
+# /data is an ephemeral disk mounted at boot, and ZeroFS is configured for a 70 GB
+# cache against a 50 GB root volume. Starting without it would not fail — it would
+# fill the disk the host runs from.
+Requires=nibrun-data.service
+After=nibrun-data.service
 
 [Service]
 Type=exec

--- a/infra/app-host/zerofs/checkpoint.toml
+++ b/infra/app-host/zerofs/checkpoint.toml
@@ -16,7 +16,7 @@ dir = "/data/zerofs-checkpoint/${NIBRUN_CHECKPOINT}"
 # `debugfs` walks — inode tables, bitmaps, directory blocks — and not the file data
 # it copies out. Four gigabytes covers that for a filesystem far larger than any
 # one this host serves, and is small enough that an export cannot eat into the
-# headroom the live cache deliberately leaves on this volume.
+# headroom the live cache deliberately leaves on this disk.
 disk_size_gb = 4.0
 # The default, written down because 2.0 sits in the file next to this one and
 # silence would read as an oversight rather than a decision.

--- a/infra/app-host/zerofs/config.toml
+++ b/infra/app-host/zerofs/config.toml
@@ -6,8 +6,9 @@
 # substitution is a string one.
 
 [cache]
-# The EBS data volume, and the only thing on it. Sized well under the volume so a
-# full cache cannot fill the disk out from under the segments being written.
+# The instance store, mounted at /data by nibrun-data.service. Sized well under the
+# disk so a full cache cannot fill it out from under the segments being written, and
+# so a checkpoint server's cache has room beside it.
 dir = "/data/zerofs"
 disk_size_gb = 70.0
 memory_size_gb = 2.0

--- a/infra/terraform/app_host.tf
+++ b/infra/terraform/app_host.tf
@@ -118,11 +118,12 @@ resource "aws_eip" "app_host" {
   }
 }
 
-# ZeroFS's local cache, mounted at /data. Not where tenant data lives — S3 is
-# the source of truth and a host can be rebuilt from it — so the snapshots this
-# picks up are about bringing a replacement host back warm rather than about
-# durability, and prevent_destroy is about a plan never pulling a disk out from
-# under running microVMs.
+# Nothing mounts this any more: /data is the instance store the m8id carries, and
+# infra/app-host/deploy/ensure_ephemeral_data.sh is what puts it there. The volume
+# stays only so a revert has a disk to go back to, and goes once that stops being
+# worth keeping — with its Backup tag, which still bills for a daily snapshot of a
+# cache nothing reads. Removing it is not a plan away: prevent_destroy below makes
+# it the same two-step operation scaling down is.
 #
 # prevent_destroy under count applies to every element, which makes scaling
 # *down* a two-step operation rather than a decrement: lowering

--- a/infra/terraform/app_host.tf
+++ b/infra/terraform/app_host.tf
@@ -96,6 +96,13 @@ resource "aws_instance" "app_host" {
 
   lifecycle {
     ignore_changes = [ami]
+
+    # Checked here rather than in a variable validation, which cannot read a data
+    # source and so cannot ask AWS what a type actually has.
+    precondition {
+      condition     = data.aws_ec2_instance_type.app_host.instance_storage_supported
+      error_message = "app_host_instance_type must name a type with an instance store: /data is mounted from it and ZeroFS does not start without it. The `d` families — m8id, r8id, c8id — have one; m7i and m8i do not."
+    }
   }
 
   tags = {

--- a/infra/terraform/data.tf
+++ b/infra/terraform/data.tf
@@ -7,6 +7,15 @@ data "aws_ssm_parameter" "al2023_ami" {
   name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 }
 
+# Read to answer one question about the type an app host is given: whether it comes
+# with an instance store. `nibrun-data.service` mounts /data from it and fails when
+# there is none, deliberately — falling back would put a 70 GB ZeroFS cache on a 50 GB
+# root volume. The precondition in app_host.tf is what turns that into a plan error
+# naming the variable, rather than a host that deploys and then never starts ZeroFS.
+data "aws_ec2_instance_type" "app_host" {
+  instance_type = var.app_host_instance_type
+}
+
 data "aws_availability_zones" "available" {
   state = "available"
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -27,11 +27,10 @@ variable "data_volume_size" {
 # runs out.
 #
 # m8id rather than m7i because it is the cheaper of the two on spot and carries a
-# 118 GB NVMe instance store. Nothing uses that disk yet: /data is still the EBS
-# volume below, and moving the ZeroFS cache onto ephemeral storage needs a
-# boot-time format that nothing here does — ensure_data_volume.sh runs from the
-# deploy while /data remounts from fstab, so a blank instance store would come back
-# unmounted after every spot stop rather than merely cold.
+# 118 GB NVMe instance store, which is what /data is: see
+# infra/app-host/deploy/ensure_ephemeral_data.sh. That makes the instance store
+# load-bearing rather than a bonus — a type without one has no /data, and
+# nibrun-zerofs.service is ordered behind the unit that would fail to mount it.
 variable "app_host_instance_type" {
   type        = string
   default     = "m8id.large"
@@ -42,8 +41,9 @@ variable "app_host_instance_type" {
 # request is terminated, which would put a replacement host on the same ZeroFS
 # prefix while the old one still held the writer epoch — and infra/app-host/AGENTS.md
 # is explicit that two read-write `zerofs run` against one prefix is an outage
-# rather than an error message. Stopping keeps the instance id, its data volume and
-# its elastic ip, so what comes back is the same host rather than a rival to it.
+# rather than an error message. Stopping keeps the instance id and the elastic ip,
+# so what comes back is the same host rather than a rival to it — with a cold /data,
+# which is an instance store and blank on every start.
 #
 # What this does not buy: `ignore_fsync = true` puts the entire durability
 # guarantee in ZeroFS's five-second flush, so a reclaim loses 5-15 s of writes the
@@ -91,7 +91,7 @@ variable "app_host_root_volume_size" {
 variable "app_host_data_volume_size" {
   type        = number
   default     = 100
-  description = "Per-host data EBS volume size in GB, mounted at /data. Sized for ZeroFS's working set, not for the fleet's data — S3 holds that."
+  description = "Per-host data EBS volume size in GB. Nothing mounts it any more — /data is the instance store — and it stays attached only so a revert has a disk to go back to."
 }
 
 variable "export_retention_days" {

--- a/packages/internal-scripts/src/publish-app-host-bundle.ts
+++ b/packages/internal-scripts/src/publish-app-host-bundle.ts
@@ -17,10 +17,12 @@ const BUNDLE_DIRECTORIES = ['systemd', 'zerofs', 'caddy'];
 // Shell, not TypeScript: these run on the box, which has no Bun. Flattened to the
 // bundle root next to the directories above, because the deploy script resolves
 // everything relative to itself.
-const ON_BOX_SCRIPTS = ['on_box_deploy.sh'];
+const ON_BOX_SCRIPTS = ['on_box_deploy.sh', 'ensure_ephemeral_data.sh'];
 
-// Shared with the control plane's bundle — both machine classes have a data
-// volume, and what they keep on it arrives as arguments.
+// Shared with the control plane's bundle. Only the control plane reads it now —
+// an app host's /data is the instance store and `ensure_ephemeral_data.sh` is
+// what mounts it — but it ships here until the EBS volume is removed, so a
+// rollback to a revision that still calls it finds it on the box.
 const SHARED_ON_BOX_SCRIPTS = ['ensure_data_volume.sh'];
 
 // Also shared: Cloudflare's origin-pull CA is one certificate, and both proxies


### PR DESCRIPTION
`/data` on an app host moves from the 100 GB EBS volume to the instance store the
`m8id.large` already carries and nothing has ever mounted.

**Why it is the right medium.** Everything on `/data` is a cache — ZeroFS's, and a
checkpoint server's while an export reads — and S3 is the source of truth for
every byte. `app_host.tf` says so already: the volume is "sized for ZeroFS's
working set, not for the fleet's data". The EBS under it was buying durability
nothing there wants, and 110 GiB of NVMe was sitting idle beside it.

**Mounted at boot, not at deploy.** An instance store is blank every time the
instance starts, and with `app_host_spot = true` a reclaim *is* a stop. A
filesystem made once by a deploy would be gone before anything looked for it, so
`nibrun-data.service` runs on every boot: find the device, format it if blank,
mount it, recreate the two directories and their ownership.

**ZeroFS now requires that unit.** This is the part worth reviewing. A `/data`
that is quietly a directory on the root volume does not fail — it succeeds, and
fills the 50 GB disk the host runs from with a cache configured for 70. So the
mount failing has to stop ZeroFS, and it does.

**Migration.** The EBS volume is left attached and untouched; this PR does not
remove it. On an existing host the script drops the legacy `/data` line from
`/etc/fstab` — left there it would win the race at boot — and takes the mount
point back if nothing has opened it. A deploy that runs while ZeroFS is holding
its cache cannot unmount, says so, and leaves the host on EBS until it next boots.
So the change converges on a reboot or a replacement rather than yanking a disk
out from under a running host.

Rolling back is a revert, not a restore, for as long as the volume is still there.

**What this is worth.** ~$9.29/month once the volume goes, a ZeroFS cache on NVMe
instead of gp3's 3000 IOPS, and somewhere to put Firecracker memory snapshots —
256 MiB per sleeping app — which is what the on-request work needs next.

**Follow-up, deliberately not here:** removing `aws_ebs_volume.app_host_data`, its
output, its `Backup` tag and `app_host_data_volume_size`. That one is blocked by
`prevent_destroy`, so it needs the manual state surgery `app_host.tf` documents
for scaling down — and it should wait until this is proven on a real host.

**Verified:** shell syntax, the whole suite, 23/23 tasks. **Not yet verified:** the
script has not run on a host with an actual instance store. I am about to stand
one up for the snapshot spike and will run it there first; I would not merge this
before that.