### PR TITLE
feat(agent): a microVM can be put down at a point it can be put back on

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -115,5 +115,9 @@ credentials, and the gap is wider than the test count suggests.
   microseconds of the cut being recorded would get past this.
 - The Firecracker drive-on-`/dev/nbdN` path is upstream-undocumented — mechanically sound, never
   run here.
+- **No microVM has been slept or woken.** The API client is asserted against a listening unix
+  socket, so the request shapes are the ones 1.16.1's swagger describes; that Firecracker accepts
+  them, that a bare process restores a guest whose NBD drive was reattached under it, and that
+  `vm_launch.sh` picks the right mode under systemd are all questions only a host can answer.
 - **No test builds the full layer graph**, so a service wired wrong in `index.ts` is caught by
   `tsc` and by starting the binary, not by `bun test`.

--- a/apps/agent/src/lib/network/tap.ts
+++ b/apps/agent/src/lib/network/tap.ts
@@ -52,3 +52,36 @@ export const ensureTap = Effect.fn('ensureTap')(function* (tap: TapInterface) {
   // the nftables SNAT can rewrite them — and the local proxy reaches every app that way.
   yield* stdoutOf({ command: [SYSCTL, '-w', `net.ipv4.conf.${tap.tapName}.route_localnet=1`] });
 });
