### PR TITLE
chore(api): bun-sqlgen 0.6 keeps the migrations in a dependable order

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
     "build": "bun run scripts/build.ts",
     "check:types": "bun codegen:sql:check && bun run --bun tsc",
     "codegen:sql": "bun bun-sqlgen generate 'src/repositories/*.repository.ts' --migrations src/db/migrations --out src/db/queries.gen.ts",
-    "codegen:sql:check": "bun bun-sqlgen generate 'src/repositories/*.repository.ts' --migrations src/db/migrations --out src/db/queries.gen.ts --check",
+    "codegen:sql:check": "bun codegen:sql --check",
     "test": "bun test"
   },
   "dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/client-s3": "^3.1105.0",
     "@aws-sdk/s3-request-presigner": "^3.1105.0",
     "@ilbertt/better-auth-bun-sql": "^0.4.0",
-    "@ilbertt/bun-sqlgen": "^0.5.0",
+    "@ilbertt/bun-sqlgen": "^0.6.0",
     "@repo/protocol": "workspace:*",
     "better-auth": "catalog:",
     "elysia": "^1.4.29"

--- a/apps/api/sqlgen.config.ts
+++ b/apps/api/sqlgen.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@ilbertt/bun-sqlgen/config';
+
+export default defineConfig({
+  checkMigrationOrder: { prefixPattern: /^[0-9]{4}_/ },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "@aws-sdk/client-s3": "^3.1105.0",
         "@aws-sdk/s3-request-presigner": "^3.1105.0",
         "@ilbertt/better-auth-bun-sql": "^0.4.0",
-        "@ilbertt/bun-sqlgen": "^0.5.0",
+        "@ilbertt/bun-sqlgen": "^0.6.0",
         "@repo/protocol": "workspace:*",
         "better-auth": "catalog:",
         "elysia": "^1.4.29",
@@ -144,7 +144,7 @@
     },
     "packages/cli": {
       "name": "@repo/cli",
-      "version": "2026.8.29-2",
+      "version": "2026.8.31-3",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
         "@parshjs/core": "^0.0.10",
@@ -548,7 +548,7 @@
 
     "@ilbertt/better-auth-bun-sql": ["@ilbertt/better-auth-bun-sql@0.4.0", "", { "peerDependencies": { "better-auth": ">=1.6.0" } }, "sha512-g6az7IO5XpnZhA3h1REoHRND0VhojADcqWSu5LX+jl6/l5be0o9JlJHQnceisUFQWsYDMJDoQbZu2vX8sMbCQQ=="],
 
-    "@ilbertt/bun-sqlgen": ["@ilbertt/bun-sqlgen@0.5.0", "", { "dependencies": { "@electric-sql/pglite": "^0.5.5", "@typescript/typescript6": "^6.0.2" }, "bin": { "bun-sqlgen": "dist/cli/main.js" } }, "sha512-WhuFjZxhrTmmOju69poe9L8mwCKVkGxCph2hOS3ZZSleGSRKyKy9WCJxUNcRrHKDVdjISzmotzKFn4JSOK+QBQ=="],
+    "@ilbertt/bun-sqlgen": ["@ilbertt/bun-sqlgen@0.6.0", "", { "dependencies": { "@electric-sql/pglite": "^0.5.5", "@typescript/typescript6": "^6.0.2" }, "bin": { "bun-sqlgen": "dist/cli/main.js" } }, "sha512-Ml3vHpTcovuDl055Aarg8yZy3F1S/JlSgKFj+H7EhYafVnfHVBXFUUqTWgh6kBfWj2iNo31KUXFV0sYMOS+igg=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 


### PR DESCRIPTION
Migrations apply in filename order, so a prefix of the wrong width applies out of the order it was written for. 0.6 can check that, and `sqlgen.config.ts` names the convention `apps/api` already follows.

Verified by dropping in a `999_` file: the check names it and exits non-zero. `queries.gen.ts` is byte-identical under 0.6.