### PR TITLE
docs(www): the copy leads with the app that already ships as one file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,11 @@ Small apps don't need to scale. They need a machine and a disk.
 
 ## Why
 
-PocketBase is one file with a database, auth, file storage and an admin UI in it. So is a lot of
-good open source. Then you go to host it.
+A compiled binary is already a whole application in one file. Whatever language produced it,
+nothing has to be installed on the other side. The only two things it still needs are somewhere
+to run and somewhere to read and write files.
 
-The "batteries included" platforms hand you Postgres and object storage but nowhere to run your
-own binary. The ones that will run your code run it as a function, on a filesystem that resets
-between requests, so a SQLite file is gone the moment the request ends. And a VM means ssh, a
-firewall to open, TLS to renew, and an OS to keep updated.
-
-Self-hostable projects are great until you have to host them.
+For an app that five people use, most of the rest is ceremony:
 
 | What it usually gets | What it actually needs |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 </div>
 
-Self-hostable projects are great until you have to host them.
+Small apps don't need to scale. They need a machine and a disk.
 
 ## Why
 
@@ -19,6 +19,8 @@ The "batteries included" platforms hand you Postgres and object storage but nowh
 own binary. The ones that will run your code run it as a function, on a filesystem that resets
 between requests, so a SQLite file is gone the moment the request ends. And a VM means ssh, a
 firewall to open, TLS to renew, and an OS to keep updated.
+
+Self-hostable projects are great until you have to host them.
 
 | What it usually gets | What it actually needs |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -42,13 +42,19 @@ it boots, sleeps after five minutes idle, and wakes on the next request in ~120 
 If your app needs to be more than one machine, it has outgrown this — and that is not a roadmap,
 it is the design.
 
-## Get started
+## Preconfigured deployments
 
-Already a single binary? Deploy it:
+Open source that already ships as a single binary. One click, nothing to fill in:
 
