### PR TITLE
feat(agent): a woken app is the microVM it had, not a new one

### DIFF
--- a/apps/agent/src/lib/reconcile/idle.ts
+++ b/apps/agent/src/lib/reconcile/idle.ts
@@ -1,6 +1,6 @@
 import type { AppId } from '@repo/protocol';
 import { Clock, Effect, Option } from 'effect';
-import { stopInstance } from '#lib/reconcile/instances.ts';
+import { suspendInstance } from '#lib/reconcile/instances.ts';
 import { applyNetwork } from '#lib/reconcile/network.ts';
 import type { InstanceRecord } from '#lib/report/instance-record.ts';
 import { AgentState } from '#services/agent-state.service.ts';
@@ -68,12 +68,12 @@ const idleTimeouts = Effect.gen(function* () {
 });
 
 /**
- * Stops the `on-request` apps nobody has asked for in a while.
+ * Puts the `on-request` apps nobody has asked for in a while to sleep.
  *
  * Runs on the measurement tick rather than the status one: the moment it reads is only written
- * there, so asking sixty times more often would be sixty readings of the same answer — and a stop
- * freezes a filesystem and waits on systemd, which is not work to put in front of the health
- * probes of every other app on the host.
+ * there, so asking sixty times more often would be sixty readings of the same answer — and a
+ * sleep freezes a filesystem, snapshots a microVM and waits on systemd, which is not work to put
+ * in front of the health probes of every other app on the host.
  */
 export const applySleep = Effect.gen(function* () {
   const timeouts = yield* idleTimeouts;
@@ -102,11 +102,20 @@ export const applySleep = Effect.gen(function* () {
             quietForMs: nowMs - (current.lastActiveAtMs.get(record.appId) ?? nowMs),
           }),
         )
-        .pipe(Effect.andThen(stopInstance({ appId: record.appId, reason: 'idle' }))),
+        .pipe(
+          Effect.andThen(
+            suspendInstance({
+              appId: record.appId,
+              deploymentId: record.deploymentId,
+              reason: 'idle',
+            }),
+          ),
+        ),
     { discard: true },
   );
   // Here rather than on the next status tick: the record already says the app is not running, so
   // until this runs the forward rule points at a guest that has gone, and a request arriving in
-  // that second is refused rather than answered by the activator.
+  // that second is refused rather than answered by the activator. A sleep that was refused leaves
+  // the record saying `running`, so this renders the forward it already had.
   yield* applyNetwork;
 });

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -1,5 +1,11 @@
-import type { AppId, DesiredInstance, InstanceState } from '@repo/protocol';
-import { Clock, Duration, Effect } from 'effect';
+import type {
+  AppId,
+  DeploymentId,
+  DesiredInstance,
+  InstanceState,
+  Timestamp,
+} from '@repo/protocol';
+import { Clock, Duration, Effect, Option } from 'effect';
 import { isReadyToRetry, nextAttemptWindow } from '#lib/backoff.ts';
 import { nowTimestamp } from '#lib/clock.ts';
 import { frozen } from '#lib/exports/freeze.ts';
@@ -35,21 +41,22 @@ const ONE_RESTART = 1;
 const NO_RESTART = 0;
 
 /**
- * A stop pulls the plug: the unit signals the VMM, and the guest is not asked to shut down
- * first. Freezing is what makes that survivable — the guest checkpoints its ext4 journal, so
- * the writes it had acknowledged are on the device rather than in a page cache that is about to
- * stop existing. The flush then carries them from ZeroFS to the bucket, and the freeze is held
- * across both, because a guest that thawed in between could write again behind the flush.
- *
- * Bounded and best-effort. A guest too wedged to answer is exactly the one that has to be
- * stopped, and it would otherwise hold up the deploy replacing it.
+ * Bounded and best-effort. A guest too wedged to answer is exactly the one that has to be taken
+ * down, and it would otherwise hold up the deploy replacing it.
  */
 const FREEZE_TIMEOUT_SECONDS = 5;
 const FREEZE_TIMEOUT = Duration.seconds(FREEZE_TIMEOUT_SECONDS);
 
-const settleAndStop = ({ appId, reason }: { appId: AppId; reason: string }) =>
+/**
+ * The disk brought to a point a cold boot can start from, which is what both ways down need first.
+ *
+ * A microVM is not asked to shut down: the unit signals the VMM, or the VMM is paused where it
+ * stands. Freezing is what makes either survivable — the guest checkpoints its ext4 journal, so
+ * the writes it had acknowledged are on the device rather than in a page cache that is about to
+ * stop existing — and the flush then carries them from ZeroFS to the bucket.
+ */
+const settled = ({ appId, reason }: { appId: AppId; reason: string }) =>
   Effect.gen(function* () {
-    const vms = yield* VmManager;
     const config = yield* AgentConfig;
     yield* frozen({ appId, vmDir: config.vmDir }).pipe(
       Effect.asVoid,
@@ -61,12 +68,45 @@ const settleAndStop = ({ appId, reason }: { appId: AppId; reason: string }) =>
       ),
     );
     yield* (yield* ZerofsTopology).flushAll;
+  });
+
+/** The freeze is held across the stop: a guest that thawed in between could write behind the flush. */
+const settleAndStop = ({ appId, reason }: { appId: AppId; reason: string }) =>
+  Effect.gen(function* () {
+    const vms = yield* VmManager;
+    yield* settled({ appId, reason });
     yield* vms.stop(appId).pipe(
       Effect.andThen(Effect.logInfo('instance stopped')),
       Effect.catchAll((error) => Effect.logError('instance stop failed', error)),
       Effect.annotateLogs({ appId, reason }),
     );
   }).pipe(Effect.scoped);
