### PR TITLE
feat(cli): nib upgrade runs the install against the nib that ran it

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -85,3 +85,12 @@ the layout under `src/commands/` is the command tree.
   the tag that PR names is what builds the binaries and cuts the release.
   `cliff.toml` scopes both to commits touching this package, which is why the
   release commit has to touch it — a tag outside that filter is not a release.
+- **`nib upgrade` runs `install.sh`**, fetched from nibrun.com and piped to `sh`
+  exactly as the documented `curl … | sh` pipes it — `apps/www/public/install.sh`
+  is a symlink to this package's copy, so the two are one file. Which release is
+  newest, the checksum and the rename into place are all the script's and are not
+  written a second time in TypeScript; what the command decides is the one thing
+  the script cannot know — which nib is running, handed over as
+  `NIB_INSTALL_DIR`. Fetched rather than compiled in, because the nib running an
+  upgrade is by definition the old one: a fix to the script then reaches every nib
+  ever shipped.

--- a/packages/cli/src/command-tree.gen.ts
+++ b/packages/cli/src/command-tree.gen.ts
@@ -17,6 +17,7 @@ import type { command as appsSuspendCmd } from './commands/apps/suspend.ts';
 import type { command as appsUpdateCmd } from './commands/apps/update.ts';
 import type { command as loginCmd } from './commands/login.ts';
 import type { command as runCommandCmd } from './commands/run/[command].ts';
+import type { command as upgradeCmd } from './commands/upgrade.ts';
 
 declare module '@parshjs/core' {
   interface CommandRegistry {
@@ -110,6 +111,10 @@ declare module '@parshjs/core' {
       rootOptions: {};
     };
     'run [command]': {
+      parents: {};
+      rootOptions: {};
+    };
+    'upgrade': {
       parents: {};
       rootOptions: {};
     };
@@ -243,6 +248,12 @@ export const commandTree: RuntimeNode = {
         literalChildren: {},
         paramChild: null,
       },
+    },
+    'upgrade': {
+      segment: { kind: 'literal', value: 'upgrade' },
+      command: { path: 'upgrade', load: () => import('./commands/upgrade.ts').then((m) => m.command) },
+      literalChildren: {},
+      paramChild: null,
     },
   },
   paramChild: null,

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -1,0 +1,12 @@
+import { defineCommand } from '@parshjs/core';
+import { installedBinary, upgradeCli } from '#lib/upgrade.ts';
+
+/**
+ * The one command that talks to nibrun.com rather than to the api, and so the one that needs no
+ * token: a nib too old to sign in is exactly the nib this exists to replace.
+ */
+export const command = defineCommand('upgrade', {
+  description: 'Replace this nib with the newest released one, by running the install again.',
+  options: {},
+  handler: () => upgradeCli({ binary: installedBinary() }),
+});

--- a/packages/cli/src/lib/upgrade.ts
+++ b/packages/cli/src/lib/upgrade.ts
@@ -1,0 +1,109 @@
+import { access, constants } from 'node:fs/promises';
+import { basename, dirname } from 'node:path';
+import { ApiError } from '@repo/api-client/unwrap';
+import { PROGRAM_NAME } from '#config.ts';
+import { UsageError } from '#lib/errors.ts';
+
+/**
+ * The script an owner installs with is the script an owner upgrades with. Resolving the newest
+ * `cli-v*` release, checking what arrives against the checksum that release publishes and renaming
+ * it into place are all its, and none of it is worth saying a second time here.
+ *
+ * Fetched rather than compiled in, because the nib running an upgrade is by definition the old one:
+ * a github that moves its release feed is then a fix every nib ever shipped picks up, rather than
+ * one only a nib built after it can.
+ */
+const INSTALL_SCRIPT_URL = 'https://nibrun.com/install.sh';
+
+/** Where the script installs what it downloads, and the whole of what this tells it. */
+const INSTALL_DIR_VAR = 'NIB_INSTALL_DIR';
+
+/** The filesystem Bun mounts a compiled executable's own sources under, and nothing else. */
+const COMPILED_ROOT = '/$bunfs/';
+
+/**
+ * Replace the running nib with the newest released one, by running the install. What is decided
+ * here is only what the script cannot know: which nib is running, and so which one to replace.
+ */
+export async function upgradeCli({ binary }: { binary: string }): Promise<void> {
+  const installDir = dirname(binary);
+
+  requireReplaceable(binary);
+  await requireWritable(installDir);
+  await runInstallScript({ script: await installScript(), installDir });
+}
+
+/**
+ * The binary an upgrade replaces, which is this one. `bun run src/main.ts` is not a released nib —
+ * `execPath` there is Bun itself, and Bun is not what anybody asked to have replaced.
+ */
+export function installedBinary(): string {
+  if (!Bun.main.startsWith(COMPILED_ROOT)) {
+    throw new UsageError(
+      `This ${PROGRAM_NAME} runs from source rather than from a release, so there is nothing to upgrade.`,
+    );
+  }
+  return process.execPath;
+}
+
+/**
+ * The script writes `$NIB_INSTALL_DIR/nib`, so a nib that has been renamed is one it would install
+ * beside rather than replace. Refusing is better than reporting an upgrade that left the binary
+ * that ran it exactly where it was.
+ */
+function requireReplaceable(binary: string): void {
+  if (basename(binary) !== PROGRAM_NAME) {
+    throw new UsageError(
+      `The install replaces a binary called ${PROGRAM_NAME}, and this one is ${basename(binary)}. Install it again under its own name to upgrade it.`,
+    );
+  }
+}
+
+/**
+ * Asked before the script is fetched rather than left to the `mktemp` inside it: a nib installed
+ * where only root can write is a nib only root can replace, and that is worth saying in the words
+ * `nib` refuses anything else in.
+ */
+async function requireWritable(dir: string): Promise<void> {
+  try {
+    await access(dir, constants.W_OK);
+  } catch {
+    throw new UsageError(
+      `${dir} is not writable by this user, so ${PROGRAM_NAME} cannot replace itself there. Run this as whoever owns it.`,
+    );
+  }
+}
+
+async function installScript(): Promise<string> {
+  const response = await fetch(INSTALL_SCRIPT_URL);
+  if (!response.ok) {
+    throw new ApiError(`${INSTALL_SCRIPT_URL} could not be read: ${response.status}.`);
+  }
+  return response.text();
+}
+
+/**
+ * Piped to `sh` rather than fetched by it, so the only thing this asks of the machine is the shell
+ * that `curl -fsSL … | sh` already asks of it — the same script, arriving the same way.
+ *
+ * The terminal is the script's: it says which release it found, what it checked and where the
+ * result went, and a commentary written over the top of that would only disagree with it.
+ */
+export async function runInstallScript({
+  script,
+  installDir,
+}: {
+  script: string;
+  installDir: string;
+}): Promise<void> {
+  const installing = Bun.spawn(['sh'], {
+    stdin: new TextEncoder().encode(script),
+    stdout: 'inherit',
+    stderr: 'inherit',
+    env: { ...process.env, [INSTALL_DIR_VAR]: installDir },
+  });
+
+  if ((await installing.exited) !== 0) {
+    throw new ApiError(`The install did not finish, so ${PROGRAM_NAME} was not replaced.`);
+  }
+}