-**[Deploy PocketBase on nibrun](https://nibrun.com/deploy/pocketbase)** — preconfigured, one click.
+- **[PocketBase](https://nibrun.com/deploy/pocketbase)** — a database, auth, file storage and an
+  admin UI, in one file.
+- **[Sharkord](https://nibrun.com/deploy/sharkord)** — a self-hosted chat server with voice,
+  video and screen sharing.
+- **[Boop](https://nibrun.com/deploy/boop)** — a self-hosted notification inbox for your own apps.
 
-Or bring your own. Create an HTTP app (use the
+## Deploy your own app
+
+Create an HTTP app (use the
 [bun-full-stack-starter](https://github.com/ilbertt/bun-full-stack-starter) template) and compile
 it to a single Linux x86_64 binary. Then deploy it:
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,53 @@
 <div align="center">
   <img src="apps/www/public/favicon.svg" alt="nibrun logo" width="128" />
   <h1>nibrun</h1>
-  <p><em>Drop a binary. Get a server.</em></p>
+  <p><em>One-click deployment for any single-binary app.</em></p>
 
 [![runtime](https://img.shields.io/github/package-json/packageManager/ilbertt/nibrun?label=runtime&logo=bun&logoColor=fbf0df&color=fbf0df)](https://bun.com)
 [![skills.sh](https://skills.sh/b/ilbertt/nibrun)](https://skills.sh/ilbertt/nibrun)
 
 </div>
 
-Small apps don't need to scale. They need a machine and a disk.
+Self-hostable projects are great until you have to host them.
 
 ## Why
 
-A compiled binary is already a whole application in one file. Whatever language produced it,
-nothing has to be installed on the other side. The only two things it still needs are somewhere
-to run and somewhere to read and write files.
+PocketBase is one file with a database, auth, file storage and an admin UI in it. So is a lot of
+good open source. Then you go to host it.
 
-For an app that five people use, most of the rest is ceremony:
+The "batteries included" platforms hand you Postgres and object storage but nowhere to run your
+own binary. The ones that will run your code run it as a function, on a filesystem that resets
+between requests, so a SQLite file is gone the moment the request ends. And a VM means ssh, a
+firewall to open, TLS to renew, and an OS to keep updated.
 
 | What it usually gets | What it actually needs |
 | --- | --- |
-| ❌ ~~A container image~~ | ✅ **A machine to run on** |
+| ❌ ~~A container image, around a single file~~ | ✅ **A machine to run on** |
 | ❌ ~~A managed Postgres~~ | ✅ **A disk to write to** |
 | ❌ ~~An object storage bucket~~ | |
-| ❌ ~~A load balancer, for one instance~~ | |
-| ❌ ~~A build pipeline~~ | |
-| ❌ ~~A YAML file you copied~~ | |
+| ❌ ~~A VM to ssh into~~ | |
+| ❌ ~~A firewall to open~~ | |
+| ❌ ~~TLS to renew~~ | |
+| ❌ ~~An OS to keep updated~~ | |
 
 ## What it is
 
-nibrun is those two things and nothing else: a Firecracker microVM of its own, and a `data/`
-directory that survives every redeploy. It answers on an HTTPS subdomain the moment it boots.
+nibrun is those two things and nothing else: a Firecracker microVM of its own (1 vCPU, 256 MiB)
+and a `data/` directory that survives every redeploy. It answers on an HTTPS subdomain the moment
+it boots, sleeps after five minutes idle, and wakes on the next request in ~114 ms.
 
 If your app needs to be more than one machine, it has outgrown this — and that is not a roadmap,
 it is the design.
 
 ## Get started
 
-Create an HTTP app (use the [bun-full-stack-starter](https://github.com/ilbertt/bun-full-stack-starter)
-template) and compile it to a single Linux x86_64 binary. Then deploy it:
+Already a single binary? Deploy it:
+
+**[Deploy PocketBase on nibrun](https://nibrun.com/deploy/pocketbase)** — preconfigured, one click.
+
+Or bring your own. Create an HTTP app (use the
+[bun-full-stack-starter](https://github.com/ilbertt/bun-full-stack-starter) template) and compile
+it to a single Linux x86_64 binary. Then deploy it:
 
 ### For Agents
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ firewall to open, TLS to renew, and an OS to keep updated.
 
 nibrun is those two things and nothing else: a Firecracker microVM of its own (1 vCPU, 256 MiB)
 and a `data/` directory that survives every redeploy. It answers on an HTTPS subdomain the moment
-it boots, sleeps after five minutes idle, and wakes on the next request in ~114 ms.
+it boots, sleeps after five minutes idle, and wakes on the next request in ~120 ms.
 
 If your app needs to be more than one machine, it has outgrown this — and that is not a roadmap,
 it is the design.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ firewall to open, TLS to renew, and an OS to keep updated.
 
 | What it usually gets | What it actually needs |
 | --- | --- |
-| ❌ ~~A container image, around a single file~~ | ✅ **A machine to run on** |
+| ❌ ~~A container image~~ | ✅ **A machine to run on** |
 | ❌ ~~A managed Postgres~~ | ✅ **A disk to write to** |
 | ❌ ~~An object storage bucket~~ | |
+| ❌ ~~A load balancer, for one instance~~ | |
 | ❌ ~~A VM to ssh into~~ | |
 | ❌ ~~A firewall to open~~ | |
 | ❌ ~~TLS to renew~~ | |

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -1,6 +1,10 @@
 import type { DeployLink } from '@repo/deploy-link';
 import { interpolableRuntimeValue, RUNTIME_VALUES } from '@repo/protocol';
 
+/**
+ * The root README names these one by one, and nothing here reaches it: a preset added, renamed or
+ * dropped is carried over by hand or not at all.
+ */
 export const DEPLOY_PRESETS = {
   boop: {
     name: 'boop',

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -1,10 +1,7 @@
 import type { DeployLink } from '@repo/deploy-link';
 import { interpolableRuntimeValue, RUNTIME_VALUES } from '@repo/protocol';
 
-/**
- * The root README names these one by one, and nothing here reaches it: a preset added, renamed or
- * dropped is carried over by hand or not at all.
- */
+// Update the root README when changing any entry here.
 export const DEPLOY_PRESETS = {
   boop: {
     name: 'boop',

--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -33,7 +33,7 @@ listen on it, on `0.0.0.0`.
 
 One microVM per app: no horizontal scaling, no load balancing. A deploy stops the old VM before
 starting the new one, so it is a few seconds of downtime rather than blue/green. An app sleeps
-after five minutes idle and wakes on the next request in ~114 ms. It fits a single-binary app that
+after five minutes idle and wakes on the next request in ~120 ms. It fits a single-binary app that
 owns its own state; it does not fit anything that has to be several machines.
 
 ## Links

--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -1,7 +1,7 @@
 # nibrun
 
-> Drop a binary. Get a server. Each compiled binary gets a microVM of its own, a persistent
-> filesystem, and an HTTPS URL. No Dockerfile, no YAML, no cluster.
+> One-click deployment for any single-binary app. Each compiled binary gets a microVM of its own,
+> a persistent filesystem, and an HTTPS URL. No Dockerfile, no YAML, no cluster.
 
 ## What you get
 
@@ -32,9 +32,9 @@ listen on it, on `0.0.0.0`.
 ## The tradeoffs
 
 One microVM per app: no horizontal scaling, no load balancing. A deploy stops the old VM before
-starting the new one, so it is a few seconds of downtime rather than blue/green. The disk is local
-and unreplicated, so `nib apps export` is the backup. It fits a single-binary app that owns its own
-state; it does not fit anything that has to be several machines.
+starting the new one, so it is a few seconds of downtime rather than blue/green. An app sleeps
+after five minutes idle and wakes on the next request in ~114 ms. It fits a single-binary app that
+owns its own state; it does not fit anything that has to be several machines.
 
 ## Links
 

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -2,10 +2,10 @@ export function Hero() {
   return (
     <div className="flex flex-col items-center gap-4 text-center">
       <h1 className="text-balance font-semibold text-4xl tracking-tight sm:text-5xl">
-        Drop a binary. Get a server.
+        One-click deployment for any single-binary app.
       </h1>
       <p className="text-balance text-lg text-muted-foreground">
-        Small apps don&apos;t need to scale. They need a binary and a disk.
+        Self-hostable projects are great until you have to host them.
       </p>
     </div>
   );

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -5,7 +5,7 @@ export function Hero() {
         One-click deployment for any single-binary app.
       </h1>
       <p className="text-balance text-lg text-muted-foreground">
-        Self-hostable projects are great until you have to host them.
+        Small apps don&apos;t need to scale. They need a binary and a disk.
       </p>
     </div>
   );

--- a/apps/www/src/components/what-it-actually-needs.tsx
+++ b/apps/www/src/components/what-it-actually-needs.tsx
@@ -1,7 +1,8 @@
 const CEREMONY = [
-  'A container image, around a single file',
+  'A container image',
   'A managed Postgres',
   'An object storage bucket',
+  'A load balancer, for one instance',
   'A VM to ssh into',
   'A firewall to open',
   'TLS to renew',

--- a/apps/www/src/components/what-it-actually-needs.tsx
+++ b/apps/www/src/components/what-it-actually-needs.tsx
@@ -1,10 +1,11 @@
 const CEREMONY = [
-  'A container image',
+  'A container image, around a single file',
   'A managed Postgres',
   'An object storage bucket',
-  'A load balancer, for one instance',
-  'A build pipeline',
-  'A YAML file you copied',
+  'A VM to ssh into',
+  'A firewall to open',
+  'TLS to renew',
+  'An OS to keep updated',
 ];
 
 const ESSENTIALS = ['A machine to run on', 'A disk to write to'];

--- a/apps/www/src/content/blog/small-apps-dont-need-to-scale.md
+++ b/apps/www/src/content/blog/small-apps-dont-need-to-scale.md
@@ -36,6 +36,7 @@ Unzip it on any Linux box, run the binary, and you have the same app back with t
 it.
 
 The catch is that this only works for apps that fit on one machine. There's no horizontal scaling,
-a deploy means a few seconds of downtime while the old VM stops and the new one starts, and the
-disk isn't replicated, so that export is also your backup. If your app needs to be more than one
-machine, nibrun is the wrong tool. Most small apps never do.
+and a deploy means a few seconds of downtime while the old VM stops and the new one starts. The
+volume is backed by S3 rather than by the host it runs on, so the export is how you leave rather
+than the only copy you have. If your app needs to be more than one machine, nibrun is the wrong
+tool. Most small apps never do.

--- a/apps/www/src/lib/site.ts
+++ b/apps/www/src/lib/site.ts
@@ -8,6 +8,6 @@ export function pageTitle(name: string): string {
 }
 
 export const SITE_DESCRIPTION =
-  'Upload a compiled binary and it gets a Firecracker microVM of its own, 8 GiB of persistent disk, and an HTTPS URL. No Dockerfile, no YAML, no database to provision, and no machine of yours to keep patched.';
+  "Small apps don't need to scale. Drop a compiled binary and get a microVM of its own, a persistent filesystem, and an HTTPS URL. Export the binary and the whole disk whenever you want.";
 
 export const REPO_URL = 'https://github.com/ilbertt/nibrun';

--- a/apps/www/src/lib/site.ts
+++ b/apps/www/src/lib/site.ts
@@ -1,6 +1,6 @@
 export const SITE_URL = 'https://nibrun.com';
 
-export const SITE_TITLE = 'nibrun — drop your binary, get a server';
+export const SITE_TITLE = 'nibrun — one-click deployment for any single-binary app';
 
 /** Every page but the landing one, which is named after the site rather than suffixed with it. */
 export function pageTitle(name: string): string {
@@ -8,6 +8,6 @@ export function pageTitle(name: string): string {
 }
 
 export const SITE_DESCRIPTION =
-  "Small apps don't need to scale. Drop a compiled binary and get a microVM of its own, a filesystem that persists, and an HTTPS URL. Export the binary and the whole disk whenever you want.";
+  'Upload a compiled binary and it gets a Firecracker microVM of its own, 8 GiB of persistent disk, and an HTTPS URL. No Dockerfile, no YAML, no database to provision, and no machine of yours to keep patched.';
 
 export const REPO_URL = 'https://github.com/ilbertt/nibrun';


### PR DESCRIPTION
Repositions the public copy ahead of a Show HN launch: the pitch is now the hosting problem a single-binary app runs into, not the upload gesture. Landing headline becomes "One-click deployment for any single-binary app."

Also drops a false claim from the small-apps post — the volume is S3-backed, not local and unreplicated.

Not covered here: `og.png` still carries the old tagline (flat PNG, no source in the repo), and the GitHub repo description is a setting rather than a file.