### PR TITLE
fix(agent): a detached volume is not a healthy one

### DIFF
--- a/apps/agent/src/lib/volumes/nbd.ts
+++ b/apps/agent/src/lib/volumes/nbd.ts
@@ -23,6 +23,7 @@ export const isAttached = (devicePath: string) =>
 
 /** One block, at the offset every filesystem on the device keeps something at. */
 const PROBE_BYTES = 4096;
+const NO_BYTES = 0;
 
 /**
  * A dead device answers instantly and a live one answers from cache, so this bounds the case
@@ -44,8 +45,33 @@ const PROBE_TIMEOUT = Duration.seconds(PROBE_TIMEOUT_SECONDS);
  * `iflag=direct` is what makes it a read of the device rather than of the page cache. Without it
  * the host answers out of memory for a device that has been dead for hours, which is the same
  * false yes this replaces.
+ *
+ * The size is checked first, and it is not belt-and-braces. A detached nbd device is zero bytes
+ * long, and reading one block of a zero-length device is not an error: `dd` reports `0+0 records
+ * in` and exits 0. Asking only whether the read succeeded therefore answers yes for a device that
+ * is not attached at all — which is every device on a host that has just rebooted, and a host
+ * whose volumes are then never attached because nothing believes anything is wrong with them.
  */
 export const isUsable = (devicePath: string) =>
