### PR TITLE
fix(agent): a snapshot may not spend the disk every app runs from

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -118,6 +118,8 @@ credentials, and the gap is wider than the test count suggests.
 - **No microVM has been slept or woken.** The API client is asserted against a listening unix
   socket, so the request shapes are the ones 1.16.1's swagger describes; that Firecracker accepts
   them, that a bare process restores a guest whose NBD drive was reattached under it, and that
-  `vm_launch.sh` picks the right mode under systemd are all questions only a host can answer.
+  `vm_launch.sh` picks the right mode under systemd are all questions only a host can answer. The
+  disk bound a sleep is refused by is arithmetic here; what `statfs` reports for a real `/data`,
+  and whether ZeroFS reads its own `disk_size_gb` as GiB or GB, are not.
 - **No test builds the full layer graph**, so a service wired wrong in `index.ts` is caught by
   `tsc` and by starting the binary, not by `bun test`.

--- a/apps/agent/src/lib/report/capacity.ts
+++ b/apps/agent/src/lib/report/capacity.ts
@@ -6,30 +6,39 @@ import { Effect } from 'effect';
 const BYTES_PER_MIB = 1_048_576;
 const NONE = 0;
 
-const filesystemBytes = ({
-  cacheDir,
-  of,
-}: {
-  cacheDir: string;
-  of: (stats: Awaited<ReturnType<typeof statfs>>) => number;
-}) =>
-  Effect.tryPromise(() => statfs(cacheDir)).pipe(
-    Effect.map(of),
-    Effect.orElseSucceed(() => NONE),
-  );
+export type FilesystemSpace = {
+  readonly totalBytes: number;
+  readonly availableBytes: number;
+};
 
-export const readAvailableCacheBytes = (cacheDir: string) =>
-  filesystemBytes({ cacheDir, of: (stats) => Number(stats.bavail) * Number(stats.bsize) });
+const UNMEASURED: FilesystemSpace = { totalBytes: NONE, availableBytes: NONE };
 
