### PR TITLE
fix(agent): a snapshot in flight is not a microVM that crashed

### DIFF
--- a/apps/agent/src/lib/health/state.ts
+++ b/apps/agent/src/lib/health/state.ts
@@ -135,6 +135,7 @@ export type LifecycleInputs = {
   desiredRunning: boolean;
   onRequest: boolean;
   stopRequested: boolean;
+  snapshotting: boolean;
   startedAtMs?: number;
   nowMs: number;
 };
@@ -150,18 +151,23 @@ export type LifecycleInputs = {
  * A boot that did happen rules out `idle` whatever the activation policy says: a microVM a
  * request brought up and that then went down unasked is a crash, and calling that idle would
  * wait for another request to find out.
+ *
+ * Unasked is the whole of it, and a snapshot in flight is the one absence that is asked for
+ * without `stopRequested` saying so: the capture ends with the VMM gone and the flag is only
+ * written once it has finished, so a pass landing in between would read a sleep as that crash.
  */
 function evaluateStoppedState({
   desiredRunning,
   onRequest,
   stopRequested,
+  snapshotting,
   startedAtMs,
 }: Pick<
   LifecycleInputs,
-  'desiredRunning' | 'onRequest' | 'stopRequested' | 'startedAtMs'
+  'desiredRunning' | 'onRequest' | 'stopRequested' | 'snapshotting' | 'startedAtMs'
 >): InstanceState {
   const down = onRequest && desiredRunning ? 'idle' : 'stopped';
-  if (stopRequested || !desiredRunning) {
+  if (stopRequested || snapshotting || !desiredRunning) {
     return down;
   }
   if (startedAtMs !== undefined) {
@@ -184,6 +190,7 @@ export function evaluateInstanceState({
   desiredRunning,
   onRequest,
   stopRequested,
+  snapshotting,
   startedAtMs,
   nowMs,
 }: LifecycleInputs): InstanceState {
@@ -191,7 +198,13 @@ export function evaluateInstanceState({
     return 'failed';
   }
   if (!unit.active) {
-    return evaluateStoppedState({ desiredRunning, onRequest, stopRequested, startedAtMs });
+    return evaluateStoppedState({
+      desiredRunning,
+      onRequest,
+      stopRequested,
+      snapshotting,
+      startedAtMs,
+    });
   }
   if (stopRequested) {
     return 'stopping';

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -137,6 +137,12 @@ export const stopInstance = Effect.fn('stopInstance')(function* ({
  * microVM that is gone is asleep rather than crashed, and what keeps the boot that follows a
  * discarded snapshot from being counted as a restart.
  *
+ * Which leaves the capture itself, at the end of which the VMM is gone and the flag is not yet
+ * written. `markSnapshotting` spans exactly that, because the health loop runs on its own tick
+ * and one landing in there would read the sleep as the crash `stopRequested` exists to rule out.
+ * It is cleared however this ends: a refusal leaves the microVM up, and an app marked as being
+ * captured when nothing is capturing it is one whose next real crash reads as a sleep.
+ *
  * The state stays `running` for the whole of it rather than going to `stopping` the way a stop
  * does. That keeps the forward rule pointing at the guest while it is being captured, which is
  * what the requests still arriving want: withdrawing it would hand them to the activator, which
@@ -164,6 +170,7 @@ export const suspendInstance = Effect.fn('suspendInstance')(function* ({
     return yield* stopInstance({ appId, reason });
   }
 
+  yield* AgentState.markSnapshotting({ appId, active: true });
   yield* settleAndSleep({ appId, deploymentId, slot: slot.value, reason }).pipe(
     Effect.andThen(
       AgentState.updateRecord({
@@ -191,6 +198,7 @@ export const suspendInstance = Effect.fn('suspendInstance')(function* ({
         Effect.annotateLogs({ appId, reason }),
       ),
     ),
+    Effect.ensuring(AgentState.markSnapshotting({ appId, active: false })),
   );
 });
 
@@ -559,11 +567,13 @@ function settle({
   record,
   status,
   due,
+  snapshotting,
   nowMs,
 }: {
   record: InstanceRecord;
   status: UnitStatus;
   due: boolean;
+  snapshotting: boolean;
   nowMs: number;
 }) {
   return Effect.gen(function* () {
@@ -574,6 +584,7 @@ function settle({
       desiredRunning: record.desiredRunning,
       onRequest: record.onRequest,
       stopRequested: record.stopRequested,
+      snapshotting,
       ...graceInputs({ record, nowMs }),
     });
 
@@ -623,6 +634,7 @@ export const refreshStates = Effect.gen(function* () {
         record,
         status: statuses.get(record.appId) ?? UNKNOWN_UNIT,
         due: nowMs >= (current.nextProbeAtMs.get(record.appId) ?? 0),
+        snapshotting: current.snapshotting.has(record.appId),
         nowMs,
       }),
     { discard: true },

--- a/apps/agent/src/services/agent-state.service.ts
+++ b/apps/agent/src/services/agent-state.service.ts
@@ -23,6 +23,13 @@ export type AgentSnapshot = {
   readonly deletedVolumes: ReadonlyMap<VolumeId, ReportedVolume>;
   readonly nextProbeAtMs: ReadonlyMap<AppId, number>;
   /**
+   * The apps a snapshot is being taken of right now. Here rather than on the record because it
+   * may not outlive the agent that set it: one that died mid-capture comes back with this empty,
+   * and the microVM it left behind reads as the crash it is rather than as a sleep nobody
+   * finished.
+   */
+  readonly snapshotting: ReadonlySet<AppId>;
+  /**
    * The last reading taken of each volume this host holds a slot for, which is not the same as
    * each volume a guest can currently be asked about: a suspended app keeps its slot, so its last
    * reading is kept too rather than the app going from a number to nothing on being stopped.
@@ -61,6 +68,7 @@ const EMPTY: AgentSnapshot = {
   exportReports: new Map(),
   deletedVolumes: new Map(),
   nextProbeAtMs: new Map(),
+  snapshotting: new Set(),
   volumeUsage: new Map(),
   computeUsage: new Map(),
   computeTicks: new Map(),
@@ -98,6 +106,23 @@ export class AgentState extends Effect.Service<AgentState>()('AgentState', {
           ...current,
           lastActiveAtMs: new Map(current.lastActiveAtMs).set(appId, nowMs),
         })),
+
+      /**
+       * Taking a snapshot ends with the VMM gone, so while one is in flight a microVM that is not
+       * there is expected rather than lost. `stopRequested` cannot carry this: `refusalToSleep`
+       * reads it as a stop already asked for and would refuse the very sleep it was marking, which
+       * is why the flag is written after the capture and this before it.
+       */
+      markSnapshotting: ({ appId, active }: { appId: AppId; active: boolean }) =>
+        modify((current) => {
+          const snapshotting = new Set(current.snapshotting);
+          if (active) {
+            snapshotting.add(appId);
+          } else {
+            snapshotting.delete(appId);
+          }
+          return { ...current, snapshotting };
+        }),
 
       putRecord: (record: InstanceRecord) =>
         modify((current) => ({

--- a/apps/agent/tests/lib/health/state.test.ts
+++ b/apps/agent/tests/lib/health/state.test.ts
@@ -84,6 +84,7 @@ function evaluate({
   stopRequested = false,
   desiredRunning = true,
   onRequest = false,
+  snapshotting = false,
   startedAtMs = STARTED_AT_MS as number | undefined,
 }: {
   unit: UnitStatus;
@@ -93,6 +94,7 @@ function evaluate({
   stopRequested?: boolean;
   desiredRunning?: boolean;
   onRequest?: boolean;
+  snapshotting?: boolean;
   startedAtMs?: number | undefined;
 }) {
   return evaluateInstanceState({
@@ -102,6 +104,7 @@ function evaluate({
     desiredRunning,
     onRequest,
     stopRequested,
+    snapshotting,
     ...(startedAtMs === undefined ? {} : { startedAtMs }),
     nowMs,
   });
@@ -257,6 +260,7 @@ describe('what the VM itself is doing', () => {
         desiredRunning: true,
         onRequest: false,
         stopRequested: false,
+        snapshotting: false,
         nowMs: STARTED_AT_MS,
       }),
     ).toBe('pending');
@@ -271,6 +275,7 @@ describe('what the VM itself is doing', () => {
         desiredRunning: true,
         onRequest: false,
         stopRequested: false,
+        snapshotting: false,
         nowMs: STARTED_AT_MS,
       }),
     ).toBe('pending');
@@ -291,6 +296,7 @@ describe('what the VM itself is doing', () => {
           desiredRunning: true,
           onRequest: true,
           stopRequested: false,
+          snapshotting: false,
           nowMs: STARTED_AT_MS,
         }),
       ).toBe('idle');
@@ -317,6 +323,24 @@ describe('what the VM itself is doing', () => {
           nowMs: PAST_GRACE_MS,
         }),
       ).toBe('failed');
+    });
+
+    /**
+     * The snapshot is what takes the VMM down, and `stopRequested` is only written once it has
+     * been taken — so between the two the microVM is gone with nothing yet saying it was asked
+     * for. Reading that as a crash fails the deployment, which drops the app out of desired
+     * state and takes its hostnames off the proxy with it.
+     */
+    test('and one whose snapshot is still being taken is idle, not failed', () => {
+      expect(
+        evaluate({
+          unit: exited,
+          tracker: initialTracker(),
+          onRequest: true,
+          snapshotting: true,
+          nowMs: PAST_GRACE_MS,
+        }),
+      ).toBe('idle');
     });
 
     test('and a suspended one is stopped: the owner asked for that, not the request pattern', () => {

--- a/apps/agent/tests/lib/reconcile/instances.test.ts
+++ b/apps/agent/tests/lib/reconcile/instances.test.ts
@@ -12,7 +12,13 @@ import { VmManager } from '#services/vm-manager.service.ts';
 import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
 import { succeeding } from '#tests/support/commands.ts';
 import { agentConfig } from '#tests/support/config.ts';
-import { APP_ID, DEPLOYMENT_ID, desiredInstance, instanceRecord } from '#tests/support/fixtures.ts';
+import {
+  APP_ID,
+  DEPLOYMENT_ID,
+  desiredInstance,
+  instanceRecord,
+  OBSERVED_AT,
+} from '#tests/support/fixtures.ts';
 import { platform, provided } from '#tests/support/run.ts';
 
 /** What `systemctl show` says about a microVM that is up, which is all a pass reads off it. */
@@ -61,6 +67,47 @@ function passHeldOpen() {
 }
 
 const recordOf = Effect.map(AgentState.snapshot, (current) => current.records.get(APP_ID));
+
+/** `systemctl show` answering the same way for every unit a pass asks about. */
+const reporting = (unit: string) =>
+  Layer.succeed(CommandRunner, CommandRunner.make({ run: () => succeeding({ stdout: unit }) }));
+
+/**
+ * The window from the far side, which is the outage this closes: the capture has taken the VMM
+ * down and `stopRequested` is not written until it returns, so a pass landing in between finds a
+ * microVM that is gone with nothing yet saying it was asked for. Calling that failed drops the
+ * app out of desired state, and its hostnames off the proxy with it.
+ */
+describe('a pass that lands while a snapshot is being taken', () => {
+  test('reads the microVM as asleep rather than crashed', () =>
+    run(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(
+          instanceRecord({ onRequest: true, state: 'running', startedAt: OBSERVED_AT }),
+        );
+        yield* AgentState.markSnapshotting({ appId: APP_ID, active: true });
+
+        yield* refreshStates.pipe(Effect.provide(reporting(INACTIVE_UNIT)));
+
+        const record = yield* recordOf;
+        expect(record?.state).toBe('idle');
+        expect(record?.message).toBeUndefined();
+      }),
+    ));
+
+  test('and fails it once the snapshot is no longer in flight', () =>
+    run(
+      Effect.gen(function* () {
+        yield* AgentState.putRecord(
+          instanceRecord({ onRequest: true, state: 'running', startedAt: OBSERVED_AT }),
+        );
+
+        yield* refreshStates.pipe(Effect.provide(reporting(INACTIVE_UNIT)));
+
+        expect((yield* recordOf)?.state).toBe('failed');
+      }),
+    ));
+});
 
 describe('a settle writes back only what it measured', () => {
   test('a start that lands mid-pass keeps the stop it cleared', () =>
@@ -351,6 +398,41 @@ describe('an app that has gone quiet is put down where it can be picked up', () 
         yield* suspend;
 
         expect((yield* recordOf)?.state).toBe('running');
+      }),
+    );
+  });
+
+  /**
+   * The mark is what the health loop reads while the capture is in flight, so a sleep that has
+   * returned must leave none behind: an app still marked when nothing is snapshotting it is one
+   * whose next real crash reads as a sleep and is never failed at all.
+   */
+  test('the snapshot mark is not left behind, however the sleep ended', () => {
+    const vms = recordingVms();
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* (yield* SlotAllocator).allocate(APP_ID);
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* suspend;
+
+        expect((yield* AgentState.snapshot).snapshotting.has(APP_ID)).toBe(false);
+      }),
+    );
+  });
+
+  test('and a refusal clears it too, though it never took one', () => {
+    const vms = recordingVms({
+      onSleep: new SleepRefused({ reason: 'it has already been asked to stop' }),
+    });
+    return withMicroVmDown(vms)(
+      Effect.gen(function* () {
+        yield* (yield* SlotAllocator).allocate(APP_ID);
+        yield* AgentState.putRecord(instanceRecord({ onRequest: true, state: 'running' }));
+
+        yield* suspend;
+
+        expect((yield* AgentState.snapshot).snapshotting.has(APP_ID)).toBe(false);
       }),
     );
   });


### PR DESCRIPTION
Sleeping an app ends with the VMM gone, and `stopRequested` is only written once the capture returns — so a health pass landing in that ~1.4s window read the sleep as a crash. The failed deployment then dropped the app out of desired state, taking its hostnames off the proxy: `dailychain.lol` answered `525` for 14 hours after a textbook idle sleep.

The mark spans exactly the capture and lives on `AgentState` rather than the record, so an agent that dies mid-snapshot comes back with it empty and the microVM reads as the crash it is.

The routing half of that outage is [#435](https://github.com/ilbertt/nibrun/pull/435).