+
+/**
+ * The same settling, with the freeze handed back before the microVM is captured rather than after
+ * it is killed.
+ *
+ * The lease is the vsock connection, and a snapshot is the one way down that outlives the
+ * connection it was taken over: a guest captured mid-freeze comes back still holding it, with its
+ * tenant blocked on the first write and nothing left on the far side to release it. What the
+ * freeze bought is already bought — the journal is checkpointed and the bytes are in the bucket —
+ * and `VmManager.sleep` flushes again on its way past, so the writes made in the moment between
+ * the thaw and the pause are carried too.
+ */
+const settleAndSleep = ({
+  appId,
+  deploymentId,
+  slot,
+  reason,
+}: {
+  appId: AppId;
+  deploymentId: DeploymentId;
+  slot: AppSlot;
+  reason: string;
+}) =>
+  Effect.scoped(settled({ appId, reason })).pipe(
+    Effect.andThen(Effect.flatMap(VmManager, (vms) => vms.sleep({ appId, deploymentId, slot }))),
+  );
 
 export const stopInstance = Effect.fn('stopInstance')(function* ({
   appId,
@@ -84,6 +124,74 @@ export const stopInstance = Effect.fn('stopInstance')(function* ({
     appId,
     change: (record) => ({ ...record, state: 'stopped', startAttempts: NO_START_ATTEMPTS }),
   });
+});
+
+/**
+ * A microVM taken down at a point it can be put back on, so the next request restores the guest
+ * that was serving rather than booting a new one.
+ *
+ * `stopRequested` is written after the snapshot and never before it. `VmManager.sleep` refuses a
+ * microVM with a stop in flight — waking one lands the guest supervisor's SIGTERM deadline in the
+ * past — so setting the flag first, the way `stopInstance` does, would refuse every sleep this
+ * asked for. It still has to be written afterwards: it is what tells the health loop that a
+ * microVM that is gone is asleep rather than crashed, and what keeps the boot that follows a
+ * discarded snapshot from being counted as a restart.
+ *
+ * The state stays `running` for the whole of it rather than going to `stopping` the way a stop
+ * does. That keeps the forward rule pointing at the guest while it is being captured, which is
+ * what the requests still arriving want: withdrawing it would hand them to the activator, which
+ * would find the unit still up, take that as nothing to wake, and probe a paused guest until the
+ * grace period ran out.
+ *
+ * Neither a refusal nor a VMM that would not take the snapshot is a failure here. `sleep` leaves
+ * the microVM running either way and the record untouched, so the app goes on serving and the
+ * next measurement tick asks again — which is the safe end of this to be wrong at.
+ */
+export const suspendInstance = Effect.fn('suspendInstance')(function* ({
+  appId,
+  deploymentId,
+  reason,
+}: {
+  appId: AppId;
+  deploymentId: DeploymentId;
+  reason: string;
+}) {
+  yield* Effect.annotateCurrentSpan({ appId, reason });
+  const slot = yield* (yield* SlotAllocator).lookup(appId);
+  if (Option.isNone(slot)) {
+    // No slot is no tap, no address and no NBD minor for a restore to land on, so there is
+    // nothing a snapshot could be loaded against. Stopping still reclaims the memory.
+    return yield* stopInstance({ appId, reason });
+  }
+
+  yield* settleAndSleep({ appId, deploymentId, slot: slot.value, reason }).pipe(
+    Effect.andThen(
+      AgentState.updateRecord({
+        appId,
+        change: (record) => ({
+          ...record,
+          state: 'idle',
+          stopRequested: true,
+          startAttempts: NO_START_ATTEMPTS,
+          message: undefined,
+        }),
+      }),
+    ),
+    // Loud, and carrying which refusal it was. `hasGoneQuiet` has already excluded every reason
+    // `VmManager.sleep` can refuse for something about this app, so one that reaches here is
+    // either a stop that landed in the moment since the records were read or a refusal about the
+    // host itself — and the second is an operator's to go and look at rather than a tenant's.
+    Effect.catchTag('SleepRefused', (refusal) =>
+      Effect.logWarning(
+        `this microVM may not be snapshotted, so it stays up: ${refusal.reason}`,
+      ).pipe(Effect.annotateLogs({ appId, reason })),
+    ),
+    Effect.catchAll((error) =>
+      Effect.logWarning('this microVM would not sleep; leaving it up', error).pipe(
+        Effect.annotateLogs({ appId, reason }),
+      ),
+    ),
+  );
 });
 
 function setState({
@@ -221,6 +329,15 @@ export const sleepInstance = Effect.fn('sleepInstance')(function* (desired: Desi
   }
 });
 
+/** A microVM that has just come up is not left waiting on a delay measured for the one before it. */
+function probeAtOnce(appId: AppId) {
+  return AgentState.modify((current) => {
+    const nextProbeAtMs = new Map(current.nextProbeAtMs);
+    nextProbeAtMs.delete(appId);
+    return { ...current, nextProbeAtMs };
+  });
+}
+
 export const startInstance = Effect.fn('startInstance')(function* (desired: DesiredInstance) {
   yield* Effect.annotateCurrentSpan({ appId: desired.appId });
   const allocator = yield* SlotAllocator;
@@ -265,11 +382,7 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
           restartCount: attempted.restartCount + (restarted(existing) ? ONE_RESTART : NO_RESTART),
           message: undefined,
         });
-        yield* AgentState.modify((current) => {
-          const nextProbeAtMs = new Map(current.nextProbeAtMs);
-          nextProbeAtMs.delete(desired.appId);
-          return { ...current, nextProbeAtMs };
-        });
+        yield* probeAtOnce(desired.appId);
         yield* Effect.logInfo('instance started').pipe(
           Effect.annotateLogs({
             appId: desired.appId,
@@ -293,6 +406,82 @@ export const startInstance = Effect.fn('startInstance')(function* (desired: Desi
         );
       }),
   });
+});
+
+/**
+ * What a restore writes back, which is a great deal less than a start does.
+ *
+ * The health tracker is carried across rather than reset: it describes the guest being restored
+ * and is still true of it, where clearing it would say this app had never answered — the one
+ * thing that stops it being allowed to sleep again. `startedAt` is not carried across, because
+ * every health decision is measured from it and the grace period belongs to this run.
+ */
+function restored({ appId, startedAt }: { appId: AppId; startedAt: Timestamp }) {
+  return AgentState.updateRecord({
+    appId,
+    change: (record) => ({
+      ...record,
+      state: 'starting',
+      startedAt,
+      stopRequested: false,
+      message: undefined,
+    }),
+  }).pipe(Effect.andThen(probeAtOnce(appId)));
+}
+
+/**
+ * The microVM an idle app had, back where it was — and a cold boot only where there is nothing to
+ * come back to.
+ *
+ * None of the accounting a start does. No attempt is charged to the restart budget and
+ * `restartCount` does not move, because a wake is not a restart: an app woken every morning for a
+ * year would otherwise report three hundred crashes. The budget still bounds the damage, because
+ * the fallback below is a start and a start is what spends it — so a snapshot that will never
+ * load degrades into cold boots that give up, while a restore that works costs nothing.
+ *
+ * `SnapshotUnusable` is the only failure that boots instead. Every other one leaves the app down
+ * with the reason on its record: `VmManager.wake` discards the snapshot on its way out, so the
+ * request after this one is the cold boot rather than a second attempt at the same restore.
+ */
+export const resumeInstance = Effect.fn('resumeInstance')(function* (desired: DesiredInstance) {
+  yield* Effect.annotateCurrentSpan({ appId: desired.appId });
+  const allocator = yield* SlotAllocator;
+  const vms = yield* VmManager;
+  const slot = yield* allocator.allocate(desired.appId);
+
+  // Asked of systemd rather than of the record, because the record is a cache and this is a
+  // precondition: Firecracker takes `PUT /snapshot/load` only from a process that has configured
+  // nothing, and `systemctl start` on a unit already up is the no-op that would have let the load
+  // reach a booted microVM and be refused there. Nothing to wake is not a failure — whatever is
+  // waiting on this is about to be answered by the guest that is already there.
+  const unit = (yield* Systemd.statuses([desired.appId])).get(desired.appId) ?? UNKNOWN_UNIT;
+  if (unit.active) {
+    return;
+  }
+
+  // For the reason `startInstance` marks one before its boot: the clock this starts is the one
+  // that decides when the app may sleep again.
+  yield* AgentState.markActive({
+    appId: desired.appId,
+    nowMs: yield* Clock.currentTimeMillis,
+  });
+
+  yield* vms.wake({ appId: desired.appId, deploymentId: desired.deploymentId, slot }).pipe(
+    Effect.andThen(
+      Effect.flatMap(nowTimestamp, (startedAt) => restored({ appId: desired.appId, startedAt })),
+    ),
+    Effect.catchTag('SnapshotUnusable', (unusable) =>
+      Effect.logInfo('nothing to wake this app from; booting it instead', unusable)
+        .pipe(Effect.annotateLogs({ appId: desired.appId }))
+        .pipe(Effect.andThen(startInstance(desired))),
+    ),
+    Effect.tapError((error) =>
+      AgentState.updateRecord({
+        appId: desired.appId,
+        change: (record) => ({ ...record, message: reportedMessage(error) }),
+      }),
+    ),
+  );
 });
 
 /** Only a failure has anything to say: every other state is its own account of itself. */

--- a/apps/agent/src/lib/report/capacity.ts
+++ b/apps/agent/src/lib/report/capacity.ts
@@ -22,12 +22,17 @@ const filesystemBytes = ({
 export const readAvailableCacheBytes = (cacheDir: string) =>
   filesystemBytes({ cacheDir, of: (stats) => Number(stats.bavail) * Number(stats.bsize) });
 
+/** Read rather than remembered: a host is resized by being replaced, but the agent outlives less. */
+export function readHostMemoryMib(): number {
+  return Math.floor(totalmem() / BYTES_PER_MIB);
+}
+
 export const readHostCapacity = (cacheDir: string): Effect.Effect<HostCapacity> =>
   Effect.map(
     filesystemBytes({ cacheDir, of: (stats) => Number(stats.blocks) * Number(stats.bsize) }),
     (cacheBytes) => ({
       vcpuCount: availableParallelism(),
-      memoryMib: Math.floor(totalmem() / BYTES_PER_MIB),
+      memoryMib: readHostMemoryMib(),
       cacheBytes,
     }),
   );
@@ -38,8 +43,8 @@ export const readHostCapacity = (cacheDir: string): Effect.Effect<HostCapacity> 
  * `idle` belongs here for the reason the whole of `on-request` does: the memory a sleeping app is
  * not using is the saving, and a host that went on reserving it would pay for every sleep and
  * collect on none of them. What that costs is that the request waking an app can find the host
- * full in the meantime — a real failure mode, and one for the waker to answer rather than one to
- * hide by reserving memory nothing is using.
+ * full in the meantime — a real failure mode, and one the waker answers with `memoryShortfallMib`
+ * rather than one to hide by reserving memory nothing is using.
  */
 const HOLDS_NOTHING: readonly InstanceState[] = ['idle', 'stopped', 'failed'];
 
@@ -60,6 +65,10 @@ const sum = (values: readonly number[]) => {
   return total;
 };
 
+function committedMemoryMib(committed: readonly InstanceResources[]): number {
+  return sum(committed.map((entry) => entry.memoryMib));
+}
+
 /** Floored at zero: an oversubscribed host is a fact to report, not a number to do arithmetic with. */
 export function allocatableCapacity({
   capacity,
@@ -71,10 +80,32 @@ export function allocatableCapacity({
   availableCacheBytes: number;
 }): HostCapacity {
   const usedVcpu = sum(committed.map((entry) => entry.vcpuCount));
-  const usedMemory = sum(committed.map((entry) => entry.memoryMib));
   return {
     vcpuCount: Math.max(capacity.vcpuCount - usedVcpu, NONE),
-    memoryMib: Math.max(capacity.memoryMib - usedMemory, NONE),
+    memoryMib: Math.max(capacity.memoryMib - committedMemoryMib(committed), NONE),
     cacheBytes: Math.max(Math.min(availableCacheBytes, capacity.cacheBytes), NONE),
   };
+}
+
+/**
+ * How much more memory this host would need to carry one more microVM, and zero when it has room.
+ *
+ * Memory alone. vCPUs are time-shared, so a host that has sold more of them than it has runs
+ * everything on it more slowly; memory is the one it cannot divide, and a guest that does not fit
+ * is not refused but killed — along with whichever neighbour the kernel picks instead.
+ *
+ * The arithmetic `allocatableCapacity` reports, deliberately and not by coincidence: a host that
+ * refused wakes by one measure while telling the control plane it had room by another would go on
+ * being placed onto for exactly as long as it went on refusing.
+ */
+export function memoryShortfallMib({
+  hostMemoryMib,
+  committed,
+  wanted,
+}: {
+  hostMemoryMib: number;
+  committed: readonly InstanceResources[];
+  wanted: InstanceResources;
+}): number {
+  return Math.max(committedMemoryMib(committed) + wanted.memoryMib - hostMemoryMib, NONE);
 }

--- a/apps/agent/src/services/app-activator.service.ts
+++ b/apps/agent/src/services/app-activator.service.ts
@@ -34,6 +34,14 @@ const sayAppIsDown = () => say('This app is not running.');
 const sayAppWouldNotStart = () => say('This app could not be started.');
 
 /**
+ * Its own sentence rather than the one above. An app that could not be woken because its host had
+ * no memory left is not a broken app, and telling its visitor otherwise would have its owner
+ * reading a binary that is fine — while the repair, moving the app, is not something either of
+ * them can bring about by asking again.
+ */
+const sayHostIsFull = () => say('This app could not be started: its machine is out of memory.');
+
+/**
  * A connection the proxy wants to upgrade cannot be carried across: what comes back from the
  * guest here is one HTTP message, and a websocket is the opposite of that. The wake still
  * happens, so the client that reconnects finds the app up and reaches it through the forward
@@ -75,8 +83,9 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
 
     /**
      * A request that finds no microVM. For an app that runs on request it is the thing that
-     * starts one, and it waits here until the guest answers — which is a cold boot, seconds
-     * rather than milliseconds, and the whole reason the request is held rather than refused.
+     * brings one back, and it waits here until the guest answers — which is a snapshot restore
+     * where there is one to restore and a cold boot where there is not, and the second is the
+     * reason the request is held rather than refused.
      *
      * The record is read again after the wake because the wake is what wrote it: the port and
      * address to forward to are the ones the microVM that just came up is on.
@@ -103,6 +112,11 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
           httpPort: woken.httpPort,
         });
       }).pipe(
+        Effect.catchTag('HostHasNoRoom', (error) =>
+          Effect.logWarning('a request could not be given an app', error)
+            .pipe(Effect.annotateLogs({ appId }))
+            .pipe(Effect.as(sayHostIsFull())),
+        ),
         Effect.catchAll((error) =>
           Effect.logWarning('a request could not be given an app', error)
             .pipe(Effect.annotateLogs({ appId }))

--- a/apps/agent/src/services/app-waker.service.ts
+++ b/apps/agent/src/services/app-waker.service.ts
@@ -1,9 +1,10 @@
 import type { HttpClient } from '@effect/platform';
-import type { AppId } from '@repo/protocol';
+import type { AppId, DesiredInstance } from '@repo/protocol';
 import { Data, Deferred, Duration, Effect, Option, Ref, Schedule } from 'effect';
 import { reportedMessage } from '#lib/failure.ts';
 import { probeInstance } from '#lib/health/probe.ts';
-import { startInstance } from '#lib/reconcile/instances.ts';
+import { resumeInstance } from '#lib/reconcile/instances.ts';
+import { committedResources, memoryShortfallMib, readHostMemoryMib } from '#lib/report/capacity.ts';
 import type { InstanceRecord } from '#lib/report/instance-record.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
@@ -21,13 +22,15 @@ import { VmManager } from '#services/vm-manager.service.ts';
 const PROBE_INTERVAL_MS = 25;
 const PROBE_INTERVAL = Duration.millis(PROBE_INTERVAL_MS);
 
+const NO_SHORTFALL = 0;
+
 /**
- * Everything starting a microVM touches, taken from where this service is built rather than left
+ * Everything waking a microVM touches, taken from where this service is built rather than left
  * to whoever calls `wake`. The caller is a request handler bridged onto a Bun socket: it holds a
  * runtime, and a runtime has to name what is in it — so a requirement that escaped here would be
  * the whole agent, named again at that boundary and built a second time behind it.
  */
-type WakeContext = Effect.Effect.Context<ReturnType<typeof startInstance>> | HttpClient.HttpClient;
+type WakeContext = Effect.Effect.Context<ReturnType<typeof resumeInstance>> | HttpClient.HttpClient;
 
 export class WakeFailed extends Data.TaggedError('WakeFailed')<{
   readonly appId: AppId;
@@ -39,18 +42,43 @@ export class WakeFailed extends Data.TaggedError('WakeFailed')<{
 }
 
 /**
- * Brings an `on-request` app's microVM up because something asked for it, and does not come back
- * until the guest is answering — the request that caused this is waiting on it.
+ * Its own failure and not a `WakeFailed`, because it is not about this app at all: nothing is
+ * wrong with it, and nothing it or its owner can do will make it start here.
+ *
+ * The alternative was to evict a neighbour, and it is not one. Evicting makes one tenant's
+ * traffic a reason to take another tenant's app offline, and on a host that is already over its
+ * memory every wake evicts somebody whose next visitor evicts somebody else — it never settles.
+ * Refusing converges: the app stays down, its owner is told why, and the repair is to move it,
+ * which is placement's to make and not something a request can bring about.
+ */
+export class HostHasNoRoom extends Data.TaggedError('HostHasNoRoom')<{
+  readonly appId: AppId;
+  readonly shortfallMib: number;
+}> {
+  override get message() {
+    return `${this.appId} could not be woken: its host is ${this.shortfallMib} MiB short of the memory it needs`;
+  }
+}
+
+/**
+ * Brings an `on-request` app's microVM back because something asked for it, and does not come
+ * back until the guest is answering — the request that caused this is waiting on it.
+ *
+ * A restore where there is a snapshot to restore and a boot where there is not, which is the
+ * difference between tens of milliseconds and a second or so. Which one happened is
+ * `resumeInstance`'s to decide; what is decided here is whether it may happen at all.
  *
  * One wake per app at a time. A cold page load is a burst of requests, and every one of them
- * arrives to find no microVM: without this the first would boot it and the rest would each spend
- * the app's restart budget racing that boot.
+ * arrives to find no microVM: without this the first would bring it up and the rest would each
+ * spend the app's restart budget racing it.
  */
 export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
   effect: Effect.gen(function* () {
     const cache = yield* DesiredStateCache;
     const context = yield* Effect.context<WakeContext>();
-    const inFlight = yield* Ref.make(new Map<AppId, Deferred.Deferred<void, WakeFailed>>());
+    const inFlight = yield* Ref.make(
+      new Map<AppId, Deferred.Deferred<void, WakeFailed | HostHasNoRoom>>(),
+    );
 
     /**
      * The grace period is the deadline: past it the health loop would call the instance failed
@@ -77,6 +105,25 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
         Effect.asVoid,
       );
 
+    /**
+     * Whether this host can find the memory for one more microVM, asked of everything *else* it
+     * is holding: the app being woken is `idle`, so it commits nothing until it is up, and one
+     * that is somehow already running would otherwise be counted twice and refused its own room.
+     */
+    const refusalForRoom = Effect.fn('AppWaker.refusalForRoom')(function* (
+      wanted: DesiredInstance,
+    ) {
+      const others = (yield* AgentState.records).filter((record) => record.appId !== wanted.appId);
+      const shortfallMib = memoryShortfallMib({
+        hostMemoryMib: readHostMemoryMib(),
+        committed: committedResources(others),
+        wanted: wanted.config.resources,
+      });
+      return shortfallMib > NO_SHORTFALL
+        ? new HostHasNoRoom({ appId: wanted.appId, shortfallMib })
+        : undefined;
+    });
+
     const boot = Effect.fn('AppWaker.boot')(function* (appId: AppId) {
       const desired = yield* cache.latest;
       const wanted = Option.getOrUndefined(desired)?.instances.find(
@@ -94,17 +141,28 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
         return yield* new WakeFailed({ appId, reason: 'the isolation ruleset is not applied' });
       }
 
+      const noRoom = yield* refusalForRoom(wanted);
+      if (noRoom) {
+        // The record is the only account of this its owner will ever see, and left to say nothing
+        // it reads as an app asleep between requests — which is the one thing it is not.
+        yield* AgentState.updateRecord({
+          appId,
+          change: (record) => ({ ...record, message: noRoom.message }),
+        });
+        return yield* noRoom;
+      }
+
       // A slot table with nothing free is the one start failure a request can cause, and it is
       // this host's problem rather than this app's — so it is said in the same breath as any
       // other reason the microVM is not there.
-      yield* startInstance(wanted).pipe(
+      yield* resumeInstance(wanted).pipe(
         Effect.catchAll((error) => new WakeFailed({ appId, reason: reportedMessage(error) })),
       );
 
       const record = (yield* AgentState.snapshot).records.get(appId);
       if (!record?.startedAt) {
-        // A start that wrote no time never reached the VMM: the artifact would not fetch, or the
-        // restart budget was spent on boots that already failed.
+        // Neither half wrote a time, so neither reached the VMM: the artifact would not fetch,
+        // the restore was refused, or the restart budget was spent on boots that already failed.
         return yield* new WakeFailed({
           appId,
           reason: record?.message ?? 'the microVM would not start',
@@ -116,13 +174,13 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
 
     return {
       wake: Effect.fn('AppWaker.wake')(function* (appId: AppId) {
-        const claim = yield* Deferred.make<void, WakeFailed>();
+        const claim = yield* Deferred.make<void, WakeFailed | HostHasNoRoom>();
         const held = yield* Ref.modify(inFlight, (current) => {
           const existing = current.get(appId);
           return existing
             ? ([Option.some(existing), current] as const)
             : ([
-                Option.none<Deferred.Deferred<void, WakeFailed>>(),
+                Option.none<Deferred.Deferred<void, WakeFailed | HostHasNoRoom>>(),
                 new Map(current).set(appId, claim),
               ] as const);
         });

--- a/apps/agent/tests/lib/reconcile/instances.test.ts
+++ b/apps/agent/tests/lib/reconcile/instances.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, test } from 'bun:test';
 import { FetchHttpClient } from '@effect/platform';
 import { Deferred, Effect, Fiber, Layer } from 'effect';
-import { refreshStates } from '#lib/reconcile/instances.ts';
+import { refreshStates, resumeInstance, suspendInstance } from '#lib/reconcile/instances.ts';
+import { SleepRefused, SnapshotUnusable } from '#lib/vm/snapshot.ts';
 import { AgentState } from '#services/agent-state.service.ts';
+import { ArtifactStore, ArtifactTransferError } from '#services/artifact-store.service.ts';
 import { CommandRunner } from '#services/command-runner.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
+import { SlotAllocator } from '#services/slot-allocator.service.ts';
+import { VmManager } from '#services/vm-manager.service.ts';
+import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
 import { succeeding } from '#tests/support/commands.ts';
-import { APP_ID, instanceRecord } from '#tests/support/fixtures.ts';
+import { agentConfig } from '#tests/support/config.ts';
+import { APP_ID, DEPLOYMENT_ID, desiredInstance, instanceRecord } from '#tests/support/fixtures.ts';
 import { platform, provided } from '#tests/support/run.ts';
 
 /** What `systemctl show` says about a microVM that is up, which is all a pass reads off it. */
@@ -98,4 +104,222 @@ describe('a settle writes back only what it measured', () => {
         expect(yield* recordOf).toBeUndefined();
       }),
     ));
+});
+
+/** What `systemctl show` says about a microVM that is down, which is what a wake has to find. */
+const INACTIVE_UNIT = [
+  'LoadState=loaded',
+  'ActiveState=inactive',
+  'SubState=dead',
+  'Result=success',
+  'ExecMainStatus=0',
+  'InactiveExitTimestampMonotonic=1',
+].join('\n');
+
+const VM_DIR = '/nonexistent/nibrun-test/vm';
+
+/** Enough that a wake counting one more would be visible, and few enough to leave budget. */
+const RESTARTS_SO_FAR = 4;
+const NO_ATTEMPTS = 0;
+
+type VmCall = 'boot' | 'sleep' | 'wake' | 'stop' | 'discard';
+
+/**
+ * Every way the agent can act on a microVM, recorded rather than performed. Which of them a wake
+ * reached is the whole assertion: a restore and a cold boot leave the same app serving, and the
+ * only thing that tells them apart from the outside is how long the visitor waited.
+ */
+function recordingVms({
+  onSleep = Effect.succeed(undefined),
+  onWake = Effect.void,
+}: {
+  onSleep?: Effect.Effect<undefined, SleepRefused>;
+  onWake?: Effect.Effect<void, SnapshotUnusable>;
+} = {}) {
+  const calls: VmCall[] = [];
+  function taking<A, E>({ call, outcome }: { call: VmCall; outcome: Effect.Effect<A, E> }) {
+    return Effect.suspend(() => {
+      calls.push(call);
+      return outcome;
+    });
+  }
+  return {
+    calls,
+    layer: Layer.succeed(
+      VmManager,
+      VmManager.make({
+        workingDir: () => VM_DIR,
+        boot: () => taking({ call: 'boot', outcome: Effect.void }),
+        sleep: () => taking({ call: 'sleep', outcome: onSleep }),
+        wake: () => taking({ call: 'wake', outcome: onWake }),
+        stop: () => taking({ call: 'stop', outcome: Effect.void }),
+        discard: () => taking({ call: 'discard', outcome: Effect.void }),
+      }),
+    ),
+  };
+}
+
+/**
+ * A stubbed `VmManager` still asks for what a real boot would fetch, so this stands in for the
+ * bucket the artifact would come from. Reaching it is the failure: nothing here boots anything.
+ */
+const noArtifacts = Layer.succeed(
+  ArtifactStore,
+  ArtifactStore.make({
+    open: () => new ArtifactTransferError({ cause: 'no artifact store in a test' }),
+  }),
+);
+
+function onHost({ vms, unit }: { vms: ReturnType<typeof recordingVms>; unit: string }) {
+  const host = Layer.mergeAll(
+    agentConfig({ vmDir: VM_DIR }),
+    Layer.succeed(CommandRunner, CommandRunner.make({ run: () => succeeding({ stdout: unit }) })),
+  );
+  return provided(
+    Layer.mergeAll(
+      AgentState.Default,
+      ReportSignal.Default,
+      SlotAllocator.DefaultWithoutDependencies,
+      ZerofsTopology.DefaultWithoutDependencies,
+      noArtifacts,
+      vms.layer,
+    ).pipe(Layer.provideMerge(host), Layer.provideMerge(platform)),
+  );
+}
+
+function withMicroVmDown(vms: ReturnType<typeof recordingVms>) {
+  return onHost({ vms, unit: INACTIVE_UNIT });
+}
+
+/**
+ * A wake is a restore, and a cold boot is only what is left when there is nothing to restore.
+ * Both halves are checked against the same stub, because which one ran is the difference between
+ * a visitor waiting thirty milliseconds and one waiting a second.
+ */
+describe('an app is woken by putting back the microVM it had', () => {
+  test('a snapshot that loads is restored rather than booted', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'idle' }));
+
+        yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }));
+
+        expect(vms.calls).toEqual(['wake']);
+        expect((yield* recordOf)?.startedAt).toBeDefined();
+      }),
+    );
+  });
+
+  // The one path that may cold-boot: a first sleep, a redeploy, a host that rebooted, a guest
+  // image that moved. Every other failure leaves the app down and says why.
+  test('a snapshot nothing can load is a cold boot instead', () => {
+    const vms = recordingVms({
+      onWake: new SnapshotUnusable({ reason: 'the host has rebooted' }),
+    });
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'idle' }));
+
+        yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }));
+
+        expect(vms.calls).toEqual(['wake', 'boot']);
+      }),
+    );
+  });
+
+  /**
+   * An app woken every morning for a year is not an app that crashed three hundred times. The
+   * budget still bounds the damage, because the cold boot above is what spends it.
+   */
+  test('a restore is not a restart, so it costs the app nothing', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(
+          instanceRecord({ onRequest: true, state: 'idle', restartCount: RESTARTS_SO_FAR }),
+        );
+
+        yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }));
+
+        const record = yield* recordOf;
+        expect(record?.restartCount).toBe(RESTARTS_SO_FAR);
+        expect(record?.startAttempts.attempts).toBe(NO_ATTEMPTS);
+      }),
+    );
+  });
+
+  // Firecracker takes a snapshot load only from a process that has configured nothing, and
+  // `systemctl start` on a unit already up is the no-op that would have hidden it.
+  test('a microVM that is already up is left alone rather than restored onto', () => {
+    const vms = recordingVms();
+    return onHost({ vms, unit: ACTIVE_UNIT })(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }));
+
+        expect(vms.calls).toEqual([]);
+      }),
+    );
+  });
+});
+
+describe('an app that has gone quiet is put down where it can be picked up', () => {
+  const suspend = suspendInstance({ appId: APP_ID, deploymentId: DEPLOYMENT_ID, reason: 'idle' });
+
+  test('it is snapshotted rather than stopped, and reads as asleep after', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* (yield* SlotAllocator).allocate(APP_ID);
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* suspend;
+
+        expect(vms.calls).toEqual(['sleep']);
+        const record = yield* recordOf;
+        expect(record?.state).toBe('idle');
+        // What tells the health loop a microVM that is gone is asleep rather than crashed, and
+        // what keeps the boot after a discarded snapshot from counting as a restart.
+        expect(record?.stopRequested).toBe(true);
+      }),
+    );
+  });
+
+  /**
+   * A refusal is an outcome, not a failure. `VmManager.sleep` leaves the microVM running, so the
+   * app goes on serving and the next measurement tick asks again — and nothing here may mark it
+   * failed for having been asked at a moment it could not answer.
+   */
+  test('one that may not be snapshotted is left up rather than called broken', () => {
+    const vms = recordingVms({
+      onSleep: new SleepRefused({ reason: 'it has already been asked to stop' }),
+    });
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* (yield* SlotAllocator).allocate(APP_ID);
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* suspend;
+
+        expect((yield* recordOf)?.state).toBe('running');
+      }),
+    );
+  });
+
+  // No slot is no tap, no address and no NBD minor for a restore to land on. Stopping still
+  // reclaims the memory, which is what the sleep was for.
+  test('one with no slot to come back to is stopped', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* suspend;
+
+        expect(vms.calls).toEqual(['stop']);
+      }),
+    );
+  });
 });

