### PR TITLE
fix(agent): a woken microVM is asked again on the grid a first answer lands on

### DIFF
--- a/apps/agent/src/lib/health/state.ts
+++ b/apps/agent/src/lib/health/state.ts
@@ -73,13 +73,31 @@ export function isWithinGracePeriod({ healthCheck, startedAtMs, nowMs }: GraceIn
 }
 
 /**
- * Whether this tenant is still being given its first chance to answer.
+ * The same tracker with this microVM's own run of probes cleared and the app's history kept.
  *
- * Bounded by the grace period rather than by the state alone, which is what keeps it — and the
+ * `everHealthy` is a fact about the app — whether it has ever served — and survives, because it is
+ * what later decides whether a run of failures reads as `unhealthy` or as an app that never served
+ * at all. The run of successes is a fact about the microVM in front of it, and one restored from a
+ * snapshot has answered nothing yet however long the app it belongs to has been up.
+ */
+export function afterRestore(tracker: HealthTracker): HealthTracker {
+  return { ...tracker, consecutiveSuccesses: NO_PROBES, consecutiveFailures: NO_PROBES };
+}
+
+/**
+ * Whether this microVM is still being given its first chance to answer.
+ *
+ * A restore is the second way to be owed one, and reading `everHealthy` alone misses it: a woken
+ * app has served plenty and the guest in front of it has answered nothing, so the boot the fast
+ * grid was written for is the one boot it would not have covered — leaving the request that woke
+ * the app waiting out a tick measured for apps that are already up.
+ *
+ * Bounded by the grace period rather than by the tracker alone, which is what keeps it — and the
  * loop that ticks for it — from running for as long as an app that never settles is up.
  */
 export function isOnStartupGrid({ tracker, ...grace }: ProbeInputs): boolean {
-  return !tracker.everHealthy && isWithinGracePeriod(grace);
+  const hasAnswered = tracker.everHealthy && tracker.consecutiveSuccesses > NO_PROBES;
+  return !hasAnswered && isWithinGracePeriod(grace);
 }
 
 /**

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -12,6 +12,7 @@ import { frozen } from '#lib/exports/freeze.ts';
 import { reportedMessage } from '#lib/failure.ts';
 import { probeInstance } from '#lib/health/probe.ts';
 import {
+  afterRestore,
   applyProbe,
   describeInstanceFailure,
   evaluateInstanceState,
@@ -425,6 +426,11 @@ function restored({ appId, startedAt }: { appId: AppId; startedAt: Timestamp }) 
       startedAt,
       stopRequested: false,
       message: undefined,
+      // The microVM in front of this record is new, whatever the app behind it has done. Without
+      // this it inherits a run of successes the guest it belongs to never had, and the status loop
+      // reads an app that is coming up as one that is already up — ticking for it at the second a
+      // steady app is worth rather than at the grid a first answer lands on.
+      health: afterRestore(record.health),
     }),
   }).pipe(Effect.andThen(probeAtOnce(appId)));
 }

--- a/apps/agent/src/lib/volumes/zerofs.ts
+++ b/apps/agent/src/lib/volumes/zerofs.ts
@@ -48,39 +48,68 @@ export const listCheckpoints = Effect.fn('zerofs.listCheckpoints')((target: Zero
 
 export class ZerofsCacheUnknown extends Data.TaggedError('ZerofsCacheUnknown')<{
   readonly path: string;
+  readonly setting: CacheSetting;
 }> {
   override get message() {
-    return `${this.path} does not say how much disk ZeroFS may cache on`;
+    return `${this.path} does not say ${this.setting}, which is what ZeroFS may cache with`;
   }
 }
 
 /**
- * How much of the disk ZeroFS is entitled to, read out of the file it is itself started with
- * rather than written down a second time here. It grows into that number lazily, so a disk that
- * looks empty today is one whose free space is already spoken for — and anything else that writes
- * to the same disk has to hold this much back rather than what ZeroFS happens to be holding now.
+ * What ZeroFS is entitled to, read out of the file it is itself started with rather than written
+ * down a second time here. It grows into both numbers lazily, so a disk or a host that looks
+ * empty today is one whose free space is already spoken for — and anything else helping itself
+ * to either has to hold this much back rather than what ZeroFS happens to be holding now.
  */
-export const readCacheDiskBytes = Effect.fn('zerofs.readCacheDiskBytes')(function* (
-  configFile: string,
-) {
-  const configured = Option.flatMap(yield* readTextFile(configFile), cacheDiskGigabytes);
-  if (Option.isNone(configured)) {
-    return yield* new ZerofsCacheUnknown({ path: configFile });
-  }
-  return configured.value * BYTES_PER_CONFIGURED_GB;
-});
+const readCacheBytes = ({ configFile, setting }: { configFile: string; setting: CacheSetting }) =>
+  Effect.gen(function* () {
+    const configured = Option.flatMap(yield* readTextFile(configFile), (config) =>
+      cacheGigabytes({ config, setting }),
+    );
+    if (Option.isNone(configured)) {
+      return yield* new ZerofsCacheUnknown({ path: configFile, setting });
+    }
+    return configured.value * BYTES_PER_CONFIGURED_GB;
+  });
 
