### PR TITLE
refactor(infra): an app host keeps no volume it does not mount

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -166,7 +166,6 @@ jobs:
     env:
       DEPLOY_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).deploy_bucket }}
       APP_HOST_DEPLOY_GROUP: ${{ fromJSON(needs.terraform.outputs.values).app_host_deploy_group }}
-      APP_HOST_DATA_VOLUME_IDS: ${{ fromJSON(needs.terraform.outputs.values).app_host_data_volume_ids }}
       SSM_SECRET_PREFIX: ${{ fromJSON(needs.terraform.outputs.values).ssm_secret_prefix }}
       GUEST_IMAGES_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).guest_images_bucket }}
       FILESYSTEMS_BUCKET: ${{ fromJSON(needs.terraform.outputs.values).filesystems_bucket }}

--- a/infra/app-host/deploy/ensure_ephemeral_data.sh
+++ b/infra/app-host/deploy/ensure_ephemeral_data.sh
@@ -43,32 +43,20 @@ if [ -z "$device" ]; then
 fi
 log "instance store is $device"
 
-# The EBS volume's entry, written by ensure_data_volume.sh on a host deployed
-# before this existed. Left in place it would win the race at boot and take the
-# mount point this needs, so it goes — the volume itself is left attached and
-# untouched, which is what makes rolling back a matter of putting the line back.
-if grep -q "[[:space:]]${MOUNT_POINT}[[:space:]]" /etc/fstab 2>/dev/null; then
-  log "removing the legacy ${MOUNT_POINT} entry from /etc/fstab"
-  sed -i "\\#[[:space:]]${MOUNT_POINT}[[:space:]]#d" /etc/fstab
-fi
-
 mkdir -p "$MOUNT_POINT"
 
-# A host being migrated comes up with the EBS volume already mounted here. At
-# boot nothing has opened it yet, so it can simply be taken back; if something
-# has — a deploy re-running this while ZeroFS holds its cache — the unmount fails
-# and the host keeps the disk it is using until it next boots.
+# A deploy re-runs this while ZeroFS holds the cache underneath it, so finding the
+# disk already mounted is the ordinary case and not an error. Finding anything
+# else there is: nothing mounts /data but this, so mounting over whatever
+# took it would hide a disk something is using rather than replace it.
 if mountpoint -q "$MOUNT_POINT"; then
   current=$(findmnt -no SOURCE "$MOUNT_POINT")
-  if [ "$(readlink -f "$current")" = "$(readlink -f "$device")" ]; then
-    log "already mounted from the instance store"
-    exit 0
+  if [ "$(readlink -f "$current")" != "$(readlink -f "$device")" ]; then
+    log "${MOUNT_POINT} is mounted from ${current}, which is not the instance store"
+    exit 1
   fi
-  log "${MOUNT_POINT} is mounted from ${current}, taking it back"
-  if ! umount "$MOUNT_POINT"; then
-    log "could not unmount ${current} — it is in use, so ${MOUNT_POINT} stays where it is"
-    exit 0
-  fi
+  log "already mounted from the instance store"
+  exit 0
 fi
 
 # Blank on every start, so this is the ordinary path rather than the first-run

--- a/infra/app-host/deploy/on_box_deploy.sh
+++ b/infra/app-host/deploy/on_box_deploy.sh
@@ -13,7 +13,7 @@ cd "$(dirname "$0")"
 
 log() { echo "=== [on_box_deploy $(date -u +%H:%M:%S)] $* ==="; }
 
-: "${AWS_REGION:?}" "${SSM_SECRET_PREFIX:?}" "${DATA_VOLUME_ID:?}" \
+: "${AWS_REGION:?}" "${SSM_SECRET_PREFIX:?}" \
   "${AGENT_VERSION:?}" "${AGENT_URL:?}" \
   "${ZEROFS_VERSION:?}" "${ZEROFS_URL:?}" "${ZEROFS_SHA256:?}" "${ZEROFS_MEMBER:?}" \
   "${FIRECRACKER_VERSION:?}" "${FIRECRACKER_URL:?}" "${FIRECRACKER_SHA256:?}" \

--- a/infra/terraform/app_host.tf
+++ b/infra/terraform/app_host.tf
@@ -124,35 +124,3 @@ resource "aws_eip" "app_host" {
     Name = "${local.resource_name_prefix}-app-host-${count.index}-public-ip"
   }
 }
