### PR TITLE
fix(agent): a device that will not answer is judged, not waited on

### DIFF
--- a/apps/agent/src/lib/volumes/ext4.ts
+++ b/apps/agent/src/lib/volumes/ext4.ts
@@ -1,5 +1,5 @@
 import { FileSystem } from '@effect/platform';
-import { Effect } from 'effect';
+import { Data, Duration, Effect } from 'effect';
 import { stdoutOf } from '#services/command-runner.service.ts';
 
 const SUPERBLOCK_MAGIC_OFFSET = 1080;
@@ -29,8 +29,28 @@ export function hasExtMagic(bytes: Uint8Array): boolean {
 }
 
 /**
+ * The same ceiling the liveness probe carries, for the same reason: this opens a block device,
+ * and one whose NBD server has gone answers neither the open nor the read.
+ */
+const SUPERBLOCK_READ_TIMEOUT_SECONDS = 15;
+const SUPERBLOCK_READ_TIMEOUT = Duration.seconds(SUPERBLOCK_READ_TIMEOUT_SECONDS);
+
+export class SuperblockUnreadable extends Data.TaggedError('SuperblockUnreadable')<{
+  readonly devicePath: string;
+}> {
+  override get message() {
+    return `${this.devicePath} did not answer a read of its superblock`;
+  }
+}
+
+/**
  * Comparing a constant, not parsing a filesystem: the host must never let its kernel interpret
  * tenant-controlled metadata, and this is the only thing distinguishing a blank device.
+ *
+ * Raised rather than guessed when the device will not answer. Both guesses are wrong in a way
+ * this is not allowed to be: unformatted destroys a tenant's filesystem, and formatted reports a
+ * volume ready that nothing can read. A failure here is a volume reported failed, which is the
+ * only one of the three an operator can act on.
  */
 export const isFormatted = (devicePath: string) =>
   Effect.gen(function* () {
@@ -42,6 +62,14 @@ export const isFormatted = (devicePath: string) =>
         const buffer = new Uint8Array(MAGIC_BYTE_COUNT);
         yield* file.read(buffer);
         return hasExtMagic(buffer);
+      }),
+    ).pipe(
+      // As in `CommandRunner`: the read is on a thread this side cannot recall, so the deadline
+      // has to be the moment this stops waiting rather than the moment the read gives up.
+      Effect.disconnect,
+      Effect.timeoutFail({
+        duration: SUPERBLOCK_READ_TIMEOUT,
+        onTimeout: () => new SuperblockUnreadable({ devicePath }),
       }),
     );
   });

--- a/apps/agent/src/lib/volumes/nbd.ts
+++ b/apps/agent/src/lib/volumes/nbd.ts
@@ -1,28 +1,61 @@
+import { basename } from 'node:path';
+import { FileSystem } from '@effect/platform';
 import type { VolumeId } from '@repo/protocol';
 import { Duration, Effect } from 'effect';
 import { run, stdoutOf } from '#services/command-runner.service.ts';
 
 const NBD_CLIENT = 'nbd-client';
-const CONNECTED_EXIT_CODE = 0;
 
 const NBD_CONNECTIONS = 4;
 const NBD_BLOCK_SIZE_BYTES = 4096;
-/** S3 round trips under load turn a short timeout into an EIO the guest's ext4 answers by
- * remounting read-only. */
+/**
+ * S3 round trips under load turn a short timeout into an EIO the guest's ext4 answers by
+ * remounting read-only.
+ *
+ * It is also the only ceiling anything on this host has over a dead export. A request the kernel
+ * has accepted cannot be taken back by a signal — the process waiting on it sleeps
+ * uninterruptibly, past SIGKILL and past systemd — so this number, and not any timeout in
+ * userspace, is what eventually frees a waiter. Nothing below waits on one, which is what lets
+ * this stay long enough to be safe for the guest.
+ */
 const NBD_TIMEOUT_SECONDS = 600;
