### PR TITLE
fix(agent): memory the host needs is not memory a guest may be given

### DIFF
--- a/apps/agent/src/lib/agent/report.ts
+++ b/apps/agent/src/lib/agent/report.ts
@@ -55,7 +55,10 @@ const report = Effect.gen(function* () {
   const session = yield* sessions.current;
   const current = yield* AgentState.snapshot;
   const records = [...current.records.values()];
-  const capacity = yield* readHostCapacity(config.stateDir);
+  const capacity = yield* readHostCapacity({
+    cacheDir: config.stateDir,
+    zerofsConfigFile: config.zerofsConfigFile,
+  });
   const reachedAt = yield* publicAddresses(records);
 
   yield* control.sendReportedState({

--- a/apps/agent/src/lib/report/capacity.ts
+++ b/apps/agent/src/lib/report/capacity.ts
@@ -22,15 +22,19 @@ export function readHostMemoryMib(): number {
 }
 
 /**
- * Host memory that is nobody's guest to take: the kernel, this agent, Caddy, and the Firecracker
- * process standing in front of each microVM, which costs a few MiB over and above the RAM its
- * guest was configured with.
+ * Host memory that is nobody's guest to take: this agent, Caddy, journald, and what systemd and
+ * the SSM agent hold — about 420 MiB together on a live app host.
  *
- * Rounder than a measurement of any of them, because it is a floor and not a reading. What it
- * buys is that the host stays answerable once it is full — an agent that has sold the last of its
- * memory to tenants cannot report, cannot converge and cannot be asked to give any of it back.
+ * Not the Firecracker processes, which is the tempting mistake to make here. A VMM's resident
+ * size *is* its guest's memory rather than an overhead on top of it — four 256 MiB guests measure
+ * between 216 and 257 MiB each — so counting them would reserve every guest a second time.
+ *
+ * Headroom over that reading rather than the reading itself, because this is a floor and the
+ * things behind it grow. What it buys is that the host stays answerable once it is full: an agent
+ * that has sold the last of its memory to tenants cannot report, cannot converge, and cannot be
+ * asked to give any of it back.
  */
-const HOST_BASELINE_MIB = 1024;
+const HOST_BASELINE_MIB = 640;
 
 /**
  * What ZeroFS is assumed to want when its own config cannot be read, which is the number that

--- a/apps/agent/src/lib/report/capacity.ts
+++ b/apps/agent/src/lib/report/capacity.ts
@@ -1,8 +1,10 @@
 import { statfs } from 'node:fs/promises';
 import { availableParallelism, totalmem } from 'node:os';
+import type { FileSystem } from '@effect/platform';
 import type { HostCapacity, InstanceResources, InstanceState } from '@repo/protocol';
-import { Effect } from 'effect';
+import { Effect, Either } from 'effect';
 import type { InstanceRecord } from '#lib/report/instance-record.ts';
+import { readCacheMemoryBytes } from '#lib/volumes/zerofs.ts';
 
 const BYTES_PER_MIB = 1_048_576;
 const NONE = 0;
@@ -18,6 +20,67 @@ const UNMEASURED: FilesystemSpace = { totalBytes: NONE, availableBytes: NONE };
 export function readHostMemoryMib(): number {
   return Math.floor(totalmem() / BYTES_PER_MIB);
 }
+
+/**
+ * Host memory that is nobody's guest to take: the kernel, this agent, Caddy, and the Firecracker
+ * process standing in front of each microVM, which costs a few MiB over and above the RAM its
+ * guest was configured with.
+ *
+ * Rounder than a measurement of any of them, because it is a floor and not a reading. What it
+ * buys is that the host stays answerable once it is full — an agent that has sold the last of its
+ * memory to tenants cannot report, cannot converge and cannot be asked to give any of it back.
+ */
+const HOST_BASELINE_MIB = 1024;
+
+/**
+ * What ZeroFS is assumed to want when its own config cannot be read, which is the number that
+ * config holds today.
+ *
+ * Guessed rather than raised into a failure, because the two ways of being wrong are not
+ * symmetrical: a host that reports no capacity is one nothing is ever placed on, where a host
+ * that reports memory it does not have kills a tenant — and, ZeroFS being the disk every app on
+ * the host runs through, most likely several of them.
+ */
+const ASSUMED_ZEROFS_CACHE_MIB = 2048;
+
+/**
+ * The memory a guest may actually be given, which is the host's total less what is already spoken
+ * for. ZeroFS fills its cache lazily, exactly as it fills the disk one, so free memory on a host
+ * that has just booted is not memory that is going spare.
+ *
+ * **The one number both the report and a wake are made on.** They have to agree by construction
+ * rather than by coincidence: a host that refused wakes by one measure while telling the control
+ * plane it had room by another would go on being placed onto for as long as it went on refusing.
+ */
+export function guestMemoryMib({
+  hostMemoryMib,
+  zerofsCacheMib,
+}: {
+  hostMemoryMib: number;
+  zerofsCacheMib: number;
+}): number {
+  return Math.max(hostMemoryMib - zerofsCacheMib - HOST_BASELINE_MIB, NONE);
+}
+
+export const readGuestMemoryMib = Effect.fn('capacity.readGuestMemoryMib')(function* (
+  zerofsConfigFile: string,
+) {
+  const configured = yield* Effect.either(readCacheMemoryBytes(zerofsConfigFile));
+  if (Either.isLeft(configured)) {
+    yield* Effect.logWarning('zerofs memory cache could not be read').pipe(
+      Effect.annotateLogs({
+        assumedMib: ASSUMED_ZEROFS_CACHE_MIB,
+        reason: configured.left.message,
+      }),
+    );
+  }
+  return guestMemoryMib({
+    hostMemoryMib: readHostMemoryMib(),
+    zerofsCacheMib: Either.isLeft(configured)
+      ? ASSUMED_ZEROFS_CACHE_MIB
+      : Math.ceil(configured.right / BYTES_PER_MIB),
+  });
+});
 
 /**
  * Fails where the path cannot be stat'd, which a report can shrug off and a decision about what
@@ -39,12 +102,28 @@ const spaceOrUnmeasured = (directory: string) =>
 export const readAvailableCacheBytes = (cacheDir: string) =>
   Effect.map(spaceOrUnmeasured(cacheDir), (space) => space.availableBytes);
 
-export const readHostCapacity = (cacheDir: string): Effect.Effect<HostCapacity> =>
-  Effect.map(spaceOrUnmeasured(cacheDir), (space) => ({
-    vcpuCount: availableParallelism(),
-    memoryMib: readHostMemoryMib(),
-    cacheBytes: space.totalBytes,
-  }));
+/**
+ * `memoryMib` is what may be given to guests rather than what the instance was sold with — the
+ * host's own needs are not capacity, and reporting them as capacity is what fills a host past
+ * what it can carry.
+ */
+export const readHostCapacity = ({
+  cacheDir,
+  zerofsConfigFile,
+}: {
+  cacheDir: string;
+  zerofsConfigFile: string;
+}): Effect.Effect<HostCapacity, never, FileSystem.FileSystem> =>
+  Effect.all({
+    space: spaceOrUnmeasured(cacheDir),
+    memoryMib: readGuestMemoryMib(zerofsConfigFile),
+  }).pipe(
+    Effect.map(({ space, memoryMib }) => ({
+      vcpuCount: availableParallelism(),
+      memoryMib,
+      cacheBytes: space.totalBytes,
+    })),
+  );
 
 /**
  * The states in which an app has no microVM, and so is holding nothing of the host.

--- a/apps/agent/src/lib/volumes/zerofs.ts
+++ b/apps/agent/src/lib/volumes/zerofs.ts
@@ -48,39 +48,68 @@ export const listCheckpoints = Effect.fn('zerofs.listCheckpoints')((target: Zero
 
 export class ZerofsCacheUnknown extends Data.TaggedError('ZerofsCacheUnknown')<{
   readonly path: string;
+  readonly setting: CacheSetting;
 }> {
   override get message() {
-    return `${this.path} does not say how much disk ZeroFS may cache on`;
+    return `${this.path} does not say ${this.setting}, which is what ZeroFS may cache with`;
   }
 }
 
 /**
- * How much of the disk ZeroFS is entitled to, read out of the file it is itself started with
- * rather than written down a second time here. It grows into that number lazily, so a disk that
- * looks empty today is one whose free space is already spoken for — and anything else that writes
- * to the same disk has to hold this much back rather than what ZeroFS happens to be holding now.
+ * What ZeroFS is entitled to, read out of the file it is itself started with rather than written
+ * down a second time here. It grows into both numbers lazily, so a disk or a host that looks
+ * empty today is one whose free space is already spoken for — and anything else helping itself
+ * to either has to hold this much back rather than what ZeroFS happens to be holding now.
  */
-export const readCacheDiskBytes = Effect.fn('zerofs.readCacheDiskBytes')(function* (
-  configFile: string,
-) {
-  const configured = Option.flatMap(yield* readTextFile(configFile), cacheDiskGigabytes);
-  if (Option.isNone(configured)) {
-    return yield* new ZerofsCacheUnknown({ path: configFile });
-  }
-  return configured.value * BYTES_PER_CONFIGURED_GB;
-});
+const readCacheBytes = ({ configFile, setting }: { configFile: string; setting: CacheSetting }) =>
+  Effect.gen(function* () {
+    const configured = Option.flatMap(yield* readTextFile(configFile), (config) =>
+      cacheGigabytes({ config, setting }),
+    );
+    if (Option.isNone(configured)) {
+      return yield* new ZerofsCacheUnknown({ path: configFile, setting });
+    }
+    return configured.value * BYTES_PER_CONFIGURED_GB;
+  });
 
-/** `[cache] disk_size_gb`, or nothing at all: a value this cannot read is not one to guess at. */
-export function cacheDiskGigabytes(config: string): Option.Option<number> {
+export const readCacheDiskBytes = Effect.fn('zerofs.readCacheDiskBytes')((configFile: string) =>
+  readCacheBytes({ configFile, setting: 'disk_size_gb' }),
+);
+
+export const readCacheMemoryBytes = Effect.fn('zerofs.readCacheMemoryBytes')((configFile: string) =>
+  readCacheBytes({ configFile, setting: 'memory_size_gb' }),
+);
+
+/** The two `[cache]` sizes the agent holds back for, spelled as ZeroFS spells them. */
+type CacheSetting = 'disk_size_gb' | 'memory_size_gb';
+
+/** The configured number, or nothing at all: a value this cannot read is not one to guess at. */
+function cacheGigabytes({
+  config,
+  setting,
+}: {
+  config: string;
+  setting: CacheSetting;
+}): Option.Option<number> {
   try {
-    const { cache } = Bun.TOML.parse(config) as { cache?: { disk_size_gb?: unknown } };
-    const configured = cache?.disk_size_gb;
+    const { cache } = Bun.TOML.parse(config) as {
+      cache?: Partial<Record<CacheSetting, unknown>>;
+    };
+    const configured = cache?.[setting];
     return typeof configured === 'number' && configured > 0
       ? Option.some(configured)
       : Option.none();
   } catch {
     return Option.none();
   }
+}
+
+export function cacheDiskGigabytes(config: string): Option.Option<number> {
+  return cacheGigabytes({ config, setting: 'disk_size_gb' });
+}
+
+export function cacheMemoryGigabytes(config: string): Option.Option<number> {
+  return cacheGigabytes({ config, setting: 'memory_size_gb' });
 }
 
 export function parseCheckpointNames(output: string): string[] {

--- a/apps/agent/src/services/agent-session-holder.service.ts
+++ b/apps/agent/src/services/agent-session-holder.service.ts
@@ -22,7 +22,10 @@ export class AgentSessionHolder extends Effect.Service<AgentSessionHolder>()('Ag
         if (Option.isSome(existing) && !isSessionExpiring({ session: existing.value, nowMs })) {
           return [existing.value, existing] as const;
         }
-        const capacity = yield* readHostCapacity(config.stateDir);
+        const capacity = yield* readHostCapacity({
+          cacheDir: config.stateDir,
+          zerofsConfigFile: config.zerofsConfigFile,
+        });
         const session = yield* openSession({ versions, capacity });
         yield* Effect.logInfo('session opened').pipe(
           Effect.annotateLogs({ hostId: session.hostId, expiresAt: session.expiresAt }),

--- a/apps/agent/src/services/app-waker.service.ts
+++ b/apps/agent/src/services/app-waker.service.ts
@@ -4,7 +4,11 @@ import { Clock, Data, Deferred, Duration, Effect, Option, Ref, Schedule } from '
 import { reportedMessage } from '#lib/failure.ts';
 import { probeInstance } from '#lib/health/probe.ts';
 import { resumeInstance } from '#lib/reconcile/instances.ts';
-import { committedResources, memoryShortfallMib, readHostMemoryMib } from '#lib/report/capacity.ts';
+import {
+  committedResources,
+  memoryShortfallMib,
+  readGuestMemoryMib,
+} from '#lib/report/capacity.ts';
 import type { InstanceRecord } from '#lib/report/instance-record.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
@@ -79,6 +83,7 @@ export class HostHasNoRoom extends Data.TaggedError('HostHasNoRoom')<{
  */
 export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
   effect: Effect.gen(function* () {
+    const config = yield* AgentConfig;
     const cache = yield* DesiredStateCache;
     const context = yield* Effect.context<WakeContext>();
     /**
@@ -123,7 +128,7 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
     ) {
       const others = (yield* AgentState.records).filter((record) => record.appId !== wanted.appId);
       const shortfallMib = memoryShortfallMib({
-        hostMemoryMib: readHostMemoryMib(),
+        hostMemoryMib: yield* readGuestMemoryMib(config.zerofsConfigFile),
         committed: committedResources(others),
         wanted: wanted.config.resources,
       });

--- a/apps/agent/tests/lib/report/capacity.test.ts
+++ b/apps/agent/tests/lib/report/capacity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { AppIdSchema, DEFAULT_INSTANCE_RESOURCES, type InstanceState, Value } from '@repo/protocol';
-import { committedResources, memoryShortfallMib } from '#lib/report/capacity.ts';
+import { committedResources, guestMemoryMib, memoryShortfallMib } from '#lib/report/capacity.ts';
 import { instanceRecord } from '#tests/support/fixtures.ts';
 
 const APP_MEMORY_MIB = DEFAULT_INSTANCE_RESOURCES.memoryMib;
@@ -46,5 +46,55 @@ describe('a host has room for one more microVM until it does not', () => {
   // its memory free, and every one of them can be woken until the memory runs out.
   test('a neighbour asleep between requests is holding none of it', () => {
     expect(shortfall({ count: NEIGHBOURS_THAT_FIT * 2, state: 'idle' })).toBe(0);
+  });
+});
+
+const A_GIB_IN_MIB = 1024;
+const HOST_MIB = 7779;
+const ZEROFS_CACHE_MIB = 2 * A_GIB_IN_MIB;
+
+/**
+ * The host's own needs come off the top before anything is placed. Reporting the whole of an
+ * instance's RAM as capacity is what let a host admit more microVMs than it could carry — and a
+ * guest that does not fit is not refused but killed, along with whichever neighbour the kernel
+ * picks instead.
+ */
+describe('memory the host needs is not memory a guest may be given', () => {
+  test('what is left is the total less what ZeroFS will grow into, less the host itself', () => {
+    expect(guestMemoryMib({ hostMemoryMib: HOST_MIB, zerofsCacheMib: ZEROFS_CACHE_MIB })).toBe(
+      HOST_MIB - ZEROFS_CACHE_MIB - A_GIB_IN_MIB,
+    );
+  });
+
+  test('a bigger ZeroFS cache is memory the guests do not get', () => {
+    const roomier = guestMemoryMib({ hostMemoryMib: HOST_MIB, zerofsCacheMib: ZEROFS_CACHE_MIB });
+    const tighter = guestMemoryMib({
+      hostMemoryMib: HOST_MIB,
+      zerofsCacheMib: ZEROFS_CACHE_MIB + A_GIB_IN_MIB,
+    });
+
+    expect(roomier - tighter).toBe(A_GIB_IN_MIB);
+  });
+
+  // Floored rather than negative: an oversubscribed host is a fact to report, and a shortfall
+  // computed against a negative total would read as room.
+  test('a host too small for what is already spoken for offers nothing rather than less', () => {
+    expect(guestMemoryMib({ hostMemoryMib: 512, zerofsCacheMib: ZEROFS_CACHE_MIB })).toBe(0);
+  });
+
+  test('and it is the number a wake is refused on, so the two cannot drift apart', () => {
+    const available = guestMemoryMib({
+      hostMemoryMib: HOST_MIB,
+      zerofsCacheMib: ZEROFS_CACHE_MIB,
+    });
+    const fits = Math.floor(available / APP_MEMORY_MIB);
+
+    expect(
+      memoryShortfallMib({
+        hostMemoryMib: available,
+        committed: committedResources(neighbours({ count: fits, state: 'running' })),
+        wanted: DEFAULT_INSTANCE_RESOURCES,
+      }),
+    ).toBeGreaterThan(0);
   });
 });

--- a/apps/agent/tests/lib/report/capacity.test.ts
+++ b/apps/agent/tests/lib/report/capacity.test.ts
@@ -50,8 +50,11 @@ describe('a host has room for one more microVM until it does not', () => {
 });
 
 const A_GIB_IN_MIB = 1024;
+/** What an m8id.large reports once the kernel has taken its own share of the 8 GiB it is sold as. */
 const HOST_MIB = 7779;
 const ZEROFS_CACHE_MIB = 2 * A_GIB_IN_MIB;
+/** `HOST_BASELINE_MIB`, restated so that moving it has to be a deliberate edit in two places. */
+const HOST_BASELINE_MIB = 640;
 
 /**
  * The host's own needs come off the top before anything is placed. Reporting the whole of an
@@ -62,7 +65,7 @@ const ZEROFS_CACHE_MIB = 2 * A_GIB_IN_MIB;
 describe('memory the host needs is not memory a guest may be given', () => {
   test('what is left is the total less what ZeroFS will grow into, less the host itself', () => {
     expect(guestMemoryMib({ hostMemoryMib: HOST_MIB, zerofsCacheMib: ZEROFS_CACHE_MIB })).toBe(
-      HOST_MIB - ZEROFS_CACHE_MIB - A_GIB_IN_MIB,
+      HOST_MIB - ZEROFS_CACHE_MIB - HOST_BASELINE_MIB,
     );
   });
 

--- a/apps/agent/tests/lib/volumes/zerofs.test.ts
+++ b/apps/agent/tests/lib/volumes/zerofs.test.ts
@@ -5,6 +5,7 @@ import { CheckpointIdSchema, Value } from '@repo/protocol';
 import { Effect, Option } from 'effect';
 import {
   cacheDiskGigabytes,
+  cacheMemoryGigabytes,
   createCheckpoint,
   deleteCheckpoint,
   flush,
@@ -16,6 +17,8 @@ import { recordingCommands } from '#tests/support/commands.ts';
 const BINARY = '/opt/nibrun/bin/zerofs/zerofs';
 /** What `infra/app-host/zerofs/config.toml` and `checkpoint.toml` hold this host's disk at. */
 const DEPLOYED_CACHE_GIB = 70;
+/** And what the same file lets it hold in memory, which is memory no guest may be given. */
+const DEPLOYED_MEMORY_GIB = 2;
 const CHECKPOINT_CACHE_GIB = 4;
 const target = { binary: BINARY, configFile: '/etc/z.toml' };
 const checkpointId = Value.Parse(CheckpointIdSchema, 'cp-1');
@@ -73,5 +76,25 @@ describe('the disk ZeroFS is entitled to is read out of its own config', () => {
   test('a file that is not a config, or a config without the key, reads as nothing', () => {
     expect(cacheDiskGigabytes('not a config at all {')).toEqual(Option.none());
     expect(cacheDiskGigabytes('[cache]\ndir = "/data/zerofs"\n')).toEqual(Option.none());
+  });
+});
+
+/**
+ * Read for the same reason the disk is, against the same file: ZeroFS grows into this lazily, so
+ * a host with memory free is not a host with memory to spare. A renamed key or a moved section is
+ * this reading silently going missing, and a host then selling ZeroFS's cache to tenants.
+ */
+describe('the memory ZeroFS is entitled to is read out of its own config', () => {
+  test('the config an app host is deployed with says what it says', async () => {
+    const config = await readFile(
+      join(import.meta.dir, '../../../../../infra/app-host/zerofs/config.toml'),
+      'utf8',
+    );
+
+    expect(cacheMemoryGigabytes(config)).toEqual(Option.some(DEPLOYED_MEMORY_GIB));
+  });
+
+  test('a config naming only the disk says nothing about the memory', () => {
+    expect(cacheMemoryGigabytes('[cache]\ndisk_size_gb = 70.0\n')).toEqual(Option.none());
   });
 });


### PR DESCRIPTION
A host reported the whole of its RAM as capacity and made every wake decision against that number.
Nothing came off the top for ZeroFS — the disk every app on the host runs through — or for the
agent, Caddy and the kernel. An 8 GiB app host offers 7779 MiB, so it would admit 30 of the
256 MiB microVMs it can actually carry about 19 of.

`capacity.ts` already names the consequence: a guest that does not fit is not refused but killed,
along with whichever neighbour the kernel picks instead. Invisible so far because no host has been
near full — and the first thing that happens at the density snapshots are meant to buy.

ZeroFS's share is read out of the config it is started with, the way the snapshot disk budget
already reads `disk_size_gb` from the same file. It grows into that memory lazily, so a host with
memory free is not a host with memory to spare — the same reason the disk budget is computed
against the configured size rather than against what is free.

An unreadable config assumes rather than fails. The two ways of being wrong are not symmetrical: a
host reporting no capacity is one nothing is ever placed on, where a host reporting memory it does
not have kills tenants.

One number, `guestMemoryMib`, behind both the report and the wake, so they cannot drift into
disagreeing about the same host — which is what the existing comment on `memoryShortfallMib` asks
for and nothing enforced.

## What the reserve is

Measured on the live app host rather than guessed:

| | MiB | |
|---|---|---|
| instance | 8192 | |
| `totalmem()` | 7779 | the kernel's own share, gone before the agent sees it |
| − ZeroFS | 5731 | `memory_size_gb = 2.0`, what it is entitled to grow into |
| − host baseline | 5091 | agent, Caddy, journald, systemd, SSM — ~420 MiB measured |

Which leaves 19 of the default 256 MiB microVMs, against the 30 a host would have admitted.

The second commit is a correction to the first: the baseline was 1 GiB, and part of its
justification was that a Firecracker process costs a few MiB above its guest's configured RAM. It
does not — a VMM's resident size *is* its guest's memory, measured at 216–257 MiB for four 256 MiB
guests — so counting the VMMs would have reserved every guest twice.