### PR TITLE
feat(cli): a command answers with a typed value, and --json prints it

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -31,6 +31,20 @@ the layout under `src/commands/` is the command tree.
   literals and `parents['<path>'].options` stays typed. The `satisfies` on
   `SHARED_OPTIONS` is what makes a mistyped field an error where it is written
   rather than an overload failure at every command taking it.
+- **A flag every command takes lives on the root command**, `src/commands/_root.ts`,
+  forwarded like any other and read as `rootOptions`. `--json` is the one there is:
+  it is what decides which surface a command's answer reaches.
+- **What a command answers with is declared once**, as an `Output` — a zod schema and a
+  renderer over that same value — beside the code that produces it, so the two spellings
+  of `apps files ls` share one and the layout helpers stay testable on their own. `--json`
+  prints the schema's parse of the value, one line per value, and the renderer never runs;
+  without it the renderer is the only thing that says anything. A field reaches both
+  surfaces or neither, which is the whole point. A handler builds `createOutput` from
+  `rootOptions.json` and gets back `emit`, the `ui`, whether there is anybody to put a
+  question to, and an `aside` print that moves to stderr under `--json` so nothing said in
+  passing corrupts the payload. This is a stopgap for parsh's own `output` and
+  `renderOutput` — ilbertt/parsh#8 — so keep an output a schema and a pure renderer, and
+  migrating is moving the pair onto `defineCommand`.
 - A positional is a path segment, so a command taking one lives at
   `commands/<…>/[name].ts` and its path string ends in `[name]`. Leaving it out
   prints the parent's usage rather than a missing-argument error, because the

--- a/packages/cli/src/command-tree.gen.ts
+++ b/packages/cli/src/command-tree.gen.ts
@@ -16,109 +16,110 @@ import type { command as appsStatusCmd } from './commands/apps/status.ts';
 import type { command as appsSuspendCmd } from './commands/apps/suspend.ts';
 import type { command as appsUpdateCmd } from './commands/apps/update.ts';
 import type { command as loginCmd } from './commands/login.ts';
