### PR TITLE
fix(agent): a first deploy comes up rather than waiting to be asked for

### DIFF
--- a/apps/agent/src/lib/reconcile/plan.ts
+++ b/apps/agent/src/lib/reconcile/plan.ts
@@ -155,17 +155,21 @@ function planInstance({
       ? { action: 'stop', appId: wanted.appId, reason: 'desired-stopped' }
       : { action: 'none', appId: wanted.appId };
   }
-  // A microVM already up is reconciled the way any other is — new bytes must not go on being
-  // served by the release they replaced, and a deploy is the one moment an owner is watching, so
-  // the replacement comes up rather than waiting to be asked for. Everything else sleeps: the
-  // boot belongs to whoever visits next.
+  // An app that runs on request is reconciled like any other up to the last line: a release this
+  // host has not served yet comes up rather than waiting to be asked for, because a deploy is the
+  // one moment an owner is watching and the only one where the health check runs at all — an app
+  // first booted by a visitor reports a broken binary to them. Sleep is what a release that has
+  // already had its microVM does between requests.
   if (wanted.desiredState === 'on-request') {
-    if (!current?.running) {
-      return { action: 'sleep', desired: wanted };
+    if (!current?.present) {
+      return { action: 'start', desired: wanted };
     }
-    return current.deploymentId === wanted.deploymentId
+    if (current.deploymentId !== wanted.deploymentId) {
+      return { action: 'replace', desired: wanted };
+    }
+    return current.running
       ? { action: 'none', appId: wanted.appId }
-      : { action: 'replace', desired: wanted };
+      : { action: 'sleep', desired: wanted };
   }
   if (!current?.present) {
     return { action: 'start', desired: wanted };

--- a/apps/agent/tests/lib/reconcile/plan.test.ts
+++ b/apps/agent/tests/lib/reconcile/plan.test.ts
@@ -120,18 +120,21 @@ describe('instances are authoritative', () => {
 });
 
 /**
- * Nothing here boots. What the plan has to produce for an app that runs on request is the part a
- * request arrives to — the slot and the record — and the microVM is left to whoever visits.
+ * A release comes up once so that somebody watches it come up, and sleeps from then on. What the
+ * plan has to produce for the sleeping part is what a request arrives to — the slot and the
+ * record — and the microVM after that is left to whoever visits.
  */
-describe('an app that runs on request is prepared rather than started', () => {
+describe('an app that runs on request comes up once and sleeps after', () => {
   const onRequest = desiredInstance({ desiredState: 'on-request' });
 
-  test('one nothing is running is put to sleep rather than started', () => {
+  // Where the health check happens: a release nothing has ever run is one nothing has ever
+  // checked, and leaving the first boot to a visitor reports a broken binary to them.
+  test('one this host has never served is started rather than put to sleep', () => {
     const plan = planReconcile({
       desired: desiredState({ instances: [onRequest] }),
       observed: observedState(),
     });
-    expect(plan.instances).toEqual([{ action: 'sleep', desired: onRequest }]);
+    expect(plan.instances).toEqual([{ action: 'start', desired: onRequest }]);
   });
 
   test('one already sleeping stays that way, however many times this runs', () => {
@@ -142,6 +145,24 @@ describe('an app that runs on request is prepared rather than started', () => {
       }),
     });
     expect(plan.instances).toEqual([{ action: 'sleep', desired: onRequest }]);
+  });
+
+  // Replaced rather than started: a start keeps the record it found, so the release the host
+  // reports would stay the one this deploy supersedes.
+  test('a deploy onto one that is asleep replaces it rather than leaving it asleep', () => {
+    const plan = planReconcile({
+      desired: desiredState({ instances: [onRequest] }),
+      observed: observedState({
+        instances: [
+          observedInstance({
+            running: false,
+            exited: false,
+            deploymentId: Value.Parse(DeploymentIdSchema, 'dep-0'),
+          }),
+        ],
+      }),
+    });
+    expect(plan.instances).toEqual([{ action: 'replace', desired: onRequest }]);
   });
 
   test('one that is up and serving the release it should be is left alone', () => {


### PR DESCRIPTION
An `on-request` app was planned on whether a microVM was up, so a release that had never had one slept instead of starting. Since new apps default to `on-request`, every first deploy read as `idle` — and never ran its health check, so a binary that crashes on boot deployed green and failed on its first visitor instead.

Planned on the release instead: one this host has not served starts, one whose deployment differs is replaced, and only a release that has already had its microVM sleeps. It then idles on the normal timer like any other.