### PR TITLE
refactor(app-operations): an app between requests is idle, in that word

### DIFF
--- a/apps/dashboard/src/lib/app-actions.ts
+++ b/apps/dashboard/src/lib/app-actions.ts
@@ -70,7 +70,7 @@ const AVAILABILITY: Record<AppStatusKey, AppActions> = {
     suspend: ENABLED,
     delete: ENABLED,
   },
-  // Everything a running app offers: an app asleep between requests is one that is up as far as
+  // Everything a running app offers: an app idle between requests is one that is up as far as
   // its owner is concerned, and suspend is still what takes it offline for good rather than
   // until the next visitor. Redeploy stays hidden — nothing has failed to run again.
   idle: {

--- a/packages/app-operations/src/operations.ts
+++ b/packages/app-operations/src/operations.ts
@@ -44,7 +44,7 @@ const STATE: Record<AppStatusKey, AppState> = {
   // and a browse is not a visit. Everything else is asked of the app rather than of the guest,
   // and an app waiting to be asked for is one an owner may still release, export or suspend.
   idle: {
-    because: 'is asleep until something asks for it',
+    because: 'is idle until something asks for it',
     hint: 'Open it to wake it.',
     refuses: ['files'],
   },

--- a/packages/app-operations/src/status.ts
+++ b/packages/app-operations/src/status.ts
@@ -21,7 +21,7 @@ export type AppStatus =
   | { readonly kind: 'deployment'; readonly state: Exclude<DeploymentState, 'stopped'> }
   // The one thing the release cannot say about itself. An `on-request` app between visitors has a
   // running release and no microVM, and the two are not the same news: the release is serving, and
-  // the app is asleep until somebody asks for it.
+  // the app is idle until somebody asks for it.
   | { readonly kind: 'instance'; readonly state: Extract<InstanceState, 'idle'> }
   | { readonly kind: 'transition'; readonly label: AppTransition }
   | { readonly kind: 'never-deployed' };
@@ -48,7 +48,7 @@ export function statusKey(status: AppStatus): AppStatusKey {
   }
 }
 
-const ASLEEP: AppStatus = { kind: 'instance', state: 'idle' };
+const IDLE: AppStatus = { kind: 'instance', state: 'idle' };
 const SUSPENDED: AppStatus = { kind: 'app', state: 'suspended' };
 const SUSPENDING: AppStatus = { kind: 'transition', label: 'suspending' };
 const RESUMING: AppStatus = { kind: 'transition', label: 'resuming' };
@@ -83,7 +83,7 @@ export function appStatus({
   // that sleeps between requests has a running release with no microVM behind it, and telling the
   // owner it is running would have them reading a page about an app that is not there.
   if (deploymentState === 'running' && instanceState === 'idle') {
-    return ASLEEP;
+    return IDLE;
   }
   // The one state the release holds only because the app was suspended. Asking for the app back
   // is not the host having started it, so this is the gap between the two said out loud.
@@ -104,9 +104,7 @@ export const APP_STATUS_LABELS: Record<AppStatusKey, string> = {
   pending: 'pending',
   starting: 'starting',
   running: 'running',
-  // Not the key: `idle` is a word for a machine doing nothing, and this is an app doing exactly
-  // what its owner configured — waiting to be asked, at no cost, until somebody visits it.
-  idle: 'asleep',
+  idle: 'idle',
   failed: 'failed',
   superseded: 'superseded',
   suspended: 'suspended',

--- a/packages/app-operations/tests/operations.test.ts
+++ b/packages/app-operations/tests/operations.test.ts
@@ -115,14 +115,14 @@ describe('an app on its way out', () => {
   });
 });
 
-describe('an app asleep between requests', () => {
-  const asleep = { deploymentState: 'running', instanceState: 'idle' } as const;
+describe('an app idle between requests', () => {
+  const idle = { deploymentState: 'running', instanceState: 'idle' } as const;
 
   // The one thing that has to reach inside a microVM, and there is none until a visitor causes
   // one — which a browse is not.
   test('has no microVM mounting its filesystem, and says what would make one', () => {
-    expect(refusal({ operation: 'files', ...asleep })).toBe(
-      'App quiet-otter is asleep until something asks for it, so nothing is mounting its filesystem to read. Open it to wake it.',
+    expect(refusal({ operation: 'files', ...idle })).toBe(
+      'App quiet-otter is idle until something asks for it, so nothing is mounting its filesystem to read. Open it to wake it.',
     );
   });
 
@@ -130,7 +130,7 @@ describe('an app asleep between requests', () => {
 
   for (const operation of still) {
     test(`is still an app to ${operation}`, () => {
-      expect(refusal({ operation, ...asleep })).toBeUndefined();
+      expect(refusal({ operation, ...idle })).toBeUndefined();
     });
   }
 });

--- a/packages/app-operations/tests/status.test.ts
+++ b/packages/app-operations/tests/status.test.ts
@@ -100,8 +100,8 @@ describe('resuming is not running until the host has started it', () => {
  * does. The owner is owed the second half — a page saying `running` about an app holding no memory
  * and reporting no readings is a page they would read as broken.
  */
-describe('an app asleep between requests says so', () => {
-  test('a running release with no microVM behind it is asleep', () => {
+describe('an app idle between requests says so', () => {
+  test('a running release with no microVM behind it is idle', () => {
     expect(status({ deploymentState: 'running', instanceState: 'idle' })).toEqual({
       kind: 'instance',
       state: 'idle',
@@ -111,7 +111,7 @@ describe('an app asleep between requests says so', () => {
   test('and it is not an error: waiting to be asked is what it was configured for', () => {
     expect(
       APP_STATUS_LABELS[statusKey(status({ deploymentState: 'running', instanceState: 'idle' }))],
-    ).toBe('asleep');
+    ).toBe('idle');
   });
 
   // Read only under a release that is serving. Anything else is a host still catching up with a
@@ -163,7 +163,7 @@ describe('what is worth asking about again', () => {
     ['a suspended app', { kind: 'app', state: 'suspended' }],
     ['an app never deployed', { kind: 'never-deployed' }],
     // Nothing is going to move it: only a visitor can, and no amount of asking is one.
-    ['an app asleep between requests', { kind: 'instance', state: 'idle' }],
+    ['an app idle between requests', { kind: 'instance', state: 'idle' }],
   ];
 
   for (const [name, status] of settled) {
@@ -196,7 +196,7 @@ describe('what has something running to write output', () => {
     ['a suspended app', status({ appState: 'suspended', deploymentState: 'stopped' })],
     ['one nobody has deployed', status()],
     ['one being deleted', status({ appState: 'deleting' })],
-    ['one asleep between requests', status({ deploymentState: 'running', instanceState: 'idle' })],
+    ['one idle between requests', status({ deploymentState: 'running', instanceState: 'idle' })],
   ];
 
   for (const [name, each] of silent) {

--- a/packages/cli/src/lib/app-status.ts
+++ b/packages/cli/src/lib/app-status.ts
@@ -127,7 +127,7 @@ export function renderStatus(app: AppStatusReport): RenderedStatus {
   return {
     lines: [
       `${app.slug}  ${APP_STATUS_LABELS[app.status]}`,
-      // Under the status rather than in the table: `asleep` is only an answer beside the setting
+      // Under the status rather than in the table: `idle` is only an answer beside the setting
       // that put it there, and neither is something the app is spending.
       activationSummary(app),
       '',

--- a/packages/cli/tests/lib/app-status.test.ts
+++ b/packages/cli/tests/lib/app-status.test.ts
@@ -93,19 +93,19 @@ describe('a status says what one app is using of what it was given', () => {
   });
 
   /**
-   * `asleep` on its own reads as something that went wrong. Beside the setting that put it there
-   * it reads as the app doing what it was configured to do, which is why the two are one block.
+   * `idle` on its own reads as something that went wrong. Beside the setting that put it there it
+   * reads as the app doing what it was configured to do, which is why the two are one block.
    */
-  test('an app that is asleep says what put it there', () => {
+  test('an app that is idle says what put it there', () => {
     const lines = renderStatus(
       app({ status: 'idle', activation: 'on-request', idleTimeoutMs: A_QUARTER_HOUR_MS }),
     ).lines;
 
-    expect(lines[0]).toBe(`${SLUG}  asleep`);
+    expect(lines[0]).toBe(`${SLUG}  idle`);
     expect(lines[1]).toBe('On request, stopped after 15m of quiet');
   });
 
-  test('an app that is always on says so where the sleeping one says its wait', () => {
+  test('an app that is always on says so where the idle one says its wait', () => {
     expect(renderStatus(app()).lines[1]).toBe('Always on');
   });
 


### PR DESCRIPTION
`idle` is what the protocol enum, the column's CHECK and the host's own reports call this. Only the
two surfaces an owner reads called it `asleep` — so `--json` answered `"status":"idle"` beside a
table that said `asleep`, and the refusal that explains why a filesystem will not mount said the
same third thing again.

The label that differed was arguing that `idle` sounds like a fault where this is an app doing what
it was configured to do. That is a real risk and not one a second word fixes: what answers it is the
activation shown beside the status, which #422 put on both surfaces.

Labels and the refusal sentence only. No enum value, column or log line moves.