### PR TITLE
fix(runtime): a boot test that fails on an apostrophe is not a result

### DIFF
--- a/apps/runtime/test.sh
+++ b/apps/runtime/test.sh
@@ -43,6 +43,10 @@ require() {
 }
 
 contains() { grep -qF "$2" <<<"$1"; }
+# Not `bash -c "! grep ... <<<'$haystack'"`: that reopens the captured output as
+# shell source, so one apostrophe in a tenant's log line ends the run as a syntax
+# error rather than as a result.
+lacks() { ! contains "$1" "$2"; }
 
 echo '=== unit tests ==='
 # Never cached: a test whose result was reused is a test that did not run, and these
@@ -82,8 +86,7 @@ mounts=$(docker exec "$container" cat /proc/1/mounts)
 require 'the artifact is read-only and the data filesystem is not' \
   contains "$mounts" '/mnt/artifact squashfs ro,nosuid,nodev'
 require 'the tenant volume is mounted noatime' contains "$mounts" '/app/data ext4 rw,nosuid,nodev,noatime'
-require 'the config drive, which carries the secrets, is gone' \
-  bash -c "! grep -q /run/config <<<'$mounts'"
+require 'the config drive, which carries the secrets, is gone' lacks "$mounts" /run/config
 
 echo "PID 1 memory: $(docker exec "$container" grep VmRSS /proc/1/status)"
 
@@ -93,7 +96,7 @@ require 'the guest ends the machine rather than lingering' [ "$exit_code" = 129 
 
 logs=$(docker logs "$container" 2>&1)
 require 'the tenant was asked to stop and did' contains "$logs" 'the tenant has stopped'
-require 'no tenant had to be killed' bash -c "! grep -q 'killing it' <<<'$logs'"
+require 'no tenant had to be killed' lacks "$logs" 'killing it'
 
 image=$(mktemp "${TMPDIR:-/tmp}/nibrun-data.XXXXXX")
 docker cp "$container:/images/data.ext4" "$image" >/dev/null

--- a/infra/guest-image/AGENTS.md
+++ b/infra/guest-image/AGENTS.md
@@ -75,9 +75,16 @@ pay for it by naming every divergence in `kernel/config-drift.allow`.
 
 That file is enforced: every assignment in the base config must survive into the generated
 `.config` unless listed there or deliberately overridden. The whole measured divergence is
-thirteen lines. The only one worth knowing: `CONFIG_SYSGENID`, which tells userspace to reseed
-its RNG after a snapshot restore. **nibrun takes no Firecracker snapshots — if it ever does,
-this is the missing symbol and the reason to move onto the Amazon Linux source tree.**
+fifteen lines. The only one worth knowing: `CONFIG_SYSGENID`, the generation counter userspace
+watches to reseed a PRNG of its own after a snapshot restore. The kernel's half is already
+covered by `CONFIG_VMGENID=y`, so `getrandom()` comes back fresh; what is missing duplicates
+nothing unless **one snapshot is restored more than once**, which is an invariant to hold rather
+than a symbol to chase.
+
+Enforcement runs the other way too, which is worth knowing before generating a `.config` to
+settle an argument: a symbol the base config sets and `config-drift.allow` does not list is
+already guaranteed to be in the built kernel. `CONFIG_PTP_1588_CLOCK_KVM=y` is one of those —
+the guest has `/dev/ptp0` without `nibrun.config` asking for it.
 
 `assert-config.sh` exists because kconfig drops a symbol whose dependencies are unmet **without
 failing**. A fragment is a request, not a guarantee, and the classic way to lose virtio-blk is

--- a/infra/guest-image/kernel/config-drift.allow
+++ b/infra/guest-image/kernel/config-drift.allow
@@ -23,11 +23,15 @@ CONFIG_DMA_PAGE_TOUCHING
 # asserts.
 CONFIG_PTP_1588_CLOCK_VMCLOCK
 
-# Amazon Linux out-of-tree driver: /dev/sysgenid tells userspace to reseed its
-# RNG after a snapshot restore, because a restored VM replays entropy the
-# original already used. nibrun takes no Firecracker snapshots, so nothing reads
-# it. **If snapshots are ever adopted, this is the missing symbol and the reason
-# to move the build onto the Amazon Linux source tree.**
+# Amazon Linux out-of-tree driver: /dev/sysgenid is the generation counter
+# userspace watches to know a snapshot was restored and reseed a PRNG of its own.
+# The kernel's half of that is already covered — CONFIG_VMGENID=y is in the base
+# config and asserted by nibrun.config, so Firecracker's generation-id interrupt
+# reseeds the CRNG before the vCPUs run and getrandom() comes back fresh. What is
+# left is a tenant that seeded its own PRNG and never asks the kernel again, and
+# that duplicates nothing unless one snapshot is restored more than once.
+# **Restore-once is the invariant that keeps this line cheap; giving it up is what
+# would make moving the build onto the Amazon Linux source tree worth it.**
 CONFIG_SYSGENID
 
 # Oversampling rate for the jitter entropy RNG; the symbol does not exist in

--- a/infra/guest-image/kernel/nibrun.config
+++ b/infra/guest-image/kernel/nibrun.config
@@ -71,6 +71,12 @@ CONFIG_PARAVIRT_CLOCK=y
 CONFIG_HW_RANDOM_VIRTIO=y
 CONFIG_RANDOM_TRUST_CPU=y
 
+# And reseeded after a snapshot restore, which hands the guest back entropy it has
+# already spent. Firecracker updates the generation id and injects its interrupt
+# before the vCPUs run; this is the driver that turns that into a CRNG reseed, and
+# it is asserted because config-drift.allow now leans on it being here.
+CONFIG_VMGENID=y
+
 # --- real changes to the base config below ---
 
 # The cmdline already carries `panic=1 reboot=k`, so a panic ends the VM and the


### PR DESCRIPTION
Two small things found while looking at what a Firecracker snapshot restore does to the guest.

The boot test's two negative assertions reopened captured guest output as shell source, so any
apostrophe in a log line ended the run as a syntax error instead of a result. Verified both ways:
with an apostrophe injected into the captured output the suite is red before the change and green
after.

The `CONFIG_SYSGENID` notes framed it as the symbol missing once snapshots are adopted. That is
misleading now: `CONFIG_VMGENID=y` already reseeds the CRNG before the vCPUs resume, so what
SYSGENID would add is a userspace-visible counter, and it only matters if one snapshot is
restored more than once. `nibrun.config` now asserts VMGENID, since the note leans on it — a
no-op merge today, confirmed by generating the `.config` on both sides and diffing (identical).

Also corrects "thirteen lines" of drift to fifteen, which was already stale on main.
