### PR TITLE
feat(www): gogs deploys in one click with the git it carries itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Open source that already ships as a single binary. One click, nothing to fill in
 - **[Sharkord](https://nibrun.com/deploy/sharkord)** — a self-hosted chat server with voice,
   video and screen sharing.
 - **[Boop](https://nibrun.com/deploy/boop)** — a self-hosted notification inbox for your own apps.
+- **[Gogs](https://nibrun.com/deploy/gogs)** — a self-hosted Git service with repositories, issues
+  and pull requests.
 
 ## Deploy your own app
 

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -20,6 +20,18 @@ export const DEPLOY_PRESETS = {
     ],
     minimal: true,
   },
+  // Gogs shells out to git for every repository operation and the guest carries none, so
+  // this build bundles a static one and unpacks it onto the volume. `nibrun` is the
+  // subcommand that does that and then serves.
+  gogs: {
+    name: 'gogs',
+    binary:
+      'https://github.com/ilbertt/gogs/releases/download/v0.15.0-nibrun.2/gogs-nibrun-linux-amd64',
+    sha256: '2ccc30e5f0626239a1814d2b17244bfee366fbb3324025577e8fd77d81fea794',
+    port: 3000,
+    arg: ['nibrun'],
+    minimal: true,
+  },
   pocketbase: {
     name: 'pocketbase',
     binary:


### PR DESCRIPTION
Adds Gogs to the preconfigured deployments, so `/deploy/gogs` opens a form with nothing left to fill in.

The binary is a [fork build](https://github.com/ilbertt/gogs/releases/tag/v0.15.0-nibrun.2) rather than an upstream release. Gogs shells out to git for every repository operation and refuses to start without one, and the guest carries none, so it bundles a statically linked git and unpacks it onto the volume. The `nibrun` argument selects the subcommand that does that and then serves.

Verified by deploying it: clone and push over HTTPS both work, and it sits at 62 MiB of the 256 MiB guest.