--- a/packages/cli/tests/lib/upgrade.test.ts
+++ b/packages/cli/tests/lib/upgrade.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { installedBinary, runInstallScript } from '#lib/upgrade.ts';
+
+const dirs: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+/**
+ * These tests run from source, which is the case `installedBinary` exists to catch: `execPath` here
+ * is Bun, and replacing Bun with a nib is not what an upgrade was ever asking for.
+ */
+test('a nib running from source has nothing to upgrade', () => {
+  expect(() => installedBinary()).toThrow('runs from source');
+});
+
+// The one thing the script is told, and the whole reason this runs it rather than an owner: the
+// directory the install writes to is the one the nib running the upgrade is in.
+test('the install is pointed at the directory the running nib is in', async () => {
+  const dir = await scratchDir();
+  const reported = join(dir, 'install-dir');
+
+  await runInstallScript({
+    script: `printf '%s' "$NIB_INSTALL_DIR" > ${reported}`,
+    installDir: dir,
+  });
+
+  expect(await Bun.file(reported).text()).toBe(dir);
+});
+
+// The script says what went wrong on the way past; what this adds is that it was not an upgrade.
+test('an install that does not finish is not reported as one that did', async () => {
+  const dir = await scratchDir();
+
+  await expect(runInstallScript({ script: 'exit 1', installDir: dir })).rejects.toThrow(
+    'nib was not replaced',
+  );
+});
+
+async function scratchDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'nib-upgrade-'));
+  dirs.push(dir);
+  return dir;
+}


### PR DESCRIPTION
Running `install.sh` again was the only way to upgrade, and it installs to `~/.local/bin` rather
than to wherever the nib being upgraded is.

So the command runs that same script — fetched from nibrun.com and piped to `sh`, as the documented
`curl … | sh` pipes it — with `NIB_INSTALL_DIR` set to the directory the running binary sits in.

```
$ nib upgrade
↓ Updating nib 2026.8.29-2 → 2026.8.31-1 (darwin-arm64)
✓ nib 2026.8.31-1 is installed at /Users/me/.local/bin/nib
```

Which release is newest, the checksum against what that release publishes and the staged rename into
place stay the script's alone, and `apps/www/public/install.sh` is already a symlink to this
package's copy — so there is one of it in the repo rather than one and a translation of it.

Fetched rather than compiled in, because the nib running an upgrade is by definition the old one: a
github that moves its release feed is then a fix every nib ever shipped picks up, rather than one
only a nib built after it can. The consequence worth naming: the binary now runs a script it
fetched, where before it only ran a binary it downloaded.

What is decided in TypeScript is the rest — that this is a released nib rather than
`bun run src/main.ts`, that it is still called `nib`, and that the directory it sits in can be
written, which is said in the words `nib` refuses anything else in rather than left to the `mktemp`
inside the script.

Ran from a compiled binary against the live release: the replacement, the already-installed line,
the unwritable directory, a renamed binary, and the refusal to replace Bun when run from source.