-export const readHostCapacity = (cacheDir: string): Effect.Effect<HostCapacity> =>
+/**
+ * Fails where the path cannot be stat'd, which a report can shrug off and a decision about what
+ * else may be written to that disk cannot: a zero there reads as a full disk, and a zero total
+ * reads as no disk at all.
+ */
+export const readFilesystemSpace = (directory: string) =>
   Effect.map(
-    filesystemBytes({ cacheDir, of: (stats) => Number(stats.blocks) * Number(stats.bsize) }),
-    (cacheBytes) => ({
-      vcpuCount: availableParallelism(),
-      memoryMib: Math.floor(totalmem() / BYTES_PER_MIB),
-      cacheBytes,
+    Effect.tryPromise(() => statfs(directory)),
+    (stats): FilesystemSpace => ({
+      totalBytes: Number(stats.blocks) * Number(stats.bsize),
+      availableBytes: Number(stats.bavail) * Number(stats.bsize),
     }),
   );
+
+const spaceOrUnmeasured = (directory: string) =>
+  readFilesystemSpace(directory).pipe(Effect.orElseSucceed(() => UNMEASURED));
+
+export const readAvailableCacheBytes = (cacheDir: string) =>
+  Effect.map(spaceOrUnmeasured(cacheDir), (space) => space.availableBytes);
+
+export const readHostCapacity = (cacheDir: string): Effect.Effect<HostCapacity> =>
+  Effect.map(spaceOrUnmeasured(cacheDir), (space) => ({
+    vcpuCount: availableParallelism(),
+    memoryMib: Math.floor(totalmem() / BYTES_PER_MIB),
+    cacheBytes: space.totalBytes,
+  }));
 
 const sum = (values: readonly number[]) => {
   let total = NONE;

--- a/apps/agent/src/lib/vm/snapshot.ts
+++ b/apps/agent/src/lib/vm/snapshot.ts
@@ -113,6 +113,107 @@ export function refusalToSleep(
   return undefined;
 }
 
+/**
+ * What the disk a snapshot goes on has to keep free for everything on it that is not one: a
+ * checkpoint server's four gigabytes while an export reads
+ * (`infra/app-host/zerofs/checkpoint.toml`), and slack for a filesystem nobody wants at 100%.
+ *
+ * Snapshots are the only consumer of that disk with a number to obey, so this is where the others
+ * get their room. It is held free *beyond* ZeroFS's configured cache rather than out of it —
+ * running out of instance store breaks ZeroFS, and ZeroFS is every app's disk on the host,
+ * sleeping or not.
+ */
+const DISK_RESERVE_GIB = 8;
+
+const BYTES_PER_MIB = 1_048_576;
+const BYTES_PER_GIB = 1_073_741_824;
+const DISK_RESERVE_BYTES = DISK_RESERVE_GIB * BYTES_PER_GIB;
+const GIB_DECIMALS = 1;
+const NONE = 0;
+
+/** The disk `snapshotDir` is on, as the decision to write another snapshot to it needs it. */
+export type SnapshotDisk = {
+  readonly totalBytes: number;
+  readonly availableBytes: number;
+  /** What ZeroFS may cache here, which is disk it has not taken yet rather than disk it is using. */
+  readonly zerofsCacheBytes: number;
+  /** What the snapshots already here hold. */
+  readonly snapshotBytes: number;
+};
+
+/** A memory file is exactly the guest's RAM. The vmstate beside it is kilobytes, and is slack. */
+export function snapshotBytesFor(memoryMib: number): number {
+  return memoryMib * BYTES_PER_MIB;
+}
+
+/** All the disk snapshots may ever hold together, floored at none for a host with no room at all. */
+export function snapshotBudget(disk: SnapshotDisk): number {
+  return Math.max(disk.totalBytes - disk.zerofsCacheBytes - DISK_RESERVE_BYTES, NONE);
+}
+
+function gibibytes(bytes: number): string {
+  return `${(bytes / BYTES_PER_GIB).toFixed(GIB_DECIMALS)} GiB`;
+}
+
+/**
+ * Why this host will not keep another snapshot, or `undefined` when it will.
+ *
+ * A snapshot is the size of the app's configured memory rather than of the default, so a host
+ * carrying a few multi-gigabyte apps runs out of instance store on its own. What that costs is
+ * not the sleeping apps: `/data` is where ZeroFS caches, and ZeroFS is the disk **every** app on
+ * the host is running from. A cost optimisation nobody opted into would be taking down apps that
+ * never sleep — so the two bounds below are what stands between it and them, and a refusal here
+ * costs one app one cold start it was not going to take anyway.
+ *
+ * Both bounds are needed and neither implies the other. The budget is against the disk's *size*,
+ * because ZeroFS fills its cache lazily: free space on a fresh host is space already promised.
+ * The floor is against what is *actually* free, because the promise is not the only claim — a
+ * checkpoint server's cache, an overshoot, anything else that arrived on this disk — and at the
+ * moment those have eaten it, adding a snapshot is the thing that must not happen.
+ */
+export function refusalForDisk({
+  disk,
+  wantedBytes,
+}: {
+  disk: SnapshotDisk;
+  wantedBytes: number;
+}): string | undefined {
+  const budget = snapshotBudget(disk);
+  if (disk.snapshotBytes + wantedBytes > budget) {
+    return `snapshots on this host may hold ${gibibytes(budget)} and already hold ${gibibytes(disk.snapshotBytes)}`;
+  }
+  if (disk.availableBytes - wantedBytes < DISK_RESERVE_BYTES) {
+    return `the disk it would be written to has ${gibibytes(disk.availableBytes)} left, which the filesystem every app runs from needs more than it does`;
+  }
+  return undefined;
+}
+
+/**
+ * What the snapshots on this host hold, measured rather than derived from the agent's own record
+ * of which apps are asleep: one an earlier agent left behind occupies the same disk as one this
+ * agent wrote, and the disk is what is running out.
+ */
+export const readSnapshotBytes = Effect.fn('snapshot.readSnapshotBytes')(function* (
+  snapshotDir: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const entries = yield* fs.readDirectory(snapshotDir, { recursive: true });
+  let held = NONE;
+  for (const entry of entries) {
+    held += yield* fileBytes(join(snapshotDir, entry));
+  }
+  return held;
+});
+
+/** A file gone between the listing and the stat is a snapshot being discarded — disk given back. */
+function fileBytes(path: string) {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.stat(path)),
+    Effect.map((info) => (info.type === 'File' ? Number(info.size) : NONE)),
+    Effect.orElseSucceed(() => NONE),
+  );
+}
+
 export type SnapshotPaths = {
   readonly directory: string;
   readonly statePath: string;

--- a/apps/agent/src/lib/volumes/zerofs.ts
+++ b/apps/agent/src/lib/volumes/zerofs.ts
@@ -1,6 +1,14 @@
 import type { CheckpointId } from '@repo/protocol';
-import { Effect } from 'effect';
+import { Data, Effect, Option } from 'effect';
+import { readTextFile } from '#lib/json-store.ts';
 import { stdoutOf } from '#services/command-runner.service.ts';
+
+/**
+ * ZeroFS's `gb` read as GiB, the larger of the two it could mean. The reading is only ever used
+ * to hold disk back for it, and reserving five gigabytes too many costs a cold boot where
+ * reserving five too few costs the cache every app on the host runs from.
+ */
+const BYTES_PER_CONFIGURED_GB = 1_073_741_824;
 
 /**
  * ZeroFS is a long-running service this agent does not own. Restarting it stalls every attached
@@ -37,6 +45,43 @@ export const deleteCheckpoint = Effect.fn('zerofs.deleteCheckpoint')(
 export const listCheckpoints = Effect.fn('zerofs.listCheckpoints')((target: ZerofsAdmin) =>
   Effect.map(admin({ target, args: ['checkpoint', 'list'] }), parseCheckpointNames),
 );
+
+export class ZerofsCacheUnknown extends Data.TaggedError('ZerofsCacheUnknown')<{
+  readonly path: string;
+}> {
+  override get message() {
+    return `${this.path} does not say how much disk ZeroFS may cache on`;
+  }
+}
+
+/**
+ * How much of the disk ZeroFS is entitled to, read out of the file it is itself started with
+ * rather than written down a second time here. It grows into that number lazily, so a disk that
+ * looks empty today is one whose free space is already spoken for — and anything else that writes
+ * to the same disk has to hold this much back rather than what ZeroFS happens to be holding now.
+ */
+export const readCacheDiskBytes = Effect.fn('zerofs.readCacheDiskBytes')(function* (
+  configFile: string,
+) {
+  const configured = Option.flatMap(yield* readTextFile(configFile), cacheDiskGigabytes);
+  if (Option.isNone(configured)) {
+    return yield* new ZerofsCacheUnknown({ path: configFile });
+  }
+  return configured.value * BYTES_PER_CONFIGURED_GB;
+});
+
+/** `[cache] disk_size_gb`, or nothing at all: a value this cannot read is not one to guess at. */
+export function cacheDiskGigabytes(config: string): Option.Option<number> {
+  try {
+    const { cache } = Bun.TOML.parse(config) as { cache?: { disk_size_gb?: unknown } };
+    const configured = cache?.disk_size_gb;
+    return typeof configured === 'number' && configured > 0
+      ? Option.some(configured)
+      : Option.none();
+  } catch {
+    return Option.none();
+  }
+}
 
 export function parseCheckpointNames(output: string): string[] {
   return output

--- a/apps/agent/src/services/agent-config.service.ts
+++ b/apps/agent/src/services/agent-config.service.ts
@@ -11,7 +11,9 @@ const DEFAULT_ZEROFS_NBD_SOCKET = '/run/zerofs/nbd.sock';
 const DEFAULT_ZEROFS_CHECKPOINT_RUNTIME_DIR = '/run/zerofs-checkpoint';
 /**
  * On the instance store, because a snapshot is a cache: losing one costs a cold boot and nothing
- * else. It budgets ~256 MiB a slot against a disk ZeroFS already keeps a 70 GB cache on.
+ * else. It shares that disk with the ZeroFS cache every app on the host reads and writes through,
+ * so what may accumulate here is bounded — `refusalForDisk` in `lib/vm/snapshot.ts` is the bound,
+ * and it is why an app's memory being far larger than the default cannot fill the disk.
  *
  * `vm_launch.sh` spells this path too, and nothing compares the two — a start reads the directory
  * to decide whether it is a restore or a cold boot, so moving one is moving both.

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -1,10 +1,11 @@
 import { FileSystem, Path } from '@effect/platform';
 import type { AppId, DeploymentId, DesiredInstance } from '@repo/protocol';
-import { Effect } from 'effect';
+import { Effect, Either } from 'effect';
 import { writeJsonFile } from '#lib/json-store.ts';
 import { tenantLogSocketPath } from '#lib/logs/vsock.ts';
 import type { AppSlot } from '#lib/network/slot.ts';
 import { ensureTap, refreshNeighbour } from '#lib/network/tap.ts';
+import { readFilesystemSpace } from '#lib/report/capacity.ts';
 import { readHostVersions } from '#lib/report/versions.ts';
 import * as Artifacts from '#lib/vm/artifacts.ts';
 import * as Firecracker from '#lib/vm/firecracker-api.ts';
@@ -13,13 +14,19 @@ import { buildInstanceConfigImage } from '#lib/vm/instance-env.ts';
 import {
   ensureLoadable,
   readHostBootId,
+  readSnapshotBytes,
+  refusalForDisk,
   refusalToSleep,
   SleepRefused,
+  type SnapshotDisk,
   type SnapshotStamp,
+  snapshotBudget,
+  snapshotBytesFor,
   snapshotPaths,
 } from '#lib/vm/snapshot.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { GUEST_VSOCK_FILENAME, vmWorkingDir } from '#lib/vm/vsock.ts';
+import { readCacheDiskBytes } from '#lib/volumes/zerofs.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { TenantLogReceiver } from '#services/tenant-log-receiver.service.ts';
@@ -174,12 +181,69 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
     });
 
     /**
-     * A microVM taken down at a point it can be put back on, rather than one taken down.
+     * The disk this host's snapshots are on, as the decision to write another one needs it. The
+     * directory is made first so a host that has never slept an app still measures the instance
+     * store rather than failing to stat a path that is not there yet.
+     */
+    const readSnapshotDisk = Effect.fn('VmManager.readSnapshotDisk')(function* () {
+      yield* fs.makeDirectory(config.vmSnapshotDir, { recursive: true, mode: VM_DIR_MODE });
+      const space = yield* readFilesystemSpace(config.vmSnapshotDir);
+      return {
+        ...space,
+        zerofsCacheBytes: yield* readCacheDiskBytes(config.zerofsConfigFile),
+        snapshotBytes: yield* readSnapshotBytes(config.vmSnapshotDir),
+      } satisfies SnapshotDisk;
+    });
+
+    /**
+     * Every reason this microVM must not be snapshotted now, or `undefined`.
      *
-     * The two states a snapshot must never be taken in are read from this agent's own record of
-     * the instance rather than accepted from the caller, because they are the preconditions of
-     * the operation and not an opinion about it: a caller that could supply them could also
-     * forget to. `refusalToSleep` is where each one is spelled out.
+     * The states a snapshot must never be taken in are read from this agent's own record of the
+     * instance rather than accepted from the caller, because they are the preconditions of the
+     * operation and not an opinion about it: a caller that could supply them could also forget
+     * to. `refusalToSleep` is where each one is spelled out, and `refusalForDisk` is what keeps a
+     * host's sleeping apps from filling the disk its running ones read and write through.
+     *
+     * A disk that cannot be measured refuses too. Sleeping is an optimisation and refusing it
+     * costs an app nothing it notices, so every doubt here resolves the same way.
+     */
+    const refusalToSnapshot = Effect.fn('VmManager.refusalToSnapshot')(function* (appId: AppId) {
+      const record = (yield* agentState.snapshot).records.get(appId);
+      if (record === undefined) {
+        return refusalToSleep(undefined);
+      }
+      const refusal = refusalToSleep({
+        stopRequested: record.stopRequested,
+        desiredRunning: record.desiredRunning,
+        everHealthy: record.health.everHealthy,
+      });
+      if (refusal !== undefined) {
+        return refusal;
+      }
+      const disk = yield* Effect.either(readSnapshotDisk());
+      if (Either.isLeft(disk)) {
+        yield* Effect.logWarning('snapshot disk could not be measured', disk.left).pipe(
+          Effect.annotateLogs({ appId }),
+        );
+        return 'the disk it would be written to cannot be measured';
+      }
+      // The one place these numbers exist. Nothing else on the fleet can be asked what snapshots
+      // are holding, so a sleep says it on the way past whether or not it is allowed to proceed.
+      yield* Effect.logInfo('snapshot disk measured').pipe(
+        Effect.annotateLogs({
+          appId,
+          ...disk.right,
+          budgetBytes: snapshotBudget(disk.right),
+        }),
+      );
+      return refusalForDisk({
+        disk: disk.right,
+        wantedBytes: snapshotBytesFor(record.resources.memoryMib),
+      });
+    });
+
+    /**
+     * A microVM taken down at a point it can be put back on, rather than one taken down.
      *
      * The flush comes before the pause on purpose: one that hangs then leaves a microVM that is
      * still serving, where a pause first would freeze the tenant for the whole of it. It is what
@@ -197,14 +261,7 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       slot,
     }: SuspendRequest) {
       yield* Effect.annotateCurrentSpan({ appId });
-      const record = (yield* agentState.snapshot).records.get(appId);
-      const refusal = refusalToSleep(
-        record && {
-          stopRequested: record.stopRequested,
-          desiredRunning: record.desiredRunning,
-          everHealthy: record.health.everHealthy,
-        },
-      );
+      const refusal = yield* refusalToSnapshot(appId);
       if (refusal !== undefined) {
         return yield* new SleepRefused({ reason: refusal });
       }

--- a/apps/agent/tests/lib/vm/snapshot.test.ts
+++ b/apps/agent/tests/lib/vm/snapshot.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { DeploymentIdSchema, Value } from '@repo/protocol';
 import { Effect, Option } from 'effect';
@@ -6,10 +7,15 @@ import { writeJsonFile } from '#lib/json-store.ts';
 import {
   driftFrom,
   ensureLoadable,
+  readSnapshotBytes,
   readStamp,
+  refusalForDisk,
   refusalToSleep,
   SNAPSHOT_STAMP_FILENAME,
+  type SnapshotDisk,
   type SnapshotStamp,
+  snapshotBudget,
+  snapshotBytesFor,
   snapshotPaths,
 } from '#lib/vm/snapshot.ts';
 import { APP_ID, DEPLOYMENT_ID } from '#tests/support/fixtures.ts';
@@ -119,6 +125,110 @@ describe('the moments a microVM must not be snapshotted', () => {
 
   test('an app this host holds no record of is refused rather than assumed healthy', () => {
     expect(refusalToSleep(undefined)).toBeDefined();
+  });
+});
+
+const GIB = 1_073_741_824;
+const DEFAULT_MEMORY_MIB = 256;
+const A_GENEROUS_MEMORY_MIB = 4_096;
+const SLOTS = 63;
+const NOTHING = 0;
+
+/** An app host as the fleet runs it: 110 GiB of instance store, 70 GiB of it ZeroFS's. */
+const INSTANCE_STORE_GIB = 110;
+const ZEROFS_CACHE_GIB = 70;
+const WARM_HOST_FREE_GIB = 38;
+
+const hostDisk: SnapshotDisk = {
+  totalBytes: INSTANCE_STORE_GIB * GIB,
+  availableBytes: WARM_HOST_FREE_GIB * GIB,
+  zerofsCacheBytes: ZEROFS_CACHE_GIB * GIB,
+  snapshotBytes: NOTHING,
+};
+
+const NEARLY_SPENT_GIB = 30;
+/** A cache ZeroFS has not grown into yet, so the disk looks emptier than it is. */
+const COLD_CACHE_FREE_GIB = 105;
+/** A checkpoint server reading an export, and the disk down to the reserve. */
+const CROWDED_FREE_GIB = 8;
+
+const ONE_MEMORY_FILE_BYTES = 1_024;
+const ANOTHER_MEMORY_FILE_BYTES = 512;
+
+// The bound exists for the disk rather than for the snapshots: /data is where ZeroFS caches, so a
+// disk snapshots filled is every app on the host losing the filesystem it runs from — including
+// every app that never sleeps.
+describe('what snapshots may hold on a host', () => {
+  test('a host asleep in every slot at the default memory size is nowhere near the bound', () => {
+    const asleep = SLOTS * snapshotBytesFor(DEFAULT_MEMORY_MIB);
+    expect(asleep).toBeLessThan(snapshotBudget(hostDisk));
+    expect(
+      refusalForDisk({
+        disk: { ...hostDisk, snapshotBytes: asleep },
+        wantedBytes: snapshotBytesFor(DEFAULT_MEMORY_MIB),
+      }),
+    ).toBeUndefined();
+  });
+
+  // A snapshot is the size of the app's configured memory and not of the default, which is what
+  // makes a bound necessary at all: a few of these are the disk.
+  test('an app that asked for gigabytes is refused once they would not fit', () => {
+    expect(
+      refusalForDisk({
+        disk: { ...hostDisk, snapshotBytes: NEARLY_SPENT_GIB * GIB },
+        wantedBytes: snapshotBytesFor(A_GENEROUS_MEMORY_MIB),
+      }),
+    ).toContain('already hold');
+  });
+
+  // ZeroFS grows into its cache lazily, so the free space on a fresh host is already spoken for.
+  test('the budget is against the size of the disk, not what is free on it today', () => {
+    expect(
+      refusalForDisk({
+        disk: {
+          ...hostDisk,
+          availableBytes: COLD_CACHE_FREE_GIB * GIB,
+          snapshotBytes: NEARLY_SPENT_GIB * GIB,
+        },
+        wantedBytes: snapshotBytesFor(A_GENEROUS_MEMORY_MIB),
+      }),
+    ).toBeDefined();
+  });
+
+  // And the other way: the budget is untouched and the disk is gone anyway — a checkpoint server
+  // reading an export, or a cache that overshot.
+  test('a disk something else has eaten refuses a snapshot the budget would allow', () => {
+    expect(
+      refusalForDisk({
+        disk: { ...hostDisk, availableBytes: CROWDED_FREE_GIB * GIB, snapshotBytes: GIB },
+        wantedBytes: snapshotBytesFor(DEFAULT_MEMORY_MIB),
+      }),
+    ).toContain('every app');
+  });
+
+  test('a disk that cannot hold the cache alone has no budget rather than a negative one', () => {
+    expect(snapshotBudget({ ...hostDisk, totalBytes: NOTHING })).toBe(NOTHING);
+  });
+
+  // Read off the disk rather than from the agent's record of which apps are asleep: a snapshot
+  // some earlier agent left behind occupies the disk exactly as one this agent wrote does.
+  test('what snapshots hold is measured from the directory they are in', async () => {
+    const held = await run(
+      Effect.gen(function* () {
+        const snapshotDir = yield* temporaryDirectory;
+        yield* Effect.promise(async () => {
+          await mkdir(join(snapshotDir, 'inst-1'), { recursive: true });
+          await writeFile(join(snapshotDir, 'inst-1', 'memory'), 'x'.repeat(ONE_MEMORY_FILE_BYTES));
+          await mkdir(join(snapshotDir, 'inst-2'), { recursive: true });
+          await writeFile(
+            join(snapshotDir, 'inst-2', 'memory'),
+            'x'.repeat(ANOTHER_MEMORY_FILE_BYTES),
+          );
+        });
+        return yield* readSnapshotBytes(snapshotDir);
+      }),
+    );
+    expect(held).toBe(ONE_MEMORY_FILE_BYTES + ANOTHER_MEMORY_FILE_BYTES);
   });
 });
 

--- a/apps/agent/tests/lib/volumes/zerofs.test.ts
+++ b/apps/agent/tests/lib/volumes/zerofs.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { CheckpointIdSchema, Value } from '@repo/protocol';
-import { Effect } from 'effect';
+import { Effect, Option } from 'effect';
 import {
+  cacheDiskGigabytes,
   createCheckpoint,
   deleteCheckpoint,
   flush,
@@ -11,6 +14,9 @@ import {
 import { recordingCommands } from '#tests/support/commands.ts';
 
 const BINARY = '/opt/nibrun/bin/zerofs/zerofs';
+/** What `infra/app-host/zerofs/config.toml` and `checkpoint.toml` hold this host's disk at. */
+const DEPLOYED_CACHE_GIB = 70;
+const CHECKPOINT_CACHE_GIB = 4;
 const target = { binary: BINARY, configFile: '/etc/z.toml' };
 const checkpointId = Value.Parse(CheckpointIdSchema, 'cp-1');
 
@@ -41,4 +47,31 @@ describe('ZeroFS is invoked where the deploy put it', () => {
 
 test('only the checkpoint name is read off each line', () => {
   expect(parseCheckpointNames('cp-1  2026-08-04\n\n cp-2 \n')).toEqual(['cp-1', 'cp-2']);
+});
+
+/**
+ * How much of the instance store is not the agent's to spend. Against the committed config rather
+ * than a fixture, because the value only means anything if it comes out of the file the deploy
+ * puts on the host — a renamed key or a moved section is this reading silently going missing.
+ */
+describe('the disk ZeroFS is entitled to is read out of its own config', () => {
+  test('the config an app host is deployed with says what it says', async () => {
+    const config = await readFile(
+      join(import.meta.dir, '../../../../../infra/app-host/zerofs/config.toml'),
+      'utf8',
+    );
+    expect(cacheDiskGigabytes(config)).toEqual(Option.some(DEPLOYED_CACHE_GIB));
+  });
+
+  // ZeroFS expands these itself, so what is on disk is never the config it ends up running with.
+  test('a config whose variable references are still unexpanded parses anyway', () => {
+    const unexpanded = `[cache]\ndisk_size_gb = ${CHECKPOINT_CACHE_GIB}.0\n\n[storage]\nurl = "\${NIBRUN_FILESYSTEMS_URL}"\n`;
+    expect(cacheDiskGigabytes(unexpanded)).toEqual(Option.some(CHECKPOINT_CACHE_GIB));
+  });
+
+  // Nothing downstream may treat an unreadable number as a reason to help itself to the disk.
+  test('a file that is not a config, or a config without the key, reads as nothing', () => {
+    expect(cacheDiskGigabytes('not a config at all {')).toEqual(Option.none());
+    expect(cacheDiskGigabytes('[cache]\ndir = "/data/zerofs"\n')).toEqual(Option.none());
+  });
 });

--- a/infra/app-host/zerofs/checkpoint.toml
+++ b/infra/app-host/zerofs/checkpoint.toml
@@ -15,8 +15,12 @@ dir = "/data/zerofs-checkpoint/${NIBRUN_CHECKPOINT}"
 # only earns its size on bytes that are read twice, which here is the metadata
 # `debugfs` walks — inode tables, bitmaps, directory blocks — and not the file data
 # it copies out. Four gigabytes covers that for a filesystem far larger than any
-# one this host serves, and is small enough that an export cannot eat into the
-# headroom the live cache deliberately leaves on this disk.
+# one this host serves.
+#
+# The headroom the live cache leaves on this disk is no longer this server's alone —
+# microVM snapshots are written to it too — so an export keeps its room by the agent
+# holding it back rather than by nothing else wanting it. Growing this number means
+# growing DISK_RESERVE_GIB in apps/agent/src/lib/vm/snapshot.ts with it.
 disk_size_gb = 4.0
 # The default, written down because 2.0 sits in the file next to this one and
 # silence would read as an oversight rather than a decision.

--- a/infra/app-host/zerofs/config.toml
+++ b/infra/app-host/zerofs/config.toml
@@ -6,9 +6,18 @@
 # substitution is a string one.
 
 [cache]
-# The instance store, mounted at /data by nibrun-data.service. Sized well under the
-# disk so a full cache cannot fill it out from under the segments being written, and
-# so a checkpoint server's cache has room beside it.
+# The instance store, mounted at /data by nibrun-data.service — about 110 GiB on the
+# m8id.large this fleet runs. Sized well under the disk so a full cache cannot fill it
+# out from under the segments being written, and so the two other things on that disk
+# have room beside it: a checkpoint server's cache while an export reads, and the
+# microVM snapshots the agent writes under /data/nibrun-vm.
+#
+# This is the number that wins, and the agent reads it out of this file rather than
+# repeating it. What is left after it and the 8 GiB the agent holds back for the
+# checkpoint cache is the whole budget snapshots get; a sleep is refused once they
+# would exceed it. That asymmetry is the point — a snapshot lost costs one cold boot,
+# where a full /data breaks the filesystem every app on the host runs from, asleep or
+# not.
 dir = "/data/zerofs"
 disk_size_gb = 70.0
 memory_size_gb = 2.0


### PR DESCRIPTION
Snapshots and the ZeroFS cache share `/data`, and nothing bounded the snapshots. A snapshot is the size of the app's configured memory, so a host carrying a few multi-gigabyte apps fills the instance store on its own — which breaks ZeroFS, and ZeroFS is every app's disk on that host, not only the sleeping ones.

A sleep is now refused unless the snapshot fits a budget of the disk minus the cache ZeroFS is configured for (read out of `config.toml` rather than repeated) and an 8 GiB reserve for a checkpoint server, and unless it leaves that reserve actually free. A refusal costs one app one cold start; the numbers it decided on are logged on the way past.

**On `disk_size_gb = 70.0`:** left alone, and I think it should stay. Of the ~110 GiB measured on an `m8id.large` it now leaves 32 GiB for snapshots after the reserve — where a full host at the 256 MiB default wants 15.75 GiB, so the bound never fires on the density we actually run. Shrinking the cache to buy sleep room would trade every app's IO for a cold-start optimisation, which is the wrong direction; if large-memory apps ever need to sleep at scale, the lever is the instance store, not the cache.