+
+/**
+ * The host's neighbour entry for a guest goes stale while its microVM is down, and the first
+ * connection after a wake then pays ARP re-resolution: 1.1s against the 112ms a refreshed entry
+ * costs, which is most of what makes waking cheaper than the ~1035ms of a cold boot. A guest
+ * keeps its address and its MAC across a sleep, so this writes back the pairing that was already
+ * there rather than announcing a new one.
+ */
+export const refreshNeighbour = Effect.fn('refreshNeighbour')(
+  ({
+    guestIpv4,
+    guestMac,
+    tapName,
+  }: {
+    guestIpv4: Ipv4Address;
+    guestMac: string;
+    tapName: string;
+  }) =>
+    stdoutOf({
+      command: [
+        IP,
+        'neigh',
+        'replace',
+        guestIpv4,
+        'lladdr',
+        guestMac,
+        'dev',
+        tapName,
+        'nud',
+        'reachable',
+      ],
+    }),
+);

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -22,7 +22,6 @@ import {
 import { ensureArtifactImage } from '#lib/vm/artifacts.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { UNKNOWN_UNIT, type UnitStatus } from '#lib/vm/unit-status.ts';
-import { flush } from '#lib/volumes/zerofs.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
@@ -31,24 +30,6 @@ import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
 
 const ONE_RESTART = 1;
 const NO_RESTART = 0;
-
-/** Under `ignore_fsync` this is the only thing between a stop and the loss of everything since
- * the last periodic flush. */
-const flushEverything = Effect.gen(function* () {
-  const topology = yield* ZerofsTopology;
-  yield* Effect.forEach(
-    topology.all,
-    (filesystem) =>
-      flush(filesystem.admin).pipe(
-        Effect.catchAll((error) =>
-          Effect.logWarning('zerofs flush failed', error).pipe(
-            Effect.annotateLogs({ storagePrefix: filesystem.storagePrefix }),
-          ),
-        ),
-      ),
-    { discard: true },
-  );
-});
 
 export const stopInstance = Effect.fn('stopInstance')(function* ({
   appId,
@@ -59,8 +40,9 @@ export const stopInstance = Effect.fn('stopInstance')(function* ({
 }) {
   yield* Effect.annotateCurrentSpan({ appId, reason });
   const vms = yield* VmManager;
+  const topology = yield* ZerofsTopology;
   yield* setState({ appId, state: 'stopping', stopRequested: true });
-  yield* flushEverything;
+  yield* topology.flushAll;
   yield* vms.stop(appId).pipe(
     Effect.andThen(Effect.logInfo('instance stopped')),
     Effect.catchAll((error) => Effect.logError('instance stop failed', error)),

--- a/apps/agent/src/lib/vm/firecracker-api.ts
+++ b/apps/agent/src/lib/vm/firecracker-api.ts
@@ -1,0 +1,158 @@
+import { Data, Duration, Effect, Schedule } from 'effect';
+import { describe } from '#lib/failure.ts';
+
+/**
+ * The per-VM API socket `nibrun-vm@.service` has always given every microVM, and which nothing
+ * spoke to until there was a reason to pause one. The boot config is read once and never again,
+ * so everything after boot — pausing, snapshotting, restoring — happens here.
+ *
+ * Shapes are Firecracker 1.16.1's, off the swagger that release ships. Two of them are worth
+ * naming because a neighbouring version differs: `/vm` mounts `PATCH` and only `PATCH`, for
+ * `Paused` and `Resumed` alike, and `sync_snapshot_files` does not exist here — 1.16.1 always
+ * syncs. A body Firecracker does not recognise is rejected outright, so a field invented for a
+ * later version fails the call rather than being ignored.
+ */
+const API_ORIGIN = 'http://localhost';
+const VM_PATH = '/vm';
+const SNAPSHOT_CREATE_PATH = '/snapshot/create';
+const SNAPSHOT_LOAD_PATH = '/snapshot/load';
+
+const NO_CONTENT = 204;
+const MAX_DETAIL_LENGTH = 200;
+
+/** A 256 MiB guest measures ~1.7s to snapshot, and is paused for every millisecond of it. */
+const CALL_TIMEOUT = Duration.seconds(60);
+
+/** Firecracker binds its API socket after `exec`, and systemd calls a `Type=exec` unit started at it. */
+const BIND_POLL_INTERVAL = Duration.millis(10);
+const BIND_TIMEOUT = Duration.seconds(10);
+
+export class FirecrackerUnreachable extends Data.TaggedError('FirecrackerUnreachable')<{
+  readonly socketPath: string;
+  readonly cause: unknown;
+}> {
+  override get message() {
+    return `no microVM answered ${this.socketPath}: ${describe(this.cause)}`;
+  }
+}
+
+export class FirecrackerRejected extends Data.TaggedError('FirecrackerRejected')<{
+  readonly path: string;
+  readonly status: number;
+  readonly detail: string;
+}> {
+  override get message() {
+    const reason = this.detail.length > 0 ? `: ${this.detail}` : '';
+    return `the microVM refused ${this.path} with ${this.status}${reason}`;
+  }
+}
+
+export type FirecrackerApiError = FirecrackerUnreachable | FirecrackerRejected;
+
+type ApiCall = {
+  readonly socketPath: string;
+  readonly method: 'PATCH' | 'PUT';
+  readonly path: string;
+  readonly body: unknown;
+};
+
+const call = ({ socketPath, method, path, body }: ApiCall) =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: (signal) =>
+        fetch(`${API_ORIGIN}${path}`, {
+          unix: socketPath,
+          method,
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+          signal,
+        }),
+      catch: (cause) => new FirecrackerUnreachable({ socketPath, cause }),
+    });
+    if (response.status === NO_CONTENT) {
+      return;
+    }
+    // Every refusal is a `fault_message`, and a body that is not one is still the only account of
+    // itself the VMM gave.
+    const detail = yield* Effect.orElseSucceed(
+      Effect.tryPromise(() => response.text()),
+      () => '',
+    );
+    return yield* new FirecrackerRejected({
+      path,
+      status: response.status,
+      detail: detail.trim().slice(0, MAX_DETAIL_LENGTH),
+    });
+  }).pipe(
+    Effect.timeoutFail({
+      duration: CALL_TIMEOUT,
+      onTimeout: () =>
+        new FirecrackerUnreachable({
+          socketPath,
+          cause: `${path} did not answer within ${Duration.toSeconds(CALL_TIMEOUT)}s`,
+        }),
+    }),
+    Effect.withSpan('firecracker', { attributes: { path } }),
+  );
+
+/**
+ * A call to a Firecracker that has only just been started has to be prepared to find nothing
+ * listening yet. Only a connection that never completed is repeated: a refusal is the VMM's
+ * answer, and asking again does not change it.
+ */
+const untilBound = <A>(effect: Effect.Effect<A, FirecrackerApiError>) =>
+  Effect.retry(effect, {
+    while: (error: FirecrackerApiError) => error._tag === 'FirecrackerUnreachable',
+    schedule: Schedule.spaced(BIND_POLL_INTERVAL).pipe(Schedule.upTo(BIND_TIMEOUT)),
+  });
+
+export const pause = Effect.fn('firecracker.pause')((socketPath: string) =>
+  call({ socketPath, method: 'PATCH', path: VM_PATH, body: { state: 'Paused' } }),
+);
+
+export const resume = Effect.fn('firecracker.resume')((socketPath: string) =>
+  call({ socketPath, method: 'PATCH', path: VM_PATH, body: { state: 'Resumed' } }),
+);
+
+export type SnapshotFiles = {
+  readonly socketPath: string;
+  readonly statePath: string;
+  readonly memoryPath: string;
+};
+
+/** Both files are created or truncated by this, and the microVM has to be paused already. */
+export const createSnapshot = Effect.fn('firecracker.createSnapshot')(
+  ({ socketPath, statePath, memoryPath }: SnapshotFiles) =>
+    call({
+      socketPath,
+      method: 'PUT',
+      path: SNAPSHOT_CREATE_PATH,
+      body: {
+        snapshot_path: statePath,
+        mem_file_path: memoryPath,
+        snapshot_type: 'Full',
+      },
+    }),
+);
+
+/**
+ * Accepted only by a Firecracker that has configured nothing, which is why a restore is started
+ * without a config file. It leaves the microVM paused; resuming it is a call of its own.
+ *
+ * `mem_backend` rather than the `mem_file_path` beside it: that spelling is deprecated upstream
+ * and the two are mutually exclusive, so sending both is a rejection rather than a preference.
+ */
+export const loadSnapshot = Effect.fn('firecracker.loadSnapshot')(
+  ({ socketPath, statePath, memoryPath }: SnapshotFiles) =>
+    untilBound(
+      call({
+        socketPath,
+        method: 'PUT',
+        path: SNAPSHOT_LOAD_PATH,
+        body: {
+          snapshot_path: statePath,
+          mem_backend: { backend_type: 'File', backend_path: memoryPath },
+        },
+      }),
+    ),
+);

--- a/apps/agent/src/lib/vm/firecracker-api.ts
+++ b/apps/agent/src/lib/vm/firecracker-api.ts
@@ -141,6 +141,14 @@ export const createSnapshot = Effect.fn('firecracker.createSnapshot')(
  *
  * `mem_backend` rather than the `mem_file_path` beside it: that spelling is deprecated upstream
  * and the two are mutually exclusive, so sending both is a rejection rather than a preference.
+ *
+ * `clock_realtime` is not a refinement. Firecracker emulates no RTC on x86_64, so kvmclock is the
+ * guest's only source of wall time — `infra/guest-image/kernel/nibrun.config` builds a kernel with
+ * `CONFIG_PARAVIRT_CLOCK` and nothing else to fall back on. Its default of `false` resumes the
+ * clock where the snapshot left it, so a guest that slept an hour wakes an hour in the past and
+ * its first outbound TLS handshake fails on a certificate that is not yet valid — a wrong answer
+ * from a healthy-looking app rather than a microVM that visibly did not come up. This one field
+ * is what makes a sleep invisible to the guest, and it is why waking needs no new guest image.
  */
 export const loadSnapshot = Effect.fn('firecracker.loadSnapshot')(
   ({ socketPath, statePath, memoryPath }: SnapshotFiles) =>
@@ -152,6 +160,7 @@ export const loadSnapshot = Effect.fn('firecracker.loadSnapshot')(
         body: {
           snapshot_path: statePath,
           mem_backend: { backend_type: 'File', backend_path: memoryPath },
+          clock_realtime: true,
         },
       }),
     ),

--- a/apps/agent/src/lib/vm/firecracker-api.ts
+++ b/apps/agent/src/lib/vm/firecracker-api.ts
@@ -56,8 +56,8 @@ type ApiCall = {
   readonly body: unknown;
 };
 
-const call = ({ socketPath, method, path, body }: ApiCall) =>
-  Effect.gen(function* () {
+function call({ socketPath, method, path, body }: ApiCall) {
+  return Effect.gen(function* () {
     const response = yield* Effect.tryPromise({
       try: (signal) =>
         fetch(`${API_ORIGIN}${path}`, {
@@ -94,17 +94,19 @@ const call = ({ socketPath, method, path, body }: ApiCall) =>
     }),
     Effect.withSpan('firecracker', { attributes: { path } }),
   );
+}
 
 /**
  * A call to a Firecracker that has only just been started has to be prepared to find nothing
  * listening yet. Only a connection that never completed is repeated: a refusal is the VMM's
  * answer, and asking again does not change it.
  */
-const untilBound = <A>(effect: Effect.Effect<A, FirecrackerApiError>) =>
-  Effect.retry(effect, {
+function untilBound<A>(effect: Effect.Effect<A, FirecrackerApiError>) {
+  return Effect.retry(effect, {
     while: (error: FirecrackerApiError) => error._tag === 'FirecrackerUnreachable',
     schedule: Schedule.spaced(BIND_POLL_INTERVAL).pipe(Schedule.upTo(BIND_TIMEOUT)),
   });
+}
 
 export const pause = Effect.fn('firecracker.pause')((socketPath: string) =>
   call({ socketPath, method: 'PATCH', path: VM_PATH, body: { state: 'Paused' } }),

--- a/apps/agent/src/lib/vm/snapshot.ts
+++ b/apps/agent/src/lib/vm/snapshot.ts
@@ -8,11 +8,21 @@ export const SNAPSHOT_STATE_FILENAME = 'vmstate';
 export const SNAPSHOT_MEMORY_FILENAME = 'memory';
 
 /**
- * Written last and consumed first, which is what makes a restore happen at most once: the agent
- * writes it only once the two files beside it are complete, and the launcher deletes it before it
- * execs the Firecracker that will load them. A start that finds no stamp is a cold boot — so an
- * agent that died between the load and the cleanup leaves a microVM that boots off its disk
- * rather than one that resumes from a snapshot the disk has since moved past.
+ * Written last and consumed first, which is what makes a restore happen **at most once**: the
+ * agent writes it only once the two files beside it are complete, and `vm_launch.sh` deletes it
+ * before it execs the Firecracker that will load them. A start that finds no stamp is a cold boot
+ * — so an agent that died between the load and the cleanup leaves a microVM that boots off its
+ * disk rather than one that resumes from a snapshot the disk has since moved past.
+ *
+ * **At most once is a security invariant and not only a crash-safety one.** The guest kernel is
+ * built with `CONFIG_VMGENID=y`, so Firecracker updates the generation id and injects its
+ * interrupt before vCPUs resume, and Linux reseeds the kernel CRNG off it — `getrandom()` and
+ * `/dev/urandom` are fresh on the far side of a wake. Nothing reseeds the PRNG state already
+ * resident in tenant memory: OpenSSL's `RAND` buffer, a runtime's per-thread generator, a nonce
+ * already drawn. One snapshot restored twice is therefore the same randomness in two live VMs,
+ * which is key reuse with no symptom to notice it by. That is what is being traded away by
+ * anyone who makes a snapshot into a reusable warm-start template, and it is a trade to make
+ * deliberately rather than to discover.
  */
 export const SNAPSHOT_STAMP_FILENAME = 'stamp.json';
 
@@ -51,6 +61,56 @@ export class SnapshotUnusable extends Data.TaggedError('SnapshotUnusable')<{
   override get message() {
     return `the saved microVM state cannot be restored: ${this.reason}`;
   }
+}
+
+export class SleepRefused extends Data.TaggedError('SleepRefused')<{
+  readonly reason: string;
+}> {
+  override get message() {
+    return `this microVM must not be snapshotted: ${this.reason}`;
+  }
+}
+
+/**
+ * The two moments a microVM survives being snapshotted and its tenant does not survive being
+ * woken. Enforced here rather than left to whatever decides an app should sleep, because a
+ * policy is the thing that changes: the obvious next idea is to snapshot an app right after
+ * creating it to make cold starts cheap, and that idea has to fail here rather than in
+ * production.
+ *
+ * **A stop already in flight.** `clock_realtime` advances the clocksource rather than applying a
+ * wall-clock offset, so `CLOCK_MONOTONIC` moves forward with it. The SIGTERM-to-SIGKILL deadline
+ * the guest's supervisor holds in `PHASE_TERM_SENT` (`apps/runtime/src/supervise.c`) is a
+ * monotonic instant, so it lands in the past on the first poll after a wake and the tenant is
+ * killed for a shutdown it was in the middle of handling gracefully.
+ *
+ * **A guest that has not finished booting.** Firecracker injects the VMGenID interrupt before
+ * vCPUs resume, and a kernel snapshotted before its interrupt handling was in place can crash
+ * taking it. This guest boots with `panic=1 reboot=k` and `CONFIG_PANIC_ON_OOPS=y`, so that
+ * crash is the end of the microVM rather than a line on its console. `everHealthy` is the bar
+ * because it is the host's only first-hand evidence: the tenant accepted a connection, which is
+ * far past the window that is dangerous, and it stays true for a guest that has since gone
+ * unhealthy — being unwell is not the same as never having booted.
+ */
+export function refusalToSleep(
+  subject:
+    | {
+        readonly stopRequested: boolean;
+        readonly desiredRunning: boolean;
+        readonly everHealthy: boolean;
+      }
+    | undefined,
+): string | undefined {
+  if (subject === undefined) {
+    return 'this host holds no record of it';
+  }
+  if (subject.stopRequested || !subject.desiredRunning) {
+    return 'it has already been asked to stop';
+  }
+  if (!subject.everHealthy) {
+    return 'it has never answered, so it may not have finished booting';
+  }
+  return undefined;
 }
 
 export type SnapshotPaths = {

--- a/apps/agent/src/lib/vm/snapshot.ts
+++ b/apps/agent/src/lib/vm/snapshot.ts
@@ -1,0 +1,135 @@
+import { join } from 'node:path';
+import { FileSystem } from '@effect/platform';
+import type { AppId, DeploymentId } from '@repo/protocol';
+import { Data, Effect, Option } from 'effect';
+import { readJsonFile } from '#lib/json-store.ts';
+
+export const SNAPSHOT_STATE_FILENAME = 'vmstate';
+export const SNAPSHOT_MEMORY_FILENAME = 'memory';
+
+/**
+ * Written last and consumed first, which is what makes a restore happen at most once: the agent
+ * writes it only once the two files beside it are complete, and the launcher deletes it before it
+ * execs the Firecracker that will load them. A start that finds no stamp is a cold boot — so an
+ * agent that died between the load and the cleanup leaves a microVM that boots off its disk
+ * rather than one that resumes from a snapshot the disk has since moved past.
+ */
+export const SNAPSHOT_STAMP_FILENAME = 'stamp.json';
+
+/** systemd's own, so it changes exactly when `/dev/nbdN` and the tap devices are made again. */
+const HOST_BOOT_ID_PATH = '/proc/sys/kernel/random/boot_id';
+
+/**
+ * What a snapshot may be loaded against, and nothing else.
+ *
+ * Firecracker restores a microVM's drives, tap and vsock from paths recorded in the vmstate, and
+ * never asks whether what sits at those paths is what sat there when the snapshot was taken. A
+ * kernel, rootfs or artifact image swapped underneath one restores a guest whose page cache
+ * describes bytes that are gone — silent corruption rather than a refusal. Every field here names
+ * something that can move while a microVM sleeps.
+ */
+export type SnapshotStamp = {
+  readonly deploymentId: DeploymentId;
+  /** `/opt/nibrun/bin/guest-image` is a symlink, so the kernel and rootfs move without the path. */
+  readonly guestImageVersion: string;
+  readonly hostBootId: string;
+  /** The tap, the addresses, the MAC and the NBD minor all derive from this one number. */
+  readonly slot: number;
+};
+
+/** Ordered by what a reader most wants to hear first, and the only place a field is named twice. */
+const DRIFT: readonly (readonly [keyof SnapshotStamp, string])[] = [
+  ['deploymentId', 'the app has been deployed again since'],
+  ['guestImageVersion', 'the guest image has changed'],
+  ['hostBootId', 'the host has rebooted'],
+  ['slot', 'the app has moved to another slot'],
+];
+
+export class SnapshotUnusable extends Data.TaggedError('SnapshotUnusable')<{
+  readonly reason: string;
+}> {
+  override get message() {
+    return `the saved microVM state cannot be restored: ${this.reason}`;
+  }
+}
+
+export type SnapshotPaths = {
+  readonly directory: string;
+  readonly statePath: string;
+  readonly memoryPath: string;
+  readonly stampPath: string;
+};
+
+export function snapshotPaths({
+  snapshotDir,
+  appId,
+}: {
+  snapshotDir: string;
+  appId: AppId;
+}): SnapshotPaths {
+  const directory = join(snapshotDir, appId);
+  return {
+    directory,
+    statePath: join(directory, SNAPSHOT_STATE_FILENAME),
+    memoryPath: join(directory, SNAPSHOT_MEMORY_FILENAME),
+    stampPath: join(directory, SNAPSHOT_STAMP_FILENAME),
+  };
+}
+
+export function readStamp(value: unknown): Option.Option<SnapshotStamp> {
+  if (value === null || typeof value !== 'object') {
+    return Option.none();
+  }
+  const { deploymentId, guestImageVersion, hostBootId, slot } = value as Partial<SnapshotStamp>;
+  if (
+    typeof deploymentId !== 'string' ||
+    typeof guestImageVersion !== 'string' ||
+    typeof hostBootId !== 'string' ||
+    typeof slot !== 'number'
+  ) {
+    return Option.none();
+  }
+  return Option.some({ deploymentId, guestImageVersion, hostBootId, slot });
+}
+
+/** Why a stored stamp is not the one a restore would need, or `undefined` when it is. */
+export function driftFrom({
+  stored,
+  expected,
+}: {
+  stored: SnapshotStamp;
+  expected: SnapshotStamp;
+}): string | undefined {
+  return DRIFT.find(([field]) => stored[field] !== expected[field])?.[1];
+}
+
+/**
+ * Read rather than remembered, so a stamp is compared against the host as it is now. Failing
+ * where the file is absent is the point: an unknown boot id that compared equal to another
+ * unknown one would let a snapshot survive the reboot it exists to be invalidated by.
+ */
+export const readHostBootId = Effect.flatMap(FileSystem.FileSystem, (fs) =>
+  Effect.map(fs.readFileString(HOST_BOOT_ID_PATH), (value) => value.trim()),
+);
+
+/**
+ * That the snapshot beside this stamp describes the restore being asked for. A snapshot that
+ * fails here is one nothing may ever load, which is why the caller discards it rather than
+ * leaving it for a later start to find and take as an instruction.
+ */
+export const ensureLoadable = Effect.fn('snapshot.ensureLoadable')(function* ({
+  stampPath,
+  expected,
+}: {
+  stampPath: string;
+  expected: SnapshotStamp;
+}) {
+  const stored = Option.flatMap(yield* readJsonFile(stampPath), readStamp);
+  if (Option.isNone(stored)) {
+    return yield* new SnapshotUnusable({ reason: 'this host kept none' });
+  }
+  const drift = driftFrom({ stored: stored.value, expected });
+  if (drift !== undefined) {
+    return yield* new SnapshotUnusable({ reason: drift });
+  }
+});

--- a/apps/agent/src/lib/vm/systemd.ts
+++ b/apps/agent/src/lib/vm/systemd.ts
@@ -26,8 +26,15 @@ export const vmUnitName = (appId: AppId) => `${VM_UNIT_TEMPLATE}${appId}${UNIT_S
  * spellings, so moving one is moving the other — and the unit's runtime directory outlives the
  * agent on purpose, which is what leaves a VM started by an earlier agent still reachable here.
  */
-export const vmApiSocketPath = ({ runtimeDir, appId }: { runtimeDir: string; appId: AppId }) =>
-  join(runtimeDir, `vm-${appId}.sock`);
+export function vmApiSocketPath({
+  runtimeDir,
+  appId,
+}: {
+  runtimeDir: string;
+  appId: AppId;
+}): string {
+  return join(runtimeDir, `vm-${appId}.sock`);
+}
 
 export function appIdFromUnit(unitName: string): AppId | undefined {
   if (!unitName.startsWith(VM_UNIT_TEMPLATE) || !unitName.endsWith(UNIT_SUFFIX)) {

--- a/apps/agent/src/lib/vm/systemd.ts
+++ b/apps/agent/src/lib/vm/systemd.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import { type AppId, AppIdSchema, Value } from '@repo/protocol';
 import { Effect } from 'effect';
 import {
@@ -19,6 +20,14 @@ const UNIT_SUFFIX = '.service';
 const UNIT_PATTERN = `${VM_UNIT_TEMPLATE}*${UNIT_SUFFIX}`;
 
 export const vmUnitName = (appId: AppId) => `${VM_UNIT_TEMPLATE}${appId}${UNIT_SUFFIX}`;
+
+/**
+ * Where `nibrun-vm@.service` tells Firecracker to bind its API socket. Nothing compares the two
+ * spellings, so moving one is moving the other — and the unit's runtime directory outlives the
+ * agent on purpose, which is what leaves a VM started by an earlier agent still reachable here.
+ */
+export const vmApiSocketPath = ({ runtimeDir, appId }: { runtimeDir: string; appId: AppId }) =>
+  join(runtimeDir, `vm-${appId}.sock`);
 
 export function appIdFromUnit(unitName: string): AppId | undefined {
   if (!unitName.startsWith(VM_UNIT_TEMPLATE) || !unitName.endsWith(UNIT_SUFFIX)) {

--- a/apps/agent/src/services/agent-config.service.ts
+++ b/apps/agent/src/services/agent-config.service.ts
@@ -9,6 +9,14 @@ const DEFAULT_ZEROFS_MOUNT = '/mnt/zerofs';
 const DEFAULT_ZEROFS_CONFIG = '/etc/zerofs/config.toml';
 const DEFAULT_ZEROFS_NBD_SOCKET = '/run/zerofs/nbd.sock';
 const DEFAULT_ZEROFS_CHECKPOINT_RUNTIME_DIR = '/run/zerofs-checkpoint';
+/**
+ * On the instance store, because a snapshot is a cache: losing one costs a cold boot and nothing
+ * else. It budgets ~256 MiB a slot against a disk ZeroFS already keeps a 70 GB cache on.
+ *
+ * `vm_launch.sh` spells this path too, and nothing compares the two — a start reads the directory
+ * to decide whether it is a restore or a cold boot, so moving one is moving both.
+ */
+const DEFAULT_VM_SNAPSHOT_DIR = '/data/nibrun-vm';
 const DEFAULT_GUEST_IMAGE_DIR = '/opt/nibrun/bin/guest-image';
 const DEFAULT_FIRECRACKER_DIR = '/opt/nibrun/bin/firecracker';
 const DEFAULT_VERSIONS_FILE = '/opt/nibrun/bundle/versions.json';
@@ -88,6 +96,10 @@ export class AgentConfig extends Effect.Service<AgentConfig>()('AgentConfig', {
       exportStagingDir: inStateDir('exports'),
       artifactCacheDir: inStateDir('artifacts'),
       vmDir: inStateDir('vm'),
+      vmSnapshotDir: yield* optional({
+        name: 'AGENT_VM_SNAPSHOT_DIR',
+        fallback: DEFAULT_VM_SNAPSHOT_DIR,
+      }),
       versionsFile: yield* optional({
         name: 'AGENT_VERSIONS_FILE',
         fallback: DEFAULT_VERSIONS_FILE,

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -13,12 +13,15 @@ import { buildInstanceConfigImage } from '#lib/vm/instance-env.ts';
 import {
   ensureLoadable,
   readHostBootId,
+  refusalToSleep,
+  SleepRefused,
   type SnapshotStamp,
   snapshotPaths,
 } from '#lib/vm/snapshot.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { GUEST_VSOCK_FILENAME, vmWorkingDir } from '#lib/vm/vsock.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
+import { AgentState } from '#services/agent-state.service.ts';
 import { TenantLogReceiver } from '#services/tenant-log-receiver.service.ts';
 import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
 
@@ -43,6 +46,7 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
     const fs = yield* FileSystem.FileSystem;
     const logs = yield* TenantLogReceiver;
     const zerofs = yield* ZerofsTopology;
+    const agentState = yield* AgentState;
 
     const workingDir = (appId: AppId) => vmWorkingDir({ vmDir: config.vmDir, appId });
     const snapshotFor = (appId: AppId) =>
@@ -77,6 +81,16 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       yield* fs.remove(paths.stampPath, { force: true });
       yield* fs.remove(paths.directory, { recursive: true, force: true });
     });
+
+    /** Where the caller has a failure of its own to report and a leaked snapshot is the lesser one. */
+    const forgetSnapshot = (appId: AppId) =>
+      discardSnapshot(appId).pipe(
+        Effect.catchAll((error) =>
+          Effect.logWarning('snapshot could not be discarded', error).pipe(
+            Effect.annotateLogs({ appId }),
+          ),
+        ),
+      );
 
     /**
      * The agent never becomes the VM's parent: it stages the files, asks init to start the unit,
@@ -159,6 +173,11 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
     /**
      * A microVM taken down at a point it can be put back on, rather than one taken down.
      *
+     * The two states a snapshot must never be taken in are read from this agent's own record of
+     * the instance rather than accepted from the caller, because they are the preconditions of
+     * the operation and not an opinion about it: a caller that could supply them could also
+     * forget to. `refusalToSleep` is where each one is spelled out.
+     *
      * The flush comes before the pause on purpose: one that hangs then leaves a microVM that is
      * still serving, where a pause first would freeze the tenant for the whole of it. It is what
      * makes this a durability point at all — `ignore_fsync` has already made the guest's own
@@ -175,6 +194,18 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       slot,
     }: SuspendRequest) {
       yield* Effect.annotateCurrentSpan({ appId });
+      const record = (yield* agentState.snapshot).records.get(appId);
+      const refusal = refusalToSleep(
+        record && {
+          stopRequested: record.stopRequested,
+          desiredRunning: record.desiredRunning,
+          everHealthy: record.health.everHealthy,
+        },
+      );
+      if (refusal !== undefined) {
+        return yield* new SleepRefused({ reason: refusal });
+      }
+
       const paths = snapshotFor(appId);
       const socketPath = apiSocket(appId);
       const stamp = yield* currentStamp({ deploymentId, slot });
@@ -221,39 +252,38 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       const socketPath = apiSocket(appId);
       const expected = yield* currentStamp({ deploymentId, slot });
       yield* Effect.onError(ensureLoadable({ stampPath: paths.stampPath, expected }), () =>
-        discardSnapshot(appId).pipe(
-          Effect.catchAll((error) =>
-            Effect.logWarning('stale snapshot could not be discarded', error).pipe(
-              Effect.annotateLogs({ appId }),
-            ),
-          ),
-        ),
+        forgetSnapshot(appId),
       );
 
       yield* Systemd.start(appId);
-      yield* Effect.onError(
-        Effect.gen(function* () {
-          yield* Firecracker.loadSnapshot({
-            socketPath,
-            statePath: paths.statePath,
-            memoryPath: paths.memoryPath,
-          });
-          yield* Firecracker.resume(socketPath);
-          yield* refreshNeighbour({
-            guestIpv4: slot.guestIpv4,
-            guestMac: slot.guestMac,
-            tapName: slot.tapName,
-          });
-        }),
-        // The start already consumed the stamp, so this Firecracker holds no guest and never
-        // will: stopping it is what leaves a cold boot rather than a process in the way of one.
-        () => Effect.ignore(Systemd.stop(appId)),
+      yield* Effect.ensuring(
+        Effect.onError(
+          Effect.gen(function* () {
+            yield* Firecracker.loadSnapshot({
+              socketPath,
+              statePath: paths.statePath,
+              memoryPath: paths.memoryPath,
+            });
+            yield* Firecracker.resume(socketPath);
+            yield* refreshNeighbour({
+              guestIpv4: slot.guestIpv4,
+              guestMac: slot.guestMac,
+              tapName: slot.tapName,
+            });
+          }),
+          // The start already consumed the stamp, so this Firecracker holds no guest and never
+          // will: stopping it is what leaves a cold boot rather than a process in the way of one.
+          () => Effect.ignore(Systemd.stop(appId)),
+        ),
+        // Every way out, so no retry of a restore that failed halfway can find the files it did
+        // not finish with. The stamp is already gone and would stop a second load on its own;
+        // this is what keeps at-most-once from resting on that single fact.
+        //
+        // Unlinking while Firecracker still has the memory file mapped keeps the mapping alive
+        // and hands the disk back the moment the microVM exits, so the successful path pays
+        // nothing for it either.
+        forgetSnapshot(appId),
       );
-
-      // Unlinked while Firecracker still has the memory file mapped, which keeps the mapping
-      // alive and hands the disk back the moment the microVM exits. Leaving the files would put
-      // the burden of removing them on every path that stops a VM instead.
-      yield* discardSnapshot(appId);
       yield* Effect.logInfo('instance awake').pipe(Effect.annotateLogs({ appId, slot: slot.slot }));
     });
 
@@ -276,5 +306,10 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       }),
     };
   }),
-  dependencies: [AgentConfig.Default, TenantLogReceiver.Default, ZerofsTopology.Default],
+  dependencies: [
+    AgentConfig.Default,
+    AgentState.Default,
+    TenantLogReceiver.Default,
+    ZerofsTopology.Default,
+  ],
 }) {}

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -49,10 +49,12 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
     const agentState = yield* AgentState;
 
     const workingDir = (appId: AppId) => vmWorkingDir({ vmDir: config.vmDir, appId });
-    const snapshotFor = (appId: AppId) =>
-      snapshotPaths({ snapshotDir: config.vmSnapshotDir, appId });
-    const apiSocket = (appId: AppId) =>
-      Systemd.vmApiSocketPath({ runtimeDir: config.runtimeDir, appId });
+    function snapshotFor(appId: AppId) {
+      return snapshotPaths({ snapshotDir: config.vmSnapshotDir, appId });
+    }
+    function apiSocket(appId: AppId) {
+      return Systemd.vmApiSocketPath({ runtimeDir: config.runtimeDir, appId });
+    }
 
     /**
      * The stamp a snapshot taken now would carry, and the one a stored snapshot has to match to
@@ -83,14 +85,15 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
     });
 
     /** Where the caller has a failure of its own to report and a leaked snapshot is the lesser one. */
-    const forgetSnapshot = (appId: AppId) =>
-      discardSnapshot(appId).pipe(
+    function forgetSnapshot(appId: AppId) {
+      return discardSnapshot(appId).pipe(
         Effect.catchAll((error) =>
           Effect.logWarning('snapshot could not be discarded', error).pipe(
             Effect.annotateLogs({ appId }),
           ),
         ),
       );
+    }
 
     /**
      * The agent never becomes the VM's parent: it stages the files, asks init to start the unit,

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -1,17 +1,26 @@
 import { FileSystem, Path } from '@effect/platform';
-import type { AppId, DesiredInstance } from '@repo/protocol';
+import type { AppId, DeploymentId, DesiredInstance } from '@repo/protocol';
 import { Effect } from 'effect';
 import { writeJsonFile } from '#lib/json-store.ts';
 import { tenantLogSocketPath } from '#lib/logs/vsock.ts';
 import type { AppSlot } from '#lib/network/slot.ts';
-import { ensureTap } from '#lib/network/tap.ts';
+import { ensureTap, refreshNeighbour } from '#lib/network/tap.ts';
+import { readHostVersions } from '#lib/report/versions.ts';
 import * as Artifacts from '#lib/vm/artifacts.ts';
+import * as Firecracker from '#lib/vm/firecracker-api.ts';
 import { renderFirecrackerConfig } from '#lib/vm/firecracker-config.ts';
 import { buildInstanceConfigImage } from '#lib/vm/instance-env.ts';
+import {
+  ensureLoadable,
+  readHostBootId,
+  type SnapshotStamp,
+  snapshotPaths,
+} from '#lib/vm/snapshot.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { GUEST_VSOCK_FILENAME, vmWorkingDir } from '#lib/vm/vsock.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { TenantLogReceiver } from '#services/tenant-log-receiver.service.ts';
+import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
 
 export const FIRECRACKER_CONFIG_FILENAME = 'firecracker.json';
 export const GUEST_KERNEL_FILENAME = 'vmlinux';
@@ -20,14 +29,54 @@ export const GUEST_ROOTFS_FILENAME = 'rootfs.ext4';
 const VM_DIR_MODE = 0o700;
 const FIRST_GUEST_CID = 3;
 
+/** What both halves of a suspend need to name the microVM they are acting on. */
+type SuspendRequest = {
+  readonly appId: AppId;
+  readonly deploymentId: DeploymentId;
+  readonly slot: AppSlot;
+};
+
 export class VmManager extends Effect.Service<VmManager>()('VmManager', {
   effect: Effect.gen(function* () {
     const config = yield* AgentConfig;
     const path = yield* Path.Path;
     const fs = yield* FileSystem.FileSystem;
     const logs = yield* TenantLogReceiver;
+    const zerofs = yield* ZerofsTopology;
 
     const workingDir = (appId: AppId) => vmWorkingDir({ vmDir: config.vmDir, appId });
+    const snapshotFor = (appId: AppId) =>
+      snapshotPaths({ snapshotDir: config.vmSnapshotDir, appId });
+    const apiSocket = (appId: AppId) =>
+      Systemd.vmApiSocketPath({ runtimeDir: config.runtimeDir, appId });
+
+    /**
+     * The stamp a snapshot taken now would carry, and the one a stored snapshot has to match to
+     * be loadable. Both readings are of the host as it is at this moment rather than as it was
+     * when the agent started, because a deploy moves the guest image under a running agent.
+     */
+    const currentStamp = Effect.fn('VmManager.currentStamp')(function* ({
+      deploymentId,
+      slot,
+    }: Omit<SuspendRequest, 'appId'>) {
+      const versions = yield* readHostVersions(config.versionsFile);
+      return {
+        deploymentId,
+        guestImageVersion: versions.guestImage,
+        hostBootId: yield* readHostBootId,
+        slot: slot.slot,
+      } satisfies SnapshotStamp;
+    });
+
+    /**
+     * The stamp first and on its own: while it is there a start takes the snapshot beside it as
+     * an instruction, and once it is gone none of what remains is loadable by anything.
+     */
+    const discardSnapshot = Effect.fn('VmManager.discardSnapshot')(function* (appId: AppId) {
+      const paths = snapshotFor(appId);
+      yield* fs.remove(paths.stampPath, { force: true });
+      yield* fs.remove(paths.directory, { recursive: true, force: true });
+    });
 
     /**
      * The agent never becomes the VM's parent: it stages the files, asks init to start the unit,
@@ -45,6 +94,10 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       yield* Effect.annotateCurrentSpan({
         appId: desired.appId,
       });
+      // Ahead of everything, because everything below replaces what a snapshot of this app was
+      // taken against — and a start that still found a stamp would restore the old guest onto
+      // the new deployment's disk rather than boot the new one.
+      yield* discardSnapshot(desired.appId);
       const artifactImagePath = yield* Artifacts.ensureArtifactImage(desired.artifact);
       yield* ensureTap({
         tapName: slot.tapName,
@@ -103,17 +156,125 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       );
     });
 
+    /**
+     * A microVM taken down at a point it can be put back on, rather than one taken down.
+     *
+     * The flush comes before the pause on purpose: one that hangs then leaves a microVM that is
+     * still serving, where a pause first would freeze the tenant for the whole of it. It is what
+     * makes this a durability point at all — `ignore_fsync` has already made the guest's own
+     * fsync a no-op — and it has to hold even for the snapshot that is later discarded, because
+     * that app cold-boots off its disk and finds only what was flushed.
+     *
+     * The stamp is written last, once the microVM is down and the files beside it are complete.
+     * Nothing before that point is loadable, which is what makes every way this can fail leave a
+     * cold boot rather than a half-restore.
+     */
+    const sleep = Effect.fn('VmManager.sleep')(function* ({
+      appId,
+      deploymentId,
+      slot,
+    }: SuspendRequest) {
+      yield* Effect.annotateCurrentSpan({ appId });
+      const paths = snapshotFor(appId);
+      const socketPath = apiSocket(appId);
+      const stamp = yield* currentStamp({ deploymentId, slot });
+
+      yield* discardSnapshot(appId);
+      yield* fs.makeDirectory(paths.directory, { recursive: true, mode: VM_DIR_MODE });
+      yield* zerofs.flushAll;
+
+      yield* Firecracker.pause(socketPath);
+      yield* Effect.onError(
+        Effect.gen(function* () {
+          yield* Firecracker.createSnapshot({
+            socketPath,
+            statePath: paths.statePath,
+            memoryPath: paths.memoryPath,
+          });
+          yield* Systemd.stop(appId);
+        }),
+        // A microVM left paused answers nothing and is never asked to run again.
+        () => Effect.ignore(Firecracker.resume(socketPath)),
+      );
+
+      yield* writeJsonFile({ path: paths.stampPath, value: stamp });
+      yield* Effect.logInfo('instance asleep').pipe(
+        Effect.annotateLogs({ appId, slot: slot.slot }),
+      );
+    });
+
+    /**
+     * The microVM that went to sleep, back where it was.
+     *
+     * The stamp is checked before anything starts, and a snapshot that fails the check is thrown
+     * away rather than left: it is unloadable from here on, and a stamp on disk is what a start
+     * reads to decide it is a restore. The start itself consumes the stamp, so every way this can
+     * fail past that point leaves the next start a cold boot.
+     */
+    const wake = Effect.fn('VmManager.wake')(function* ({
+      appId,
+      deploymentId,
+      slot,
+    }: SuspendRequest) {
+      yield* Effect.annotateCurrentSpan({ appId });
+      const paths = snapshotFor(appId);
+      const socketPath = apiSocket(appId);
+      const expected = yield* currentStamp({ deploymentId, slot });
+      yield* Effect.onError(ensureLoadable({ stampPath: paths.stampPath, expected }), () =>
+        discardSnapshot(appId).pipe(
+          Effect.catchAll((error) =>
+            Effect.logWarning('stale snapshot could not be discarded', error).pipe(
+              Effect.annotateLogs({ appId }),
+            ),
+          ),
+        ),
+      );
+
+      yield* Systemd.start(appId);
+      yield* Effect.onError(
+        Effect.gen(function* () {
+          yield* Firecracker.loadSnapshot({
+            socketPath,
+            statePath: paths.statePath,
+            memoryPath: paths.memoryPath,
+          });
+          yield* Firecracker.resume(socketPath);
+          yield* refreshNeighbour({
+            guestIpv4: slot.guestIpv4,
+            guestMac: slot.guestMac,
+            tapName: slot.tapName,
+          });
+        }),
+        // The start already consumed the stamp, so this Firecracker holds no guest and never
+        // will: stopping it is what leaves a cold boot rather than a process in the way of one.
+        () => Effect.ignore(Systemd.stop(appId)),
+      );
+
+      // Unlinked while Firecracker still has the memory file mapped, which keeps the mapping
+      // alive and hands the disk back the moment the microVM exits. Leaving the files would put
+      // the burden of removing them on every path that stops a VM instead.
+      yield* discardSnapshot(appId);
+      yield* Effect.logInfo('instance awake').pipe(Effect.annotateLogs({ appId, slot: slot.slot }));
+    });
+
     return {
       workingDir,
       boot,
-      stop: Systemd.stop,
+      sleep,
+      wake,
+      /** Before the stop, so a stop that fails leaves a running microVM and never a stale snapshot. */
+      stop: Effect.fn('VmManager.stop')(function* (appId: AppId) {
+        yield* discardSnapshot(appId);
+        yield* Systemd.stop(appId);
+      }),
       discard: Effect.fn('VmManager.discard')(function* (appId: AppId) {
         yield* Effect.annotateCurrentSpan({ appId });
+        yield* discardSnapshot(appId);
         yield* Systemd.forget(appId);
         yield* logs.detach(appId);
         yield* fs.remove(workingDir(appId), { recursive: true, force: true });
       }),
     };
   }),
-  dependencies: [AgentConfig.Default, TenantLogReceiver.Default],
+  dependencies: [AgentConfig.Default, TenantLogReceiver.Default, ZerofsTopology.Default],
 }) {}

--- a/apps/agent/src/services/zerofs-topology.service.ts
+++ b/apps/agent/src/services/zerofs-topology.service.ts
@@ -1,6 +1,7 @@
 import { ObjectKeySchema, Value } from '@repo/protocol';
 import { Effect } from 'effect';
 import type { ZerofsFilesystem } from '#lib/volumes/topology.ts';
+import { flush } from '#lib/volumes/zerofs.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 
 /**
@@ -32,7 +33,28 @@ export class ZerofsTopology extends Effect.Service<ZerofsTopology>()('ZerofsTopo
         admin: { binary: config.zerofsBinary, configFile: config.zerofsConfigFile },
       },
     ];
-    return { place: () => filesystems[0], all: filesystems };
+    /**
+     * Every filesystem on the host brought to a durability point. Under `ignore_fsync` the guest's
+     * own flushes are a no-op, so this is the whole of what stands between a microVM going down —
+     * stopped or asleep — and the loss of everything since the last periodic flush.
+     *
+     * Best-effort per filesystem, and deliberately: a microVM nothing could take down because a
+     * flush failed is worse than one taken down having lost what the flush would have saved.
+     */
+    const flushAll = Effect.forEach(
+      filesystems,
+      (filesystem) =>
+        flush(filesystem.admin).pipe(
+          Effect.catchAll((error) =>
+            Effect.logWarning('zerofs flush failed', error).pipe(
+              Effect.annotateLogs({ storagePrefix: filesystem.storagePrefix }),
+            ),
+          ),
+        ),
+      { discard: true },
+    ).pipe(Effect.withSpan('ZerofsTopology.flushAll'));
+
+    return { place: () => filesystems[0], all: filesystems, flushAll };
   }),
   dependencies: [AgentConfig.Default],
 }) {}

--- a/apps/agent/tests/lib/vm/firecracker-api.test.ts
+++ b/apps/agent/tests/lib/vm/firecracker-api.test.ts
@@ -49,11 +49,13 @@ function servingApi({ socketPath, fault }: { socketPath: string; fault?: string 
   );
 }
 
-const files = ({ socketPath }: { socketPath: string }) => ({
-  socketPath,
-  statePath: '/data/nibrun-vm/app/vmstate',
-  memoryPath: '/data/nibrun-vm/app/memory',
-});
+function files({ socketPath }: { socketPath: string }) {
+  return {
+    socketPath,
+    statePath: '/data/nibrun-vm/app/vmstate',
+    memoryPath: '/data/nibrun-vm/app/memory',
+  };
+}
 
 function against({
   fault,

--- a/apps/agent/tests/lib/vm/firecracker-api.test.ts
+++ b/apps/agent/tests/lib/vm/firecracker-api.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { Duration, Effect, Fiber } from 'effect';
+import {
+  createSnapshot,
+  type FirecrackerApiError,
+  loadSnapshot,
+  pause,
+  resume,
+} from '#lib/vm/firecracker-api.ts';
+import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
+
+const run = provided(platform);
+
+const HTTP_NO_CONTENT = 204;
+const HTTP_BAD_REQUEST = 400;
+
+/** Long enough that the load has certainly failed to connect at least once before anything binds. */
+const LATE_BIND_MS = 100;
+
+type ReceivedCall = { readonly method: string; readonly path: string; readonly body: unknown };
+
+/**
+ * A listening unix socket rather than a substituted `fetch`: the request Firecracker would have
+ * to recognise is the thing under test, and the only honest way to read one is to receive it.
+ */
+function servingApi({ socketPath, fault }: { socketPath: string; fault?: string }) {
+  const received: ReceivedCall[] = [];
+  return Effect.as(
+    Effect.acquireRelease(
+      Effect.sync(() =>
+        Bun.serve({
+          unix: socketPath,
+          fetch: async (request) => {
+            received.push({
+              method: request.method,
+              path: new URL(request.url).pathname,
+              body: await request.json(),
+            });
+            return fault === undefined
+              ? new Response(null, { status: HTTP_NO_CONTENT })
+              : Response.json({ fault_message: fault }, { status: HTTP_BAD_REQUEST });
+          },
+        }),
+      ),
+      (server) => Effect.asVoid(Effect.sync(() => server.stop(true))),
+    ),
+    received,
+  );
+}
+
+const files = ({ socketPath }: { socketPath: string }) => ({
+  socketPath,
+  statePath: '/data/nibrun-vm/app/vmstate',
+  memoryPath: '/data/nibrun-vm/app/memory',
+});
+
+function against({
+  fault,
+  call,
+}: {
+  fault?: string;
+  call: (socketPath: string) => Effect.Effect<void, FirecrackerApiError>;
+}) {
+  return run(
+    Effect.gen(function* () {
+      const socketPath = join(yield* temporaryDirectory, 'vm.sock');
+      const received = yield* servingApi({ socketPath, ...(fault === undefined ? {} : { fault }) });
+      const outcome = yield* Effect.either(call(socketPath));
+      return { received, outcome };
+    }),
+  );
+}
+
+// Firecracker 1.16.1 mounts one method on /vm and rejects the other outright, and the two
+// snapshot bodies name fields a neighbouring version spells differently — so what is asserted
+// here is the wire shape rather than that this module can reach a socket.
+describe('the requests are the ones Firecracker 1.16.1 answers', () => {
+  test('a pause and a resume are both PATCH on /vm', async () => {
+    const { received } = await against({
+      call: (socketPath) => Effect.andThen(pause(socketPath), resume(socketPath)),
+    });
+    expect(received).toEqual([
+      { method: 'PATCH', path: '/vm', body: { state: 'Paused' } },
+      { method: 'PATCH', path: '/vm', body: { state: 'Resumed' } },
+    ]);
+  });
+
+  test('a create names both files and asks for a full snapshot', async () => {
+    const { received } = await against({
+      call: (socketPath) => createSnapshot(files({ socketPath })),
+    });
+    expect(received[0]).toEqual({
+      method: 'PUT',
+      path: '/snapshot/create',
+      body: {
+        snapshot_path: '/data/nibrun-vm/app/vmstate',
+        mem_file_path: '/data/nibrun-vm/app/memory',
+        snapshot_type: 'Full',
+      },
+    });
+  });
+
+  // The two spellings are mutually exclusive: sending both is a refusal rather than a preference.
+  test('a load carries mem_backend and never the deprecated mem_file_path', async () => {
+    const { received } = await against({
+      call: (socketPath) => loadSnapshot(files({ socketPath })),
+    });
+    expect(received[0]).toEqual({
+      method: 'PUT',
+      path: '/snapshot/load',
+      body: {
+        snapshot_path: '/data/nibrun-vm/app/vmstate',
+        mem_backend: { backend_type: 'File', backend_path: '/data/nibrun-vm/app/memory' },
+      },
+    });
+  });
+});
+
+test("a refusal is reported as the VMM's own account of it", async () => {
+  const { outcome } = await against({
+    fault: 'Cannot pause microVM',
+    call: (socketPath) => pause(socketPath),
+  });
+  expect(outcome._tag === 'Left' && outcome.left.message).toContain('Cannot pause microVM');
+});
+
+// systemd calls a Type=exec unit started at the exec, which is before Firecracker has bound
+// anything — so the first call of a restore has to outlast a socket that is not there yet.
+test('a load waits for a Firecracker that has not bound its socket', async () => {
+  await run(
+    Effect.gen(function* () {
+      const socketPath = join(yield* temporaryDirectory, 'vm.sock');
+      const loading = yield* Effect.fork(loadSnapshot(files({ socketPath })));
+      yield* Effect.sleep(Duration.millis(LATE_BIND_MS));
+      const received = yield* servingApi({ socketPath });
+      yield* Fiber.join(loading);
+      expect(received).toHaveLength(1);
+    }),
+  );
+});

--- a/apps/agent/tests/lib/vm/firecracker-api.test.ts
+++ b/apps/agent/tests/lib/vm/firecracker-api.test.ts
@@ -112,8 +112,19 @@ describe('the requests are the ones Firecracker 1.16.1 answers', () => {
       body: {
         snapshot_path: '/data/nibrun-vm/app/vmstate',
         mem_backend: { backend_type: 'File', backend_path: '/data/nibrun-vm/app/memory' },
+        clock_realtime: true,
       },
     });
+  });
+
+  // Asserted on its own because the default is silent breakage: kvmclock is the guest's only
+  // wall clock, so a load that omitted this would restore a guest as far in the past as it slept
+  // and every certificate it checked would read as not yet valid.
+  test('a load advances the guest clock by the time it was asleep', async () => {
+    const { received } = await against({
+      call: (socketPath) => loadSnapshot(files({ socketPath })),
+    });
+    expect(received[0]?.body).toHaveProperty('clock_realtime', true);
   });
 });
 

--- a/apps/agent/tests/lib/vm/snapshot.test.ts
+++ b/apps/agent/tests/lib/vm/snapshot.test.ts
@@ -7,6 +7,7 @@ import {
   driftFrom,
   ensureLoadable,
   readStamp,
+  refusalToSleep,
   SNAPSHOT_STAMP_FILENAME,
   type SnapshotStamp,
   snapshotPaths,
@@ -82,6 +83,40 @@ describe('every way a snapshot stops being loadable is named', () => {
     expect(driftFrom({ stored: { ...stamp, slot: SLOT + 1 }, expected: stamp })).toContain(
       'another slot',
     );
+  });
+});
+
+// Both refusals are about surviving the wake, not about whether sleeping is a good idea — and
+// both are enforced against the agent's own record rather than asked of the caller, because the
+// caller is the part that changes.
+describe('the moments a microVM must not be snapshotted', () => {
+  const sleepable = { stopRequested: false, desiredRunning: true, everHealthy: true };
+
+  // The bar is having answered, not being well now: the dangerous window closed the first time
+  // the tenant accepted a connection, and going unhealthy since does not reopen it.
+  test('an app that has answered at least once is sleepable', () => {
+    expect(refusalToSleep(sleepable)).toBeUndefined();
+  });
+
+  // `clock_realtime` moves CLOCK_MONOTONIC forward with the clocksource, so the guest
+  // supervisor's SIGTERM-to-SIGKILL deadline would land in the past on the first poll after a
+  // wake and kill a tenant that was shutting down cleanly.
+  test('one already asked to stop is refused', () => {
+    expect(refusalToSleep({ ...sleepable, stopRequested: true })).toContain('asked to stop');
+  });
+
+  test('so is one the control plane no longer wants running', () => {
+    expect(refusalToSleep({ ...sleepable, desiredRunning: false })).toContain('asked to stop');
+  });
+
+  // Firecracker injects the VMGenID interrupt before vCPUs resume, and a kernel snapshotted
+  // before its interrupt handling was in place can crash taking it — fatally, under `panic=1`.
+  test('one that has never answered may not have finished booting', () => {
+    expect(refusalToSleep({ ...sleepable, everHealthy: false })).toContain('finished booting');
+  });
+
+  test('an app this host holds no record of is refused rather than assumed healthy', () => {
+    expect(refusalToSleep(undefined)).toBeDefined();
   });
 });
 

--- a/apps/agent/tests/lib/vm/snapshot.test.ts
+++ b/apps/agent/tests/lib/vm/snapshot.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { DeploymentIdSchema, Value } from '@repo/protocol';
+import { Effect, Option } from 'effect';
+import { writeJsonFile } from '#lib/json-store.ts';
+import {
+  driftFrom,
+  ensureLoadable,
+  readStamp,
+  SNAPSHOT_STAMP_FILENAME,
+  type SnapshotStamp,
+  snapshotPaths,
+} from '#lib/vm/snapshot.ts';
+import { APP_ID, DEPLOYMENT_ID } from '#tests/support/fixtures.ts';
+import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
+
+const run = provided(platform);
+
+const SLOT = 7;
+const OTHER_DEPLOYMENT_ID = Value.Parse(DeploymentIdSchema, 'dep-2');
+
+const stamp: SnapshotStamp = {
+  deploymentId: DEPLOYMENT_ID,
+  guestImageVersion: '2026.08.01',
+  hostBootId: 'b6b8f0d2-0000-4000-8000-000000000001',
+  slot: SLOT,
+};
+
+const stampedIn = (directory: string) => join(directory, SNAPSHOT_STAMP_FILENAME);
+
+test('a snapshot is three files under the app it belongs to', () => {
+  const paths = snapshotPaths({ snapshotDir: '/data/nibrun-vm', appId: APP_ID });
+  expect(paths.directory).toBe(`/data/nibrun-vm/${APP_ID}`);
+  expect(paths.stampPath).toBe(stampedIn(paths.directory));
+  expect(
+    [paths.statePath, paths.memoryPath].every((file) => file.startsWith(paths.directory)),
+  ).toBe(true);
+});
+
+// A stamp is host-local state some earlier agent wrote, so anything but the shape this one reads
+// has to come back as no stamp at all — which is a cold boot rather than a guessed restore.
+describe('a stamp is read back only when it is whole', () => {
+  test('a complete one round-trips', () => {
+    expect(readStamp(JSON.parse(JSON.stringify(stamp)))).toEqual(Option.some(stamp));
+  });
+
+  test('a missing field is no stamp', () => {
+    expect(readStamp({ ...stamp, hostBootId: undefined })).toEqual(Option.none());
+  });
+
+  test('neither is a slot that came back as text', () => {
+    expect(readStamp({ ...stamp, slot: String(SLOT) })).toEqual(Option.none());
+  });
+});
+
+// Each of these is a way the files a snapshot names get replaced underneath it, and Firecracker
+// restores drive paths out of the vmstate without checking any of them.
+describe('every way a snapshot stops being loadable is named', () => {
+  test('an identical stamp has not drifted', () => {
+    expect(driftFrom({ stored: stamp, expected: stamp })).toBeUndefined();
+  });
+
+  test('a redeploy has replaced the artifact image and the instance config', () => {
+    expect(
+      driftFrom({ stored: { ...stamp, deploymentId: OTHER_DEPLOYMENT_ID }, expected: stamp }),
+    ).toContain('deployed again');
+  });
+
+  test('a guest image change has moved the kernel and the rootfs under one path', () => {
+    expect(
+      driftFrom({ stored: { ...stamp, guestImageVersion: '2026.09.01' }, expected: stamp }),
+    ).toContain('guest image');
+  });
+
+  test('a reboot has renumbered the NBD devices', () => {
+    expect(driftFrom({ stored: { ...stamp, hostBootId: 'another' }, expected: stamp })).toContain(
+      'rebooted',
+    );
+  });
+
+  test('a moved slot has taken the tap, the address and the MAC with it', () => {
+    expect(driftFrom({ stored: { ...stamp, slot: SLOT + 1 }, expected: stamp })).toContain(
+      'another slot',
+    );
+  });
+});
+
+describe('what a wake checks before anything is started', () => {
+  test('a stamp matching the host as it is now passes', async () => {
+    await run(
+      Effect.gen(function* () {
+        const stampPath = stampedIn(yield* temporaryDirectory);
+        yield* writeJsonFile({ path: stampPath, value: stamp });
+        yield* ensureLoadable({ stampPath, expected: stamp });
+      }),
+    );
+  });
+
+  test('a host that has rebooted since keeps nothing loadable', async () => {
+    const outcome = await run(
+      Effect.gen(function* () {
+        const stampPath = stampedIn(yield* temporaryDirectory);
+        yield* writeJsonFile({ path: stampPath, value: stamp });
+        return yield* Effect.either(
+          ensureLoadable({ stampPath, expected: { ...stamp, hostBootId: 'after-a-reboot' } }),
+        );
+      }),
+    );
+    expect(outcome._tag === 'Left' && outcome.left.message).toContain('rebooted');
+  });
+
+  test('an app this host kept no snapshot of is refused rather than guessed at', async () => {
+    const outcome = await run(
+      Effect.gen(function* () {
+        const stampPath = stampedIn(yield* temporaryDirectory);
+        return yield* Effect.either(ensureLoadable({ stampPath, expected: stamp }));
+      }),
+    );
+    expect(outcome._tag === 'Left' && outcome.left._tag).toBe('SnapshotUnusable');
+  });
+});

--- a/apps/agent/tests/lib/vm/snapshot.test.ts
+++ b/apps/agent/tests/lib/vm/snapshot.test.ts
@@ -27,7 +27,9 @@ const stamp: SnapshotStamp = {
   slot: SLOT,
 };
 
-const stampedIn = (directory: string) => join(directory, SNAPSHOT_STAMP_FILENAME);
+function stampedIn(directory: string) {
+  return join(directory, SNAPSHOT_STAMP_FILENAME);
+}
 
 test('a snapshot is three files under the app it belongs to', () => {
   const paths = snapshotPaths({ snapshotDir: '/data/nibrun-vm', appId: APP_ID });

--- a/infra/app-host/deploy/vm_launch.sh
+++ b/infra/app-host/deploy/vm_launch.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Which Firecracker a start of nibrun-vm@%i is.
+#
+# The two are not one process with a flag. `--config-file` boots a fresh microVM
+# the moment it is read, and a restore has to reach a process that has configured
+# nothing at all — `PUT /snapshot/load` is refused by a Firecracker that has been
+# given any resource but a logger. So the choice is made before exec, here,
+# rather than by the agent after the fact.
+#
+# A launcher and not a second template unit, because the unit name is what the
+# agent enumerates, stops and reads a guest's console out of: two of them would
+# double every one of those questions to answer none of them better.
+set -euo pipefail
+
+instance=$1
+
+FIRECRACKER=/opt/nibrun/bin/firecracker/firecracker
+API_SOCK="/run/nibrun/vm-${instance}.sock"
+CONFIG_FILE="/var/lib/nibrun/vm/${instance}/firecracker.json"
+# AGENT_VM_SNAPSHOT_DIR's default in apps/agent. Nothing compares the two.
+SNAPSHOT_DIR="/data/nibrun-vm/${instance}"
+
+# The stamp is the marker, and taking it is what makes a restore happen at most
+# once. The agent writes it only after the microVM is down and the two files
+# beside it are complete, so its presence is the whole guarantee that there is
+# something to load; removing it here means an agent that dies between this exec
+# and the load leaves a microVM that cold-boots off its disk, rather than one
+# that resumes into a guest whose disk has since moved on without it.
+if [ -f "$SNAPSHOT_DIR/stamp.json" ]; then
+  rm -f "$SNAPSHOT_DIR/stamp.json"
+  exec "$FIRECRACKER" --api-sock "$API_SOCK"
+fi
+
+exec "$FIRECRACKER" --api-sock "$API_SOCK" --config-file "$CONFIG_FILE"

--- a/infra/app-host/deploy/vm_launch.sh
+++ b/infra/app-host/deploy/vm_launch.sh
@@ -26,6 +26,14 @@ SNAPSHOT_DIR="/data/nibrun-vm/${instance}"
 # something to load; removing it here means an agent that dies between this exec
 # and the load leaves a microVM that cold-boots off its disk, rather than one
 # that resumes into a guest whose disk has since moved on without it.
+#
+# At most once is also a security invariant, so this `rm` is not tidying up. The
+# guest kernel has CONFIG_VMGENID=y and Linux reseeds its own CRNG on a restore,
+# but nothing reseeds the PRNG state already sitting in tenant memory — an
+# OpenSSL RAND buffer, a runtime's generator, a nonce already drawn. Loading one
+# snapshot into two microVMs is the same randomness live in both, which is key
+# reuse that nothing shows up as. Anyone turning this into a reusable warm-start
+# template is trading that away, and should be doing it on purpose.
 if [ -f "$SNAPSHOT_DIR/stamp.json" ]; then
   rm -f "$SNAPSHOT_DIR/stamp.json"
   exec "$FIRECRACKER" --api-sock "$API_SOCK"

--- a/infra/app-host/systemd/nibrun-vm@.service
+++ b/infra/app-host/systemd/nibrun-vm@.service
@@ -17,9 +17,11 @@ WorkingDirectory=/var/lib/nibrun/vm/%i
 # a unit at a time, so nothing can be listening on it when this runs.
 ExecStartPre=-/bin/rm -f /run/nibrun/vm-%i.sock
 ExecStartPre=-/bin/rm -f /var/lib/nibrun/vm/%i/logs.vsock
-ExecStart=/opt/nibrun/bin/firecracker/firecracker \
-  --api-sock /run/nibrun/vm-%i.sock \
-  --config-file /var/lib/nibrun/vm/%i/firecracker.json
+# A launcher rather than the binary, because a start is one of two things and only
+# one of them may name a config file: a fresh boot, or a restore of the snapshot
+# the agent left when it put this microVM to sleep. It `exec`s Firecracker, so
+# what Type=exec waits for and what KillSignal reaches are still the VMM itself.
+ExecStart=/opt/nibrun/bundle/vm_launch.sh %i
 
 # No restart here on purpose. The guest's own init supervises the tenant process
 # with backoff and powers the VM off once that budget is exhausted, and the agent

--- a/packages/internal-scripts/src/publish-app-host-bundle.ts
+++ b/packages/internal-scripts/src/publish-app-host-bundle.ts
@@ -17,7 +17,7 @@ const BUNDLE_DIRECTORIES = ['systemd', 'zerofs', 'caddy'];
 // Shell, not TypeScript: these run on the box, which has no Bun. Flattened to the
 // bundle root next to the directories above, because the deploy script resolves
 // everything relative to itself.
-const ON_BOX_SCRIPTS = ['on_box_deploy.sh', 'ensure_ephemeral_data.sh'];
+const ON_BOX_SCRIPTS = ['on_box_deploy.sh', 'ensure_ephemeral_data.sh', 'vm_launch.sh'];
 
 // Shared with the control plane's bundle: Cloudflare's origin-pull CA is one
 // certificate, and both proxies authenticate the same edge against it.


### PR DESCRIPTION
The machinery for Firecracker snapshot sleep/wake: an API client over the per-VM socket the unit has always created and nothing has ever used, `VmManager.sleep`/`wake`, and a launcher the unit execs so a start can be a restore instead of a boot.

A snapshot is stamped with the deployment, guest image version, host boot id and slot it was taken against, and refused rather than loaded when any of them has moved — Firecracker restores drive paths out of the vmstate without checking them, so a mismatch is corruption rather than a crash.

Nothing calls sleep or wake yet: the trigger, the decision and the `idle` state are separate PRs.