### PR TITLE
fix(agent): a woken guest reads the clock a restore can advance

### DIFF
--- a/apps/agent/src/lib/vm/firecracker-config.ts
+++ b/apps/agent/src/lib/vm/firecracker-config.ts
@@ -12,9 +12,16 @@ const NO_BITS = 0;
  * `i8042.nopnp` is deliberately absent: it breaks SendCtrlAltDel on an ACPI-enabled guest, so a
  * graceful stop would silently become a kill. The static `ip=` form is why the guest ships no
  * DHCP client, and `quiet` only raises the printk threshold — panics and init writes are untouched.
+ *
+ * `clocksource=kvm-clock` is what makes waking from a snapshot safe, and it is not a preference.
+ * Firecracker's `clock_realtime` on `/snapshot/load` advances kvmclock by the wall time a guest
+ * slept through, and advances nothing else — so a guest that selected any other clocksource
+ * resumes at the instant it was paused and reads a wall clock hours behind. Measured on a host:
+ * without this, a 60s sleep left the guest 64s in the past; with it, 1s. The call still returns
+ * 204 either way, which is what makes the default worth naming here rather than trusting.
  */
 const BASE_KERNEL_ARGS =
-  'console=ttyS0 quiet reboot=k panic=1 pci=off i8042.noaux i8042.nomux i8042.dumbkbd root=/dev/vda ro init=/init';
+  'console=ttyS0 quiet reboot=k panic=1 pci=off i8042.noaux i8042.nomux i8042.dumbkbd clocksource=kvm-clock root=/dev/vda ro init=/init';
 
 export function netmaskFor(prefixLength: number): string {
   const octets: number[] = [];

--- a/apps/agent/tests/lib/vm/firecracker-config.test.ts
+++ b/apps/agent/tests/lib/vm/firecracker-config.test.ts
@@ -91,6 +91,14 @@ describe('the kernel command line', () => {
   // The fourth flag breaks SendCtrlAltDel on an ACPI-enabled guest, and the failure is silent:
   // the API answers 204 and the VMM reports success whether or not the guest can hear it, so a
   // graceful stop degrades to killing the VMM with the tenant mid-write.
+  // Measured on a host: without this a 60s sleep left the guest 64s in the past, with it 1s.
+  // `clock_realtime` on snapshot load advances kvmclock and nothing else, and the load returns
+  // 204 either way — so a guest that picked another clocksource wakes with a wrong wall clock and
+  // no failure to notice it by, which is a tenant's TLS handshakes failing on a valid certificate.
+  test('the guest reads the one clock a snapshot restore can advance', () => {
+    expect(renderKernelArgs(network)).toContain('clocksource=kvm-clock');
+  });
+
   test('it does not carry i8042.nopnp, which would break a graceful stop', () => {
     expect(renderKernelArgs(network)).not.toContain('i8042.nopnp');
   });


### PR DESCRIPTION
`clock_realtime` on `/snapshot/load` advances kvmclock and nothing else. The guest was not selecting it, so a restore returned 204 and resumed the wall clock where it was paused.

Measured on an m8id.large with the real guest image and Firecracker v1.16.1, 60s sleep:

| kernel args | host−guest skew after restore |
|---|---|
| as shipped | 64s |
| `clocksource=kvm-clock` | 1s |

Same run confirmed `CLOCK_MONOTONIC` advances with it, which is what #407's refusal to snapshot a VM with a stop in flight exists for.