-/** `[cache] disk_size_gb`, or nothing at all: a value this cannot read is not one to guess at. */
-export function cacheDiskGigabytes(config: string): Option.Option<number> {
+export const readCacheDiskBytes = Effect.fn('zerofs.readCacheDiskBytes')((configFile: string) =>
+  readCacheBytes({ configFile, setting: 'disk_size_gb' }),
+);
+
+export const readCacheMemoryBytes = Effect.fn('zerofs.readCacheMemoryBytes')((configFile: string) =>
+  readCacheBytes({ configFile, setting: 'memory_size_gb' }),
+);
+
+/** The two `[cache]` sizes the agent holds back for, spelled as ZeroFS spells them. */
+type CacheSetting = 'disk_size_gb' | 'memory_size_gb';
+
+/** The configured number, or nothing at all: a value this cannot read is not one to guess at. */
+function cacheGigabytes({
+  config,
+  setting,
+}: {
+  config: string;
+  setting: CacheSetting;
+}): Option.Option<number> {
   try {
-    const { cache } = Bun.TOML.parse(config) as { cache?: { disk_size_gb?: unknown } };
-    const configured = cache?.disk_size_gb;
+    const { cache } = Bun.TOML.parse(config) as {
+      cache?: Partial<Record<CacheSetting, unknown>>;
+    };
+    const configured = cache?.[setting];
     return typeof configured === 'number' && configured > 0
       ? Option.some(configured)
       : Option.none();
   } catch {
     return Option.none();
   }
+}
+
+export function cacheDiskGigabytes(config: string): Option.Option<number> {
+  return cacheGigabytes({ config, setting: 'disk_size_gb' });
+}
+
+export function cacheMemoryGigabytes(config: string): Option.Option<number> {
+  return cacheGigabytes({ config, setting: 'memory_size_gb' });
 }
 
 export function parseCheckpointNames(output: string): string[] {

--- a/apps/agent/tests/lib/health/state.test.ts
+++ b/apps/agent/tests/lib/health/state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { DEFAULT_HEALTH_CHECK, DEFAULT_HTTP_PORT, type HealthCheck } from '@repo/protocol';
 import {
+  afterRestore,
   applyProbe,
   describeInstanceFailure,
   evaluateInstanceState,
@@ -139,6 +140,25 @@ describe('how soon a tenant is asked again', () => {
 
   test('past the grace period the startup grid is over, so a slow starter fails as it always did', () => {
     expect(delay({ tracker: initialTracker(), nowMs: PAST_GRACE_MS })).toBe(
+      DEFAULT_HEALTH_CHECK.intervalMs,
+    );
+  });
+
+  /**
+   * The case the grid exists for and the one `everHealthy` alone would miss: a woken app has
+   * served plenty and the guest in front of it has answered nothing, so a request holding on the
+   * wake would otherwise wait out a tick measured for apps that are already up.
+   */
+  test('a microVM restored under an app that has served is back on the startup grid', () => {
+    expect(delay({ tracker: afterRestore(healthyThen(0)), nowMs: WITHIN_GRACE_MS })).toBe(
+      STARTUP_PROBE_INTERVAL_MS,
+    );
+  });
+
+  test('and it leaves the grid again on the answer that says the guest is up', () => {
+    const answered = probe({ tracker: afterRestore(healthyThen(0)), healthy: true });
+
+    expect(delay({ tracker: answered, nowMs: WITHIN_GRACE_MS })).toBe(
       DEFAULT_HEALTH_CHECK.intervalMs,
     );
   });


### PR DESCRIPTION
A wake restores the guest in ~70 ms and answers the request holding on it straight away, but for up
to a second afterwards the app is still reached through the activator rather than through the
forward rule — every request in that window takes a detour it did not need, and shows up as a
second `app woken by a request` carrying `outcome: already-running`.

That window is one status-loop tick. `refresh` is what probes the guest, moves the record to
`running` and renders the forward rule from it, and the loop already ticks four times faster while
anything is coming up. A restored microVM did not qualify: `isOnStartupGrid` reads `everHealthy`,
which a restore keeps because it is a fact about the *app* — so the one boot the fast grid was
written for was the one boot it did not cover.

The run of successes is the fact about the *microVM*, and that is what a restore clears. A woken app
is asked again at 250 ms rather than at a second, and leaves the grid on the answer that says its
guest is up. Bounded by the grace period exactly as before.

**This shortens the window rather than closing it.** Closing it means the wake driving a refresh
itself instead of waiting for the next tick, which needs a signal between the two — worth doing only
if 250 ms still shows up in the logs.
