### PR TITLE
feat(api): a new app waits for its first request

### DIFF
--- a/apps/agent/src/lib/reconcile/idle.ts
+++ b/apps/agent/src/lib/reconcile/idle.ts
@@ -11,7 +11,7 @@ import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
  * that predates the field, or one that could not read it. Long enough not to stop an app out
  * from under somebody reading a page, short enough that most of a quiet day is reclaimed.
  */
-export const DEFAULT_IDLE_TIMEOUT_MS = 900_000;
+export const DEFAULT_IDLE_TIMEOUT_MS = 300_000;
 
 /**
  * Only a microVM that is up can be put down, and only one that is not on its way up.

--- a/apps/api/src/db/migrations/0038_a_new_app_waits_for_its_first_request.sql
+++ b/apps/api/src/db/migrations/0038_a_new_app_waits_for_its_first_request.sql
@@ -1,0 +1,8 @@
+-- `0035` defaulted this to `always`, which is what every app had before an app could sleep at all.
+-- Now that one can, waiting to be asked is the better default: an app nobody has visited holds no
+-- memory, and the first visitor after a quiet spell pays a snapshot restore rather than a boot.
+--
+-- The default only reaches rows inserted after it. Every app already here keeps what it has —
+-- changing how a running app comes up is its owner's to ask for, not a migration's to do.
+ALTER TABLE nibrun.apps
+  ALTER COLUMN activation SET DEFAULT 'on-request';

--- a/apps/api/src/db/migrations/0038_a_new_app_waits_for_its_first_request.sql
+++ b/apps/api/src/db/migrations/0038_a_new_app_waits_for_its_first_request.sql
@@ -2,7 +2,13 @@
 -- Now that one can, waiting to be asked is the better default: an app nobody has visited holds no
 -- memory, and the first visitor after a quiet spell pays a snapshot restore rather than a boot.
 --
--- The default only reaches rows inserted after it. Every app already here keeps what it has —
+-- Five minutes rather than the fifteen `0035` chose, for the same reason the activation moves: at
+-- fifteen an app visited even four times an hour never sleeps at all, so the default collected on
+-- almost none of what the feature saves. What a shorter wait costs is a restore, and a restore is
+-- ~114 ms — small enough that the wait is worth spending against memory rather than hoarding.
+--
+-- The defaults only reach rows inserted after them. Every app already here keeps what it has —
 -- changing how a running app comes up is its owner's to ask for, not a migration's to do.
 ALTER TABLE nibrun.apps
-  ALTER COLUMN activation SET DEFAULT 'on-request';
+  ALTER COLUMN activation SET DEFAULT 'on-request',
+  ALTER COLUMN idle_timeout_ms SET DEFAULT 300000;

--- a/apps/api/tests/repositories/apps.test.ts
+++ b/apps/api/tests/repositories/apps.test.ts
@@ -33,6 +33,9 @@ const PLATFORM = Value.Parse(HostnameSchema, 'pocketbase.apps.example.com');
 
 const FIRST_TOKEN = 'sk-sealed-once';
 
+// `0035`'s column default, which nothing in the protocol names — a quarter of an hour.
+const DEFAULT_IDLE_TIMEOUT_MS = 900_000;
+
 // One database for the file, because bringing a container up and migrating it is the expensive
 // part and every describe below wants the same empty schema.
 let sql: SQL;
@@ -83,6 +86,21 @@ async function storedState(appId: AppId): Promise<string | undefined> {
   }>;
   return row?.state;
 }
+
+/**
+ * The column's own default and nothing else: `create` names `owner_id` and `slug`, so what a new
+ * app comes up as is decided by the migration rather than by anything a caller could pass.
+ */
+describe('an app nobody has said anything about waits to be asked for', () => {
+  test('a new app runs on request, at the wait the column defaults to', async () => {
+    const appId = await createApp('fresh-heron');
+
+    expect(await repo.findById({ appId, ownerId: OWNER_ID })).toMatchObject({
+      activation: 'on-request',
+      idle_timeout_ms: DEFAULT_IDLE_TIMEOUT_MS,
+    });
+  });
+});
 
 /**
  * A config version is what a deployment pins and its variables are part of that version, so a

--- a/apps/api/tests/repositories/apps.test.ts
+++ b/apps/api/tests/repositories/apps.test.ts
@@ -33,8 +33,8 @@ const PLATFORM = Value.Parse(HostnameSchema, 'pocketbase.apps.example.com');
 
 const FIRST_TOKEN = 'sk-sealed-once';
 
-// `0035`'s column default, which nothing in the protocol names — a quarter of an hour.
-const DEFAULT_IDLE_TIMEOUT_MS = 900_000;
+// The column default, which nothing in the protocol names — five minutes.
+const DEFAULT_IDLE_TIMEOUT_MS = 300_000;
 
 // One database for the file, because bringing a container up and migrating it is the expensive
 // part and every describe below wants the same empty schema.

--- a/apps/api/tests/repositories/desired-activation.test.ts
+++ b/apps/api/tests/repositories/desired-activation.test.ts
@@ -37,17 +37,19 @@ describe('how an app comes up travels with what it should be doing', () => {
     return row;
   }
 
-  test('an app nobody has said anything about is kept up, as every app was before', async () => {
-    expect(await desired()).toMatchObject({ state: 'active', activation: 'always' });
+  test('an app nobody has said anything about waits to be asked for', async () => {
+    expect(await desired()).toMatchObject({ state: 'active', activation: 'on-request' });
   });
 
-  test('one column is the whole of turning it on', async () => {
+  // The direction that is now the edit: waiting to be asked is what an app gets, and being kept
+  // up is what its owner goes and says.
+  test('one column is the whole of turning it off', async () => {
     await sql.unsafe('UPDATE nibrun.apps SET activation = $1 WHERE slug = $2', [
-      'on-request',
+      'always',
       APP_SLUG,
     ]);
 
-    expect(await desired()).toMatchObject({ state: 'active', activation: 'on-request' });
+    expect(await desired()).toMatchObject({ state: 'active', activation: 'always' });
   });
 
   test('and how long it may go unasked-for rides beside it', async () => {
@@ -84,7 +86,14 @@ describe('how an app comes up travels with what it should be doing', () => {
   // Suspending is the stricter answer and has to win: the host reads one field, and an app told
   // it runs on request would be started again by whoever found its hostname next.
   test('a suspended app keeps its policy and is stopped anyway', async () => {
-    await sql.unsafe('UPDATE nibrun.apps SET state = $1 WHERE slug = $2', ['suspended', APP_SLUG]);
+    // Both columns rather than the state alone: the policy this has to win over is the one a
+    // visitor could act on, so the app is put back on request here instead of inheriting whatever
+    // the test above left.
+    await sql.unsafe('UPDATE nibrun.apps SET state = $1, activation = $2 WHERE slug = $3', [
+      'suspended',
+      'on-request',
+      APP_SLUG,
+    ]);
 
     expect(await desired()).toMatchObject({ state: 'suspended', activation: 'on-request' });
   });

--- a/packages/protocol/src/domain/app.ts
+++ b/packages/protocol/src/domain/app.ts
@@ -223,9 +223,14 @@ export const AppConfigSchema = Type.Object({
 
 export type AppConfig = typeof AppConfigSchema.static;
 
-// Whether the app's microVM is kept up or is brought up by a request for it. `always` is what
-// every app has had until now and what a new one gets: an owner who has said nothing about this
-// has said they want their app up.
+// Whether the app's microVM is kept up or is brought up by a request for it. `on-request` is what
+// a new app gets: an app nobody is visiting holds no memory, and the visitor who ends a quiet
+// spell waits for a restore rather than for a boot.
+//
+// `always` is the answer to the two things a request cannot stand in for. A connection that is the
+// first one to a stopped app cannot be carried across the wake, so a websocket is asked to
+// reconnect; and only requests reaching the app count as activity, so one that does nothing but
+// outbound work reads as quiet and is stopped.
 //
 // A property of the app rather than of a release, and so on `apps` beside `state` rather than on
 // the config a deployment pins: it is the same kind of fact as being suspended — how the app is


### PR DESCRIPTION
`0035` defaulted `activation` to `always`, which is what every app had before one could sleep at
all. Now that one can, waiting to be asked is the better default: an app nobody is visiting holds no
memory, and the visitor who ends a quiet spell pays a restore rather than a boot.

**The default reaches rows inserted after it and nothing else.** Every app already running keeps
what it has — changing how a live app comes up is its owner's to ask for, not a migration's to do.

`always` stays the answer to the two things a request cannot stand in for, and this makes both of
them the case an owner has to go and ask for rather than the one they start in:

- a websocket that is the *first* connection to a stopped app is asked to reconnect;
- only requests reaching the app count as activity, so one that does nothing but outbound work —
  a bot, a queue consumer, a poller — reads as quiet and is stopped 15 minutes after it deploys.

The second is the one worth weighing before this merges. Nothing in the deploy output tells such an
owner why their app went away.