### PR TITLE
feat(agent): a sleep and a wake say what they cost

### DIFF
--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -443,6 +443,13 @@ function restored({ appId, startedAt }: { appId: AppId; startedAt: Timestamp }) 
  * with the reason on its record: `VmManager.wake` discards the snapshot on its way out, so the
  * request after this one is the cold boot rather than a second attempt at the same restore.
  */
+/**
+ * Which of the three ways a wake can end. Returned rather than inferred from the record, because
+ * a cold boot and a restore leave the same record behind and only this can tell them apart —
+ * which is the difference between the feature working and it quietly not.
+ */
+export type WakeOutcome = 'restored' | 'already-running' | 'cold-boot';
+
 export const resumeInstance = Effect.fn('resumeInstance')(function* (desired: DesiredInstance) {
   yield* Effect.annotateCurrentSpan({ appId: desired.appId });
   const allocator = yield* SlotAllocator;
@@ -456,7 +463,7 @@ export const resumeInstance = Effect.fn('resumeInstance')(function* (desired: De
   // waiting on this is about to be answered by the guest that is already there.
   const unit = (yield* Systemd.statuses([desired.appId])).get(desired.appId) ?? UNKNOWN_UNIT;
   if (unit.active) {
-    return;
+    return 'already-running' as const;
   }
 
   // For the reason `startInstance` marks one before its boot: the clock this starts is the one
@@ -466,14 +473,16 @@ export const resumeInstance = Effect.fn('resumeInstance')(function* (desired: De
     nowMs: yield* Clock.currentTimeMillis,
   });
 
-  yield* vms.wake({ appId: desired.appId, deploymentId: desired.deploymentId, slot }).pipe(
+  return yield* vms.wake({ appId: desired.appId, deploymentId: desired.deploymentId, slot }).pipe(
     Effect.andThen(
       Effect.flatMap(nowTimestamp, (startedAt) => restored({ appId: desired.appId, startedAt })),
     ),
+    Effect.as('restored' as const),
     Effect.catchTag('SnapshotUnusable', (unusable) =>
       Effect.logInfo('nothing to wake this app from; booting it instead', unusable)
         .pipe(Effect.annotateLogs({ appId: desired.appId }))
-        .pipe(Effect.andThen(startInstance(desired))),
+        .pipe(Effect.andThen(startInstance(desired)))
+        .pipe(Effect.as('cold-boot' as const)),
     ),
     Effect.tapError((error) =>
       AgentState.updateRecord({

--- a/apps/agent/src/services/app-waker.service.ts
+++ b/apps/agent/src/services/app-waker.service.ts
@@ -1,6 +1,6 @@
 import type { HttpClient } from '@effect/platform';
 import type { AppId, DesiredInstance } from '@repo/protocol';
-import { Data, Deferred, Duration, Effect, Option, Ref, Schedule } from 'effect';
+import { Clock, Data, Deferred, Duration, Effect, Option, Ref, Schedule } from 'effect';
 import { reportedMessage } from '#lib/failure.ts';
 import { probeInstance } from '#lib/health/probe.ts';
 import { resumeInstance } from '#lib/reconcile/instances.ts';
@@ -31,6 +31,11 @@ const NO_SHORTFALL = 0;
  * the whole agent, named again at that boundary and built a second time behind it.
  */
 type WakeContext = Effect.Effect.Context<ReturnType<typeof resumeInstance>> | HttpClient.HttpClient;
+
+type Claim = {
+  readonly deferred: Deferred.Deferred<void, WakeFailed | HostHasNoRoom>;
+  readonly joined: Ref.Ref<number>;
+};
 
 export class WakeFailed extends Data.TaggedError('WakeFailed')<{
   readonly appId: AppId;
@@ -76,9 +81,12 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
   effect: Effect.gen(function* () {
     const cache = yield* DesiredStateCache;
     const context = yield* Effect.context<WakeContext>();
-    const inFlight = yield* Ref.make(
-      new Map<AppId, Deferred.Deferred<void, WakeFailed | HostHasNoRoom>>(),
-    );
+    /**
+     * The joiners are counted beside the deferred rather than derived afterwards: a cold page
+     * load is one wake and a burst of requests, and without the count every reading of how often
+     * apps wake is really a reading of how many requests arrived while one was waking.
+     */
+    const inFlight = yield* Ref.make(new Map<AppId, Claim>());
 
     /**
      * The grace period is the deadline: past it the health loop would call the instance failed
@@ -124,7 +132,14 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
         : undefined;
     });
 
-    const boot = Effect.fn('AppWaker.boot')(function* (appId: AppId) {
+    const boot = Effect.fn('AppWaker.boot')(function* ({
+      appId,
+      joined,
+    }: {
+      appId: AppId;
+      joined: Ref.Ref<number>;
+    }) {
+      const startedMs = yield* Clock.currentTimeMillis;
       const desired = yield* cache.latest;
       const wanted = Option.getOrUndefined(desired)?.instances.find(
         (instance) => instance.appId === appId,
@@ -155,7 +170,7 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
       // A slot table with nothing free is the one start failure a request can cause, and it is
       // this host's problem rather than this app's — so it is said in the same breath as any
       // other reason the microVM is not there.
-      yield* resumeInstance(wanted).pipe(
+      const outcome = yield* resumeInstance(wanted).pipe(
         Effect.catchAll((error) => new WakeFailed({ appId, reason: reportedMessage(error) })),
       );
 
@@ -169,28 +184,40 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
         });
       }
       yield* untilAnswering(record);
-      yield* Effect.logInfo('app woken by a request').pipe(Effect.annotateLogs({ appId }));
+      // `waitedMs` is the whole of what the visitor paid, `outcome` is what they paid it for:
+      // a restore and a cold boot are the same line otherwise, and the difference between them
+      // is the feature. `coalesced` is how many more requests waited on this same wake, so a
+      // count of these lines is a count of wakes rather than of requests.
+      yield* Effect.logInfo('app woken by a request').pipe(
+        Effect.annotateLogs({
+          appId,
+          outcome,
+          waitedMs: (yield* Clock.currentTimeMillis) - startedMs,
+          coalesced: yield* Ref.get(joined),
+        }),
+      );
     });
 
     return {
       wake: Effect.fn('AppWaker.wake')(function* (appId: AppId) {
-        const claim = yield* Deferred.make<void, WakeFailed | HostHasNoRoom>();
+        const claim: Claim = {
+          deferred: yield* Deferred.make<void, WakeFailed | HostHasNoRoom>(),
+          joined: yield* Ref.make(0),
+        };
         const held = yield* Ref.modify(inFlight, (current) => {
           const existing = current.get(appId);
           return existing
             ? ([Option.some(existing), current] as const)
-            : ([
-                Option.none<Deferred.Deferred<void, WakeFailed | HostHasNoRoom>>(),
-                new Map(current).set(appId, claim),
-              ] as const);
+            : ([Option.none<Claim>(), new Map(current).set(appId, claim)] as const);
         });
         if (Option.isSome(held)) {
-          return yield* Deferred.await(held.value);
+          yield* Ref.update(held.value.joined, (count) => count + 1);
+          return yield* Deferred.await(held.value.deferred);
         }
-        return yield* boot(appId).pipe(
+        return yield* boot({ appId, joined: claim.joined }).pipe(
           Effect.provide(context),
           Effect.onExit((exit) =>
-            Deferred.done(claim, exit).pipe(
+            Deferred.done(claim.deferred, exit).pipe(
               Effect.andThen(
                 Ref.update(inFlight, (current) => {
                   const remaining = new Map(current);

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -1,6 +1,6 @@
 import { FileSystem, Path } from '@effect/platform';
 import type { AppId, DeploymentId, DesiredInstance } from '@repo/protocol';
-import { Effect, Either } from 'effect';
+import { Duration, Effect, Either } from 'effect';
 import { writeJsonFile } from '#lib/json-store.ts';
 import { tenantLogSocketPath } from '#lib/logs/vsock.ts';
 import type { AppSlot } from '#lib/network/slot.ts';
@@ -274,23 +274,38 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       yield* fs.makeDirectory(paths.directory, { recursive: true, mode: VM_DIR_MODE });
       yield* zerofs.flushAll;
 
-      yield* Firecracker.pause(socketPath);
-      yield* Effect.onError(
+      // Timed as one window because it is one: the guest is stopped from the pause to the stop,
+      // so this is what sleeping costs a tenant rather than what it costs the host.
+      const [paused] = yield* Effect.timed(
         Effect.gen(function* () {
-          yield* Firecracker.createSnapshot({
-            socketPath,
-            statePath: paths.statePath,
-            memoryPath: paths.memoryPath,
-          });
-          yield* Systemd.stop(appId);
+          yield* Firecracker.pause(socketPath);
+          yield* Effect.onError(
+            Effect.gen(function* () {
+              yield* Firecracker.createSnapshot({
+                socketPath,
+                statePath: paths.statePath,
+                memoryPath: paths.memoryPath,
+              });
+              yield* Systemd.stop(appId);
+            }),
+            // A microVM left paused answers nothing and is never asked to run again.
+            () => Effect.ignore(Firecracker.resume(socketPath)),
+          );
         }),
-        // A microVM left paused answers nothing and is never asked to run again.
-        () => Effect.ignore(Firecracker.resume(socketPath)),
       );
 
       yield* writeJsonFile({ path: paths.stampPath, value: stamp });
+      // `memoryBytes` beside the duration because the two move together — a snapshot is the
+      // guest's whole RAM, so what this costs grows with what an app asked for and not with
+      // anything the host can tune.
+      const captured = yield* Effect.orElseSucceed(fs.stat(paths.memoryPath), () => undefined);
       yield* Effect.logInfo('instance asleep').pipe(
-        Effect.annotateLogs({ appId, slot: slot.slot }),
+        Effect.annotateLogs({
+          appId,
+          slot: slot.slot,
+          snapshotMs: Duration.toMillis(paused),
+          ...(captured && { memoryBytes: Number(captured.size) }),
+        }),
       );
     });
 
@@ -315,36 +330,45 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
         forgetSnapshot(appId),
       );
 
-      yield* Systemd.start(appId);
-      yield* Effect.ensuring(
-        Effect.onError(
-          Effect.gen(function* () {
-            yield* Firecracker.loadSnapshot({
-              socketPath,
-              statePath: paths.statePath,
-              memoryPath: paths.memoryPath,
-            });
-            yield* Firecracker.resume(socketPath);
-            yield* refreshNeighbour({
-              guestIpv4: slot.guestIpv4,
-              guestMac: slot.guestMac,
-              tapName: slot.tapName,
-            });
-          }),
-          // The start already consumed the stamp, so this Firecracker holds no guest and never
-          // will: stopping it is what leaves a cold boot rather than a process in the way of one.
-          () => Effect.ignore(Systemd.stop(appId)),
-        ),
-        // Every way out, so no retry of a restore that failed halfway can find the files it did
-        // not finish with. The stamp is already gone and would stop a second load on its own;
-        // this is what keeps at-most-once from resting on that single fact.
-        //
-        // Unlinking while Firecracker still has the memory file mapped keeps the mapping alive
-        // and hands the disk back the moment the microVM exits, so the successful path pays
-        // nothing for it either.
-        forgetSnapshot(appId),
+      // From the start to the neighbour refresh, which is the whole of what the request that
+      // caused this is waiting on — the stamp check above it happens before anything is asked
+      // of the VMM and costs a file read.
+      const [restoring] = yield* Effect.timed(
+        Effect.gen(function* () {
+          yield* Systemd.start(appId);
+          yield* Effect.ensuring(
+            Effect.onError(
+              Effect.gen(function* () {
+                yield* Firecracker.loadSnapshot({
+                  socketPath,
+                  statePath: paths.statePath,
+                  memoryPath: paths.memoryPath,
+                });
+                yield* Firecracker.resume(socketPath);
+                yield* refreshNeighbour({
+                  guestIpv4: slot.guestIpv4,
+                  guestMac: slot.guestMac,
+                  tapName: slot.tapName,
+                });
+              }),
+              // The start already consumed the stamp, so this Firecracker holds no guest and never
+              // will: stopping it is what leaves a cold boot rather than a process in the way of one.
+              () => Effect.ignore(Systemd.stop(appId)),
+            ),
+            // Every way out, so no retry of a restore that failed halfway can find the files it did
+            // not finish with. The stamp is already gone and would stop a second load on its own;
+            // this is what keeps at-most-once from resting on that single fact.
+            //
+            // Unlinking while Firecracker still has the memory file mapped keeps the mapping alive
+            // and hands the disk back the moment the microVM exits, so the successful path pays
+            // nothing for it either.
+            forgetSnapshot(appId),
+          );
+        }),
       );
-      yield* Effect.logInfo('instance awake').pipe(Effect.annotateLogs({ appId, slot: slot.slot }));
+      yield* Effect.logInfo('instance awake').pipe(
+        Effect.annotateLogs({ appId, slot: slot.slot, restoreMs: Duration.toMillis(restoring) }),
+      );
     });
 
     return {

--- a/apps/agent/tests/lib/reconcile/instances.test.ts
+++ b/apps/agent/tests/lib/reconcile/instances.test.ts
@@ -249,6 +249,53 @@ describe('an app is woken by putting back the microVM it had', () => {
     );
   });
 
+  /**
+   * The three endings are the same record and the same log line otherwise, and telling them
+   * apart is the whole of knowing whether the feature is working: an app that cold-boots every
+   * time is one whose snapshots never load, which is indistinguishable from a fast wake until
+   * somebody reads the outcome.
+   */
+  test('a restore says so', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'idle' }));
+
+        expect(yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }))).toBe(
+          'restored',
+        );
+      }),
+    );
+  });
+
+  test('a cold boot says so rather than passing for a restore', () => {
+    const vms = recordingVms({
+      onWake: new SnapshotUnusable({ reason: 'the host has rebooted' }),
+    });
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'idle' }));
+
+        expect(yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }))).toBe(
+          'cold-boot',
+        );
+      }),
+    );
+  });
+
+  test('a wake that found the microVM already up is neither', () => {
+    const vms = recordingVms();
+    return onHost({ vms, unit: ACTIVE_UNIT })(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        expect(yield* resumeInstance(desiredInstance({ desiredState: 'on-request' }))).toBe(
+          'already-running',
+        );
+      }),
+    );
+  });
+
   // Firecracker takes a snapshot load only from a process that has configured nothing, and
   // `systemctl start` on a unit already up is the no-op that would have hidden it.
   test('a microVM that is already up is left alone rather than restored onto', () => {


### PR DESCRIPTION
The sleep/wake events reach VictoriaLogs already; none of the durations did. A count of wakes was answerable and `what does a wake cost` was not — which is the wrong way round for a feature whose whole justification is cost and whose whole risk is latency.

- `instance asleep` carries `snapshotMs` (the paused window, so what sleeping costs the tenant rather than the host) and `memoryBytes`
- `instance awake` carries `restoreMs`
- `app woken by a request` carries `outcome` (`restored` / `cold-boot` / `already-running`), `waitedMs` and `coalesced`

`outcome` is the load-bearing one: a cold boot and a restore leave the same record behind, so an app whose snapshots never load is indistinguishable from a fast wake until somebody reads it. `coalesced` makes a count of those lines a count of wakes rather than of requests.