+import type { command as rootCmd } from './commands/_root.ts';
 import type { command as runCommandCmd } from './commands/run/[command].ts';
 
 declare module '@parshjs/core' {
   interface CommandRegistry {
     'apps': {
       parents: {};
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps delete': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps domains': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps domains add [hostname]': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
         'apps domains': { options: InferForwardedOptions<typeof appsDomainsCmd.options>; params: InferParams<typeof appsDomainsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps domains remove [hostname]': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
         'apps domains': { options: InferForwardedOptions<typeof appsDomainsCmd.options>; params: InferParams<typeof appsDomainsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps export [destination]': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps files ls': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps files ls [path]': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
         'apps files ls': { options: InferForwardedOptions<typeof appsFilesLsCmd.options>; params: InferParams<typeof appsFilesLsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps list': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps logs': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps resume': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps status': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps suspend': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'apps update': {
       parents: {
         'apps': { options: InferForwardedOptions<typeof appsCmd.options>; params: InferParams<typeof appsCmd.params> };
       };
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'login': {
       parents: {};
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'run [command]': {
       parents: {};
-      rootOptions: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
   }
 }
 
 export const commandTree: RuntimeNode = {
   segment: null,
-  command: null,
+  command: { path: '', load: () => import('./commands/_root.ts').then((m) => m.command) },
   literalChildren: {
     'apps': {
       segment: { kind: 'literal', value: 'apps' },

--- a/packages/cli/src/commands/_root.ts
+++ b/packages/cli/src/commands/_root.ts
@@ -1,0 +1,12 @@
+import { defineRootCommand } from '@parshjs/core';
+import { z } from 'zod';
+
+export const command = defineRootCommand({
+  options: {
+    json: {
+      schema: z.boolean().default(false),
+      forwardToChildren: true,
+      description: 'Print what the command answered with as JSON, one object to a line.',
+    },
+  },
+});

--- a/packages/cli/src/commands/apps/delete.ts
+++ b/packages/cli/src/commands/apps/delete.ts
@@ -2,8 +2,8 @@ import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { deleteApp } from '#lib/delete.ts';
-import { createUi, isInteractive } from '#lib/ui.ts';
+import { DELETED_OUTPUT, deleteApp } from '#lib/delete.ts';
+import { createOutput } from '#lib/output.ts';
 
 export const command = defineCommand('apps delete', {
   description:
@@ -16,17 +16,20 @@ export const command = defineCommand('apps delete', {
     },
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ options, parents, context, print }) => {
-    const { api } = context;
+  handler: async ({ options, parents, context, print, rootOptions }) => {
     // A terminal decides more here than how the output looks — which app, when the flag named
     // none, and whether the confirmation can be asked at all — so the handler keeps the answer
     // rather than only the `ui` built from it.
-    const interactive = isInteractive();
-    const ui = createUi({ print, interactive });
+    const { interactive, ui, emit } = createOutput({
+      output: DELETED_OUTPUT,
+      print,
+      json: rootOptions.json,
+    });
+    const { api } = context;
 
     ui.open('nib apps delete');
     const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
 
-    await deleteApp({ api, slug, ui, yes: options.yes === true, interactive });
+    emit(await deleteApp({ api, slug, yes: options.yes === true, interactive }));
   },
 });

--- a/packages/cli/src/commands/apps/domains.ts
+++ b/packages/cli/src/commands/apps/domains.ts
@@ -1,22 +1,23 @@
 import { defineCommand } from '@parshjs/core';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { listDomains } from '#lib/domains.ts';
-import { isInteractive } from '#lib/ui.ts';
+import { APP_DOMAINS_OUTPUT, listDomains } from '#lib/domains.ts';
+import { createOutput } from '#lib/output.ts';
 
 export const command = defineCommand('apps domains', {
   description:
     "List the hostnames an app answers on: the one nibrun issued it, and any domain you brought. A brought domain is 'pending' until your DNS points at us.",
   options: {},
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ parents, context, print }) => {
-    const { api } = context;
-    const slug = await selectApp({
-      api,
-      slug: parents.apps.options.app,
-      interactive: isInteractive(),
+  handler: async ({ parents, context, print, rootOptions }) => {
+    const { interactive, emit } = createOutput({
+      output: APP_DOMAINS_OUTPUT,
+      print,
+      json: rootOptions.json,
     });
+    const { api } = context;
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
 
-    await listDomains({ api, slug, print });
+    emit(await listDomains({ api, slug }));
   },
 });

--- a/packages/cli/src/commands/apps/domains/add/[hostname].ts
+++ b/packages/cli/src/commands/apps/domains/add/[hostname].ts
@@ -2,8 +2,8 @@ import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { addAppDomain } from '#lib/domains.ts';
-import { createUi, isInteractive } from '#lib/ui.ts';
+import { addAppDomain, DOMAIN_ADDED_OUTPUT } from '#lib/domains.ts';
+import { createOutput } from '#lib/output.ts';
 
 export const command = defineCommand('apps domains add [hostname]', {
   description:
@@ -15,14 +15,17 @@ export const command = defineCommand('apps domains add [hostname]', {
     },
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ params, parents, context, print }) => {
+  handler: async ({ params, parents, context, print, rootOptions }) => {
+    const { interactive, ui, emit } = createOutput({
+      output: DOMAIN_ADDED_OUTPUT,
+      print,
+      json: rootOptions.json,
+    });
     const { api } = context;
-    const interactive = isInteractive();
-    const ui = createUi({ print, interactive });
 
     ui.open('nib apps domains add');
     const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
 
-    await addAppDomain({ api, slug, hostname: params.hostname, ui });
+    emit(await addAppDomain({ api, slug, hostname: params.hostname }));
   },
 });

--- a/packages/cli/src/commands/apps/domains/remove/[hostname].ts
+++ b/packages/cli/src/commands/apps/domains/remove/[hostname].ts
@@ -2,8 +2,8 @@ import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { removeAppDomain } from '#lib/domains.ts';
-import { createUi, isInteractive } from '#lib/ui.ts';
+import { DOMAIN_REMOVED_OUTPUT, removeAppDomain } from '#lib/domains.ts';
+import { createOutput } from '#lib/output.ts';
 
 // Unasked, unlike `apps delete`: the app keeps running on every other hostname, and re-adding
 // this one costs the same two records it cost the first time.
@@ -16,14 +16,17 @@ export const command = defineCommand('apps domains remove [hostname]', {
     },
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ params, parents, context, print }) => {
+  handler: async ({ params, parents, context, print, rootOptions }) => {
+    const { interactive, ui, emit } = createOutput({
+      output: DOMAIN_REMOVED_OUTPUT,
+      print,
+      json: rootOptions.json,
+    });
     const { api } = context;
-    const interactive = isInteractive();
-    const ui = createUi({ print, interactive });
 
     ui.open('nib apps domains remove');
     const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
 
-    await removeAppDomain({ api, slug, hostname: params.hostname, ui });
+    emit(await removeAppDomain({ api, slug, hostname: params.hostname }));
   },
 });

--- a/packages/cli/src/commands/apps/export/[destination].ts
+++ b/packages/cli/src/commands/apps/export/[destination].ts
@@ -2,8 +2,8 @@ import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { exportApp } from '#lib/exports.ts';
-import { createUi, isInteractive } from '#lib/ui.ts';
+import { EXPORT_OUTPUT, exportApp } from '#lib/exports.ts';
+import { createOutput } from '#lib/output.ts';
 
 export const command = defineCommand('apps export [destination]', {
   description:
@@ -15,14 +15,17 @@ export const command = defineCommand('apps export [destination]', {
     },
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ params, parents, context, print }) => {
+  handler: async ({ params, parents, context, print, rootOptions }) => {
+    const { interactive, ui, emit } = createOutput({
+      output: EXPORT_OUTPUT,
+      print,
+      json: rootOptions.json,
+    });
     const { api } = context;
-    const interactive = isInteractive();
-    const ui = createUi({ print, interactive });
 
     ui.open('nib apps export');
     const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
 
-    await exportApp({ api, slug, destination: params.destination, ui });
+    emit(await exportApp({ api, slug, destination: params.destination, ui }));
   },
 });

--- a/packages/cli/src/commands/apps/files/ls.ts
+++ b/packages/cli/src/commands/apps/files/ls.ts
@@ -3,8 +3,8 @@ import { GUEST_PATH_ROOT } from '@repo/protocol';
 import { SHARED_OPTIONS } from '#config.ts';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { listDirectory } from '#lib/filesystem.ts';
-import { isInteractive } from '#lib/ui.ts';
+import { DIRECTORY_OUTPUT, listDirectory } from '#lib/filesystem.ts';
+import { createOutput } from '#lib/output.ts';
 
 /**
  * A command and the parent of `apps files ls [path]` at once, which is how an optional positional
@@ -21,20 +21,23 @@ export const command = defineCommand('apps files ls', {
     },
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ options, parents, context, print }) => {
-    const { api } = context;
-    const slug = await selectApp({
-      api,
-      slug: parents.apps.options.app,
-      interactive: isInteractive(),
-    });
-
-    await listDirectory({
-      api,
-      slug,
-      deploymentId: options[SHARED_OPTIONS.deploymentId.name],
-      path: GUEST_PATH_ROOT,
+  handler: async ({ options, parents, context, print, rootOptions }) => {
+    const { interactive, aside, emit } = createOutput({
+      output: DIRECTORY_OUTPUT,
       print,
+      json: rootOptions.json,
     });
+    const { api } = context;
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
+
+    emit(
+      await listDirectory({
+        api,
+        slug,
+        deploymentId: options[SHARED_OPTIONS.deploymentId.name],
+        path: GUEST_PATH_ROOT,
+        print: aside,
+      }),
+    );
   },
 });

--- a/packages/cli/src/commands/apps/files/ls/[path].ts
+++ b/packages/cli/src/commands/apps/files/ls/[path].ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 import { SHARED_OPTIONS } from '#config.ts';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { listDirectory, typedPath } from '#lib/filesystem.ts';
-import { isInteractive } from '#lib/ui.ts';
+import { DIRECTORY_OUTPUT, listDirectory, typedPath } from '#lib/filesystem.ts';
+import { createOutput } from '#lib/output.ts';
 
 export const command = defineCommand('apps files ls [path]', {
   description: 'Directory to list, as a path inside the app filesystem.',
@@ -15,24 +15,27 @@ export const command = defineCommand('apps files ls [path]', {
     },
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ params, parents, context, print }) => {
+  handler: async ({ params, parents, context, print, rootOptions }) => {
     // Parsed before anything is asked for: the read is a wait on a host, and a path that could
     // never have been read is worth one line now rather than one line half a minute from now.
     const path = typedPath(params.path);
 
-    const { api } = context;
-    const slug = await selectApp({
-      api,
-      slug: parents.apps.options.app,
-      interactive: isInteractive(),
-    });
-
-    await listDirectory({
-      api,
-      slug,
-      deploymentId: parents['apps files ls'].options[SHARED_OPTIONS.deploymentId.name],
-      path,
+    const { interactive, aside, emit } = createOutput({
+      output: DIRECTORY_OUTPUT,
       print,
+      json: rootOptions.json,
     });
+    const { api } = context;
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
+
+    emit(
+      await listDirectory({
+        api,
+        slug,
+        deploymentId: parents['apps files ls'].options[SHARED_OPTIONS.deploymentId.name],
+        path,
+        print: aside,
+      }),
+    );
   },
 });

--- a/packages/cli/src/commands/apps/list.ts
+++ b/packages/cli/src/commands/apps/list.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from '@parshjs/core';
-import { listApps } from '#lib/app-list.ts';
+import { APP_LIST_OUTPUT, listApps } from '#lib/app-list.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
+import { createOutput } from '#lib/output.ts';
 
 /**
  * The one command under `apps` that names no app, so `--app` is the one thing forwarded here that
@@ -12,7 +13,9 @@ export const command = defineCommand('apps list', {
     'List your apps: what each is called, what state it is in, and when it last changed.',
   options: {},
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ context, print }) => {
-    await listApps({ api: context.api, print });
+  handler: async ({ context, print, rootOptions }) => {
+    const { emit } = createOutput({ output: APP_LIST_OUTPUT, print, json: rootOptions.json });
+
+    emit(await listApps({ api: context.api }));
   },
 });

--- a/packages/cli/src/commands/apps/logs.ts
+++ b/packages/cli/src/commands/apps/logs.ts
@@ -4,8 +4,8 @@ import { z } from 'zod';
 import { SHARED_OPTIONS } from '#config.ts';
 import { announcedDeployment, selectApp, stillWriting } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { follow, untilInterrupted } from '#lib/logs.ts';
-import { isInteractive } from '#lib/ui.ts';
+import { follow, LOG_RECORD_OUTPUT, untilInterrupted } from '#lib/logs.ts';
+import { createOutput } from '#lib/output.ts';
 
 export const command = defineCommand('apps logs', {
   description: 'Print an app output and keep printing it. Ends when you do.',
@@ -23,19 +23,20 @@ export const command = defineCommand('apps logs', {
     [SHARED_OPTIONS.deploymentId.name]: SHARED_OPTIONS.deploymentId.option,
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ options, parents, context, print }) => {
-    const { api } = context;
-    const slug = await selectApp({
-      api,
-      slug: parents.apps.options.app,
-      interactive: isInteractive(),
+  handler: async ({ options, parents, context, print, rootOptions }) => {
+    const { interactive, aside, emit } = createOutput({
+      output: LOG_RECORD_OUTPUT,
+      print,
+      json: rootOptions.json,
     });
+    const { api } = context;
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
     const addressed = await announcedDeployment({
       api,
       slug,
       deploymentId: options[SHARED_OPTIONS.deploymentId.name],
       operation: 'logs',
-      print,
+      print: aside,
     });
 
     await follow({
@@ -44,7 +45,8 @@ export const command = defineCommand('apps logs', {
       deploymentId: addressed.deploymentId,
       timerange: options.timerange,
       following: stillWriting(addressed),
-      print,
+      emit,
+      print: aside,
       signal: untilInterrupted(),
     });
   },

--- a/packages/cli/src/commands/apps/resume.ts
+++ b/packages/cli/src/commands/apps/resume.ts
@@ -1,22 +1,25 @@
 import { defineCommand } from '@parshjs/core';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { resumeApp } from '#lib/suspend.ts';
-import { createUi, isInteractive } from '#lib/ui.ts';
+import { createOutput } from '#lib/output.ts';
+import { RESUMED_OUTPUT, resumeApp } from '#lib/suspend.ts';
 
 export const command = defineCommand('apps resume', {
   description:
     'Put a suspended app back online. The host boots the deployment it was suspended on, onto the volume it left behind.',
   options: {},
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ parents, context, print }) => {
+  handler: async ({ parents, context, print, rootOptions }) => {
+    const { interactive, ui, emit } = createOutput({
+      output: RESUMED_OUTPUT,
+      print,
+      json: rootOptions.json,
+    });
     const { api } = context;
-    const interactive = isInteractive();
-    const ui = createUi({ print, interactive });
 
     ui.open('nib apps resume');
     const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
 
-    await resumeApp({ api, slug, ui });
+    emit(await resumeApp({ api, slug }));
   },
 });

--- a/packages/cli/src/commands/apps/status.ts
+++ b/packages/cli/src/commands/apps/status.ts
@@ -1,22 +1,23 @@
 import { defineCommand } from '@parshjs/core';
-import { showStatus } from '#lib/app-status.ts';
+import { APP_STATUS_OUTPUT, readStatus } from '#lib/app-status.ts';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { isInteractive } from '#lib/ui.ts';
+import { createOutput } from '#lib/output.ts';
 
 export const command = defineCommand('apps status', {
   description:
     'What one app is using of the machine it was given: vCPU, memory and volume, as the host last measured them.',
   options: {},
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ parents, context, print }) => {
-    const { api } = context;
-    const slug = await selectApp({
-      api,
-      slug: parents.apps.options.app,
-      interactive: isInteractive(),
+  handler: async ({ parents, context, print, rootOptions }) => {
+    const { interactive, emit } = createOutput({
+      output: APP_STATUS_OUTPUT,
+      print,
+      json: rootOptions.json,
     });
+    const { api } = context;
+    const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
 
-    await showStatus({ api, slug, print });
+    emit(await readStatus({ api, slug }));
   },
 });

--- a/packages/cli/src/commands/apps/suspend.ts
+++ b/packages/cli/src/commands/apps/suspend.ts
@@ -1,22 +1,25 @@
 import { defineCommand } from '@parshjs/core';
 import { selectApp } from '#lib/apps.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { suspendApp } from '#lib/suspend.ts';
-import { createUi, isInteractive } from '#lib/ui.ts';
+import { createOutput } from '#lib/output.ts';
+import { SUSPENDED_OUTPUT, suspendApp } from '#lib/suspend.ts';
 
 export const command = defineCommand('apps suspend', {
   description:
     'Take the app offline. Its microVM stops; the volume, everything on it and every hostname stay. `nib apps resume` puts it back.',
   options: {},
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ parents, context, print }) => {
+  handler: async ({ parents, context, print, rootOptions }) => {
+    const { interactive, ui, emit } = createOutput({
+      output: SUSPENDED_OUTPUT,
+      print,
+      json: rootOptions.json,
+    });
     const { api } = context;
-    const interactive = isInteractive();
-    const ui = createUi({ print, interactive });
 
     ui.open('nib apps suspend');
     const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
 
-    await suspendApp({ api, slug, ui });
+    emit(await suspendApp({ api, slug }));
   },
 });

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -4,7 +4,8 @@ import { SHARED_OPTIONS } from '#config.ts';
 import { selectApp } from '#lib/apps.ts';
 import { parseArguments } from '#lib/command-line.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
-import { createUi, isInteractive } from '#lib/ui.ts';
+import { createOutput } from '#lib/output.ts';
+import { RELEASE_OUTPUT } from '#lib/release.ts';
 import { updateApp } from '#lib/update.ts';
 
 export const command = defineCommand('apps update', {
@@ -23,25 +24,30 @@ export const command = defineCommand('apps update', {
     [SHARED_OPTIONS.detach.name]: SHARED_OPTIONS.detach.option,
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ options, parents, context, print }) => {
+  handler: async ({ options, parents, context, print, rootOptions }) => {
     const { args, ...given } = options;
+    const { interactive, ui, emit } = createOutput({
+      output: RELEASE_OUTPUT,
+      print,
+      json: rootOptions.json,
+    });
     const { api } = context;
-    const interactive = isInteractive();
-    const ui = createUi({ print, interactive });
 
     ui.open('nib apps update');
     const slug = await selectApp({ api, slug: parents.apps.options.app, interactive });
 
-    await updateApp({
-      api,
-      ui,
-      slug,
-      args: args === undefined ? undefined : parseArguments(args),
-      port: given[SHARED_OPTIONS.port.name],
-      extraPublicPort: given[SHARED_OPTIONS.extraPublicPort.name],
-      env: given[SHARED_OPTIONS.env.name],
-      unset: given[SHARED_OPTIONS.unset.name],
-      detach: given[SHARED_OPTIONS.detach.name],
-    });
+    emit(
+      await updateApp({
+        api,
+        ui,
+        slug,
+        args: args === undefined ? undefined : parseArguments(args),
+        port: given[SHARED_OPTIONS.port.name],
+        extraPublicPort: given[SHARED_OPTIONS.extraPublicPort.name],
+        env: given[SHARED_OPTIONS.env.name],
+        unset: given[SHARED_OPTIONS.unset.name],
+        detach: given[SHARED_OPTIONS.detach.name],
+      }),
+    );
   },
 });

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,12 +1,16 @@
 import { defineCommand } from '@parshjs/core';
-import { openInBrowser, startLogin } from '#lib/device-login.ts';
-import { createUi, isInteractive } from '#lib/ui.ts';
+import { openInBrowser, SIGNED_IN_OUTPUT, startLogin } from '#lib/device-login.ts';
+import { createOutput } from '#lib/output.ts';
 
 export const command = defineCommand('login', {
   description: 'Sign this terminal in. Approve it in the browser to finish.',
   options: {},
-  handler: async ({ context, print }) => {
-    const ui = createUi({ print, interactive: isInteractive() });
+  handler: async ({ context, print, rootOptions }) => {
+    const { ui, emit } = createOutput({
+      output: SIGNED_IN_OUTPUT,
+      print,
+      json: rootOptions.json,
+    });
     const { apiUrl } = context;
 
     const login = await startLogin({ apiUrl });
@@ -21,6 +25,6 @@ export const command = defineCommand('login', {
     });
 
     await context.files.credentials.write({ apiUrl, accessToken });
-    ui.done(`Signed in to ${apiUrl}.`);
+    emit({ apiUrl });
   },
 });

--- a/packages/cli/src/commands/run/[command].ts
+++ b/packages/cli/src/commands/run/[command].ts
@@ -4,8 +4,9 @@ import { SHARED_OPTIONS } from '#config.ts';
 import { parseCommandLine } from '#lib/command-line.ts';
 import { requireSignedIn } from '#lib/credentials.ts';
 import { binaryFrom, deploy } from '#lib/deploy.ts';
+import { createOutput } from '#lib/output.ts';
 import { completeOptions } from '#lib/plan.ts';
-import { createUi, isInteractive } from '#lib/ui.ts';
+import { RELEASE_OUTPUT } from '#lib/release.ts';
 
 export const command = defineCommand('run [command]', {
   description:
@@ -34,7 +35,7 @@ export const command = defineCommand('run [command]', {
     [SHARED_OPTIONS.detach.name]: SHARED_OPTIONS.detach.option,
   },
   beforeHandler: ({ context }) => requireSignedIn(context),
-  handler: async ({ params, options, context, print }) => {
+  handler: async ({ params, options, context, print, rootOptions }) => {
     // parsh names an option as it is typed, so a flag with hyphens in it does not arrive under the
     // name the deploy takes and has to be renamed rather than spread through.
     const {
@@ -47,8 +48,11 @@ export const command = defineCommand('run [command]', {
     const { binarySource, args } = parseCommandLine(params.command);
     const { api } = context;
 
-    const interactive = isInteractive();
-    const ui = createUi({ print, interactive });
+    const { interactive, ui, emit } = createOutput({
+      output: RELEASE_OUTPUT,
+      print,
+      json: rootOptions.json,
+    });
 
     // Before anything is asked, so a path nobody can read costs one line rather than a
     // questionnaire whose answers are then thrown away. A url is not opened here at all: the api
@@ -60,6 +64,6 @@ export const command = defineCommand('run [command]', {
       ? await completeOptions({ api, options: given, binarySource, args })
       : given;
 
-    await deploy({ ...resolved, api, ui, binary, args, detach });
+    emit(await deploy({ ...resolved, api, ui, binary, args, detach }));
   },
 });

--- a/packages/cli/src/lib/app-list.ts
+++ b/packages/cli/src/lib/app-list.ts
@@ -1,15 +1,41 @@
-import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { unwrap } from '@repo/api-client/unwrap';
 import type { ListedApp } from '@repo/app-operations';
 import { APP_STATES } from '@repo/protocol';
+import { z } from 'zod';
 import { NO_APPS } from '#lib/apps.ts';
+import { defineOutput } from '#lib/output.ts';
 import { dayAndMinute } from '#lib/timestamp.ts';
 
-export type AppListing = Pick<
+/**
+ * What is spent of one resource and what there is of it, in bytes. Both figures rather than the
+ * share the column shows: a share is what a listing is read down, and the bytes behind it are
+ * what anything reading this with a program would have had to reconstruct.
+ */
+const MeasuredSchema = z.object({
+  /** `null` for an app nothing has measured, which is every app that has not yet run. */
+  usedBytes: z.number().nullable(),
+  totalBytes: z.number(),
+});
+
+const AppRowSchema = z.object({
+  slug: z.string(),
+  state: z.enum(APP_STATES),
+  updatedAt: z.string(),
+  cpuShare: z.number().nullable(),
+  memory: MeasuredSchema,
+  volume: MeasuredSchema,
+});
+
+export type AppRow = z.infer<typeof AppRowSchema>;
+
+/** The half of the api's answer a row is read off. */
+type AppListing = Pick<
   ListedApp,
   'slug' | 'state' | 'updatedAt' | 'config' | 'volumeUsage' | 'computeUsage'
 >;
+
+const AppListSchema = z.object({ apps: z.array(AppRowSchema) });
 
 // `LAST CHANGE` rather than `UPDATED`, which reads as the owner having done it: the row moves on
 // a config patch or a state change, and a deploy leaves it alone entirely.
@@ -48,29 +74,54 @@ function shareWidth(heading: string): number {
  * looking for is the app that is filling up or pinning a core, and the bytes behind it are a line
  * on that app's own page.
  */
-function share(measured: number | undefined): string {
-  return measured === undefined
+function share(measured: number | null): string {
+  return measured === null
     ? UNMEASURED
     : `${Math.round(Math.min(measured, FULL) * PERCENT_SCALE)}%`;
 }
 
-/** Print what the owner has, one app to a line. */
+function ratio({ usedBytes, totalBytes }: z.infer<typeof MeasuredSchema>): number | null {
+  return usedBytes === null ? null : usedBytes / totalBytes;
+}
+
+export const APP_LIST_OUTPUT = defineOutput({
+  schema: AppListSchema,
+  render: ({ value, out }) => {
+    if (value.apps.length === 0) {
+      out.dim(NO_APPS);
+      return;
+    }
+    for (const line of render(value.apps)) {
+      out.info(line);
+    }
+  },
+});
+
+/** What the owner has, one app to a row. */
 export async function listApps({
   api,
-  print,
 }: {
   api: PublicApiClient;
-  print: Print;
-}): Promise<void> {
+}): Promise<z.input<typeof AppListSchema>> {
   const { apps } = unwrap(await api.api.apps.get());
-  if (apps.length === 0) {
-    print.dim(NO_APPS);
-    return;
-  }
+  return { apps: apps.map(toRow) };
+}
 
-  for (const line of render(apps)) {
-    print.info(line);
-  }
+function toRow(app: AppListing): AppRow {
+  return {
+    slug: app.slug,
+    state: app.state,
+    updatedAt: app.updatedAt,
+    cpuShare: app.computeUsage?.cpuShare ?? null,
+    memory: {
+      usedBytes: app.computeUsage?.memoryUsedBytes ?? null,
+      totalBytes: app.config.resources.memoryMib * BYTES_PER_MIB,
+    },
+    volume: {
+      usedBytes: app.volumeUsage?.usedBytes ?? null,
+      totalBytes: app.config.volumeSizeBytes,
+    },
+  };
 }
 
 /**
@@ -81,8 +132,8 @@ export async function listApps({
  * A heading, unlike the filesystem listing: there a name and a size say what they are, and here
  * every column but one is a number that would read as any of the others.
  */
-export function render(apps: readonly AppListing[]): string[] {
-  const rows = [HEADINGS, ...apps.map(toRow)];
+export function render(apps: readonly AppRow[]): string[] {
+  const rows = [HEADINGS, ...apps.map(toColumns)];
   const slugWidth = Math.max(...rows.map((row) => row.slug.length));
 
   return rows.map((row) =>
@@ -97,20 +148,13 @@ export function render(apps: readonly AppListing[]): string[] {
   );
 }
 
-function toRow(app: AppListing) {
-  const compute = app.computeUsage;
+function toColumns(app: AppRow) {
   return {
     slug: app.slug,
     state: app.state,
-    cpu: share(compute?.cpuShare),
-    memory: share(
-      compute
-        ? compute.memoryUsedBytes / (app.config.resources.memoryMib * BYTES_PER_MIB)
-        : undefined,
-    ),
-    volume: share(
-      app.volumeUsage ? app.volumeUsage.usedBytes / app.config.volumeSizeBytes : undefined,
-    ),
+    cpu: share(app.cpuShare),
+    memory: share(ratio(app.memory)),
+    volume: share(ratio(app.volume)),
     updated: dayAndMinute(app.updatedAt),
   };
 }

--- a/packages/cli/src/lib/app-status.ts
+++ b/packages/cli/src/lib/app-status.ts
@@ -1,23 +1,48 @@
-import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
 import {
   APP_STATUS_LABELS,
   type AppStatusKey,
   appWithStatus,
-  type ListedApp,
   statusKey,
 } from '@repo/app-operations';
+import { z } from 'zod';
 import { formatBytes } from '#lib/format-bytes.ts';
+import { defineOutput } from '#lib/output.ts';
 import { dayAndMinute } from '#lib/timestamp.ts';
 
-export type AppStatusView = Pick<ListedApp, 'slug' | 'config' | 'volumeUsage' | 'computeUsage'> & {
+// `Object.keys` is typed `string[]`, and an exhaustive `Record<AppStatusKey, …>` is the one place
+// the whole set is written down — so the tuple is read off it rather than repeated here.
+const STATUS_KEYS = Object.keys(APP_STATUS_LABELS) as [AppStatusKey, ...AppStatusKey[]];
+
+/**
+ * What is spent of one resource, what there is of it, and when that was last looked at. The
+ * moment is per resource because the readings are two exchanges with the guest and can come
+ * apart; what a reader is shown is the older of them, which is the renderer's to work out.
+ */
+const SpentSchema = z.object({
+  /** `null` for a resource nothing has measured, which is every app that is not running. */
+  used: z.number().nullable(),
+  total: z.number(),
+  measuredAt: z.string().nullable(),
+});
+
+type Spent = z.infer<typeof SpentSchema>;
+
+const AppStatusSchema = z.object({
+  slug: z.string(),
   /**
    * What the app is doing, not what its row says. An app row is `active` from the moment it is
    * created, so on its own it says nothing about whether anything is serving — the release
    * answers that, and `running` is the word an owner is looking for here.
    */
-  status: AppStatusKey;
-};
+  status: z.enum(STATUS_KEYS),
+  /** In vCPUs, so it is read against the count beside it rather than as a share of it. */
+  vcpu: SpentSchema,
+  memory: SpentSchema,
+  volume: SpentSchema,
+});
+
+export type AppStatusReport = z.infer<typeof AppStatusSchema>;
 
 const BYTES_PER_MIB = 1_048_576;
 
@@ -33,15 +58,8 @@ type Resource = {
   label: string;
   /** What is spent over what there is, already read as one thing: `1.4 GiB / 8.0 GiB`. */
   spent: string;
-  measuredAt: string | undefined;
+  measuredAt: string | null;
 };
-
-function spent({ used, total }: { used: string | undefined; total: string }): string {
-  return `${used ?? UNMEASURED} / ${total}`;
-}
-
-/** The table, and the one moment printed under it — dimmed, which is the caller's to do. */
-export type RenderedStatus = { lines: string[]; measured: string | undefined };
 
 /**
  * The oldest reading's moment, not the newest.
@@ -52,15 +70,33 @@ export type RenderedStatus = { lines: string[]; measured: string | undefined };
  * and the oldest is the summary that stays true when they do. The newest would date a stale
  * reading as fresh, which is the one thing a moment is here to stop.
  */
-function measuredAt(moments: readonly (string | undefined)[]): string | undefined {
-  const taken = moments.filter((moment) => moment !== undefined);
+function measuredAt(moments: readonly (string | null)[]): string | undefined {
   let oldest: string | undefined;
-  for (const moment of taken) {
-    if (oldest === undefined || Date.parse(moment) < Date.parse(oldest)) {
+  for (const moment of moments) {
+    if (moment !== null && (oldest === undefined || Date.parse(moment) < Date.parse(oldest))) {
       oldest = moment;
     }
   }
   return oldest;
+}
+
+/** The table, and the one moment printed under it — dimmed, which is the caller's to do. */
+export type RenderedStatus = { lines: string[]; measured: string | undefined };
+
+function counted({ label, spent }: { label: string; spent: Spent }): Resource {
+  return {
+    label,
+    spent: `${spent.used === null ? UNMEASURED : spent.used.toFixed(VCPU_DECIMALS)} / ${spent.total}`,
+    measuredAt: spent.measuredAt,
+  };
+}
+
+function sized({ label, spent }: { label: string; spent: Spent }): Resource {
+  return {
+    label,
+    spent: `${spent.used === null ? UNMEASURED : formatBytes(spent.used)} / ${formatBytes(spent.total)}`,
+    measuredAt: spent.measuredAt,
+  };
 }
 
 /**
@@ -70,39 +106,11 @@ function measuredAt(moments: readonly (string | undefined)[]): string | undefine
  * this is read once that app is found — so the question here is how much, which a percentage does
  * not answer.
  */
-export function renderStatus(app: AppStatusView): RenderedStatus {
-  const compute = app.computeUsage;
-  const volume = app.volumeUsage;
-  const memoryBytes = app.config.resources.memoryMib * BYTES_PER_MIB;
-
+export function renderStatus(app: AppStatusReport): RenderedStatus {
   const resources: Resource[] = [
-    {
-      label: 'vCPU',
-      spent: spent({
-        used:
-          compute?.cpuShare === undefined
-            ? undefined
-            : (compute.cpuShare * app.config.resources.vcpuCount).toFixed(VCPU_DECIMALS),
-        total: String(app.config.resources.vcpuCount),
-      }),
-      measuredAt: compute?.cpuShare === undefined ? undefined : compute.measuredAt,
-    },
-    {
-      label: 'Memory',
-      spent: spent({
-        used: compute ? formatBytes(compute.memoryUsedBytes) : undefined,
-        total: formatBytes(memoryBytes),
-      }),
-      measuredAt: compute?.measuredAt,
-    },
-    {
-      label: 'Volume',
-      spent: spent({
-        used: volume ? formatBytes(volume.usedBytes) : undefined,
-        total: formatBytes(app.config.volumeSizeBytes),
-      }),
-      measuredAt: volume?.measuredAt,
-    },
+    counted({ label: 'vCPU', spent: app.vcpu }),
+    sized({ label: 'Memory', spent: app.memory }),
+    sized({ label: 'Volume', spent: app.volume }),
   ];
 
   const taken = measuredAt(resources.map((resource) => resource.measuredAt));
@@ -119,23 +127,53 @@ export function renderStatus(app: AppStatusView): RenderedStatus {
   };
 }
 
-export async function showStatus({
+export const APP_STATUS_OUTPUT = defineOutput({
+  schema: AppStatusSchema,
+  render: ({ value, out }) => {
+    const { lines, measured } = renderStatus(value);
+    for (const line of lines) {
+      out.info(line);
+    }
+    // Under the table and dimmed, because it qualifies every figure above rather than being one.
+    if (measured) {
+      out.info('');
+      out.dim(measured);
+    }
+  },
+});
+
+export async function readStatus({
   api,
   slug,
-  print,
 }: {
   api: PublicApiClient;
   slug: string;
-  print: Print;
-}): Promise<void> {
+}): Promise<z.input<typeof AppStatusSchema>> {
   const { app, status } = await appWithStatus({ api, slug });
-  const { lines, measured } = renderStatus({ ...app, status: statusKey(status) });
-  for (const line of lines) {
-    print.info(line);
-  }
-  // Under the table and dimmed, because it qualifies every figure above rather than being one.
-  if (measured) {
-    print.info('');
-    print.dim(measured);
-  }
+  const compute = app.computeUsage;
+  const volume = app.volumeUsage;
+  const { vcpuCount, memoryMib } = app.config.resources;
+  // A share needs a rate behind it, so the first reading taken of a guest has none while the
+  // memory it arrived with is already whole.
+  const cpuShare = compute?.cpuShare;
+
+  return {
+    slug: app.slug,
+    status: statusKey(status),
+    vcpu: {
+      used: cpuShare === undefined ? null : cpuShare * vcpuCount,
+      total: vcpuCount,
+      measuredAt: cpuShare === undefined ? null : (compute?.measuredAt ?? null),
+    },
+    memory: {
+      used: compute?.memoryUsedBytes ?? null,
+      total: memoryMib * BYTES_PER_MIB,
+      measuredAt: compute?.measuredAt ?? null,
+    },
+    volume: {
+      used: volume?.usedBytes ?? null,
+      total: app.config.volumeSizeBytes,
+      measuredAt: volume?.measuredAt ?? null,
+    },
+  };
 }

--- a/packages/cli/src/lib/delete.ts
+++ b/packages/cli/src/lib/delete.ts
@@ -1,9 +1,11 @@
 import { note, text } from '@clack/prompts';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { appFor, deleteApp as requestDeletion } from '@repo/app-operations';
+import { APP_STATES } from '@repo/protocol';
+import { z } from 'zod';
 import { UsageError } from '#lib/errors.ts';
+import { defineOutput } from '#lib/output.ts';
 import { answered } from '#lib/prompts.ts';
-import type { Ui } from '#lib/ui.ts';
 
 /**
  * A phrase rather than a y/n, because a y/n is answered by the muscle that has answered every
@@ -12,10 +14,28 @@ import type { Ui } from '#lib/ui.ts';
  */
 const CONFIRMATION_PHRASE = 'delete permanently';
 
+const DeletedSchema = z.object({
+  slug: z.string(),
+  state: z.enum(APP_STATES),
+  /** Whether this run is what started the teardown, rather than finding one already under way. */
+  changed: z.boolean(),
+});
+
+export type Deleted = z.infer<typeof DeletedSchema>;
+
+export const DELETED_OUTPUT = defineOutput({
+  schema: DeletedSchema,
+  render: ({ value, out }) =>
+    out.done(
+      value.changed
+        ? `${value.slug} is ${value.state}. What is on the volume goes when the host holding it says so.`
+        : `${value.slug} is already being deleted.`,
+    ),
+});
+
 export type DeleteInput = {
   api: PublicApiClient;
   slug: string;
-  ui: Ui;
   yes: boolean;
   interactive: boolean;
 };
@@ -28,12 +48,11 @@ export type DeleteInput = {
  * The app is looked up before anything is asked, so a slug that names nothing costs one line
  * rather than a phrase typed out for an app that was never there.
  */
-export async function deleteApp({ api, slug, ui, yes, interactive }: DeleteInput): Promise<void> {
+export async function deleteApp({ api, slug, yes, interactive }: DeleteInput): Promise<Deleted> {
   const { app } = await appFor({ api, slug, operation: 'delete' });
   // Asking twice is asking once: the teardown already running is the answer to the second.
   if (app.state === 'deleting') {
-    ui.done(`${app.slug} is already being deleted.`);
-    return;
+    return { slug: app.slug, state: app.state, changed: false };
   }
 
   if (!yes) {
@@ -45,9 +64,7 @@ export async function deleteApp({ api, slug, ui, yes, interactive }: DeleteInput
   }
 
   const deleting = await requestDeletion({ api, appId: app.id });
-  ui.done(
-    `${deleting.slug} is ${deleting.state}. What is on the volume goes when the host holding it says so.`,
-  );
+  return { slug: deleting.slug, state: deleting.state, changed: true };
 }
 
 /**

--- a/packages/cli/src/lib/deploy.ts
+++ b/packages/cli/src/lib/deploy.ts
@@ -16,7 +16,7 @@ import {
 import { environmentEdit } from '#lib/environment.ts';
 import { UsageError } from '#lib/errors.ts';
 import type { RunOptions } from '#lib/plan.ts';
-import { announce, awaitServing } from '#lib/release.ts';
+import { announce, awaitServing, type Release } from '#lib/release.ts';
 import type { Ui } from '#lib/ui.ts';
 import { describeProgress } from '#lib/upload-progress.ts';
 
@@ -40,7 +40,7 @@ export async function deploy({
   env,
   unset,
   detach,
-}: DeployInput): Promise<void> {
+}: DeployInput): Promise<Release> {
   const environment = environmentEdit({ env, unset });
   const deployed = await startDeployment({
     api,
@@ -66,7 +66,7 @@ export async function deploy({
     },
   });
 
-  await awaitServing({ api, ui, deployed, detach });
+  return await awaitServing({ api, ui, deployed, detach });
 }
 
 const SECURE_SCHEME = 'https://';

--- a/packages/cli/src/lib/device-login.ts
+++ b/packages/cli/src/lib/device-login.ts
@@ -1,7 +1,9 @@
 import { ApiError } from '@repo/api-client/unwrap';
 import { createAuthClient } from 'better-auth/client';
 import { deviceAuthorizationClient } from 'better-auth/client/plugins';
+import { z } from 'zod';
 import { UsageError } from '#lib/errors.ts';
+import { defineOutput } from '#lib/output.ts';
 
 // Sent so the record of a pending login says what asked for it. Not a secret and not a
 // credential: a public client has nothing to prove, which is the whole reason this flow exists.
@@ -14,6 +16,17 @@ const MS_PER_SECOND = 1_000;
 const SLOW_DOWN_SECONDS = 5;
 
 const EXPIRED = 'That code expired. Run `nib login` again.';
+
+/**
+ * The api the terminal is now signed in to. Which one is the whole of what a login leaves behind
+ * that anything else can read — the token itself is on disk and belongs nowhere near stdout.
+ */
+const SignedInSchema = z.object({ apiUrl: z.string() });
+
+export const SIGNED_IN_OUTPUT = defineOutput({
+  schema: SignedInSchema,
+  render: ({ value, out }) => out.done(`Signed in to ${value.apiUrl}.`),
+});
 
 type DeviceClient = ReturnType<typeof createDeviceClient>;
 type StartedLogin = NonNullable<Awaited<ReturnType<DeviceClient['device']['code']>>['data']>;

--- a/packages/cli/src/lib/domains.ts
+++ b/packages/cli/src/lib/domains.ts
@@ -1,66 +1,129 @@
-import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { addDomain, appBySlug, appFor, removeDomain } from '@repo/app-operations';
-import type { Ui } from '#lib/ui.ts';
+import { APP_HOSTNAME_KINDS, APP_HOSTNAME_STATES } from '@repo/protocol';
+import { z } from 'zod';
+import { defineOutput } from '#lib/output.ts';
 
 const COLUMN_GAP = '  ';
 
 const HEADINGS = { hostname: 'HOSTNAME', kind: 'KIND', state: 'STATE' };
 
-type DomainRow = { hostname: string; kind: string; state: string };
+/**
+ * One record the owner's DNS is still missing. Structured rather than the line it is printed as,
+ * because the whole use of reading this with a program is to place it.
+ */
+const DnsRecordSchema = z.object({
+  hostname: z.string(),
+  type: z.literal('CNAME'),
+  target: z.string(),
+});
 
-/** Print every hostname the app answers on, or is waiting to. */
+type DnsRecord = z.infer<typeof DnsRecordSchema>;
+
+const AppHostnameSchema = z.object({
+  hostname: z.string(),
+  kind: z.enum(APP_HOSTNAME_KINDS),
+  state: z.enum(APP_HOSTNAME_STATES),
+  /** What the domain is waiting on. Empty for one that is already answering. */
+  records: z.array(DnsRecordSchema),
+});
+
+const DomainListSchema = z.object({ hostnames: z.array(AppHostnameSchema) });
+
+const DomainAddedSchema = z.object({
+  slug: z.string(),
+  hostname: z.string(),
+  records: z.array(DnsRecordSchema),
+});
+
+const DomainRemovedSchema = z.object({ slug: z.string(), hostname: z.string() });
+
+type AppHostname = z.infer<typeof AppHostnameSchema>;
+
+/** One record as a line, in the three columns a DNS panel asks for them in. */
+function spell(record: DnsRecord): string {
+  return `${record.hostname}  ${record.type}  ${record.target}`;
+}
+
+export const APP_DOMAINS_OUTPUT = defineOutput({
+  schema: DomainListSchema,
+  render: ({ value, out }) => {
+    for (const line of render(value.hostnames)) {
+      out.info(line);
+    }
+
+    // Under the table rather than in it: a pending domain is waiting on the reader's own DNS, and
+    // a column wide enough to say which records would not be a column.
+    for (const waiting of value.hostnames.filter((each) => each.records.length > 0)) {
+      out.dim('');
+      out.dim(`${waiting.hostname} is waiting on:`);
+      for (const record of waiting.records) {
+        out.dim(`  ${spell(record)}`);
+      }
+    }
+  },
+});
+
+export const DOMAIN_ADDED_OUTPUT = defineOutput({
+  schema: DomainAddedSchema,
+  render: ({ value, out }) => {
+    for (const record of value.records) {
+      out.step(spell(record));
+    }
+    out.done(`${value.hostname} answers once those resolve. Nothing here has to be run again.`);
+  },
+});
+
+export const DOMAIN_REMOVED_OUTPUT = defineOutput({
+  schema: DomainRemovedSchema,
+  render: ({ value, out }) => out.done(`${value.hostname} no longer points at ${value.slug}.`),
+});
+
+/** Every hostname the app answers on, or is waiting to. */
 export async function listDomains({
   api,
   slug,
-  print,
 }: {
   api: PublicApiClient;
   slug: string;
-  print: Print;
-}): Promise<void> {
+}): Promise<z.input<typeof DomainListSchema>> {
   const app = await appBySlug({ api, slug });
-  for (const line of render(app.hostnames)) {
-    print.info(line);
-  }
+  const target = platformTarget({ slug: app.slug, hostnames: app.hostnames });
 
-  // Under the table rather than in it: a pending domain is waiting on the reader's own DNS, and
-  // a column wide enough to say which records would not be a column.
-  for (const pending of app.hostnames.filter((each) => each.state === 'pending')) {
-    print.dim('');
-    print.dim(`${pending.hostname} is waiting on:`);
-    for (const record of pendingRecords({
-      hostname: pending.hostname,
-      dcvTarget: pending.dcvTarget,
-      app,
-    })) {
-      print.dim(`  ${record}`);
-    }
-  }
+  return {
+    hostnames: app.hostnames.map((each) => ({
+      hostname: each.hostname,
+      kind: each.kind,
+      state: each.state,
+      records:
+        each.state === 'pending'
+          ? pendingRecords({ hostname: each.hostname, dcvTarget: each.dcvTarget, target })
+          : [],
+    })),
+  };
 }
 
 export async function addAppDomain({
   api,
   slug,
   hostname,
-  ui,
 }: {
   api: PublicApiClient;
   slug: string;
   hostname: string;
-  ui: Ui;
-}): Promise<void> {
+}): Promise<z.input<typeof DomainAddedSchema>> {
   const { app } = await appFor({ api, slug, operation: 'domains' });
   const added = await addDomain({ api, appId: app.id, hostname });
 
-  for (const record of pendingRecords({
+  return {
+    slug: app.slug,
     hostname: added.hostname,
-    dcvTarget: added.dcvTarget,
-    app,
-  })) {
-    ui.step(record);
-  }
-  ui.done(`${added.hostname} answers once those resolve. Nothing here has to be run again.`);
+    records: pendingRecords({
+      hostname: added.hostname,
+      dcvTarget: added.dcvTarget,
+      target: platformTarget({ slug: app.slug, hostnames: app.hostnames }),
+    }),
+  };
 }
 
 /**
@@ -71,15 +134,15 @@ export async function addAppDomain({
 function pendingRecords({
   hostname,
   dcvTarget,
-  app,
+  target,
 }: {
   hostname: string;
   dcvTarget: string | null;
-  app: { slug: string; hostnames: readonly { hostname: string; kind: string }[] };
-}): string[] {
-  const records = [`${hostname}  CNAME  ${app.slug}.${platformSuffix(app.hostnames)}`];
+  target: string;
+}): DnsRecord[] {
+  const records: DnsRecord[] = [{ hostname, type: 'CNAME', target }];
   if (dcvTarget) {
-    records.push(`_acme-challenge.${hostname}  CNAME  ${dcvTarget}`);
+    records.push({ hostname: `_acme-challenge.${hostname}`, type: 'CNAME', target: dcvTarget });
   }
   return records;
 }
@@ -93,17 +156,15 @@ export async function removeAppDomain({
   api,
   slug,
   hostname,
-  ui,
 }: {
   api: PublicApiClient;
   slug: string;
   hostname: string;
-  ui: Ui;
-}): Promise<void> {
+}): Promise<z.input<typeof DomainRemovedSchema>> {
   const { app } = await appFor({ api, slug, operation: 'domains' });
   await removeDomain({ api, appId: app.id, hostname });
 
-  ui.done(`${hostname} no longer points at ${app.slug}.`);
+  return { slug: app.slug, hostname };
 }
 
 /**
@@ -111,12 +172,18 @@ export async function removeAppDomain({
  * fleet already. Read off the app rather than configured here, so the CLI holds no copy of a
  * domain the deployment owns.
  */
-function platformSuffix(hostnames: readonly { hostname: string; kind: string }[]): string {
+function platformTarget({
+  slug,
+  hostnames,
+}: {
+  slug: string;
+  hostnames: readonly { hostname: string; kind: string }[];
+}): string {
   const platform = hostnames.find((each) => each.kind === 'platform');
-  return platform?.hostname.split('.').slice(1).join('.') ?? '';
+  return `${slug}.${platform?.hostname.split('.').slice(1).join('.') ?? ''}`;
 }
 
-export function render(hostnames: readonly DomainRow[]): string[] {
+export function render(hostnames: readonly Pick<AppHostname, 'hostname' | 'kind' | 'state'>[]) {
   const rows = [HEADINGS, ...hostnames];
   const hostnameWidth = Math.max(...rows.map((row) => row.hostname.length));
   const kindWidth = Math.max(...rows.map((row) => row.kind.length));

--- a/packages/cli/src/lib/exports.ts
+++ b/packages/cli/src/lib/exports.ts
@@ -3,7 +3,9 @@ import { dirname, join } from 'node:path';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { ApiError } from '@repo/api-client/unwrap';
 import { appFor, awaitExportBundle, requestExport } from '@repo/app-operations';
+import { z } from 'zod';
 import { UsageError } from '#lib/errors.ts';
+import { defineOutput } from '#lib/output.ts';
 import type { Ui } from '#lib/ui.ts';
 
 /** What the host writes, so what the file is called when the caller left the naming to us. */
@@ -17,6 +19,19 @@ const PARTIAL_SUFFIX = '.partial';
 
 const BYTES_PER_MIB = 1_048_576;
 const MIB_DECIMALS = 1;
+
+const ExportSchema = z.object({
+  slug: z.string(),
+  exportId: z.string(),
+  /** Where the bundle was written, which is the whole of what this command is asked for. */
+  path: z.string(),
+  sizeBytes: z.number().nullable(),
+});
+
+export const EXPORT_OUTPUT = defineOutput({
+  schema: ExportSchema,
+  render: ({ value, out }) => out.done(value.path),
+});
 
 export type ExportInput = {
   api: PublicApiClient;
@@ -33,7 +48,12 @@ export type ExportInput = {
  * filesystem is the most expensive thing the platform does on an owner's behalf: a path that
  * cannot be written is worth one line now rather than one line several minutes from now.
  */
-export async function exportApp({ api, slug, destination, ui }: ExportInput): Promise<void> {
+export async function exportApp({
+  api,
+  slug,
+  destination,
+  ui,
+}: ExportInput): Promise<z.input<typeof ExportSchema>> {
   const path = await bundlePath({ destination, slug });
   const { app } = await appFor({ api, slug, operation: 'export' });
 
@@ -49,7 +69,7 @@ export async function exportApp({ api, slug, destination, ui }: ExportInput): Pr
     task: () => download({ url: bundle.downloadUrl, path }),
   });
 
-  ui.done(path);
+  return { slug: app.slug, exportId: requested.id, path, sizeBytes: bundle.sizeBytes ?? null };
 }
 
 /**

--- a/packages/cli/src/lib/filesystem.ts
+++ b/packages/cli/src/lib/filesystem.ts
@@ -1,17 +1,36 @@
 import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { guestPath, InvalidPathError, readDirectory } from '@repo/app-operations';
-import {
-  DIRECTORY_ENTRY_LIMIT,
-  FILESYSTEM_ENTRY_KINDS,
-  type FilesystemEntry,
-  type GuestPath,
-} from '@repo/protocol';
+import { DIRECTORY_ENTRY_LIMIT, FILESYSTEM_ENTRY_KINDS, type GuestPath } from '@repo/protocol';
+import { z } from 'zod';
 import { announcedDeployment } from '#lib/apps.ts';
 import { UsageError } from '#lib/errors.ts';
+import { defineOutput } from '#lib/output.ts';
 import { dayAndMinute } from '#lib/timestamp.ts';
 
 const KIND_WIDTH = Math.max(...FILESYSTEM_ENTRY_KINDS.map((kind) => kind.length));
+
+const EntrySchema = z.object({
+  name: z.string(),
+  kind: z.enum(FILESYSTEM_ENTRY_KINDS),
+  sizeBytes: z.number(),
+  modifiedAt: z.string(),
+});
+
+type Entry = z.infer<typeof EntrySchema>;
+
+/**
+ * The deployment as well as the directory: which release was read is a question rather than a
+ * default when no `--deployment-id` named one, and its answer is the difference between reading
+ * what an app is writing now and what the release before it left behind.
+ */
+const DirectorySchema = z.object({
+  slug: z.string(),
+  deploymentId: z.string(),
+  path: z.string(),
+  truncated: z.boolean(),
+  entries: z.array(EntrySchema),
+});
 
 export function typedPath(typed: string): GuestPath {
   try {
@@ -24,6 +43,18 @@ export function typedPath(typed: string): GuestPath {
   }
 }
 
+export const DIRECTORY_OUTPUT = defineOutput({
+  schema: DirectorySchema,
+  render: ({ value, out }) => {
+    for (const line of render(value.entries)) {
+      out.info(line);
+    }
+    if (value.truncated) {
+      out.warn(`Only the first ${DIRECTORY_ENTRY_LIMIT} entries of ${value.path} are shown.`);
+    }
+  },
+});
+
 export type ListInput = {
   api: PublicApiClient;
   slug: string;
@@ -33,7 +64,7 @@ export type ListInput = {
 };
 
 /**
- * Print one directory of an app's filesystem.
+ * One directory of an app's filesystem.
  *
  * The request is held open by the api until a host next polls, so this is a wait rather than a
  * read — hence the deployment being named before it starts rather than alongside the answer, and
@@ -46,7 +77,7 @@ export async function listDirectory({
   deploymentId,
   path,
   print,
-}: ListInput): Promise<void> {
+}: ListInput): Promise<z.input<typeof DirectorySchema>> {
   const addressed = await announcedDeployment({
     api,
     slug,
@@ -62,12 +93,13 @@ export async function listDirectory({
     path,
   });
 
-  for (const line of render(listing.entries)) {
-    print.info(line);
-  }
-  if (listing.truncated) {
-    print.warn(`Only the first ${DIRECTORY_ENTRY_LIMIT} entries of ${listing.path} are shown.`);
-  }
+  return {
+    slug: addressed.slug,
+    deploymentId: addressed.deploymentId,
+    path: listing.path,
+    truncated: listing.truncated,
+    entries: listing.entries,
+  };
 }
 
 /**
@@ -80,7 +112,7 @@ export async function listDirectory({
  * Sizes stay exact rather than rounded, because someone reading a tenant's filesystem is checking
  * what their binary wrote, and `1.2 MiB` is what a second listing cannot be compared against.
  */
-export function render(entries: readonly FilesystemEntry[]): string[] {
+export function render(entries: readonly Entry[]): string[] {
   const sizeWidth = Math.max(0, ...entries.map((entry) => String(entry.sizeBytes).length));
   return byName(entries).map((entry) =>
     [
@@ -92,7 +124,7 @@ export function render(entries: readonly FilesystemEntry[]): string[] {
   );
 }
 
-function byName(entries: readonly FilesystemEntry[]): FilesystemEntry[] {
+function byName(entries: readonly Entry[]): Entry[] {
   // biome-ignore lint/complexity/useMaxParams: a comparator compares two entries
   return [...entries].sort((left, right) => (left.name < right.name ? -1 : 1));
 }

--- a/packages/cli/src/lib/logs.ts
+++ b/packages/cli/src/lib/logs.ts
@@ -1,7 +1,9 @@
 import type { Print } from '@parshjs/core';
 import type { PublicApiClient } from '@repo/api-client/public';
 import { followLogs } from '@repo/app-operations';
-import type { TenantLogRecord, TenantLogStream } from '@repo/protocol';
+import { TENANT_LOG_STREAMS, type TenantLogRecord, type TenantLogStream } from '@repo/protocol';
+import { z } from 'zod';
+import { defineOutput } from '#lib/output.ts';
 
 /**
  * Ctrl-C, as something a loop can read rather than something that kills it mid-line.
@@ -16,6 +18,43 @@ export function untilInterrupted(): AbortSignal {
   return stopping.signal;
 }
 
+/**
+ * One record, as much of it as a reader has any use for. The keys the store needs to tell a
+ * second copy from a second record are not among them: they are how the stream is assembled, and
+ * what arrives here is already assembled.
+ */
+const LogRecordSchema = z.object({
+  time: z.string(),
+  stream: z.enum(TENANT_LOG_STREAMS),
+  message: z.string(),
+  /** How much output the host had to drop, for a record that stands for a gap rather than a line. */
+  droppedBytes: z.number().nullable(),
+});
+
+export type LogRecord = z.infer<typeof LogRecordSchema>;
+
+/**
+ * Which stream a record came out of decides which one it goes back into, the way `docker logs`
+ * does it: the app's error output is this program's error output, so `2>` and `>` separate them
+ * again downstream. Under `--json` they arrive together and `stream` is what separates them,
+ * which is the same distinction said in a way a program can read.
+ */
+export const LOG_RECORD_OUTPUT = defineOutput({
+  schema: LogRecordSchema,
+  render: ({ value, out }) => {
+    const line = render(value);
+    if (value.droppedBytes !== null) {
+      out.warn(line);
+      return;
+    }
+    if (value.stream === 'stderr') {
+      out.error(line);
+      return;
+    }
+    out.info(line);
+  },
+});
+
 export type FollowInput = {
   api: PublicApiClient;
   appId: string;
@@ -23,15 +62,16 @@ export type FollowInput = {
   timerange: string;
   /** Whether there is a microVM to write anything more, which is what makes this a wait at all. */
   following: boolean;
+  emit: (record: LogRecord) => void;
   print: Print;
   signal: AbortSignal;
 };
 
 /**
- * Print what a deployment has written, and keep printing what it writes until stopped.
+ * Hand over what a deployment has written, and keep handing over what it writes until stopped.
  *
  * An app with nothing running is not waited on: what it wrote is printed and that is the end of
- * it, said in the last line so a log that stops is not read as one that was cut off.
+ * it, said beside the output so a log that stops is not read as one that was cut off.
  */
 export async function follow({
   api,
@@ -39,6 +79,7 @@ export async function follow({
   deploymentId,
   timerange,
   following,
+  emit,
   print,
   signal,
 }: FollowInput): Promise<void> {
@@ -50,29 +91,20 @@ export async function follow({
     following,
     signal,
   })) {
-    show({ record, print });
+    emit(asRecord(record));
   }
   if (!following) {
     print.dim('nothing is running, so that is everything it wrote');
   }
 }
 
-/**
- * Which stream a record came out of decides which one it goes back into, the way `docker logs`
- * does it: the app's error output is this program's error output, so `2>` and `>` separate them
- * again downstream. `print` colours by level, which is the same distinction said in colour.
- */
-export function show({ record, print }: { record: TenantLogRecord; print: Print }): void {
-  const line = render(record);
-  if (record.droppedBytes !== undefined) {
-    print.warn(line);
-    return;
-  }
-  if (record.stream === 'stderr') {
-    print.error(line);
-    return;
-  }
-  print.info(line);
+function asRecord(record: TenantLogRecord): LogRecord {
+  return {
+    time: record._time,
+    stream: record.stream,
+    message: record._msg,
+    droppedBytes: record.droppedBytes ?? null,
+  };
 }
 
 /** Wide enough that a column still reads as one against a message that begins with a space. */
@@ -87,14 +119,14 @@ const COLUMN_GAP = '  ';
 const TERMINATOR = /\r?\n$/;
 
 /** One record, one line: what the app wrote, behind a dimmed column saying when and from where. */
-export function render(record: TenantLogRecord): string {
-  const gap = record.droppedBytes === undefined ? '' : ` (${record.droppedBytes} bytes)`;
+export function render(record: LogRecord): string {
+  const gap = record.droppedBytes === null ? '' : ` (${record.droppedBytes} bytes)`;
   const mark = record.stream === 'stderr' ? 'err' : 'out';
   const column = dimmed({
-    text: `${stampOf(record._time)}${COLUMN_GAP}${mark}`,
+    text: `${stampOf(record.time)}${COLUMN_GAP}${mark}`,
     stream: record.stream,
   });
-  return `${column}${COLUMN_GAP}${record._msg.replace(TERMINATOR, '')}${gap}`;
+  return `${column}${COLUMN_GAP}${record.message.replace(TERMINATOR, '')}${gap}`;
 }
 
 const MS_PER_MINUTE = 60_000;

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -1,0 +1,94 @@
+import type { Print } from '@parshjs/core';
+import type { z } from 'zod';
+import { createUi, isInteractive, type Ui } from '#lib/ui.ts';
+
+/**
+ * Where a rendered answer lands: `print` for the body of it, `step` and `done` for the lines that
+ * fill in and close the frame an interactive flow opened.
+ */
+export type Writer = Print & Pick<Ui, 'step' | 'done'>;
+
+/**
+ * What a command answers with, said once.
+ *
+ * The schema is the contract `--json` prints against, and the renderer is that same value read by
+ * a person — handed nothing else, so a field cannot reach one surface and be missing from the
+ * other. Adding something to what a command says is adding it to the schema, and the renderer is
+ * where that is turned back into a sentence.
+ *
+ * Declared beside the code that produces the value rather than in the command, so the two
+ * spellings of `apps files ls` share one, and so the layout helpers stay testable on their own.
+ */
+export type Output<Schema extends z.ZodType> = {
+  schema: Schema;
+  render: (answer: { value: z.output<Schema>; out: Writer }) => void;
+};
+
+export function defineOutput<Schema extends z.ZodType>(output: Output<Schema>): Output<Schema> {
+  return output;
+}
+
+/**
+ * Progress written while `--json` is on. stdout carries the answer and nothing but the answer, so
+ * everything said to whoever is watching goes to stderr instead — which is what keeps a command
+ * that has something to show mid-flight usable, `nib login` and the code it prints above all.
+ */
+const ASIDE: Print = {
+  info: aside,
+  success: aside,
+  warn: aside,
+  error: aside,
+  dim: aside,
+};
+
+function aside(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export type Emitting<Schema extends z.ZodType> = {
+  /**
+   * Whether there is anybody to put a question to. `--json` answers that on its own: a caller
+   * reading the output with a program is not sat at the prompt a question would be asked at.
+   */
+  interactive: boolean;
+  ui: Ui;
+  /**
+   * Anything said beside the answer rather than as part of it — which release is being read, what
+   * a wait is for. The same `print` a handler was given, until `--json` moves it off stdout.
+   */
+  aside: Print;
+  /** Called once by most commands, and once per record by the ones that follow something. */
+  emit: (value: z.input<Schema>) => void;
+};
+
+export function createOutput<Schema extends z.ZodType>({
+  output,
+  print,
+  json,
+}: {
+  output: Output<Schema>;
+  print: Print;
+  json: boolean;
+}): Emitting<Schema> {
+  const interactive = !json && isInteractive();
+  const commentary = json ? ASIDE : print;
+  const ui = createUi({ print: commentary, interactive });
+
+  return {
+    interactive,
+    ui,
+    aside: commentary,
+    emit: (value) => {
+      // Parsed rather than passed through: the schema is what the JSON promises, so it is what
+      // decides which fields either surface gets to see.
+      const answer = output.schema.parse(value);
+      if (json) {
+        // One line per value, so a command that answers once and a command that follows a stream
+        // are read by the same reader.
+        process.stdout.write(`${JSON.stringify(answer)}\n`);
+        return;
+      }
+      output.render({ value: answer, out: { ...print, step: ui.step, done: ui.done } });
+    },
+  };
+}

--- a/packages/cli/src/lib/release.ts
+++ b/packages/cli/src/lib/release.ts
@@ -6,10 +6,33 @@ import {
   type DeployStep,
   describeUnservedDeployment,
 } from '@repo/app-operations';
+import { z } from 'zod';
+import { defineOutput } from '#lib/output.ts';
 import type { Ui } from '#lib/ui.ts';
 
 const MS_PER_SECOND = 1_000;
 const ELAPSED_DECIMALS = 1;
+
+const ReleaseSchema = z.object({
+  slug: z.string(),
+  appId: z.string(),
+  deploymentId: z.string(),
+  url: z.string(),
+  /** How long the release took to answer, or `null` for a caller that detached rather than wait. */
+  readyInMs: z.number().nullable(),
+});
+
+export type Release = z.infer<typeof ReleaseSchema>;
+
+export const RELEASE_OUTPUT = defineOutput({
+  schema: ReleaseSchema,
+  render: ({ value, out }) =>
+    out.done(
+      value.readyInMs === null
+        ? `${value.url} — deployment ${value.deploymentId} is starting`
+        : `${value.url} — ready in ${elapsed(value.readyInMs)}`,
+    ),
+});
 
 export function announce({ step, ui }: { step: DeployStep; ui: Ui }): void {
   if (step.kind === 'app') {
@@ -22,7 +45,7 @@ export function announce({ step, ui }: { step: DeployStep; ui: Ui }): void {
 
 /**
  * Wait for the release to answer, then say where it answers. Detached, the address is still what
- * is printed — a caller who did not want the wait still wants the app.
+ * is answered with — a caller who did not want the wait still wants the app.
  */
 export async function awaitServing({
   api,
@@ -34,10 +57,15 @@ export async function awaitServing({
   ui: Ui;
   deployed: Deployed;
   detach: boolean | undefined;
-}): Promise<void> {
+}): Promise<Release> {
+  const address = {
+    slug: deployed.slug,
+    appId: deployed.appId,
+    deploymentId: deployed.deploymentId,
+    url: deployed.url,
+  };
   if (detach === true) {
-    ui.done(`${deployed.url} — deployment ${deployed.deploymentId} is starting`);
-    return;
+    return { ...address, readyInMs: null };
   }
 
   const startedAt = Date.now();
@@ -53,7 +81,7 @@ export async function awaitServing({
   if (settled.state !== 'running') {
     throw new ApiError(describeUnservedDeployment(settled));
   }
-  ui.done(`${deployed.url} — ready in ${elapsed(Date.now() - startedAt)}`);
+  return { ...address, readyInMs: Date.now() - startedAt };
 }
 
 function elapsed(ms: number): string {

--- a/packages/cli/src/lib/suspend.ts
+++ b/packages/cli/src/lib/suspend.ts
@@ -4,34 +4,61 @@ import {
   resumeApp as requestResume,
   suspendApp as requestSuspension,
 } from '@repo/app-operations';
-import type { Ui } from '#lib/ui.ts';
+import { APP_STATES } from '@repo/protocol';
+import { z } from 'zod';
+import { defineOutput } from '#lib/output.ts';
 
-export type SuspendInput = { api: PublicApiClient; slug: string; ui: Ui };
+/** Where the app was left, and whether this run is what put it there. */
+const AppStateChangeSchema = z.object({
+  slug: z.string(),
+  state: z.enum(APP_STATES),
+  changed: z.boolean(),
+});
+
+export type AppStateChange = z.infer<typeof AppStateChangeSchema>;
+
+export const SUSPENDED_OUTPUT = defineOutput({
+  schema: AppStateChangeSchema,
+  render: ({ value, out }) =>
+    out.done(
+      value.changed
+        ? `${value.slug} is suspended. Its microVM stops; the volume, everything on it and every hostname stay.`
+        : `${value.slug} is already suspended.`,
+    ),
+});
+
+export const RESUMED_OUTPUT = defineOutput({
+  schema: AppStateChangeSchema,
+  render: ({ value, out }) =>
+    out.done(
+      value.changed
+        ? `${value.slug} is active. The host boots the deployment it was suspended on.`
+        : `${value.slug} is already running.`,
+    ),
+});
+
+export type SuspendInput = { api: PublicApiClient; slug: string };
 
 /**
  * Take an app offline without giving anything of it up. Nothing here is destructive and there is
  * nothing to confirm: what a suspended app costs is its uptime, and resuming is the undo.
  */
-export async function suspendApp({ api, slug, ui }: SuspendInput): Promise<void> {
+export async function suspendApp({ api, slug }: SuspendInput): Promise<AppStateChange> {
   const { app } = await appFor({ api, slug, operation: 'suspend' });
   if (app.state === 'suspended') {
-    ui.done(`${app.slug} is already suspended.`);
-    return;
+    return { slug: app.slug, state: app.state, changed: false };
   }
 
   const suspended = await requestSuspension({ api, appId: app.id });
-  ui.done(
-    `${suspended.slug} is suspended. Its microVM stops; the volume, everything on it and every hostname stay.`,
-  );
+  return { slug: suspended.slug, state: suspended.state, changed: true };
 }
 
-export async function resumeApp({ api, slug, ui }: SuspendInput): Promise<void> {
+export async function resumeApp({ api, slug }: SuspendInput): Promise<AppStateChange> {
   const { app } = await appFor({ api, slug, operation: 'resume' });
   if (app.state === 'active') {
-    ui.done(`${app.slug} is already running.`);
-    return;
+    return { slug: app.slug, state: app.state, changed: false };
   }
 
   const resumed = await requestResume({ api, appId: app.id });
-  ui.done(`${resumed.slug} is active. The host boots the deployment it was suspended on.`);
+  return { slug: resumed.slug, state: resumed.state, changed: true };
 }

--- a/packages/cli/src/lib/update.ts
+++ b/packages/cli/src/lib/update.ts
@@ -2,7 +2,7 @@ import type { PublicApiClient } from '@repo/api-client/public';
 import { redeploy } from '@repo/app-operations';
 import type { TenantArguments } from '@repo/protocol';
 import { environmentEdit } from '#lib/environment.ts';
-import { announce, awaitServing } from '#lib/release.ts';
+import { announce, awaitServing, type Release } from '#lib/release.ts';
 import type { Ui } from '#lib/ui.ts';
 
 export type UpdateInput = {
@@ -34,7 +34,7 @@ export async function updateApp({
   env,
   unset,
   detach,
-}: UpdateInput): Promise<void> {
+}: UpdateInput): Promise<Release> {
   const deployed = await redeploy({
     api,
     app: slug,
@@ -45,5 +45,5 @@ export async function updateApp({
     onStep: (step) => announce({ step, ui }),
   });
 
-  await awaitServing({ api, ui, deployed, detach });
+  return await awaitServing({ api, ui, deployed, detach });
 }

--- a/packages/cli/tests/lib/app-list.test.ts
+++ b/packages/cli/tests/lib/app-list.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { type AppListing, render } from '#lib/app-list.ts';
+import { APP_LIST_OUTPUT, type AppRow, render } from '#lib/app-list.ts';
 import { BYTES_PER_MIB, MEMORY_MIB, SLUG, VOLUME_SIZE_BYTES } from '#tests/support/app.ts';
+import { writerRecording } from '#tests/support/output.ts';
 
 const MEASURED_SHARE = 0.17;
 const MEASURED_PERCENT = '17%';
@@ -9,47 +10,22 @@ const CPU_PERCENT = '42%';
 const MEMORY_SHARE = 0.5;
 const MEMORY_PERCENT = '50%';
 
-type Overrides = Partial<{
-  [Key in keyof AppListing]: AppListing[Key] | string;
-}>;
+const MEMORY_BYTES = MEMORY_MIB * BYTES_PER_MIB;
 
-// Plain strings rather than the branded ones the wire carries: what is pinned down here is how a
-// row is laid out, and a cast per field would be spelling rather than meaning.
-function app(overrides: Overrides = {}): AppListing {
+function app(overrides: Partial<AppRow> = {}): AppRow {
   return {
     slug: SLUG,
     state: 'active',
     updatedAt: '2026-08-07T09:41:00.123Z',
-    config: { volumeSizeBytes: VOLUME_SIZE_BYTES, resources: { memoryMib: MEMORY_MIB } },
-    volumeUsage: null,
-    computeUsage: null,
+    cpuShare: null,
+    memory: { usedBytes: null, totalBytes: MEMORY_BYTES },
+    volume: { usedBytes: null, totalBytes: VOLUME_SIZE_BYTES },
     ...overrides,
-  } as AppListing;
+  };
 }
 
-// Cast once here for the same reason `app` casts once: the branding is the wire's, and what this
-// file is about is the column, not the parsing that produced it.
-function used(share: number): AppListing['volumeUsage'] {
-  return {
-    totalBytes: VOLUME_SIZE_BYTES,
-    usedBytes: VOLUME_SIZE_BYTES * share,
-    measuredAt: '2026-08-07T09:40:00.000Z',
-  } as NonNullable<AppListing['volumeUsage']>;
-}
-
-function spending({
-  memoryShare,
-  cpuShare,
-}: {
-  memoryShare: number;
-  cpuShare?: number;
-}): AppListing['computeUsage'] {
-  return {
-    memoryTotalBytes: MEMORY_MIB * BYTES_PER_MIB,
-    memoryUsedBytes: MEMORY_MIB * BYTES_PER_MIB * memoryShare,
-    ...(cpuShare === undefined ? {} : { cpuShare }),
-    measuredAt: '2026-08-07T09:40:00.000Z',
-  } as NonNullable<AppListing['computeUsage']>;
+function used({ share, of }: { share: number; of: number }) {
+  return { usedBytes: of * share, totalBytes: of };
 }
 
 describe('a listing is read down a column', () => {
@@ -87,12 +63,19 @@ describe('a listing is read down a column', () => {
 
 describe('the share columns say what an app is using of what it was given', () => {
   test('a measured app shows what share of its volume it is using', () => {
-    expect(render([app({ volumeUsage: used(MEASURED_SHARE) })]).at(-1)).toContain(MEASURED_PERCENT);
+    const line = render([
+      app({ volume: used({ share: MEASURED_SHARE, of: VOLUME_SIZE_BYTES }) }),
+    ]).at(-1);
+
+    expect(line).toContain(MEASURED_PERCENT);
   });
 
   test('a measured guest shows what share of its cpu and memory it is using', () => {
     const line = render([
-      app({ computeUsage: spending({ memoryShare: MEMORY_SHARE, cpuShare: CPU_SHARE }) }),
+      app({
+        cpuShare: CPU_SHARE,
+        memory: used({ share: MEMORY_SHARE, of: MEMORY_BYTES }),
+      }),
     ]).at(-1);
 
     expect(line).toContain(CPU_PERCENT);
@@ -102,7 +85,7 @@ describe('the share columns say what an app is using of what it was given', () =
   // A share is a rate, so the first reading taken of a guest has none — while the memory beside
   // it is a level and arrives whole. One column empty must not empty the other.
   test('a guest measured before it had a rate still shows its memory', () => {
-    const line = render([app({ computeUsage: spending({ memoryShare: MEMORY_SHARE }) })]).at(-1);
+    const line = render([app({ memory: used({ share: MEMORY_SHARE, of: MEMORY_BYTES }) })]).at(-1);
 
     expect(line).toContain(MEMORY_PERCENT);
     expect(line).toContain(`-   ${MEMORY_PERCENT}`);
@@ -121,4 +104,14 @@ test('the order the api answered with is the order that is printed', () => {
   const lines = render([app({ slug: 'newest' }), app({ slug: 'oldest' })]);
 
   expect(lines.map((line) => line.split(' ')[0])).toEqual(['SLUG', 'newest', 'oldest']);
+});
+
+// A heading over nothing reads as a listing that failed rather than an account with nothing in it.
+test('an owner with no apps is told what makes one instead of shown a heading', () => {
+  const out = writerRecording();
+
+  APP_LIST_OUTPUT.render({ value: { apps: [] }, out });
+
+  expect(out.at).toEqual(['dim']);
+  expect(out.said[0]).toContain('`nib run`');
 });

--- a/packages/cli/tests/lib/app-status.test.ts
+++ b/packages/cli/tests/lib/app-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { type AppStatusView, renderStatus } from '#lib/app-status.ts';
+import { type AppStatusReport, renderStatus } from '#lib/app-status.ts';
 import {
   BYTES_PER_MIB,
   MEMORY_MIB,
@@ -11,35 +11,27 @@ import {
 const MEMORY_USED_BYTES = 412_401_664;
 const VOLUME_USED_BYTES = 1_503_238_553;
 const CPU_SHARE = 0.18;
+const MEASURED_AT = '2026-08-29T11:01:00.000Z';
 
-// Plain strings rather than the branded ones the wire carries: what is pinned down here is how a
-// status reads, and a cast per field would be spelling rather than meaning.
-function app(overrides: object = {}): AppStatusView {
+function app(overrides: Partial<AppStatusReport> = {}): AppStatusReport {
   return {
     slug: SLUG,
     status: 'running',
-    config: {
-      volumeSizeBytes: VOLUME_SIZE_BYTES,
-      resources: { vcpuCount: VCPU_COUNT, memoryMib: MEMORY_MIB },
-    },
-    volumeUsage: null,
-    computeUsage: null,
+    vcpu: { used: null, total: VCPU_COUNT, measuredAt: null },
+    memory: { used: null, total: MEMORY_MIB * BYTES_PER_MIB, measuredAt: null },
+    volume: { used: null, total: VOLUME_SIZE_BYTES, measuredAt: null },
     ...overrides,
-  } as AppStatusView;
+  };
 }
 
 const measured = app({
-  volumeUsage: {
-    totalBytes: VOLUME_SIZE_BYTES,
-    usedBytes: VOLUME_USED_BYTES,
-    measuredAt: '2026-08-29T11:01:00.000Z',
+  vcpu: { used: CPU_SHARE * VCPU_COUNT, total: VCPU_COUNT, measuredAt: MEASURED_AT },
+  memory: {
+    used: MEMORY_USED_BYTES,
+    total: MEMORY_MIB * BYTES_PER_MIB,
+    measuredAt: MEASURED_AT,
   },
-  computeUsage: {
-    memoryTotalBytes: MEMORY_MIB * BYTES_PER_MIB,
-    memoryUsedBytes: MEMORY_USED_BYTES,
-    cpuShare: CPU_SHARE,
-    measuredAt: '2026-08-29T11:01:00.000Z',
-  },
+  volume: { used: VOLUME_USED_BYTES, total: VOLUME_SIZE_BYTES, measuredAt: MEASURED_AT },
 });
 
 describe('a status says what one app is using of what it was given', () => {
@@ -76,14 +68,10 @@ describe('a status says what one app is using of what it was given', () => {
   test('two readings taken apart are summarised by the older of them', () => {
     const { measured } = renderStatus(
       app({
-        volumeUsage: {
-          totalBytes: VOLUME_SIZE_BYTES,
-          usedBytes: VOLUME_USED_BYTES,
-          measuredAt: '2026-08-29T11:01:00.000Z',
-        },
-        computeUsage: {
-          memoryTotalBytes: MEMORY_MIB * BYTES_PER_MIB,
-          memoryUsedBytes: MEMORY_USED_BYTES,
+        volume: { used: VOLUME_USED_BYTES, total: VOLUME_SIZE_BYTES, measuredAt: MEASURED_AT },
+        memory: {
+          used: MEMORY_USED_BYTES,
+          total: MEMORY_MIB * BYTES_PER_MIB,
           measuredAt: '2026-08-27T09:12:00.000Z',
         },
       }),
@@ -104,10 +92,10 @@ describe('a status says what one app is using of what it was given', () => {
   test('a guest measured before it had a cpu share still reads its memory', () => {
     const lines = renderStatus(
       app({
-        computeUsage: {
-          memoryTotalBytes: MEMORY_MIB * BYTES_PER_MIB,
-          memoryUsedBytes: MEMORY_USED_BYTES,
-          measuredAt: '2026-08-29T11:01:00.000Z',
+        memory: {
+          used: MEMORY_USED_BYTES,
+          total: MEMORY_MIB * BYTES_PER_MIB,
+          measuredAt: MEASURED_AT,
         },
       }),
     ).lines.join('\n');

--- a/packages/cli/tests/lib/delete.test.ts
+++ b/packages/cli/tests/lib/delete.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { deleteApp, saysDeletePermanently } from '#lib/delete.ts';
+import { DELETED_OUTPUT, deleteApp, saysDeletePermanently } from '#lib/delete.ts';
 import {
   apiHolding,
   deploymentsHolding,
@@ -8,7 +8,7 @@ import {
   RUNNING_DEPLOYMENT,
 } from '#tests/support/api.ts';
 import { APP_ID, HOSTNAME, SLUG } from '#tests/support/app.ts';
-import { uiRecording } from '#tests/support/ui.ts';
+import { writerRecording } from '#tests/support/output.ts';
 
 function listed(overrides: Partial<ListedApp> = {}): ListedApp {
   return listedApp({ hostnames: [{ hostname: HOSTNAME }], ...overrides });
@@ -37,7 +37,6 @@ describe('what a run with nobody watching is allowed to delete', () => {
     const attempt = deleteApp({
       api: apiHoldingDeletable({ apps: [listed()], deleted }),
       slug: SLUG,
-      ui: uiRecording(),
       yes: false,
       interactive: false,
     });
@@ -52,7 +51,6 @@ describe('what a run with nobody watching is allowed to delete', () => {
     await deleteApp({
       api: apiHoldingDeletable({ apps: [listed()], deleted }),
       slug: SLUG,
-      ui: uiRecording(),
       yes: true,
       interactive: false,
     });
@@ -64,18 +62,24 @@ describe('what a run with nobody watching is allowed to delete', () => {
 // The teardown already running is the answer to the second request, so it is not sent.
 test('an app already being deleted is not deleted again', async () => {
   const deleted: string[] = [];
-  const ui = uiRecording();
 
-  await deleteApp({
+  const deleting = await deleteApp({
     api: apiHoldingDeletable({ apps: [listed({ state: 'deleting' })], deleted }),
     slug: SLUG,
-    ui,
     yes: true,
     interactive: false,
   });
 
   expect(deleted).toEqual([]);
-  expect(ui.said).toEqual([`${SLUG} is already being deleted.`]);
+  expect(deleting).toEqual({ slug: SLUG, state: 'deleting', changed: false });
+});
+
+test('and the teardown already under way is what a reader is told about', () => {
+  const out = writerRecording();
+
+  DELETED_OUTPUT.render({ value: { slug: SLUG, state: 'deleting', changed: false }, out });
+
+  expect(out.said).toEqual([`${SLUG} is already being deleted.`]);
 });
 
 describe('what counts as having typed the phrase', () => {

--- a/packages/cli/tests/lib/logs.test.ts
+++ b/packages/cli/tests/lib/logs.test.ts
@@ -1,36 +1,17 @@
 import { describe, expect, test } from 'bun:test';
-import type { Print } from '@parshjs/core';
-import type { TenantLogRecord } from '@repo/protocol';
-import { render, show } from '#lib/logs.ts';
+import { LOG_RECORD_OUTPUT, type LogRecord, render } from '#lib/logs.ts';
+import { writerRecording } from '#tests/support/output.ts';
 
 const DROPPED_BYTES = 4096;
 const ESCAPE_CODE = 27;
 
-function record(overrides: Partial<TenantLogRecord> = {}): TenantLogRecord {
+function record(overrides: Partial<LogRecord> = {}): LogRecord {
   return {
-    _time: '2026-08-06T09:41:00.123Z',
-    _msg: 'listening on 0.0.0.0:8090',
-    hostId: 'host-1',
-    SOURCE: 'tenant',
-    appId: 'app-1',
-    deploymentId: 'deployment-1',
+    time: '2026-08-06T09:41:00.123Z',
+    message: 'listening on 0.0.0.0:8090',
     stream: 'stdout',
-    sourceId: 'source-1',
-    sequence: 0,
+    droppedBytes: null,
     ...overrides,
-  } as TenantLogRecord;
-}
-
-/** Which level a record went out at is the whole of what `show` decides. */
-function printer(): Print & { at: string[] } {
-  const at: string[] = [];
-  return {
-    at,
-    info: () => at.push('info'),
-    success: () => at.push('success'),
-    warn: () => at.push('warn'),
-    error: () => at.push('error'),
-    dim: () => at.push('dim'),
   };
 }
 
@@ -92,7 +73,7 @@ describe('a record is one line of what the app wrote', () => {
   // The store keeps the newline the guest wrote and printing supplies another, which is a blank
   // line between every two records.
   test('the newline that ended the message is not printed a second time', () => {
-    const line = render(record({ _msg: 'listening on 0.0.0.0:8090\n' }));
+    const line = render(record({ message: 'listening on 0.0.0.0:8090\n' }));
 
     expect(line).not.toInclude('\n');
     expect(columns(line).message).toBe('listening on 0.0.0.0:8090');
@@ -100,7 +81,7 @@ describe('a record is one line of what the app wrote', () => {
 
   // Trailing spaces are the app's own, and only the terminator is this program's to remove.
   test('what the app wrote is otherwise left alone', () => {
-    expect(columns(render(record({ _msg: 'waiting...  ' }))).message).toBe('waiting...  ');
+    expect(columns(render(record({ message: 'waiting...  ' }))).message).toBe('waiting...  ');
   });
 
   // A gap stands for output the host had to drop, and how much is the whole of what it says.
@@ -127,27 +108,30 @@ describe('only the part of a line the app did not write is dimmed', () => {
 
 describe('the stream a record came out of is the stream it goes back into', () => {
   test('ordinary output is written plainly to ours', () => {
-    const print = printer();
+    const out = writerRecording();
 
-    show({ record: record(), print });
+    LOG_RECORD_OUTPUT.render({ value: record(), out });
 
-    expect(print.at).toEqual(['info']);
+    expect(out.at).toEqual(['info']);
   });
 
   test('what the app wrote to its error stream goes to ours', () => {
-    const print = printer();
+    const out = writerRecording();
 
-    show({ record: record({ stream: 'stderr' }), print });
+    LOG_RECORD_OUTPUT.render({ value: record({ stream: 'stderr' }), out });
 
-    expect(print.at).toEqual(['error']);
+    expect(out.at).toEqual(['error']);
   });
 
   // A gap is the host speaking, not the app, so it is not dressed as the app's own error output.
   test('a gap is a warning rather than the app error output', () => {
-    const print = printer();
+    const out = writerRecording();
 
-    show({ record: record({ stream: 'stderr', droppedBytes: DROPPED_BYTES }), print });
+    LOG_RECORD_OUTPUT.render({
+      value: record({ stream: 'stderr', droppedBytes: DROPPED_BYTES }),
+      out,
+    });
 
-    expect(print.at).toEqual(['warn']);
+    expect(out.at).toEqual(['warn']);
   });
 });

--- a/packages/cli/tests/lib/output.test.ts
+++ b/packages/cli/tests/lib/output.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+import type { Print } from '@parshjs/core';
+import { z } from 'zod';
+import { createOutput, defineOutput } from '#lib/output.ts';
+import { SLUG } from '#tests/support/app.ts';
+
+const rendered: string[] = [];
+
+const OUTPUT = defineOutput({
+  schema: z.object({ slug: z.string() }),
+  render: ({ value }) => {
+    rendered.push(value.slug);
+  },
+});
+
+function silent(): Print {
+  return { info: () => {}, success: () => {}, warn: () => {}, error: () => {}, dim: () => {} };
+}
+
+type Write = typeof process.stdout.write;
+
+/** What a run put on each of this program's own streams, which is the whole point of `--json`. */
+function captured(run: () => void): { out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdout = process.stdout.write;
+  const stderr = process.stderr.write;
+
+  process.stdout.write = ((chunk: unknown) => out.push(String(chunk)) > 0) as Write;
+  process.stderr.write = ((chunk: unknown) => err.push(String(chunk)) > 0) as Write;
+  try {
+    run();
+  } finally {
+    process.stdout.write = stdout;
+    process.stderr.write = stderr;
+  }
+  return { out, err };
+}
+
+function answering({ json }: { json: boolean }) {
+  rendered.length = 0;
+  return createOutput({ output: OUTPUT, print: silent(), json });
+}
+
+describe('the same answer reaches either surface, and only one of them at a time', () => {
+  test('--json is one line of it, and the renderer never runs', () => {
+    const { emit } = answering({ json: true });
+
+    const { out } = captured(() => emit({ slug: SLUG }));
+
+    expect(out).toEqual([`{"slug":"${SLUG}"}\n`]);
+    expect(rendered).toEqual([]);
+  });
+
+  test('without it the renderer is what says anything at all', () => {
+    const { emit } = answering({ json: false });
+
+    const { out } = captured(() => emit({ slug: SLUG }));
+
+    expect(rendered).toEqual([SLUG]);
+    expect(out).toEqual([]);
+  });
+
+  // One line per value rather than one document, so a command that answers once and a command
+  // that follows a stream are read by the same reader.
+  test('a command that answers more than once answers a line at a time', () => {
+    const { emit } = answering({ json: true });
+
+    const { out } = captured(() => {
+      emit({ slug: 'first' });
+      emit({ slug: 'second' });
+    });
+
+    expect(out).toEqual(['{"slug":"first"}\n', '{"slug":"second"}\n']);
+  });
+});
+
+// The schema is what the JSON promises, so it is what decides which fields go out — not whatever
+// the api happened to hand the command on the way past.
+test('a field the schema does not name does not reach the output', () => {
+  const { emit } = answering({ json: true });
+
+  const { out } = captured(() => emit({ slug: SLUG, accessToken: 'shh' } as { slug: string }));
+
+  expect(out).toEqual([`{"slug":"${SLUG}"}\n`]);
+});
+
+describe('what --json does to everything that is not the answer', () => {
+  test('progress goes to stderr, so nothing said in passing corrupts the payload', () => {
+    const { aside } = answering({ json: true });
+
+    const { out, err } = captured(() => aside.dim('uploading'));
+
+    expect(out).toEqual([]);
+    expect(err).toEqual(['uploading\n']);
+  });
+
+  // A caller reading this with a program is not sat at the prompt a question would be asked at.
+  test('it is not a terminal to ask a question at', () => {
+    expect(answering({ json: true }).interactive).toBe(false);
+  });
+});

--- a/packages/cli/tests/lib/suspend.test.ts
+++ b/packages/cli/tests/lib/suspend.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from 'bun:test';
-import { resumeApp, suspendApp } from '#lib/suspend.ts';
+import { describe, expect, test } from 'bun:test';
+import { RESUMED_OUTPUT, resumeApp, SUSPENDED_OUTPUT, suspendApp } from '#lib/suspend.ts';
 import {
   apiHolding,
   deploymentsHolding,
@@ -7,7 +7,7 @@ import {
   RUNNING_DEPLOYMENT,
 } from '#tests/support/api.ts';
 import { APP_ID, SLUG } from '#tests/support/app.ts';
-import { uiRecording } from '#tests/support/ui.ts';
+import { writerRecording } from '#tests/support/output.ts';
 
 type Asked = { appId: string; state: string };
 
@@ -40,43 +40,42 @@ function apiInState({
 
 test('suspending a running app asks the api for it', async () => {
   const asked: Asked[] = [];
-  const ui = uiRecording();
 
-  await suspendApp({ api: apiInState({ state: 'active', asked }), slug: SLUG, ui });
+  const suspended = await suspendApp({ api: apiInState({ state: 'active', asked }), slug: SLUG });
 
   expect(asked).toEqual([{ appId: APP_ID, state: 'suspended' }]);
-  expect(ui.said[0]).toContain('is suspended');
+  expect(suspended).toEqual({ slug: SLUG, state: 'suspended', changed: true });
 });
 
 // Asking twice is asking once, and the second is answered by the state the first left it in.
 test('suspending one that already is says so and sends nothing', async () => {
   const asked: Asked[] = [];
-  const ui = uiRecording();
 
-  await suspendApp({ api: apiInState({ state: 'suspended', asked }), slug: SLUG, ui });
+  const suspended = await suspendApp({
+    api: apiInState({ state: 'suspended', asked }),
+    slug: SLUG,
+  });
 
   expect(asked).toEqual([]);
-  expect(ui.said).toEqual([`${SLUG} is already suspended.`]);
+  expect(suspended).toEqual({ slug: SLUG, state: 'suspended', changed: false });
 });
 
 test('resuming a suspended app puts it back', async () => {
   const asked: Asked[] = [];
-  const ui = uiRecording();
 
-  await resumeApp({ api: apiInState({ state: 'suspended', asked }), slug: SLUG, ui });
+  const resumed = await resumeApp({ api: apiInState({ state: 'suspended', asked }), slug: SLUG });
 
   expect(asked).toEqual([{ appId: APP_ID, state: 'active' }]);
-  expect(ui.said[0]).toContain('is active');
+  expect(resumed).toEqual({ slug: SLUG, state: 'active', changed: true });
 });
 
 test('and resuming one that is already running sends nothing either', async () => {
   const asked: Asked[] = [];
-  const ui = uiRecording();
 
-  await resumeApp({ api: apiInState({ state: 'active', asked }), slug: SLUG, ui });
+  const resumed = await resumeApp({ api: apiInState({ state: 'active', asked }), slug: SLUG });
 
   expect(asked).toEqual([]);
-  expect(ui.said).toEqual([`${SLUG} is already running.`]);
+  expect(resumed).toEqual({ slug: SLUG, state: 'active', changed: false });
 });
 
 // The api refuses this too. Said here because the read that turns a slug into an id has already
@@ -85,11 +84,40 @@ test('an app being deleted is refused rather than sent', async () => {
   const asked: Asked[] = [];
 
   await expect(
-    resumeApp({
-      api: apiInState({ state: 'deleting', asked }),
-      slug: SLUG,
-      ui: uiRecording(),
-    }),
+    resumeApp({ api: apiInState({ state: 'deleting', asked }), slug: SLUG }),
   ).rejects.toThrow('App quiet-otter is being deleted, so there is nothing left to bring back.');
   expect(asked).toEqual([]);
+});
+
+describe('what the same answer reads as to a person', () => {
+  test('an app this run suspended is told what it kept', () => {
+    const out = writerRecording();
+
+    SUSPENDED_OUTPUT.render({
+      value: { slug: SLUG, state: 'suspended', changed: true },
+      out,
+    });
+
+    expect(out.at).toEqual(['done']);
+    expect(out.said[0]).toContain('is suspended');
+  });
+
+  test('and one that already was is told only that', () => {
+    const out = writerRecording();
+
+    SUSPENDED_OUTPUT.render({
+      value: { slug: SLUG, state: 'suspended', changed: false },
+      out,
+    });
+
+    expect(out.said).toEqual([`${SLUG} is already suspended.`]);
+  });
+
+  test('a resume reads the same way round', () => {
+    const out = writerRecording();
+
+    RESUMED_OUTPUT.render({ value: { slug: SLUG, state: 'active', changed: false }, out });
+
+    expect(out.said).toEqual([`${SLUG} is already running.`]);
+  });
 });

--- a/packages/cli/tests/lib/update.test.ts
+++ b/packages/cli/tests/lib/update.test.ts
@@ -114,19 +114,19 @@ test('a name the shell would not accept as a variable is refused in this program
   return expect(attempt).rejects.toThrow('9LIVES');
 });
 
-test('the binary being run again is named, and so is where it answers', async () => {
+// The steps are said as they happen and the address is answered with, so what a caller reading
+// this with a program gets is the release rather than the narration of it.
+test('the binary being run again is named, and the release says where it answers', async () => {
   const ui = uiRecording();
 
-  await updateApp({
+  const release = await updateApp({
     api: apiHoldingPatchable({ patched: [] }),
     ui,
     slug: SLUG,
     args: [],
   });
 
-  expect(ui.said).toEqual([
-    `app ${SLUG}`,
-    'artifact sha256:abcd',
-    expect.stringContaining(`https://${HOSTNAME}`),
-  ]);
+  expect(ui.said).toEqual([`app ${SLUG}`, 'artifact sha256:abcd']);
+  expect(release.url).toContain(`https://${HOSTNAME}`);
+  expect(release.readyInMs).not.toBeNull();
 });

--- a/packages/cli/tests/support/output.ts
+++ b/packages/cli/tests/support/output.ts
@@ -1,0 +1,33 @@
+import type { Writer } from '#lib/output.ts';
+
+export type WriterRecording = Writer & {
+  /** Every line a renderer wrote, in order. */
+  said: string[];
+  /** Which channel each of them went out on, so routing is assertable on its own. */
+  at: string[];
+};
+
+/** Where a renderer writes, when what is being pinned down is what it wrote rather than to whom. */
+export function writerRecording(): WriterRecording {
+  const said: string[] = [];
+  const at: string[] = [];
+
+  function channel(name: string) {
+    return (message: string) => {
+      at.push(name);
+      said.push(message);
+    };
+  }
+
+  return {
+    said,
+    at,
+    info: channel('info'),
+    success: channel('success'),
+    warn: channel('warn'),
+    error: channel('error'),
+    dim: channel('dim'),
+    step: channel('step'),
+    done: channel('done'),
+  };
+}


### PR DESCRIPTION
Every `nib` command now declares what it answers with once — a zod schema and a renderer over that same value — so a field reaches both surfaces or neither. A root `--json` prints the schema's parse of it, one line per value, and moves everything said in passing to stderr so stdout carries nothing but the payload.

A stopgap for the same feature in parsh itself (ilbertt/parsh#8): an output is a schema and a pure renderer, so migrating is moving the pair onto `defineCommand`.