+
+const SYSFS_BLOCK_DIRECTORY = '/sys/block';
+/** The unit the kernel publishes capacity in, whatever logical block size the device negotiated. */
+const SYSFS_SECTOR_BYTES = 512;
+
+/**
+ * The kernel's own record of a device, which is the only part of it that answers while its server
+ * does not.
+ *
+ * Opening `/dev/nbdN` is what blocks: a ZeroFS restart leaves the kernel holding a device whose
+ * socket is gone, and every read queues behind requests that will not complete until the timeout
+ * above. `blockdev --getsize64` on such a device sits in uninterruptible sleep for as long as
+ * that takes, and no signal shortens it. These files are ordinary sysfs attributes on the gendisk
+ * — they are answered from memory and cannot queue behind anything.
+ */
+const readAttribute = ({ devicePath, attribute }: { devicePath: string; attribute: string }) =>
+  Effect.flatMap(FileSystem.FileSystem, (fs) =>
+    fs.readFileString(`${SYSFS_BLOCK_DIRECTORY}/${basename(devicePath)}/${attribute}`),
+  );
 
 /**
  * Whether a device has a client, which is a different question from whether it has a working one.
  * Kept because a detach is only worth attempting against a device somebody is holding.
+ *
+ * The kernel creates `pid` when a client takes the device and removes it when one lets go, so the
+ * file being there is the whole answer. It is the same file `nbd-client -check` reads, reached
+ * without a process this host would then have to be able to kill.
  */
 export const isAttached = (devicePath: string) =>
