### PR TITLE
feat(api): a profile carries how many apps its owner may have

### DIFF
--- a/apps/api/src/db/migrations/0040_a_profile_carries_an_app_quota.sql
+++ b/apps/api/src/db/migrations/0040_a_profile_carries_an_app_quota.sql
@@ -1,0 +1,3 @@
+ALTER TABLE nibrun.profiles
+  ADD COLUMN quota_apps_max_count integer NOT NULL DEFAULT 3,
+  ADD CONSTRAINT profiles_quota_apps_max_count_check CHECK (quota_apps_max_count >= 0);

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -1384,6 +1384,7 @@ export interface IProfilesColumns {
     /** Derived from the uuidv7 id; the moment the row was created. */
     created_at: Date;
     updated_at: Date;
+    quota_apps_max_count: number;
 }
 
 /** Schema of `profiles`. */
@@ -1935,7 +1936,8 @@ export const schema = {
             id: { _columnName: "id", _foreignKeys: {} },
             owner_id: { _columnName: "owner_id", _foreignKeys: { profiles_owner_id_fkey: { _constraintName: "profiles_owner_id_fkey", _references: { _relationName: "user", _columnName: "id" } } } },
             created_at: { _columnName: "created_at", _foreignKeys: {} },
-            updated_at: { _columnName: "updated_at", _foreignKeys: {} }
+            updated_at: { _columnName: "updated_at", _foreignKeys: {} },
+            quota_apps_max_count: { _columnName: "quota_apps_max_count", _foreignKeys: {} }
         },
         _indexes: {
             profiles_owner_id_key: { _indexName: "profiles_owner_id_key" },
@@ -1944,7 +1946,8 @@ export const schema = {
         _constraints: {
             profiles_owner_id_fkey: { _constraintName: "profiles_owner_id_fkey" },
             profiles_owner_id_key: { _constraintName: "profiles_owner_id_key" },
-            profiles_pkey: { _constraintName: "profiles_pkey" }
+            profiles_pkey: { _constraintName: "profiles_pkey" },
+            profiles_quota_apps_max_count_check: { _constraintName: "profiles_quota_apps_max_count_check" }
         }
     },
     purgeable_apps: {


### PR DESCRIPTION
The column only. Nothing reads it yet — the allowance view and the refusal at create are #427.

```sql
ALTER TABLE nibrun.profiles
  ADD COLUMN quota_apps_max_count integer NOT NULL DEFAULT 3,
  ADD CONSTRAINT profiles_quota_apps_max_count_check CHECK (quota_apps_max_count >= 0);
```

`quota_` as a prefix, so the allowances group together in a table that will also hold settings that are not one.

**A stored number rather than a null meaning the platform default.** Every profile gets a literal `3`, the 17 backfilled ones included. Raising the free tier later is `ALTER COLUMN SET DEFAULT`, which reaches new signups and leaves everyone already here where they are — so grandfathering is what happens unless somebody runs an `UPDATE`. That is the deliberate half of the trade; the other half is that a tier change is two steps rather than one.

Granting:

```sql
UPDATE nibrun.profiles SET quota_apps_max_count = 10
WHERE owner_id = (SELECT id FROM auth."user" WHERE email = $1);
```

No test: that the column defaults to 3 is Postgres doing what the DDL says, and the trigger that makes the row is already covered. A test here would only assert the migration is the migration.