-
-# Nothing mounts this any more: /data is the instance store the m8id carries, and
-# infra/app-host/deploy/ensure_ephemeral_data.sh is what puts it there. It stays
-# attached only so a revert has a disk to go back to, and it keeps its Backup tag,
-# which still bills for a daily snapshot of a cache nothing reads.
-#
-# No prevent_destroy. It was written when this volume held the only copy of
-# something, and a guard that outlives the data it guards buys nothing but a
-# manual step — the plan itself, and the destroy check the deploy runs over it,
-# are what should be read before this goes.
-resource "aws_ebs_volume" "app_host_data" {
-  count = var.app_host_count
-
-  availability_zone = local.availability_zone
-  size              = var.app_host_data_volume_size
-  type              = "gp3"
-  encrypted         = true
-
-  tags = {
-    Name = "${local.resource_name_prefix}-app-host-${count.index}-data"
-    # The DLM snapshot policy targets volumes by this tag.
-    Backup = local.resource_name_prefix
-  }
-}
-
-resource "aws_volume_attachment" "app_host_data" {
-  count = var.app_host_count
-
-  device_name = "/dev/sdf"
-  volume_id   = aws_ebs_volume.app_host_data[count.index].id
-  instance_id = aws_instance.app_host[count.index].id
-}

--- a/infra/terraform/dlm.tf
+++ b/infra/terraform/dlm.tf
@@ -24,7 +24,8 @@ resource "aws_iam_role_policy_attachment" "dlm" {
 
 # Block-level counterpart to pg-backup's nightly logical dump, and the only
 # backup anything on the control plane's volume other than Postgres has. Tag-
-# driven, so an app host's cache volume opts in by carrying the same tag.
+# driven, and the control plane's volume is the only thing wearing the tag: an
+# app host's /data is the instance store, whose whole content S3 already holds.
 resource "aws_dlm_lifecycle_policy" "data" {
   description        = "Daily snapshots of the nibrun data volumes"
   execution_role_arn = aws_iam_role.dlm.arn

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -125,14 +125,6 @@ output "app_host_public_ips" {
   value       = aws_eip.app_host[*].public_ip
 }
 
-# Not a single DATA_VOLUME_ID like the control plane's, because each host has
-# its own: a deploy fanning out looks the instance it is targeting up here and
-# exports that one value under the usual name.
-output "app_host_data_volume_ids" {
-  description = "Instance id to the id of the volume mounted at /data on it."
-  value       = { for index, host in aws_instance.app_host : host.id => aws_ebs_volume.app_host_data[index].id }
-}
-
 output "exports_bucket" {
   description = "Downloadable app exports. Written by app hosts, read by the api only to sign a download URL."
   value       = aws_s3_bucket.exports.bucket

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -88,12 +88,6 @@ variable "app_host_root_volume_size" {
   description = "Root EBS volume size in GB for an app host. Holds the OS, the versioned binaries under /opt/nibrun and the artifact cache under /var/lib/nibrun."
 }
 
-variable "app_host_data_volume_size" {
-  type        = number
-  default     = 100
-  description = "Per-host data EBS volume size in GB. Nothing mounts it any more — /data is the instance store — and it stays attached only so a revert has a disk to go back to."
-}
-
 variable "export_retention_days" {
   type        = number
   default     = 1

--- a/packages/internal-scripts/src/publish-app-host-bundle.ts
+++ b/packages/internal-scripts/src/publish-app-host-bundle.ts
@@ -19,14 +19,8 @@ const BUNDLE_DIRECTORIES = ['systemd', 'zerofs', 'caddy'];
 // everything relative to itself.
 const ON_BOX_SCRIPTS = ['on_box_deploy.sh', 'ensure_ephemeral_data.sh'];
 
-// Shared with the control plane's bundle. Only the control plane reads it now —
-// an app host's /data is the instance store and `ensure_ephemeral_data.sh` is
-// what mounts it — but it ships here until the EBS volume is removed, so a
-// rollback to a revision that still calls it finds it on the box.
-const SHARED_ON_BOX_SCRIPTS = ['ensure_data_volume.sh'];
-
-// Also shared: Cloudflare's origin-pull CA is one certificate, and both proxies
-// authenticate the same edge against it.
+// Shared with the control plane's bundle: Cloudflare's origin-pull CA is one
+// certificate, and both proxies authenticate the same edge against it.
 const SHARED_CADDY_FILES = ['cloudflare-origin-pull-ca.pem'];
 
 const deployBucket = requiredEnv('DEPLOY_BUCKET');
@@ -35,7 +29,7 @@ const revision = requiredEnv('GITHUB_SHA');
 const appHostDir = join(repoRoot, 'infra/app-host');
 const bundlePath = join(tmpdir(), 'nibrun-app-host-bundle.tar.gz');
 
-await $`tar czf ${bundlePath} -C ${appHostDir} ${BUNDLE_DIRECTORIES} -C ${join(appHostDir, 'deploy')} ${ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/deploy')} ${SHARED_ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/caddy')} ${SHARED_CADDY_FILES}`;
+await $`tar czf ${bundlePath} -C ${appHostDir} ${BUNDLE_DIRECTORIES} -C ${join(appHostDir, 'deploy')} ${ON_BOX_SCRIPTS} -C ${join(repoRoot, 'infra/caddy')} ${SHARED_CADDY_FILES}`;
 
 const bundleBytes = Bun.file(bundlePath).size;
 const url = `s3://${deployBucket}/app-host-bundles/${revision}.tar.gz`;

--- a/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
+++ b/packages/internal-scripts/src/ssm-deploy-app-hosts.ts
@@ -14,10 +14,6 @@ const bundleUrl = requiredEnv('BUNDLE_URL');
 const deployGroup = requiredEnv('APP_HOST_DEPLOY_GROUP');
 const revision = requiredEnv('GITHUB_SHA');
 
-// Each host mounts its own volume, so the one value that differs per host comes
-// from a map keyed by instance id rather than a single output.
-const dataVolumeIds = JSON.parse(requiredEnv('APP_HOST_DATA_VOLUME_IDS')) as Record<string, string>;
-
 const versions = await readAppHostVersions();
 
 // Every name here is the name the box reads, and every version is the one pinned
@@ -75,23 +71,20 @@ if [ "$(cloud-init status | awk '{print $2}')" = "error" ]; then
 fi
 timeout 900 bash -c 'until [ -f /opt/nibrun-app-host-bootstrap.done ]; do echo waiting for instance bootstrap; sleep 5; done'`;
 
-const remoteScript = ({ dataVolumeId }: { dataVolumeId: string }) => `
+// The same on every host: nothing a deploy sends is per-host any more, now that
+// /data is the disk the instance came with rather than a volume named in state.
+const remoteScript = `
 set -euo pipefail
 ${awaitBootstrap}
 mkdir -p /opt/nibrun/bundle
 aws s3 cp ${quote(bundleUrl)} /tmp/app-host-bundle.tar.gz
 tar xzf /tmp/app-host-bundle.tar.gz --overwrite -C /opt/nibrun/bundle
 cd /opt/nibrun/bundle
-export ${exportLine({ ...sharedEnv, DATA_VOLUME_ID: dataVolumeId })}
+export ${exportLine(sharedEnv)}
 bash on_box_deploy.sh
 `;
 
 async function deployTo({ instanceId }: { instanceId: string }) {
-  const dataVolumeId = dataVolumeIds[instanceId];
-  if (!dataVolumeId) {
-    return { instanceId, status: 'NoDataVolume', stdout: '', stderr: '' };
-  }
-
   console.log(`[${instanceId}] waiting for SSM registration...`);
   if (!(await waitForSsmRegistration({ instanceId }))) {
     return { instanceId, status: 'NotRegistered', stdout: '', stderr: '' };
@@ -99,7 +92,7 @@ async function deployTo({ instanceId }: { instanceId: string }) {
 
   const commandId = await sendCommand({
     instanceIds: [instanceId],
-    script: remoteScript({ dataVolumeId }),
+    script: remoteScript,
     comment: `Deploy ${optionalEnv('GITHUB_SHA') ?? 'manual'}`,
   });
   console.log(`[${instanceId}] SSM command: ${commandId}`);

--- a/packages/internal-scripts/src/terraform-apply.ts
+++ b/packages/internal-scripts/src/terraform-apply.ts
@@ -59,9 +59,9 @@ const outputs = (await terraform(['output', '-json']).quiet().json()) as Record<
   { value: unknown; sensitive: boolean }
 >;
 
-// Not every output is a string — the per-host volume map is an object, and the
-// step that reads it parses it back — so everything is rendered to a string here
-// and the published object is flat.
+// Not every output is a string — the app host addresses are a list, and the step
+// that reads them parses it back — so everything is rendered to a string here and
+// the published object is flat.
 const render = (value: unknown) => (typeof value === 'string' ? value : JSON.stringify(value));
 
 console.log(green(bold('\n✓ applied')));


### PR DESCRIPTION
Deletes the 100 GB volume nothing mounts, and everything that named it: the per-host volume-id map through the deploy, `DATA_VOLUME_ID` on the box, `ensure_data_volume.sh` in the app-host bundle (the control plane still ships and reads it for Postgres), and the migration path in `ensure_ephemeral_data.sh`.

Verified on `i-03738d79b4aae4939` before opening: `/data` is `nvme2n1` (instance store), `vol-02a3666a7b4a9583d` is `nvme1n1` with no mountpoint and no holder, and `/etc/fstab` has no `/data` line — so the detach is clean.

**This plan destroys, so `failOnUnexpectedDestroys` blocks both checks.** The required `infra:required` check will fail on `aws_ebs_volume.app_host_data[0]` and `aws_volume_attachment.app_host_data[0]`, and after merge the push-to-main `terraform` job fails the same way. Merge with the admin bypass and run `cd` via `workflow_dispatch` with `allow_destroy` — or say the word and I'll put the two addresses in `ALLOWED_TERRAFORM_DESTROY_ADDRESSES` on #404 instead.

12 DLM snapshots of the volume outlive it and age out on the 14-day rule.