### PR TITLE
feat(api): an owner has a profile of nibrun's own

### DIFF
--- a/apps/api/src/db/migrations/0039_an_owner_has_a_profile_here.sql
+++ b/apps/api/src/db/migrations/0039_an_owner_has_a_profile_here.sql
@@ -1,0 +1,59 @@
+-- What nibrun holds about a person, beside what signing them in knows about them.
+--
+-- `auth."user"` belongs to better-auth: its shape is that library's to change, and a column we add
+-- there is one a future release of it can collide with. This is the other half — the shape every
+-- auth system leaves for the application to fill. Nothing better-auth already holds is copied into
+-- it: a name or an email read here would be a second copy to go stale, and the join is one key
+-- away.
+--
+-- Empty of its own fields on purpose. What goes here arrives with whatever first needs it, and a
+-- column added now would be one nothing reads.
+--
+-- `nibrun.owners` was the other candidate and is the wrong name: `apps.owner_id` references
+-- `auth."user" (id)`, so a table of *owners* carrying an `id` of its own is one every reader would
+-- take that column to point at. A profile is plainly a thing about a person rather than the
+-- person, which is what makes it safe to put beside them.
+--
+-- A field here that has a platform default should be nullable and mean it when null, rather than
+-- storing a copy: a stored default is a snapshot taken the day somebody signed up, and moving it
+-- afterwards reaches nobody who is already here.
+
+CREATE TABLE nibrun.profiles (
+  id         uuid PRIMARY KEY DEFAULT uuidv7(),
+  owner_id   text NOT NULL REFERENCES auth."user" ("id") ON DELETE CASCADE,
+  created_at timestamptz GENERATED ALWAYS AS (uuid_extract_timestamp(id)) VIRTUAL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT profiles_owner_id_key UNIQUE (owner_id)
+);
+
+COMMENT ON TABLE nibrun.profiles IS 'What nibrun holds about an owner, as against what better-auth holds.';
+COMMENT ON COLUMN nibrun.profiles.owner_id IS $c$@type import('@repo/protocol').OwnerId$c$;
+COMMENT ON COLUMN nibrun.profiles.created_at IS 'Derived from the uuidv7 id; the moment the row was created. @notNull';
+
+CREATE TRIGGER set_updated_at BEFORE UPDATE ON nibrun.profiles
+  FOR EACH ROW EXECUTE FUNCTION nibrun.set_updated_at();
+
+-- A trigger rather than a hook in the api, because this is the one way of writing the row that
+-- cannot be missed: it runs in the transaction that inserts the user, so there is no moment where
+-- one exists without the other and no crash that leaves a signed-up person half made. It also
+-- covers every path a user arrives by — better-auth's own admin calls, a seed, a test fixture —
+-- where an application hook covers only the one it is wired into.
+--
+-- `DO NOTHING` so that a row somebody made first is not an error: this asserts the row exists,
+-- which is a weaker and more useful thing to say than that this statement created it.
+--
+-- Nothing is backfilled and nothing here writes to a table that already has rows. Whatever reads a
+-- profile joins it, so an owner from before this migration has none and reads exactly like one
+-- whose fields are all still unset — which is what makes the trigger an improvement rather than
+-- something the reads have to wait for.
+CREATE FUNCTION nibrun.add_profile() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  INSERT INTO nibrun.profiles (owner_id) VALUES (NEW.id) ON CONFLICT (owner_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER add_profile AFTER INSERT ON auth."user"
+  FOR EACH ROW EXECUTE FUNCTION nibrun.add_profile();

--- a/apps/api/src/db/migrations/0039_an_owner_has_a_profile_here.sql
+++ b/apps/api/src/db/migrations/0039_an_owner_has_a_profile_here.sql
@@ -1,23 +1,3 @@
--- What nibrun holds about a person, beside what signing them in knows about them.
---
--- `auth."user"` belongs to better-auth: its shape is that library's to change, and a column we add
--- there is one a future release of it can collide with. This is the other half — the shape every
--- auth system leaves for the application to fill. Nothing better-auth already holds is copied into
--- it: a name or an email read here would be a second copy to go stale, and the join is one key
--- away.
---
--- Empty of its own fields on purpose. What goes here arrives with whatever first needs it, and a
--- column added now would be one nothing reads.
---
--- `nibrun.owners` was the other candidate and is the wrong name: `apps.owner_id` references
--- `auth."user" (id)`, so a table of *owners* carrying an `id` of its own is one every reader would
--- take that column to point at. A profile is plainly a thing about a person rather than the
--- person, which is what makes it safe to put beside them.
---
--- A field here that has a platform default should be nullable and mean it when null, rather than
--- storing a copy: a stored default is a snapshot taken the day somebody signed up, and moving it
--- afterwards reaches nobody who is already here.
-
 CREATE TABLE nibrun.profiles (
   id         uuid PRIMARY KEY DEFAULT uuidv7(),
   owner_id   text NOT NULL REFERENCES auth."user" ("id") ON DELETE CASCADE,
@@ -26,26 +6,12 @@ CREATE TABLE nibrun.profiles (
   CONSTRAINT profiles_owner_id_key UNIQUE (owner_id)
 );
 
-COMMENT ON TABLE nibrun.profiles IS 'What nibrun holds about an owner, as against what better-auth holds.';
 COMMENT ON COLUMN nibrun.profiles.owner_id IS $c$@type import('@repo/protocol').OwnerId$c$;
 COMMENT ON COLUMN nibrun.profiles.created_at IS 'Derived from the uuidv7 id; the moment the row was created. @notNull';
 
 CREATE TRIGGER set_updated_at BEFORE UPDATE ON nibrun.profiles
   FOR EACH ROW EXECUTE FUNCTION nibrun.set_updated_at();
 
--- A trigger rather than a hook in the api, because this is the one way of writing the row that
--- cannot be missed: it runs in the transaction that inserts the user, so there is no moment where
--- one exists without the other and no crash that leaves a signed-up person half made. It also
--- covers every path a user arrives by — better-auth's own admin calls, a seed, a test fixture —
--- where an application hook covers only the one it is wired into.
---
--- `DO NOTHING` so that a row somebody made first is not an error: this asserts the row exists,
--- which is a weaker and more useful thing to say than that this statement created it.
---
--- Nothing is backfilled and nothing here writes to a table that already has rows. Whatever reads a
--- profile joins it, so an owner from before this migration has none and reads exactly like one
--- whose fields are all still unset — which is what makes the trigger an improvement rather than
--- something the reads have to wait for.
 CREATE FUNCTION nibrun.add_profile() RETURNS trigger
   LANGUAGE plpgsql
   AS $$

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -1377,6 +1377,23 @@ export interface ILiveAppsTable {
     constraints: keyof (typeof schema)["live_apps"]["_constraints"];
 }
 
+/** Columns of `profiles`. */
+export interface IProfilesColumns {
+    id: string;
+    owner_id: import("@repo/protocol").OwnerId;
+    /** Derived from the uuidv7 id; the moment the row was created. */
+    created_at: Date;
+    updated_at: Date;
+}
+
+/** Schema of `profiles`. */
+export interface IProfilesTable {
+    columns: IProfilesColumns;
+    relationType: (typeof schema)["profiles"]["_relationType"];
+    indexes: keyof (typeof schema)["profiles"]["_indexes"];
+    constraints: keyof (typeof schema)["profiles"]["_constraints"];
+}
+
 /** Columns of `purgeable_apps`. */
 export interface IPurgeableAppsColumns {
     app_id: string | null;
@@ -1911,6 +1928,25 @@ export const schema = {
         _indexes: {},
         _constraints: {}
     },
+    profiles: {
+        _relationName: "profiles",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            owner_id: { _columnName: "owner_id", _foreignKeys: { profiles_owner_id_fkey: { _constraintName: "profiles_owner_id_fkey", _references: { _relationName: "user", _columnName: "id" } } } },
+            created_at: { _columnName: "created_at", _foreignKeys: {} },
+            updated_at: { _columnName: "updated_at", _foreignKeys: {} }
+        },
+        _indexes: {
+            profiles_owner_id_key: { _indexName: "profiles_owner_id_key" },
+            profiles_pkey: { _indexName: "profiles_pkey" }
+        },
+        _constraints: {
+            profiles_owner_id_fkey: { _constraintName: "profiles_owner_id_fkey" },
+            profiles_owner_id_key: { _constraintName: "profiles_owner_id_key" },
+            profiles_pkey: { _constraintName: "profiles_pkey" }
+        }
+    },
     purgeable_apps: {
         _relationName: "purgeable_apps",
         _relationType: "view",
@@ -1945,6 +1981,7 @@ export interface Tables {
     exports: IExportsTable;
     finishable_deletions: IFinishableDeletionsTable;
     live_apps: ILiveAppsTable;
+    profiles: IProfilesTable;
     purgeable_apps: IPurgeableAppsTable;
 }
 

--- a/apps/api/tests/repositories/profiles.test.ts
+++ b/apps/api/tests/repositories/profiles.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { SQL } from 'bun';
+import { startTestDatabase, stopTestDatabase } from '#tests/support/database.ts';
+
+const DATABASE_START_TIMEOUT_MS = 180_000;
+
+const SIGNED_UP = 'arrived';
+const LEAVING = 'departing';
+
+type ProfileRow = { owner_id: string };
+
+/**
+ * The row is written by a trigger and by nothing in this codebase, so the only thing that can say
+ * whether signing somebody up gives them one is the real schema.
+ */
+describe('a person nibrun has signed up has a profile from the moment they exist', () => {
+  let sql: SQL;
+
+  async function profileFor(ownerId: string): Promise<ProfileRow | undefined> {
+    const [row] = (await sql.unsafe('SELECT owner_id FROM nibrun.profiles WHERE owner_id = $1', [
+      ownerId,
+    ])) as ProfileRow[];
+    return row;
+  }
+
+  async function signUp(id: string): Promise<void> {
+    await sql.unsafe(
+      `INSERT INTO auth."user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+       VALUES ($1, $1, $2, true, now(), now())`,
+      [id, `${id}@example.com`],
+    );
+  }
+
+  beforeAll(async () => {
+    sql = await startTestDatabase();
+    await signUp(SIGNED_UP);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await stopTestDatabase(sql);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  test('the profile is there without anything having asked for one', async () => {
+    expect(await profileFor(SIGNED_UP)).toBeDefined();
+  });
+
+  /** The user is going, and what nibrun held about them is not a reason to keep them. */
+  test('deleting the person takes their profile with them', async () => {
+    await signUp(LEAVING);
+    expect(await profileFor(LEAVING)).toBeDefined();
+
+    await sql.unsafe('DELETE FROM auth."user" WHERE id = $1', [LEAVING]);
+
+    expect(await profileFor(LEAVING)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
`nibrun.profiles` and the trigger that fills it. No fields of its own yet — what goes in arrives with whatever first needs it.

`auth."user"` belongs to better-auth: its shape is that library’s to change, and a column we add there is one a future release can collide with. This is the other half — the shape every auth system leaves for the application to fill.

**Nothing better-auth already holds is copied into it.** A name or an email read from here would be a second copy to go stale, and the join is one key away. Stated in the migration so the next person adding a column has to argue against it.

**Not `nibrun.owners`.** That was the other candidate and it is the wrong name: `apps.owner_id` references `auth."user" (id)`, so a table of *owners* carrying an `id` of its own is one every reader would take that column to point at. A profile is plainly a thing about a person rather than the person, which is what makes it safe to put beside them.

**A trigger on `auth."user"`, not a hook in the api.** It runs in the transaction that inserts the user, so there is no window where one exists without the other and no crash that leaves a signed-up person half made. It also covers every path a user arrives by — better-auth’s admin calls, a seed, this repo’s own fixtures, which insert into `auth."user"` directly and would otherwise each have to remember. An application hook covers only the path it is wired into. `ON CONFLICT DO NOTHING`, so it asserts the row exists rather than claiming it created it.

Nothing is backfilled and no migration writes data. Whatever ends up reading a profile joins it, so an owner from before this has none and reads exactly like one whose fields are all still unset — which is what makes the trigger an improvement rather than something the reads have to wait for.

One rule left written down for the first field that lands: anything with a platform default should be nullable and mean it when null, rather than storing a copy. A stored default is a snapshot taken the day somebody signed up, and moving it afterwards reaches nobody who is already here.

Three files: the migration, the regenerated schema, and a test that a profile appears without anything asking for one and that deleting the person takes it with them.

Supersedes #427, which put an app allowance in a table of its own.