### PR TITLE
feat(dashboard): a failed release is offered the same one again

### DIFF
--- a/apps/dashboard/src/components/apps/app-actions.tsx
+++ b/apps/dashboard/src/components/apps/app-actions.tsx
@@ -1,5 +1,6 @@
 import { DeleteAppDialog } from '#components/apps/delete-app-dialog.tsx';
 import { ExportAppDialog } from '#components/apps/export-app-dialog.tsx';
+import { RedeployAppButton } from '#components/apps/redeploy-app-button.tsx';
 import { SuspendAppButton } from '#components/apps/suspend-app-button.tsx';
 import { DeployDialog } from '#components/deploy/deploy-dialog.tsx';
 import { useAppActions } from '#lib/hooks/use-app-actions.ts';
@@ -13,6 +14,7 @@ export function AppActions() {
   return (
     <div className="flex shrink-0 items-center gap-2">
       <DeployDialog appId={appId} availability={actions.deploy} />
+      <RedeployAppButton availability={actions.redeploy} />
       <ExportAppDialog availability={actions.export} />
       <SuspendAppButton availability={actions.suspend} />
       <DeleteAppDialog availability={actions.delete} />

--- a/apps/dashboard/src/components/apps/app-environment-dialog-content.tsx
+++ b/apps/dashboard/src/components/apps/app-environment-dialog-content.tsx
@@ -18,6 +18,7 @@ import { greyedReason } from '#lib/app-actions.ts';
 import { useAppActions } from '#lib/hooks/use-app-actions.ts';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
 import { useEnvironmentForm } from '#lib/hooks/use-environment-form.ts';
+import { isReleasing } from '#lib/hooks/use-run-app.ts';
 import type { AppSummary } from '#queries/apps.ts';
 
 export function AppEnvironmentDialogContent({ app }: { app: AppSummary }) {
@@ -26,7 +27,7 @@ export function AppEnvironmentDialogContent({ app }: { app: AppSummary }) {
   const form = useEnvironmentForm(app);
   // Saving is a release, so it is offered exactly where the deploy button is.
   const deploy = useAppActions(app.id).deploy;
-  const releasing = run.phase === 'releasing' || run.phase === 'settling';
+  const releasing = isReleasing(run.phase);
 
   function handleOpenChange(next: boolean): void {
     if (next && !releasing) {

--- a/apps/dashboard/src/components/apps/redeploy-app-button.tsx
+++ b/apps/dashboard/src/components/apps/redeploy-app-button.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@repo/ui/components/button';
+import { Spinner } from '@repo/ui/components/spinner';
+import { RotateCcwIcon } from 'lucide-react';
+import type { AppActionAvailability } from '#lib/app-actions.ts';
+import { useAppId } from '#lib/hooks/use-app-id.ts';
+import { useAppRedeploy } from '#lib/hooks/use-app-redeploy.ts';
+
+/**
+ * The one thing there is to offer a release that did not come up: the same binary again, on the
+ * config it already has. Nothing is asked and nothing is confirmed, because nothing is being
+ * changed — an owner who wants it to start differently has the deploy button beside this one.
+ *
+ * How it went is a toast rather than a panel of its own. A release that lands takes the button
+ * with it, the app no longer being failed, and one that does not leaves it here to press again.
+ */
+export function RedeployAppButton({ availability }: { availability: AppActionAvailability }) {
+  const appId = useAppId();
+  const { releasing, start } = useAppRedeploy(appId);
+
+  if (availability.kind === 'hidden' || start === undefined) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outline"
+      disabled={availability.kind === 'disabled' || releasing}
+      onClick={start}
+    >
+      {releasing ? (
+        <Spinner data-icon="inline-start" />
+      ) : (
+        <RotateCcwIcon data-icon="inline-start" />
+      )}
+      {releasing ? 'Redeploying' : 'Redeploy'}
+    </Button>
+  );
+}

--- a/apps/dashboard/src/lib/app-actions.ts
+++ b/apps/dashboard/src/lib/app-actions.ts
@@ -1,7 +1,7 @@
 import { type AppStatus, type AppStatusKey, statusKey } from '@repo/app-operations';
 
 /** Every button on an app's action bar, and so every column of the table below. */
-export const APP_ACTIONS = ['deploy', 'export', 'suspend', 'delete'] as const;
+export const APP_ACTIONS = ['deploy', 'redeploy', 'export', 'suspend', 'delete'] as const;
 
 export type AppAction = (typeof APP_ACTIONS)[number];
 
@@ -42,26 +42,82 @@ const UNTIL_RESUMED: AppActionAvailability = {
  * from here, which is a type error rather than a button someone finds behaving oddly weeks later.
  */
 const AVAILABILITY: Record<AppStatusKey, AppActions> = {
-  'never-deployed': { deploy: ENABLED, export: HIDDEN, suspend: HIDDEN, delete: ENABLED },
-  pending: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
-  starting: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
-  running: { deploy: ENABLED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
+  'never-deployed': {
+    deploy: ENABLED,
+    redeploy: HIDDEN,
+    export: HIDDEN,
+    suspend: HIDDEN,
+    delete: ENABLED,
+  },
+  pending: {
+    deploy: ENABLED,
+    redeploy: HIDDEN,
+    export: ENABLED,
+    suspend: ENABLED,
+    delete: ENABLED,
+  },
+  starting: {
+    deploy: ENABLED,
+    redeploy: HIDDEN,
+    export: ENABLED,
+    suspend: ENABLED,
+    delete: ENABLED,
+  },
+  running: {
+    deploy: ENABLED,
+    redeploy: HIDDEN,
+    export: ENABLED,
+    suspend: ENABLED,
+    delete: ENABLED,
+  },
   // Nothing is serving under either of these, so there is nothing to take offline — and a bundle
-  // is cut from the volume rather than from a running microVM, so exporting still works.
-  failed: { deploy: ENABLED, export: ENABLED, suspend: HIDDEN, delete: ENABLED },
-  superseded: { deploy: ENABLED, export: ENABLED, suspend: HIDDEN, delete: ENABLED },
-  suspended: { deploy: UNTIL_RESUMED, export: ENABLED, suspend: ENABLED, delete: ENABLED },
-  suspending: { deploy: UNTIL_RESUMED, export: ENABLED, suspend: DISABLED, delete: ENABLED },
+  // is cut from the volume rather than from a running microVM, so exporting still works. Only the
+  // one that failed is offered a redeploy: a release that did not come up is the case where
+  // running the same binary again is the whole of what an owner wants, and everywhere else that
+  // is the deploy dialog, which can change what it releases as well.
+  failed: { deploy: ENABLED, redeploy: ENABLED, export: ENABLED, suspend: HIDDEN, delete: ENABLED },
+  superseded: {
+    deploy: ENABLED,
+    redeploy: HIDDEN,
+    export: ENABLED,
+    suspend: HIDDEN,
+    delete: ENABLED,
+  },
+  suspended: {
+    deploy: UNTIL_RESUMED,
+    redeploy: HIDDEN,
+    export: ENABLED,
+    suspend: ENABLED,
+    delete: ENABLED,
+  },
+  suspending: {
+    deploy: UNTIL_RESUMED,
+    redeploy: HIDDEN,
+    export: ENABLED,
+    suspend: DISABLED,
+    delete: ENABLED,
+  },
   // Deploying is offered back the moment the app row asks to run again, which is what resuming is.
-  resuming: { deploy: ENABLED, export: ENABLED, suspend: DISABLED, delete: ENABLED },
+  resuming: {
+    deploy: ENABLED,
+    redeploy: HIDDEN,
+    export: ENABLED,
+    suspend: DISABLED,
+    delete: ENABLED,
+  },
   // An app on its way out has one thing left to say, and it is the button that says it.
-  deleting: { deploy: HIDDEN, export: HIDDEN, suspend: HIDDEN, delete: DISABLED },
-  deleted: { deploy: HIDDEN, export: HIDDEN, suspend: HIDDEN, delete: HIDDEN },
+  deleting: { deploy: HIDDEN, redeploy: HIDDEN, export: HIDDEN, suspend: HIDDEN, delete: DISABLED },
+  deleted: { deploy: HIDDEN, redeploy: HIDDEN, export: HIDDEN, suspend: HIDDEN, delete: HIDDEN },
 };
 
-/** Nothing may be pressed on an app whose status has not been read yet. */
+/**
+ * Nothing may be pressed on an app whose status has not been read yet. Redeploy is the one that
+ * is gone rather than greyed: it belongs to a single status, so greying it on every app still
+ * being read would mostly be a button that appears and then goes.
+ */
 const WHILE_UNREAD: AppActions = {
   deploy: DISABLED,
+  redeploy: HIDDEN,
   export: DISABLED,
   suspend: DISABLED,
   delete: DISABLED,

--- a/apps/dashboard/src/lib/app-actions.ts
+++ b/apps/dashboard/src/lib/app-actions.ts
@@ -90,12 +90,15 @@ const AVAILABILITY: Record<AppStatusKey, AppActions> = {
     suspend: ENABLED,
     delete: ENABLED,
   },
+  // Nothing at all in the seconds between the owner asking and the microVM stopping: what is
+  // being asked of the app is changing under every one of these, and a button that comes back the
+  // moment it has stopped is a better answer than one pressed against an app mid-shutdown.
   suspending: {
     deploy: UNTIL_RESUMED,
     redeploy: HIDDEN,
-    export: ENABLED,
+    export: DISABLED,
     suspend: DISABLED,
-    delete: ENABLED,
+    delete: DISABLED,
   },
   // Deploying is offered back the moment the app row asks to run again, which is what resuming is.
   resuming: {

--- a/apps/dashboard/src/lib/hooks/use-app-redeploy.ts
+++ b/apps/dashboard/src/lib/hooks/use-app-redeploy.ts
@@ -1,0 +1,38 @@
+import { useApp } from '#lib/hooks/use-app.ts';
+import { useFailureToast } from '#lib/hooks/use-failure-toast.ts';
+import { isReleasing, useRunApp } from '#lib/hooks/use-run-app.ts';
+
+export type AppRedeploy = {
+  readonly releasing: boolean;
+  /** Absent until the app has been read: there is no config to release again before there is one. */
+  readonly start: (() => void) | undefined;
+};
+
+/**
+ * The app released again on exactly what it already has — the binary its newest release pinned,
+ * and its arguments and port restated rather than edited.
+ *
+ * The environment is left unsaid, which is what keeps it: a browser cannot read a secret back to
+ * restate it, so a release that named the variables it wanted would be one that dropped every
+ * value it could not see.
+ */
+export function useAppRedeploy(appId: string): AppRedeploy {
+  const app = useApp(appId);
+  const run = useRunApp({ onDeployed: undefined });
+  useFailureToast(run.reason);
+
+  const released = app.data;
+
+  return {
+    releasing: isReleasing(run.phase),
+    start:
+      released === undefined
+        ? undefined
+        : () =>
+            run.start({
+              app: released.slug,
+              args: released.config.args,
+              port: released.config.httpPort,
+            }),
+  };
+}

--- a/apps/dashboard/src/lib/hooks/use-run-app.ts
+++ b/apps/dashboard/src/lib/hooks/use-run-app.ts
@@ -16,6 +16,11 @@ export type DeployPhase =
   | 'done'
   | 'failed';
 
+/** The phases where the release is in flight and nothing is left for this end to send. */
+export function isReleasing(phase: DeployPhase): boolean {
+  return phase === 'releasing' || phase === 'settling';
+}
+
 export type DeployRun = {
   phase: DeployPhase;
   steps: readonly DeployStep[];

--- a/apps/dashboard/tests/lib/app-actions.test.ts
+++ b/apps/dashboard/tests/lib/app-actions.test.ts
@@ -21,6 +21,7 @@ describe('an app is offered what its state can actually do', () => {
   test('one nobody has deployed has nothing to export and nothing to take offline', () => {
     expect(actions()).toEqual({
       deploy: ENABLED,
+      redeploy: HIDDEN,
       export: HIDDEN,
       suspend: HIDDEN,
       delete: ENABLED,
@@ -33,6 +34,7 @@ describe('an app is offered what its state can actually do', () => {
     test(`one whose release is ${deploymentState} is exportable and has nothing to suspend`, () => {
       expect(actions({ deploymentState })).toEqual({
         deploy: ENABLED,
+        redeploy: deploymentState === 'failed' ? ENABLED : HIDDEN,
         export: ENABLED,
         suspend: HIDDEN,
         delete: ENABLED,
@@ -40,9 +42,10 @@ describe('an app is offered what its state can actually do', () => {
     });
   }
 
-  test('a serving one is offered every button', () => {
+  test('a serving one is offered everything there is to do to a running app', () => {
     expect(actions({ deploymentState: 'running' })).toEqual({
       deploy: ENABLED,
+      redeploy: HIDDEN,
       export: ENABLED,
       suspend: ENABLED,
       delete: ENABLED,
@@ -72,6 +75,7 @@ describe('an app the host has not caught up with yet', () => {
   test('and one not read yet offers nothing to press', () => {
     expect(appActions(undefined)).toEqual({
       deploy: DISABLED,
+      redeploy: HIDDEN,
       export: DISABLED,
       suspend: DISABLED,
       delete: DISABLED,
@@ -99,10 +103,36 @@ describe('a suspended app', () => {
   });
 });
 
+/**
+ * A button for one status, because it is an answer to one: a release that did not come up is the
+ * case where running the same binary again is the whole of what an owner wants. Everywhere else
+ * releasing again is the deploy dialog, which can change what it releases as well.
+ */
+describe('a release that did not come up', () => {
+  test('is the one an app is offered a redeploy on', () => {
+    expect(actions({ deploymentState: 'failed' }).redeploy).toEqual(ENABLED);
+  });
+
+  for (const deploymentState of DEPLOYMENT_STATES.filter((state) => state !== 'failed')) {
+    test(`and a ${deploymentState} one is not`, () => {
+      expect(actions({ deploymentState }).redeploy).toEqual(HIDDEN);
+    });
+  }
+
+  test('nor is an app nobody has ever deployed', () => {
+    expect(actions().redeploy).toEqual(HIDDEN);
+  });
+
+  test('nor a suspended one, which would not start what it released', () => {
+    expect(actions({ appState: 'suspended', deploymentState: 'failed' }).redeploy).toEqual(HIDDEN);
+  });
+});
+
 describe('an app on its way out', () => {
   test('has one button left, and it is the one saying so', () => {
     expect(actions({ appState: 'deleting' })).toEqual({
       deploy: HIDDEN,
+      redeploy: HIDDEN,
       export: HIDDEN,
       suspend: HIDDEN,
       delete: DISABLED,
@@ -112,6 +142,7 @@ describe('an app on its way out', () => {
   test('and once it is gone, none at all', () => {
     expect(actions({ appState: 'deleted' })).toEqual({
       deploy: HIDDEN,
+      redeploy: HIDDEN,
       export: HIDDEN,
       suspend: HIDDEN,
       delete: HIDDEN,

--- a/apps/dashboard/tests/lib/app-actions.test.ts
+++ b/apps/dashboard/tests/lib/app-actions.test.ts
@@ -72,6 +72,16 @@ describe('an app the host has not caught up with yet', () => {
     expect(actions({ deploymentState: 'stopped' }).suspend).toEqual(DISABLED);
   });
 
+  test('and one on its way down offers nothing to press at all', () => {
+    expect(actions({ appState: 'suspended', deploymentState: 'running' })).toEqual({
+      deploy: { kind: 'disabled', reason: expect.any(String) },
+      redeploy: HIDDEN,
+      export: DISABLED,
+      suspend: DISABLED,
+      delete: DISABLED,
+    });
+  });
+
   test('and one not read yet offers nothing to press', () => {
     expect(appActions(undefined)).toEqual({
       deploy: DISABLED,


### PR DESCRIPTION
An app whose release did not come up gets a Redeploy button in its action bar: the binary it already pinned, released again on the config it already has. No dialog and no form — anything an owner wants changed is the Deploy button beside it.

It reuses the existing `redeploy` operation, so nothing new reaches the api.