### PR TITLE
fix(agent): a wake tells the status loop rather than waiting for it

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -19,6 +19,7 @@ import { FilesystemReader } from '#services/filesystem-reader.service.ts';
 import { HostFirewall } from '#services/host-firewall.service.ts';
 import { LogStore } from '#services/log-store.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
+import { RefreshSignal } from '#services/refresh-signal.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { TenantLogQueue } from '#services/tenant-log-queue.service.ts';
@@ -38,6 +39,7 @@ const agent = Layer.mergeAll(
   AgentConfig.Default,
   AgentState.Default,
   ReportSignal.Default,
+  RefreshSignal.Default,
   CommandRunner.Default,
   ControlPlane.Default,
   LogStore.Default,

--- a/apps/agent/src/lib/agent/status.ts
+++ b/apps/agent/src/lib/agent/status.ts
@@ -11,6 +11,16 @@ const TICK = Duration.seconds(1);
 const SETTLING_TICK = Duration.millis(STARTUP_PROBE_INTERVAL_MS);
 
 /**
+ * The floor a raise cannot get under, for the reason MIN_REPORT_GAP has one.
+ *
+ * A refresh probes every instance that is due, renders the ruleset and writes the host's state to
+ * disk, and that last part is not deduplicated the way the ruleset and the routes are. Left
+ * ungated, a host waking apps steadily would run it as fast as the disk allows — and a host with
+ * enough on-request apps to be waking them steadily is the one this whole feature is for.
+ */
+const MIN_REFRESH_GAP: Duration.DurationInput = '250 millis';
+
+/**
  * Exactly the condition the fast probe grid runs on, rather than the states it tends to appear
  * in: a tick this loop takes for something no longer being probed that fast is one it takes for
  * as long as that instance is up.
@@ -25,7 +35,10 @@ const untilNextRefresh = Effect.gen(function* () {
   // microVM that comes up during it is one this decision could not have known about, and the app
   // is reached through the activator rather than through its forward rule until the refresh that
   // renders one. The signal is what makes that wait as long as the wake and no longer.
-  yield* Effect.race(Effect.sleep(settling ? SETTLING_TICK : TICK), RefreshSignal.awaited);
+  yield* Effect.race(
+    Effect.sleep(settling ? SETTLING_TICK : TICK),
+    Effect.andThen(Effect.sleep(MIN_REFRESH_GAP), RefreshSignal.awaited),
+  );
 });
 
 export const statusLoop = Effect.gen(function* () {

--- a/apps/agent/src/lib/agent/status.ts
+++ b/apps/agent/src/lib/agent/status.ts
@@ -4,6 +4,7 @@ import { isOnStartupGrid, STARTUP_PROBE_INTERVAL_MS } from '#lib/health/state.ts
 import { graceInputs } from '#lib/report/instance-record.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { Reconciler } from '#services/reconciler.service.ts';
+import { RefreshSignal } from '#services/refresh-signal.service.ts';
 
 const TICK = Duration.seconds(1);
 /** A probe cannot land sooner than the tick that runs it, so the two share one cadence. */
@@ -20,7 +21,11 @@ const untilNextRefresh = Effect.gen(function* () {
   const settling = records.some((record) =>
     isOnStartupGrid({ tracker: record.health, ...graceInputs({ record, nowMs }) }),
   );
-  yield* Effect.sleep(settling ? SETTLING_TICK : TICK);
+  // Raced rather than slept, because the length is chosen from the state as it stands now: a
+  // microVM that comes up during it is one this decision could not have known about, and the app
+  // is reached through the activator rather than through its forward rule until the refresh that
+  // renders one. The signal is what makes that wait as long as the wake and no longer.
+  yield* Effect.race(Effect.sleep(settling ? SETTLING_TICK : TICK), RefreshSignal.awaited);
 });
 
 export const statusLoop = Effect.gen(function* () {

--- a/apps/agent/src/services/app-waker.service.ts
+++ b/apps/agent/src/services/app-waker.service.ts
@@ -11,6 +11,7 @@ import { AgentState } from '#services/agent-state.service.ts';
 import { ArtifactStore } from '#services/artifact-store.service.ts';
 import { CommandRunner } from '#services/command-runner.service.ts';
 import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
+import { RefreshSignal } from '#services/refresh-signal.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { VmManager } from '#services/vm-manager.service.ts';
 
@@ -80,6 +81,7 @@ export class HostHasNoRoom extends Data.TaggedError('HostHasNoRoom')<{
 export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
   effect: Effect.gen(function* () {
     const cache = yield* DesiredStateCache;
+    const refresh = yield* RefreshSignal;
     const context = yield* Effect.context<WakeContext>();
     /**
      * The joiners are counted beside the deferred rather than derived afterwards: a cold page
@@ -184,6 +186,10 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
         });
       }
       yield* untilAnswering(record);
+      // The guest is answering, which is the one thing the forward rule waits on — so the loop is
+      // told now rather than on its next tick. Until it refreshes, the record still says this app
+      // is coming up and every request behind this one is answered by the activator.
+      yield* refresh.raise;
       // `waitedMs` is the whole of what the visitor paid, `outcome` is what they paid it for:
       // a restore and a cold boot are the same line otherwise, and the difference between them
       // is the feature. `coalesced` is how many more requests waited on this same wake, so a
@@ -237,6 +243,7 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
     ArtifactStore.Default,
     CommandRunner.Default,
     DesiredStateCache.Default,
+    RefreshSignal.Default,
     SlotAllocator.Default,
     VmManager.Default,
   ],

--- a/apps/agent/src/services/refresh-signal.service.ts
+++ b/apps/agent/src/services/refresh-signal.service.ts
@@ -1,0 +1,26 @@
+import { Effect, Queue } from 'effect';
+
+const ONE_PENDING = 1;
+
+/**
+ * Says the host's own picture of what is running has moved, before the tick is up.
+ *
+ * The status loop chooses how long to sleep from the state as it stood when it last refreshed, so
+ * a microVM that comes up mid-sleep waits out a second measured for a host where nothing was
+ * happening. That second is the whole of it: until the loop refreshes, the record still says the
+ * app is coming up, the forward rule is rendered from records that are running, and every request
+ * arriving meanwhile is answered by the activator rather than by the guest it is already for.
+ *
+ * Sliding and one deep, for the reason `ReportSignal` is: a raise says "something moved", and two
+ * of them say nothing more than one.
+ */
+export class RefreshSignal extends Effect.Service<RefreshSignal>()('RefreshSignal', {
+  accessors: true,
+  effect: Effect.gen(function* () {
+    const news = yield* Queue.sliding<void>(ONE_PENDING);
+    return {
+      raise: Effect.asVoid(Queue.offer(news, undefined)),
+      awaited: Queue.take(news),
+    };
+  }),
+}) {}

--- a/apps/agent/tests/services/refresh-signal.test.ts
+++ b/apps/agent/tests/services/refresh-signal.test.ts
@@ -4,6 +4,9 @@ import { RefreshSignal } from '#services/refresh-signal.service.ts';
 
 const A_TICK = Duration.seconds(1);
 
+/** Long enough that a second raise would have arrived, short enough not to pad the suite. */
+const LONG_ENOUGH_FOR_A_SECOND: Duration.DurationInput = '50 millis';
+
 function withSignal<A>(body: Effect.Effect<A, never, RefreshSignal>): Promise<A> {
   return Effect.runPromise(body.pipe(Effect.provide(RefreshSignal.Default)));
 }
@@ -59,7 +62,7 @@ describe('a raise ends the wait it was raised for', () => {
         yield* RefreshSignal.raise;
         yield* RefreshSignal.awaited;
         return yield* Effect.race(
-          Effect.sleep(Duration.millis(50)).pipe(Effect.as('slept')),
+          Effect.sleep(LONG_ENOUGH_FOR_A_SECOND).pipe(Effect.as('slept')),
           RefreshSignal.awaited.pipe(Effect.as('raised')),
         );
       }),

--- a/apps/agent/tests/services/refresh-signal.test.ts
+++ b/apps/agent/tests/services/refresh-signal.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { Duration, Effect, Fiber } from 'effect';
+import { RefreshSignal } from '#services/refresh-signal.service.ts';
+
+const A_TICK = Duration.seconds(1);
+
+function withSignal<A>(body: Effect.Effect<A, never, RefreshSignal>): Promise<A> {
+  return Effect.runPromise(body.pipe(Effect.provide(RefreshSignal.Default)));
+}
+
+/**
+ * The status loop races its sleep against this, so what is being pinned here is that a raise ends
+ * that sleep however the two are ordered — the wake that raises it and the refresh that reads it
+ * run on different fibers, and nothing sequences them.
+ */
+describe('a raise ends the wait it was raised for', () => {
+  test('a waiter already holding is released by a raise', async () => {
+    const waited = await withSignal(
+      Effect.gen(function* () {
+        const waiting = yield* Effect.fork(
+          Effect.race(
+            Effect.sleep(A_TICK).pipe(Effect.as('slept')),
+            RefreshSignal.awaited.pipe(Effect.as('raised')),
+          ),
+        );
+        yield* RefreshSignal.raise;
+        return yield* Fiber.join(waiting);
+      }),
+    );
+
+    expect(waited).toBe('raised');
+  });
+
+  /**
+   * The case a handoff would lose. A wake that lands while the loop is mid-refresh has nobody
+   * waiting on it, and dropping it would leave the app it just brought up unforwarded until the
+   * tick it was raised to pre-empt.
+   */
+  test('a raise with nobody waiting is kept for the next one', async () => {
+    const waited = await withSignal(
+      Effect.gen(function* () {
+        yield* RefreshSignal.raise;
+        return yield* Effect.race(
+          Effect.sleep(A_TICK).pipe(Effect.as('slept')),
+          RefreshSignal.awaited.pipe(Effect.as('raised')),
+        );
+      }),
+    );
+
+    expect(waited).toBe('raised');
+  });
+
+  // Sliding and one deep: a raise says something moved, and a second one before anything read the
+  // first says nothing more. The refresh it wakes reads the whole of the state either way.
+  test('two raises are one refresh, not two', async () => {
+    const second = await withSignal(
+      Effect.gen(function* () {
+        yield* RefreshSignal.raise;
+        yield* RefreshSignal.raise;
+        yield* RefreshSignal.awaited;
+        return yield* Effect.race(
+          Effect.sleep(Duration.millis(50)).pipe(Effect.as('slept')),
+          RefreshSignal.awaited.pipe(Effect.as('raised')),
+        );
+      }),
+    );
+
+    expect(second).toBe('slept');
+  });
+});


### PR DESCRIPTION
Replaces #425, whose approach did not work. That one widened the startup-probe grid so a restored
microVM would be re-probed at 250 ms instead of a second — but the loop chooses its sleep length
*before* the wake happens, so it changed nothing about the trace it was written for.

## What actually holds the app back

The status loop is `refresh` → decide how long to sleep → sleep, and `refresh` is what probes the
guest, moves the record to `running`, and renders the forward rule from the records that are. A
wake landing mid-sleep waits out the remainder. Until then the app is reached through the activator
rather than through its own rule — correct, but a detour, and not a rare one: a single page load put
**23 requests** through it in production, each logging `outcome: already-running` at 7–9 ms.

## What this does

`RefreshSignal`, sliding and one deep like `ReportSignal`. The waker raises it once the guest
answers; `untilNextRefresh` races its sleep against it.

Raised on the answer rather than on the microVM coming up, because answering is what the forward
rule waits on — raising earlier buys a refresh that still finds the app `starting`.

Sliding rather than a handoff so a raise that lands while the loop is mid-refresh is kept for the
refresh after it. That case is a test, along with the two orderings of raise and wait.

Nothing about the health model, the grid, or the tracker moves — that was the mistake in #425.