-  Effect.map(
-    run({ command: [NBD_CLIENT, '-check', devicePath] }),
-    (result) => result.code === CONNECTED_EXIT_CODE,
+  readAttribute({ devicePath, attribute: 'pid' }).pipe(
+    Effect.as(true),
+    Effect.orElseSucceed(() => false),
   );
 
 /** One block, at the offset every filesystem on the device keeps something at. */
 const PROBE_BYTES = 4096;
+const READ_SUCCEEDED = 0;
 const NO_BYTES = 0;
 
 /**
@@ -34,13 +67,12 @@ const PROBE_TIMEOUT_SECONDS = 15;
 const PROBE_TIMEOUT = Duration.seconds(PROBE_TIMEOUT_SECONDS);
 
 /**
- * Whether the device answers, which is what `-check` does not ask.
+ * Whether the device answers, which is what the kernel's own record of it does not say.
  *
  * A ZeroFS restart leaves the kernel holding a device that reports its size and names its client
- * and fails every read: `-check` exits 0, `blockdev --getsize64` is right, and the guest's ext4
- * cannot read its own superblock. Observed on a live host, on both ZeroFS versions, so it is the
- * reconnect and not the release. Liveness has to be a read, because a read is the thing that is
- * broken.
+ * and fails every read: sysfs is right about both, and the guest's ext4 cannot read its own
+ * superblock. Observed on a live host, on both ZeroFS versions, so it is the reconnect and not
+ * the release. Liveness has to be a read, because a read is the thing that is broken.
  *
  * `iflag=direct` is what makes it a read of the device rather than of the page cache. Without it
  * the host answers out of memory for a device that has been dead for hours, which is the same
@@ -51,6 +83,10 @@ const PROBE_TIMEOUT = Duration.seconds(PROBE_TIMEOUT_SECONDS);
  * in` and exits 0. Asking only whether the read succeeded therefore answers yes for a device that
  * is not attached at all — which is every device on a host that has just rebooted, and a host
  * whose volumes are then never attached because nothing believes anything is wrong with them.
+ *
+ * Doing it from sysfs is what keeps the common case off the device: a host whose volumes are
+ * detached spawns nothing at all, and only a device the kernel says is carrying data is ever
+ * opened.
  */
 export const isUsable = (devicePath: string) =>
   Effect.gen(function* () {
@@ -61,16 +97,29 @@ export const isUsable = (devicePath: string) =>
     return yield* readsFirstBlock(devicePath);
   });
 
-/** Zero for a device nothing is attached to, which is the state a reboot leaves every one of them in. */
+/**
+ * Zero for a device nothing is attached to, which is the state a reboot leaves every one of them
+ * in — and the state `nbd-client -d` puts one back into, so a device this host has given up on
+ * stops being probed from the pass after it gave up.
+ */
 const attachedSizeBytes = (devicePath: string) =>
-  run({ command: ['blockdev', '--getsize64', devicePath], timeout: PROBE_TIMEOUT }).pipe(
-    Effect.map((result) =>
-      result.code === CONNECTED_EXIT_CODE ? Number.parseInt(result.stdout.trim(), 10) : NO_BYTES,
-    ),
+  readAttribute({ devicePath, attribute: 'size' }).pipe(
+    Effect.map((sectors) => Number.parseInt(sectors.trim(), 10) * SYSFS_SECTOR_BYTES),
     Effect.map((size) => (Number.isFinite(size) ? size : NO_BYTES)),
-    Effect.catchAll(() => Effect.succeed(NO_BYTES)),
+    Effect.orElseSucceed(() => NO_BYTES),
   );
 
+/**
+ * The one thing here that opens the device, and so the one thing that can be left behind.
+ *
+ * `CommandRunner` gives up on the process rather than waiting for it to die, so a `dd` the kernel
+ * will not let go of stops being this agent's problem the moment the timeout fires. What bounds
+ * the ones left behind is the repair the `false` triggers: a device judged unusable is
+ * reattached, and the `nbd-client -d` that starts the reattach errors every queued request on
+ * that device, which frees the `dd` waiting on one. After that its size reads zero and nothing
+ * probes it again until an attach succeeds — so the count is bounded by the devices on the host,
+ * not by how often the reconcile runs.
+ */
 const readsFirstBlock = (devicePath: string) =>
   run({
     command: [
@@ -83,7 +132,7 @@ const readsFirstBlock = (devicePath: string) =>
     ],
     timeout: PROBE_TIMEOUT,
   }).pipe(
-    Effect.map((result) => result.code === CONNECTED_EXIT_CODE),
+    Effect.map((result) => result.code === READ_SUCCEEDED),
     // A probe that could not be run is not evidence the device is well, and the repair it leads
     // to costs a detach and an attach against a device nobody is using yet.
     Effect.catchAll(() => Effect.succeed(false)),
@@ -147,6 +196,12 @@ export const attachCheckpoint = Effect.fn('nbd.attachCheckpoint')(
     connect({ ...target, extraArgs: [] }),
 );
 
+/**
+ * Two ioctls on a device somebody already has open, which is why this works where a read does
+ * not: `NBD_DISCONNECT` and `NBD_CLEAR_SOCK` error every request the kernel is holding rather
+ * than joining the queue behind them. It is what frees a process sleeping on a dead device, and
+ * the reason a wedged host recovers instead of waiting out the request timeout.
+ */
 export const detach = Effect.fn('nbd.detach')((devicePath: string) =>
   run({ command: [NBD_CLIENT, '-d', devicePath] }),
 );

--- a/apps/agent/src/services/command-runner.service.ts
+++ b/apps/agent/src/services/command-runner.service.ts
@@ -40,6 +40,17 @@ const execute = (request: CommandRequest) =>
     return { code, stdout, stderr };
   }).pipe(
     Effect.scoped,
+    // The timeout is only worth what this makes it worth. Closing the scope kills the process and
+    // then waits for it to exit, and that wait is a finalizer — uninterruptible, so a timeout
+    // fires and then blocks on it anyway. A process the kernel will not let go of is exactly the
+    // case: a read of a block device whose server is gone sleeps past SIGKILL, and one of those
+    // held an entire agent through its reconcile and its shutdown.
+    //
+    // `disconnect` hands that wait to a background fiber, so the deadline is when this caller
+    // stops waiting rather than when the process finally goes. The process is still signalled
+    // first, so the only ones that outlive being given up on are the ones that could not have
+    // been killed by waiting either.
+    Effect.disconnect,
     Effect.timeoutFail({
       duration: request.timeout ?? DEFAULT_TIMEOUT,
       onTimeout: () => new CommandTimedOut({ command: request.command }),

--- a/apps/agent/src/services/volume-manager.service.ts
+++ b/apps/agent/src/services/volume-manager.service.ts
@@ -97,16 +97,26 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
             // A device file with no app is one this agent has lost its record of. Reporting it
             // under a guessed app would be worse than leaving it out: the control plane reads
             // these to decide a tenant's filesystem is gone.
-            const observed = yield* Effect.forEach(names, (name) =>
-              Effect.gen(function* () {
-                const volumeId = Value.Parse(VolumeIdSchema, name);
-                const appId = appIdByVolume.get(volumeId);
-                if (appId === undefined) {
-                  return Option.none<ObservedVolume>();
-                }
-                const slot = yield* slotFor({ volumeId, appIdByVolume });
-                return yield* observeFile({ filesystem, volumeId, appId, slot });
-              }),
+            //
+            // Concurrently, because what takes any time here is the liveness probe, and the
+            // failure that makes it slow is one ZeroFS having gone — which is every volume on
+            // this filesystem at once. Sequentially that is one probe ceiling per volume before
+            // the host reports anything, and a host that reports nothing is a host the control
+            // plane cannot see. The list is one device file per slot, so it is bounded by the
+            // minors the kernel was given.
+            const observed = yield* Effect.forEach(
+              names,
+              (name) =>
+                Effect.gen(function* () {
+                  const volumeId = Value.Parse(VolumeIdSchema, name);
+                  const appId = appIdByVolume.get(volumeId);
+                  if (appId === undefined) {
+                    return Option.none<ObservedVolume>();
+                  }
+                  const slot = yield* slotFor({ volumeId, appIdByVolume });
+                  return yield* observeFile({ filesystem, volumeId, appId, slot });
+                }),
+              { concurrency: 'unbounded' },
             );
             return Arr.getSomes(observed);
           }),

--- a/apps/agent/tests/lib/failure.test.ts
+++ b/apps/agent/tests/lib/failure.test.ts
@@ -19,6 +19,7 @@ import { MissingVersionsError } from '#lib/report/versions.ts';
 import { ArtifactSizeMismatch, DigestMismatch } from '#lib/vm/artifacts.ts';
 import { UnrepresentableEnvironment } from '#lib/vm/instance-env.ts';
 import { VolumeShrinkRefused } from '#lib/volumes/device-file.ts';
+import { SuperblockUnreadable } from '#lib/volumes/ext4.ts';
 import { ArtifactTransferError } from '#services/artifact-store.service.ts';
 import { NoDeviceForApp } from '#services/filesystem-reader.service.ts';
 
@@ -52,6 +53,7 @@ const everyFailure = [
   }),
   new CommandTimedOut({ command: ['debugfs', '-R', 'rdump / /tmp/x', '/dev/nbd7'] }),
   new VolumeShrinkRefused({ current: OTHER_SIZE, requested: SOME_SIZE }),
+  new SuperblockUnreadable({ devicePath: '/dev/nbd3' }),
   new ControlPlaneError({ status: HTTP_UNAUTHORIZED, route: '/desired-state', body: 'expired' }),
   new ProtocolMismatch({ issues: [] }),
   new GuestFilesystemUnreachable({ appId: SOME_APP, cause: new Error('no such file') }),

--- a/apps/agent/tests/lib/volumes/nbd.test.ts
+++ b/apps/agent/tests/lib/volumes/nbd.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'bun:test';
+import { basename } from 'node:path';
+import { FileSystem } from '@effect/platform';
+import { SystemError } from '@effect/platform/Error';
 import { Value, VolumeIdSchema } from '@repo/protocol';
-import { Effect } from 'effect';
+import { Effect, Layer } from 'effect';
+import { CommandTimedOut } from '#lib/exec.ts';
 import { isUsable, reattach } from '#lib/volumes/nbd.ts';
+import type { CommandRunner } from '#services/command-runner.service.ts';
 import { recordingCommands, succeeding } from '#tests/support/commands.ts';
 
 const DEVICE = '/dev/nbd0';
@@ -9,28 +14,65 @@ const SOCKET = '/run/zerofs/nbd.sock';
 const VOLUME_ID = Value.Parse(VolumeIdSchema, '0198f3aa-1c2d-7e4b-9f11-a0b1c2d3e4f5');
 
 const READ_FAILED = 1;
-const NOT_ATTACHED = 1;
-const ATTACHED_SIZE = '8589934592\n';
-/** What `blockdev --getsize64` prints for a device nothing is attached to. */
-const DETACHED_SIZE = '0\n';
+const SYSFS = `/sys/block/${basename(DEVICE)}`;
+/** 8 GiB, in the 512-byte sectors `size` is published in. */
+const ATTACHED_SECTORS = '16777216\n';
+/** What the kernel publishes for a device nothing is attached to, and what a detach restores. */
+const DETACHED_SECTORS = '0\n';
+
+/** Present exactly while a client holds the device, which is what makes its presence the answer. */
+const attached: Readonly<Record<string, string>> = {
+  [`${SYSFS}/pid`]: '4213\n',
+  [`${SYSFS}/size`]: ATTACHED_SECTORS,
+};
 
 const target = { socketPath: SOCKET, devicePath: DEVICE, volumeId: VOLUME_ID };
 
 const isProbe = (command: readonly string[]) => command[0] === 'dd';
-const isSize = (command: readonly string[]) => command[0] === 'blockdev';
-const isCheck = (command: readonly string[]) => command.includes('-check');
 const isDetach = (command: readonly string[]) => command.includes('-d');
 
-function run<A>(effect: Effect.Effect<A, never, never>) {
-  return Effect.runPromise(effect);
+function sysfs(attributes: Readonly<Record<string, string>>) {
+  return FileSystem.layerNoop({
+    readFileString: (path: string) => {
+      const value = attributes[path];
+      return value === undefined
+        ? Effect.fail(
+            new SystemError({
+              reason: 'NotFound',
+              module: 'FileSystem',
+              method: 'readFileString',
+              pathOrDescriptor: path,
+            }),
+          )
+        : Effect.succeed(value);
+    },
+  });
+}
+
+type Host = CommandRunner | FileSystem.FileSystem;
+
+function running(layer: Layer.Layer<Host>) {
+  return function once<A>(effect: Effect.Effect<A, never, Host>) {
+    return Effect.runPromise(Effect.provide(effect, layer));
+  };
+}
+
+/** A host with the kernel answering about the device, and every subprocess it starts recorded. */
+function host({
+  attributes = attached,
+  answer,
+}: {
+  attributes?: Readonly<Record<string, string>>;
+  answer?: Parameters<typeof recordingCommands>[0];
+} = {}) {
+  const { commands, layer } = recordingCommands(answer);
+  return { commands, run: running(Layer.merge(layer, sysfs(attributes))) };
 }
 
 describe('a device that answers is not the same as a device with a client', () => {
   test('liveness is a read, because a read is what a dead device fails', async () => {
-    const { commands, layer } = recordingCommands((request) =>
-      isSize(request.command) ? succeeding({ stdout: ATTACHED_SIZE }) : succeeding(),
-    );
-    await run(Effect.provide(isUsable(DEVICE), layer));
+    const { commands, run } = host();
+    await run(isUsable(DEVICE));
     const probe = commands.find(({ command }) => isProbe(command));
     expect(probe?.command).toContain(`if=${DEVICE}`);
   });
@@ -38,18 +80,14 @@ describe('a device that answers is not the same as a device with a client', () =
   // Without O_DIRECT the host answers out of its own page cache for a device that has been dead
   // for hours, which is the same false yes this exists to replace.
   test('the read bypasses the page cache', async () => {
-    const { commands, layer } = recordingCommands((request) =>
-      isSize(request.command) ? succeeding({ stdout: ATTACHED_SIZE }) : succeeding(),
-    );
-    await run(Effect.provide(isUsable(DEVICE), layer));
+    const { commands, run } = host();
+    await run(isUsable(DEVICE));
     expect(commands.find(({ command }) => isProbe(command))?.command).toContain('iflag=direct');
   });
 
   test('a probe that reads is usable', async () => {
-    const { layer } = recordingCommands((request) =>
-      isSize(request.command) ? succeeding({ stdout: ATTACHED_SIZE }) : succeeding(),
-    );
-    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(true);
+    const { run } = host();
+    expect(await run(isUsable(DEVICE))).toBe(true);
   });
 
   // The regression this file exists for. A detached nbd device is zero bytes long, and reading
@@ -57,72 +95,88 @@ describe('a device that answers is not the same as a device with a client', () =
   // 0. Asking only whether the read succeeded answered yes for every device on a host that had
   // just rebooted, so nothing was ever attached and no tenant started.
   test('a detached device is not usable, however happily a read of it returns', async () => {
-    const { commands, layer } = recordingCommands((request) =>
-      isSize(request.command) ? succeeding({ stdout: DETACHED_SIZE }) : succeeding(),
-    );
-    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+    const { commands, run } = host({ attributes: { [`${SYSFS}/size`]: DETACHED_SECTORS } });
+    expect(await run(isUsable(DEVICE))).toBe(false);
     expect(commands.some(({ command }) => isProbe(command))).toBe(false);
   });
 
   test('a size that cannot be read at all is not usable', async () => {
-    const { layer } = recordingCommands((request) =>
-      isSize(request.command) ? succeeding({ code: READ_FAILED }) : succeeding(),
-    );
-    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+    const { run } = host({ attributes: {} });
+    expect(await run(isUsable(DEVICE))).toBe(false);
   });
 
   test('a size that is not a number is not usable', async () => {
-    const { layer } = recordingCommands((request) =>
-      isSize(request.command) ? succeeding({ stdout: 'not a number\n' }) : succeeding(),
-    );
-    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+    const { run } = host({ attributes: { [`${SYSFS}/size`]: 'not a number\n' } });
+    expect(await run(isUsable(DEVICE))).toBe(false);
   });
 
   test('a probe that cannot read is not usable, however healthy the device claims to be', async () => {
-    const { layer } = recordingCommands((request) =>
-      isSize(request.command)
-        ? succeeding({ stdout: ATTACHED_SIZE })
-        : succeeding({ code: READ_FAILED }),
-    );
-    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+    const { run } = host({ answer: () => succeeding({ code: READ_FAILED }) });
+    expect(await run(isUsable(DEVICE))).toBe(false);
   });
 
   // The probe is bounded, so a device that never answers is a device this says no about rather
   // than one it waits on — a reconcile held open behind it would stop every other app's.
   test('a probe that could not be run at all is not evidence of health', async () => {
-    const { layer } = recordingCommands((request) =>
-      isSize(request.command)
-        ? succeeding({ stdout: ATTACHED_SIZE })
-        : Effect.fail(new Error('spawn failed') as never),
-    );
-    expect(await run(Effect.provide(isUsable(DEVICE), layer))).toBe(false);
+    const { run } = host({ answer: () => Effect.fail(new Error('spawn failed') as never) });
+    expect(await run(isUsable(DEVICE))).toBe(false);
   });
 
   test('the probe carries a timeout, so it cannot hold the reconcile open', async () => {
-    const { commands, layer } = recordingCommands((request) =>
-      isSize(request.command) ? succeeding({ stdout: ATTACHED_SIZE }) : succeeding(),
-    );
-    await run(Effect.provide(isUsable(DEVICE), layer));
+    const { commands, run } = host();
+    await run(isUsable(DEVICE));
     for (const request of commands) {
       expect(request.timeout).toBeDefined();
     }
   });
 });
 
+describe('what may be asked about a device without opening it', () => {
+  // The outage. A ZeroFS restart left every device attached with a live client pid and a size the
+  // kernel still reported, and every read of one queued forever. `blockdev --getsize64` was how
+  // the size was read, so asking the cheap question was itself the thing that hung — in
+  // uninterruptible sleep, which no timeout and no signal ends.
+  test('the size comes from the kernel, so a device that will not answer is still measured', async () => {
+    const { commands, run } = host();
+    await run(isUsable(DEVICE));
+    expect(commands.some(({ command }) => command[0] === 'blockdev')).toBe(false);
+  });
+
+  test('nothing but the probe opens the device', async () => {
+    const { commands, run } = host();
+    await run(isUsable(DEVICE));
+    expect(commands.map(({ command }) => command[0])).toEqual(['dd']);
+  });
+
+  // A device nothing is attached to is the common case on a host that has just booted, and it is
+  // answered without a single process being started.
+  test('a device the kernel says is empty is judged without running anything', async () => {
+    const { commands, run } = host({ attributes: { [`${SYSFS}/size`]: DETACHED_SECTORS } });
+    await run(isUsable(DEVICE));
+    expect(commands).toHaveLength(0);
+  });
+
+  test('a device with a live client that still does not answer is not usable', async () => {
+    const { run } = host({
+      answer: (request) => Effect.fail(new CommandTimedOut({ command: request.command })),
+    });
+    expect(await run(isUsable(DEVICE))).toBe(false);
+  });
+});
+
 describe('repairing a device the kernel still holds', () => {
   test('a held device is taken down before it is brought up', async () => {
-    const { commands, layer } = recordingCommands(() => succeeding());
-    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
+    const { commands, run } = host();
+    await run(Effect.ignore(reattach(target)));
     const shapes = commands.map(({ command }) => command);
-    expect(isCheck(shapes[0] ?? [])).toBe(true);
-    expect(isDetach(shapes[1] ?? [])).toBe(true);
-    expect(shapes[2]).toContain('-persist');
+    expect(isDetach(shapes[0] ?? [])).toBe(true);
+    expect(shapes[1]).toContain('-persist');
   });
 
   // Attaching over a device the kernel is holding finds the minor busy; only a detach frees it.
   test('the detach is what makes the attach able to succeed', async () => {
-    const { commands, layer } = recordingCommands(() => succeeding());
-    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
+    const { commands, run } = host();
+    await run(Effect.ignore(reattach(target)));
     const detachAt = commands.findIndex(({ command }) => isDetach(command));
     const attachAt = commands.findIndex(({ command }) => command.includes('-persist'));
     expect(detachAt).toBeGreaterThanOrEqual(0);
@@ -130,27 +184,36 @@ describe('repairing a device the kernel still holds', () => {
   });
 
   test('a device nobody has attached is attached without a detach first', async () => {
-    const { commands, layer } = recordingCommands((request) =>
-      isCheck(request.command) ? succeeding({ code: NOT_ATTACHED }) : succeeding(),
-    );
-    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
+    const { commands, run } = host({ attributes: { [`${SYSFS}/size`]: DETACHED_SECTORS } });
+    await run(Effect.ignore(reattach(target)));
     expect(commands.some(({ command }) => isDetach(command))).toBe(false);
     expect(commands.some(({ command }) => command.includes('-persist'))).toBe(true);
   });
 
   test('a detach that fails does not stop the attach', async () => {
-    const { commands, layer } = recordingCommands((request) =>
-      isDetach(request.command) ? Effect.fail(new Error('busy') as never) : succeeding(),
-    );
-    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
+    const { commands, run } = host({
+      answer: (request) =>
+        isDetach(request.command) ? Effect.fail(new Error('busy') as never) : succeeding(),
+    });
+    await run(Effect.ignore(reattach(target)));
     expect(commands.some(({ command }) => command.includes('-persist'))).toBe(true);
   });
 
   test('the volume is named on the way back up, so the device serves the right export', async () => {
-    const { commands, layer } = recordingCommands(() => succeeding());
-    await run(Effect.provide(Effect.ignore(reattach(target)), layer));
-    const attached = commands.find(({ command }) => command.includes('-persist'));
-    expect(attached?.command).toContain(VOLUME_ID);
-    expect(attached?.command).toContain(SOCKET);
+    const { commands, run } = host();
+    await run(Effect.ignore(reattach(target)));
+    const attach = commands.find(({ command }) => command.includes('-persist'));
+    expect(attach?.command).toContain(VOLUME_ID);
+    expect(attach?.command).toContain(SOCKET);
+  });
+
+  // The ceiling the kernel enforces on a request nothing in userspace can take back, and the only
+  // reason a process sleeping on a dead device is ever freed without a detach.
+  test('an attached device carries a request timeout', async () => {
+    const { commands, run } = host();
+    await run(Effect.ignore(reattach(target)));
+    expect(commands.find(({ command }) => command.includes('-persist'))?.command).toContain(
+      '-timeout',
+    );
   });
 });

--- a/apps/agent/tests/services/command-runner.test.ts
+++ b/apps/agent/tests/services/command-runner.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { Duration, Effect, Either, Layer } from 'effect';
+import { CommandRunner, run } from '#services/command-runner.service.ts';
+import { platform } from '#tests/support/run.ts';
+
+const layer = Layer.provide(CommandRunner.Default, platform);
+
+const TIMEOUT_MS = 200;
+const TIMEOUT = Duration.millis(TIMEOUT_MS);
+/**
+ * How long the deaf process below stays alive. Long enough that waiting for it instead of
+ * abandoning it is unmistakable in the elapsed time, short enough not to outlive the suite.
+ */
+const DEAF_LIFETIME_MS = 3000;
+const ABANDONED_WITHIN_MS = 1500;
+
+/**
+ * A process that answers SIGTERM by carrying on, which is what a read of a wedged NBD device
+ * amounts to: the kernel will not deliver the signal to a task sleeping uninterruptibly, so the
+ * process outlives every attempt to kill it. This is the reproducible stand-in — no block device
+ * required — for the thing that held an agent through its reconcile and its shutdown.
+ */
+const DEAF = [
+  process.execPath,
+  '-e',
+  `process.on('SIGTERM', () => {}); setTimeout(() => {}, ${DEAF_LIFETIME_MS})`,
+] as const;
+
+function attempt<A, E>(effect: Effect.Effect<A, E, CommandRunner>) {
+  return Effect.runPromise(Effect.provide(Effect.either(effect), layer));
+}
+
+describe('a timeout is worth what the caller can walk away from', () => {
+  // The outage: closing the command's scope kills the process and then waits for it to exit, and
+  // that wait is a finalizer, so it is uninterruptible. A timeout fired and then blocked on it,
+  // which turned one unresponsive device into an agent that reconciled nothing, reported nothing
+  // and could not be stopped.
+  test('a process that ignores being killed does not hold the caller past the timeout', async () => {
+    const startedAt = Date.now();
+
+    const outcome = await attempt(run({ command: DEAF, timeout: TIMEOUT }));
+
+    expect(Date.now() - startedAt).toBeLessThan(ABANDONED_WITHIN_MS);
+    expect(Either.isLeft(outcome)).toBe(true);
+  });
+
+  test('what the caller gets back names the timeout rather than the process', async () => {
+    const outcome = await attempt(run({ command: DEAF, timeout: TIMEOUT }));
+
+    expect(Either.isLeft(outcome) && outcome.left._tag).toBe('CommandTimedOut');
+  });
+});
+
+describe('what a command still does when it answers', () => {
+  test('output and exit code come back', async () => {
+    const outcome = await attempt(run({ command: ['echo', 'answered'] }));
+
+    expect(outcome).toEqual(Either.right({ code: 0, stdout: 'answered\n', stderr: '' }));
+  });
+
+  test('stdin still reaches the process it was written for', async () => {
+    const outcome = await attempt(run({ command: ['cat'], stdin: 'a ruleset' }));
+
+    expect(Either.isRight(outcome) && outcome.right.stdout).toBe('a ruleset');
+  });
+});


### PR DESCRIPTION
A wedged NBD device could stop the agent entirely: the liveness check read the device's size with `blockdev`, which sleeps uninterruptibly on a device whose server has gone, and the Effect timeout then blocked on the finalizer waiting for a process that would never exit.

Attached and size now come from sysfs. The read probe stays — a read is what breaks — but `CommandRunner` abandons a process it cannot kill instead of waiting for it.