### PR TITLE
fix(agent): a start in flight is not an app waiting to be asked for

### DIFF
--- a/apps/agent/src/lib/health/state.ts
+++ b/apps/agent/src/lib/health/state.ts
@@ -137,6 +137,12 @@ export type LifecycleInputs = {
   stopRequested: boolean;
   startedAtMs?: number;
   nowMs: number;
+  /**
+   * What the record already says, which is the only thing that tells a start in flight from an
+   * app waiting to be asked for: both are `on-request` instances with no microVM behind them yet,
+   * and the planner has already decided which by writing `pending` or `idle`.
+   */
+  current: InstanceState;
 };
 
 /**
@@ -156,9 +162,10 @@ function evaluateStoppedState({
   onRequest,
   stopRequested,
   startedAtMs,
+  current,
 }: Pick<
   LifecycleInputs,
-  'desiredRunning' | 'onRequest' | 'stopRequested' | 'startedAtMs'
+  'desiredRunning' | 'onRequest' | 'stopRequested' | 'startedAtMs' | 'current'
 >): InstanceState {
   const down = onRequest && desiredRunning ? 'idle' : 'stopped';
   if (stopRequested || !desiredRunning) {
@@ -167,7 +174,13 @@ function evaluateStoppedState({
   if (startedAtMs !== undefined) {
     return 'failed';
   }
-  return onRequest ? down : 'pending';
+  // A start this agent asked for and has not seen through is not an app waiting to be asked for.
+  // `startInstance` writes `pending` before a boot that has an artifact to fetch, `sleepInstance`
+  // writes `idle`, and until the unit is up those two look identical from here. Reading a release
+  // that is coming up as `idle` tells the control plane it is as up as it will ever get: the
+  // startup deadline stops, the deployment turns `running` before a probe has run, and the memory
+  // the boot is about to take is left out of what this host counts as committed.
+  return onRequest && current !== 'pending' ? down : 'pending';
 }
 
 /**
@@ -186,12 +199,13 @@ export function evaluateInstanceState({
   stopRequested,
   startedAtMs,
   nowMs,
+  current,
 }: LifecycleInputs): InstanceState {
   if (unit.failed) {
     return 'failed';
   }
   if (!unit.active) {
-    return evaluateStoppedState({ desiredRunning, onRequest, stopRequested, startedAtMs });
+    return evaluateStoppedState({ desiredRunning, onRequest, stopRequested, startedAtMs, current });
   }
   if (stopRequested) {
     return 'stopping';

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -574,6 +574,7 @@ function settle({
       desiredRunning: record.desiredRunning,
       onRequest: record.onRequest,
       stopRequested: record.stopRequested,
+      current: record.state,
       ...graceInputs({ record, nowMs }),
     });
 

--- a/apps/agent/tests/lib/health/state.test.ts
+++ b/apps/agent/tests/lib/health/state.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { DEFAULT_HEALTH_CHECK, DEFAULT_HTTP_PORT, type HealthCheck } from '@repo/protocol';
+import {
+  DEFAULT_HEALTH_CHECK,
+  DEFAULT_HTTP_PORT,
+  type HealthCheck,
+  type InstanceState,
+} from '@repo/protocol';
 import {
   applyProbe,
   describeInstanceFailure,
@@ -85,6 +90,7 @@ function evaluate({
   desiredRunning = true,
   onRequest = false,
   startedAtMs = STARTED_AT_MS as number | undefined,
+  current = 'pending' as InstanceState,
 }: {
   unit: UnitStatus;
   tracker: Tracker;
@@ -94,6 +100,7 @@ function evaluate({
   desiredRunning?: boolean;
   onRequest?: boolean;
   startedAtMs?: number | undefined;
+  current?: InstanceState;
 }) {
   return evaluateInstanceState({
     unit,
@@ -102,6 +109,7 @@ function evaluate({
     desiredRunning,
     onRequest,
     stopRequested,
+    current,
     ...(startedAtMs === undefined ? {} : { startedAtMs }),
     nowMs,
   });
@@ -257,6 +265,7 @@ describe('what the VM itself is doing', () => {
         desiredRunning: true,
         onRequest: false,
         stopRequested: false,
+        current: 'pending',
         nowMs: STARTED_AT_MS,
       }),
     ).toBe('pending');
@@ -271,6 +280,7 @@ describe('what the VM itself is doing', () => {
         desiredRunning: true,
         onRequest: false,
         stopRequested: false,
+        current: 'pending',
         nowMs: STARTED_AT_MS,
       }),
     ).toBe('pending');
@@ -291,9 +301,31 @@ describe('what the VM itself is doing', () => {
           desiredRunning: true,
           onRequest: true,
           stopRequested: false,
+          current: 'idle',
           nowMs: STARTED_AT_MS,
         }),
       ).toBe('idle');
+    });
+
+    /**
+     * The two look identical from the unit alone — an `on-request` instance with no microVM — and
+     * the record is what tells them apart. Calling a boot `idle` stops the startup deadline, turns
+     * the deployment `running` before a probe has run, and leaves the memory it is about to take
+     * out of what the host counts as committed.
+     */
+    test('but one whose start is still in flight is pending, not idle', () => {
+      expect(
+        evaluateInstanceState({
+          unit: absent,
+          tracker: initialTracker(),
+          healthCheck: check(),
+          desiredRunning: true,
+          onRequest: true,
+          stopRequested: false,
+          current: 'pending',
+          nowMs: STARTED_AT_MS,
+        }),
+      ).toBe('pending');
     });
 
     test('one stopped for being quiet is idle', () => {


### PR DESCRIPTION
`startInstance` writes `pending` and then boots — which on a first deploy means fetching the
artifact. Until the unit is up, an `on-request` instance that is mid-boot and one the planner put to
sleep look identical from the unit alone, and `evaluateStoppedState` read both as `idle`. So the
status loop overwrote the `pending` the planner had just written.

An `idle` report says the release is as up as it will ever get. [lifecycle.ts](apps/api/src/lib/deployments/lifecycle.ts#L131)
stops measuring it against the startup deadline and turns the deployment `running`, so `awaitServing`
returned success before a probe had run: the same false green #431 fixed, reached through the boot
rather than the plan, and widest exactly when the artifact is new. The host also left the memory that
boot was about to take out of `committedResources`, because `idle` is in `HOLDS_NOTHING`.

The record already knows which of the two it is — `startInstance` writes `pending`, `sleepInstance`
writes `idle` — so the evaluation now reads it instead of guessing from the unit.

## Deploy timing

The boot path is untouched; time-to-first-response does not move. What moves is that a first deploy
is no longer reported done before the app answers, so the number the CLI prints becomes the real one.
It was previously reporting success during the artifact fetch.

## The sweep

Every branch on `onRequest` or `idle` in the agent, asked "what does this do when the app has never
run?":

| file | verdict |
|---|---|
| `reconcile/plan.ts` | fixed in #431 |
| `health/state.ts` | **this bug** |
| `report/capacity.ts` | `HOLDS_NOTHING` under-counted a booting app — same root, fixed here |
| `lib/agent/usage.ts` | skipped the first compute delta for a booting app — same root, fixed here |
| `reconcile/idle.ts` | correct: `hasGoneQuiet` needs `running`, so neither `pending` nor `idle` sleeps |
| `reconcile/instances.ts` | correct: `sleepInstance` writes `idle` only where the planner asked for sleep |
| `services/app-activator.service.ts` | correct: no record yet means nothing is placed, and a request is told so |
| `services/reconciler.service.ts` | correct: derives `onRequest` from desired state, no state assumption |
| `lib/control/client.ts` | no match — grep hit `AgentSessionRequest` |

One root cause, three symptoms. Nothing else in the class.