+  Effect.gen(function* () {
+    const size = yield* attachedSizeBytes(devicePath);
+    if (size <= NO_BYTES) {
+      return false;
+    }
+    return yield* readsFirstBlock(devicePath);
+  });
+
+/** Zero for a device nothing is attached to, which is the state a reboot leaves every one of them in. */
+const attachedSizeBytes = (devicePath: string) =>
+  run({ command: ['blockdev', '--getsize64', devicePath], timeout: PROBE_TIMEOUT }).pipe(
+    Effect.map((result) =>
+      result.code === CONNECTED_EXIT_CODE ? Number.parseInt(result.stdout.trim(), 10) : NO_BYTES,
+    ),
+    Effect.map((size) => (Number.isFinite(size) ? size : NO_BYTES)),
+    Effect.catchAll(() => Effect.succeed(NO_BYTES)),
+  );
+
+const readsFirstBlock = (devicePath: string) =>
   run({
     command: [
       'dd',

--- a/apps/agent/tests/lib/volumes/nbd.test.ts
+++ b/apps/agent/tests/lib/volumes/nbd.test.ts
@@ -10,10 +10,14 @@ const VOLUME_ID = Value.Parse(VolumeIdSchema, '0198f3aa-1c2d-7e4b-9f11-a0b1c2d3e
 
 const READ_FAILED = 1;
 const NOT_ATTACHED = 1;
+const ATTACHED_SIZE = '8589934592\n';
+/** What `blockdev --getsize64` prints for a device nothing is attached to. */
+const DETACHED_SIZE = '0\n';
 
 const target = { socketPath: SOCKET, devicePath: DEVICE, volumeId: VOLUME_ID };
 
 const isProbe = (command: readonly string[]) => command[0] === 'dd';
+const isSize = (command: readonly string[]) => command[0] === 'blockdev';
 const isCheck = (command: readonly string[]) => command.includes('-check');
 const isDetach = (command: readonly string[]) => command.includes('-d');
 
@@ -23,42 +27,85 @@ function run<A>(effect: Effect.Effect<A, never, never>) {
 
 describe('a device that answers is not the same as a device with a client', () => {
   test('liveness is a read, because a read is what a dead device fails', async () => {
-    const { commands, layer } = recordingCommands(() => succeeding());
+    const { commands, layer } = recordingCommands((request) =>
+      isSize(request.command) ? succeeding({ stdout: ATTACHED_SIZE }) : succeeding(),
+    );
     await run(Effect.provide(isUsable(DEVICE), layer));
-    expect(commands).toHaveLength(1);
-    expect(isProbe(commands[0]?.command ?? [])).toBe(true);
-    expect(commands[0]?.command).toContain(`if=${DEVICE}`);
+    const probe = commands.find(({ command }) => isProbe(command));
+    expect(probe?.command).toContain(`if=${DEVICE}`);
   });
 
   // Without O_DIRECT the host answers out of its own page cache for a device that has been dead
   // for hours, which is the same false yes this exists to replace.
   test('the read bypasses the page cache', async () => {
-    const { commands, layer } = recordingCommands(() => succeeding());
+    const { commands, layer } = recordingCommands((request) =>
+      isSize(request.command) ? succeeding({ stdout: ATTACHED_SIZE }) : succeeding(),
+    );
     await run(Effect.provide(isUsable(DEVICE), layer));
-    expect(commands[0]?.command).toContain('iflag=direct');
+    expect(commands.find(({ command }) => isProbe(command))?.command).toContain('iflag=direct');
   });
 
   test('a probe that reads is usable', async () => {
-    const { layer } = recordingCommands(() => succeeding());
+    const { layer } = recordingCommands((request) =>
+      isSize(request.command) ? succeeding({ stdout: ATTACHED_SIZE }) : succeeding(),
+    );
     expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(true);
   });
 
+  // The regression this file exists for. A detached nbd device is zero bytes long, and reading
+  // one block of a zero-length device is not an error — `dd` reports `0+0 records in` and exits
+  // 0. Asking only whether the read succeeded answered yes for every device on a host that had
+  // just rebooted, so nothing was ever attached and no tenant started.
+  test('a detached device is not usable, however happily a read of it returns', async () => {
+    const { commands, layer } = recordingCommands((request) =>
+      isSize(request.command) ? succeeding({ stdout: DETACHED_SIZE }) : succeeding(),
+    );
+    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+    expect(commands.some(({ command }) => isProbe(command))).toBe(false);
+  });
+
+  test('a size that cannot be read at all is not usable', async () => {
+    const { layer } = recordingCommands((request) =>
+      isSize(request.command) ? succeeding({ code: READ_FAILED }) : succeeding(),
+    );
+    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+  });
+
+  test('a size that is not a number is not usable', async () => {
+    const { layer } = recordingCommands((request) =>
+      isSize(request.command) ? succeeding({ stdout: 'not a number\n' }) : succeeding(),
+    );
+    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+  });
+
   test('a probe that cannot read is not usable, however healthy the device claims to be', async () => {
-    const { layer } = recordingCommands(() => succeeding({ code: READ_FAILED }));
+    const { layer } = recordingCommands((request) =>
+      isSize(request.command)
+        ? succeeding({ stdout: ATTACHED_SIZE })
+        : succeeding({ code: READ_FAILED }),
+    );
     expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
   });
 
   // The probe is bounded, so a device that never answers is a device this says no about rather
   // than one it waits on — a reconcile held open behind it would stop every other app's.
   test('a probe that could not be run at all is not evidence of health', async () => {
-    const { layer } = recordingCommands(() => Effect.fail(new Error('spawn failed') as never));
+    const { layer } = recordingCommands((request) =>
+      isSize(request.command)
+        ? succeeding({ stdout: ATTACHED_SIZE })
+        : Effect.fail(new Error('spawn failed') as never),
+    );
     expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
   });
 
   test('the probe carries a timeout, so it cannot hold the reconcile open', async () => {
-    const { commands, layer } = recordingCommands(() => succeeding());
+    const { commands, layer } = recordingCommands((request) =>
+      isSize(request.command) ? succeeding({ stdout: ATTACHED_SIZE }) : succeeding(),
+    );
     await run(Effect.provide(isUsable(DEVICE), layer));
-    expect(commands[0]?.timeout).toBeDefined();
+    for (const request of commands) {
+      expect(request.timeout).toBeDefined();
+    }
   });
 });
 


### PR DESCRIPTION
**This fixes an outage I caused.** #400 replaced "does this device have a client"
with "does a read of it succeed". On a *detached* nbd device that question has
the wrong answer:

```
blockdev --getsize64 /dev/nbd13  ->  0
dd if=/dev/nbd13 count=1 iflag=direct  ->  exit 0   (0+0 records in)
```

Reading one block of a zero-length device is not an error. So `isUsable` reported
every detached device as healthy, `planVolumes` concluded there was nothing to
do, no volume was attached, and no tenant started. The reboot after #401 put every
device on the host into exactly that state and the host served nothing until the
volumes were attached by hand.

The old `nbd-client -check` got this case right. #400 traded a rare failure —
a device poisoned by a ZeroFS restart — for a common one, and did not notice
because the spike only ever tested attached-but-poisoned, never detached.

**The fix** checks the size before the read. Zero bytes is what a device nobody is
attached to reports, and it is the state a reboot leaves every one of them in.
Both original cases still work: a poisoned device has the right size and fails the
read, and a healthy one passes both.

**No data was lost.** `formatOnce` guards on `isFormatted`, so the `mkfs.ext4`
calls in the agent log all failed harmlessly against zero-size devices. Every
volume still carries its ext4 and its contents — I mounted one of the failed apps'
volumes and its SQLite database was intact.

**Tests.** The regression now has one of its own, asserting a detached device is
not usable *and* that the read is never even attempted for it. The existing cases
are rewritten to answer the size probe, so they still cover poisoned, unreadable
and un-runnable.

**Still needed after this merges:** the four apps whose deployments went `failed`
during the outage have to be resumed from the dashboard. A failed deployment
leaves desired state, so the agent will not restart them on its own however
healthy the volumes are.