--- a/apps/agent/tests/lib/report/capacity.test.ts
+++ b/apps/agent/tests/lib/report/capacity.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { AppIdSchema, DEFAULT_INSTANCE_RESOURCES, type InstanceState, Value } from '@repo/protocol';
+import { committedResources, memoryShortfallMib } from '#lib/report/capacity.ts';
+import { instanceRecord } from '#tests/support/fixtures.ts';
+
+const APP_MEMORY_MIB = DEFAULT_INSTANCE_RESOURCES.memoryMib;
+const NEIGHBOURS_THAT_FIT = 3;
+const HOST_MEMORY_MIB = APP_MEMORY_MIB * (NEIGHBOURS_THAT_FIT + 1);
+
+function neighbours({ count, state }: { count: number; state: InstanceState }) {
+  const records = [];
+  for (let index = 0; index < count; index += 1) {
+    records.push(instanceRecord({ appId: Value.Parse(AppIdSchema, `neighbour-${index}`), state }));
+  }
+  return records;
+}
+
+/** What one more of the default-sized apps would cost this host beyond what it has. */
+function shortfall({ count, state }: { count: number; state: InstanceState }) {
+  return memoryShortfallMib({
+    hostMemoryMib: HOST_MEMORY_MIB,
+    committed: committedResources(neighbours({ count, state })),
+    wanted: DEFAULT_INSTANCE_RESOURCES,
+  });
+}
+
+/**
+ * The refusal a wake is made on. Memory is counted against what the host has rather than against
+ * what the control plane placed here, because a sleeping app gave its share back and the whole
+ * point of `on-request` is that somebody else may have taken it.
+ */
+describe('a host has room for one more microVM until it does not', () => {
+  test('an empty host has room', () => {
+    expect(shortfall({ count: 0, state: 'running' })).toBe(0);
+  });
+
+  test('so has one filled to exactly the last app it fits', () => {
+    expect(shortfall({ count: NEIGHBOURS_THAT_FIT, state: 'running' })).toBe(0);
+  });
+
+  test('one app past that is short by exactly what the app asked for', () => {
+    expect(shortfall({ count: NEIGHBOURS_THAT_FIT + 1, state: 'running' })).toBe(APP_MEMORY_MIB);
+  });
+
+  // The saving and the failure mode are the same fact: a host packed with sleeping apps has all
+  // its memory free, and every one of them can be woken until the memory runs out.
+  test('a neighbour asleep between requests is holding none of it', () => {
+    expect(shortfall({ count: NEIGHBOURS_THAT_FIT * 2, state: 'idle' })).toBe(0);
+  });
+});

--- a/apps/agent/tests/services/app-activator.test.ts
+++ b/apps/agent/tests/services/app-activator.test.ts
@@ -12,12 +12,13 @@ import {
 import { Duration, Effect, Either, Layer } from 'effect';
 import { AgentState } from '#services/agent-state.service.ts';
 import { AppActivator } from '#services/app-activator.service.ts';
-import { AppWaker, WakeFailed } from '#services/app-waker.service.ts';
+import { AppWaker, HostHasNoRoom, WakeFailed } from '#services/app-waker.service.ts';
 import { APP_ID, instanceRecord } from '#tests/support/fixtures.ts';
 import { provided } from '#tests/support/run.ts';
 import { HTTP_OK, HTTP_UNAVAILABLE, serving } from '#tests/support/server.ts';
 
 const OTHER_APP_ID = Value.Parse(AppIdSchema, 'app-2');
+const SHORT_BY_MIB = 256;
 const LOOPBACK = '127.0.0.1';
 
 /** Nothing here has a microVM to be woken, so a waker that would boot one is not the subject. */
@@ -219,6 +220,33 @@ describe('an app that runs on request is started by the request that wanted it',
 
         expect(response.status).toBe(HTTP_UNAVAILABLE);
         expect(yield* Effect.promise(() => response.text())).toContain('could not be started');
+      }),
+    );
+  });
+
+  /**
+   * A host with no memory left is not a broken app, and the visitor is not told it is one: an
+   * owner sent to read a binary that is fine would find nothing, because the repair is to move
+   * the app and neither of them can bring that about by asking again.
+   */
+  test('a wake refused for want of memory says so rather than blaming the app', () => {
+    const full = Layer.succeed(
+      AppWaker,
+      AppWaker.make({
+        wake: (appId: AppId) => new HostHasNoRoom({ appId, shortfallMib: SHORT_BY_MIB }),
+      }),
+    );
+    return activator(full)(
+      Effect.gen(function* () {
+        const app = yield* AppActivator;
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'idle' }));
+        const hostPort = unusedPort();
+        yield* app.serve([{ appId: APP_ID, hostPort }]);
+
+        const response = yield* get(hostPort);
+
+        expect(response.status).toBe(HTTP_UNAVAILABLE);
+        expect(yield* Effect.promise(() => response.text())).toContain('out of memory');
       }),
     );
   });


### PR DESCRIPTION
Stacked on #390. An `on-request` app is now snapshotted where it stands when it goes quiet, and the next request restores that microVM instead of booting a new one. A cold boot is the fallback for a snapshot nothing can load — a first sleep, a redeploy, a host reboot, a guest image that moved.

A wake is not a restart: it spends no restart budget and moves no `restartCount`. Only the fallback boot does, which is what still bounds an app whose snapshot will never load.

Also refuses a wake this host has no memory for, rather than evicting a neighbour. Evicting makes one tenant's traffic a reason to take another tenant's app offline and never converges on an oversubscribed host. The visitor gets its own answer, and the app carries the reason on its record so it reads as neither asleep nor broken. The actual repair — moving the app — belongs to placement, not to the waker.