### PR TITLE
feat(api): artifacts remember the digest they were held to

### DIFF
--- a/apps/api/src/db/migrations/0043_artifacts_remember_the_digest_they_were_held_to.sql
+++ b/apps/api/src/db/migrations/0043_artifacts_remember_the_digest_they_were_held_to.sql
@@ -1,0 +1,62 @@
+-- The digest a url was promised to serve, kept beside the url itself.
+--
+-- Not the same number as `digest`, and the two are only equal by coincidence. `digest` is taken
+-- from the executable that ends up stored; this is taken from the file the url served, which for
+-- a release published as a `.tar.gz` is the archive. That is the form a checksum is written down
+-- in — a `checksums.txt` beside a zip is the zip's — so it is the only one a link can carry and
+-- the only one two links for the same release agree on.
+--
+-- Null for every upload, for every url nobody said a digest for, and for every url that carried
+-- credentials. The first two never had one; the last is a download somebody reached with a
+-- password, and a digest is enough to ask for the bytes it names.
+
+ALTER TABLE nibrun.artifacts
+  ADD COLUMN source_digest text;
+
+COMMENT ON COLUMN nibrun.artifacts.source_digest IS $c$The digest the url's own download was held to, which for an archive is the archive's. @type import('@repo/protocol').Sha256Digest$c$;
+
+-- What a url served once, and need not serve again.
+--
+-- A view rather than a table: every column of it already belongs to the artifact, and a second
+-- copy is a second thing to write, to expire, and to be wrong. Membership is the whole of being
+-- cached, which is the same sentence as the bytes being worth keeping.
+--
+-- `activated_at IS NOT NULL` is what a deployment that worked leaves behind, so nothing reaches
+-- this view on the strength of having been fetched. A binary that was pulled, stored and never
+-- got a microVM to answer a health check is one nobody has shown is worth handing to the next
+-- person who asks for it.
+--
+-- `live_apps` is what keeps the row honest about its object. The bytes are removed when the last
+-- app naming them is purged, so a row here that outlived them would send a fetch nowhere — and an
+-- app on its way out stops vouching for its binary before that can happen.
+CREATE VIEW nibrun.cached_binaries AS
+  SELECT ar.source_digest,
+         ar.digest,
+         ar.size_bytes,
+         ar.object_key,
+         ar.original_file_name
+  FROM nibrun.artifacts ar
+  JOIN nibrun.deployments d ON d.artifact_id = ar.id
+  JOIN nibrun.live_apps a ON a.id = ar.app_id
+  WHERE ar.source_digest IS NOT NULL
+    AND ar.object_key IS NOT NULL
+    AND d.activated_at IS NOT NULL;
+
+-- The one question ever asked of the column, and partial because the rows worth looking at are
+-- the few that were fetched from a url somebody vouched for.
+CREATE INDEX artifacts_source_digest_idx ON nibrun.artifacts (source_digest)
+  WHERE source_digest IS NOT NULL;
+
+-- Read from the artifact's side, so the join above starts at the one row a digest names rather
+-- than at every deployment that ever succeeded.
+CREATE INDEX deployments_activated_artifact_idx ON nibrun.deployments (artifact_id)
+  WHERE activated_at IS NOT NULL;
+
+-- A view carries none of the column comments its table columns have, so the types the rest of
+-- this schema is read through are said again here rather than degrading to `text` at the one
+-- place a binary is chosen without being fetched.
+COMMENT ON COLUMN nibrun.cached_binaries.source_digest IS $c$@type import('@repo/protocol').Sha256Digest @notNull$c$;
+COMMENT ON COLUMN nibrun.cached_binaries.digest IS $c$@type import('@repo/protocol').Sha256Digest @notNull$c$;
+COMMENT ON COLUMN nibrun.cached_binaries.size_bytes IS 'A Postgres bigint, so it arrives as a string; the wire type is a number. @notNull';
+COMMENT ON COLUMN nibrun.cached_binaries.object_key IS $c$@type import('@repo/protocol').ObjectKey @notNull$c$;
+COMMENT ON COLUMN nibrun.cached_binaries.original_file_name IS $c$@type import('@repo/protocol').Filename @notNull$c$;

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -1186,6 +1186,8 @@ export interface IArtifactsColumns {
     created_at: Date;
     updated_at: Date;
     original_file_url: string | null;
+    /** The digest the url's own download was held to, which for an archive is the archive's. */
+    source_digest: import("@repo/protocol").Sha256Digest | null;
 }
 
 /** Schema of `artifacts`. */
@@ -1194,6 +1196,24 @@ export interface IArtifactsTable {
     relationType: (typeof schema)["artifacts"]["_relationType"];
     indexes: keyof (typeof schema)["artifacts"]["_indexes"];
     constraints: keyof (typeof schema)["artifacts"]["_constraints"];
+}
+
+/** Columns of `cached_binaries`. */
+export interface ICachedBinariesColumns {
+    source_digest: import("@repo/protocol").Sha256Digest;
+    digest: import("@repo/protocol").Sha256Digest;
+    /** A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    size_bytes: string;
+    object_key: import("@repo/protocol").ObjectKey;
+    original_file_name: import("@repo/protocol").Filename;
+}
+
+/** Schema of `cached_binaries`. */
+export interface ICachedBinariesTable {
+    columns: ICachedBinariesColumns;
+    relationType: (typeof schema)["cached_binaries"]["_relationType"];
+    indexes: keyof (typeof schema)["cached_binaries"]["_indexes"];
+    constraints: keyof (typeof schema)["cached_binaries"]["_constraints"];
 }
 
 /** Columns of `deployments`. */
@@ -1773,17 +1793,32 @@ export const schema = {
             original_file_name: { _columnName: "original_file_name", _foreignKeys: {} },
             created_at: { _columnName: "created_at", _foreignKeys: {} },
             updated_at: { _columnName: "updated_at", _foreignKeys: {} },
-            original_file_url: { _columnName: "original_file_url", _foreignKeys: {} }
+            original_file_url: { _columnName: "original_file_url", _foreignKeys: {} },
+            source_digest: { _columnName: "source_digest", _foreignKeys: {} }
         },
         _indexes: {
             artifacts_app_id_idx: { _indexName: "artifacts_app_id_idx" },
             artifacts_pending_idx: { _indexName: "artifacts_pending_idx" },
-            artifacts_pkey: { _indexName: "artifacts_pkey" }
+            artifacts_pkey: { _indexName: "artifacts_pkey" },
+            artifacts_source_digest_idx: { _indexName: "artifacts_source_digest_idx" }
         },
         _constraints: {
             artifacts_app_id_fkey: { _constraintName: "artifacts_app_id_fkey" },
             artifacts_pkey: { _constraintName: "artifacts_pkey" }
         }
+    },
+    cached_binaries: {
+        _relationName: "cached_binaries",
+        _relationType: "view",
+        _columns: {
+            source_digest: { _columnName: "source_digest", _foreignKeys: {} },
+            digest: { _columnName: "digest", _foreignKeys: {} },
+            size_bytes: { _columnName: "size_bytes", _foreignKeys: {} },
+            object_key: { _columnName: "object_key", _foreignKeys: {} },
+            original_file_name: { _columnName: "original_file_name", _foreignKeys: {} }
+        },
+        _indexes: {},
+        _constraints: {}
     },
     deployments: {
         _relationName: "deployments",
@@ -1809,6 +1844,7 @@ export const schema = {
             instance_state: { _columnName: "instance_state", _foreignKeys: {} }
         },
         _indexes: {
+            deployments_activated_artifact_idx: { _indexName: "deployments_activated_artifact_idx" },
             deployments_app_id_idx: { _indexName: "deployments_app_id_idx" },
             deployments_artifact_id_idx: { _indexName: "deployments_artifact_id_idx" },
             deployments_config_id_idx: { _indexName: "deployments_config_id_idx" },
@@ -2025,6 +2061,7 @@ export interface Tables {
     app_usage: IAppUsageTable;
     apps: IAppsTable;
     artifacts: IArtifactsTable;
+    cached_binaries: ICachedBinariesTable;
     deployments: IDeploymentsTable;
     desired_deployments: IDesiredDeploymentsTable;
     desired_environment: IDesiredEnvironmentTable;

--- a/apps/api/src/lib/binary-url.ts
+++ b/apps/api/src/lib/binary-url.ts
@@ -31,6 +31,20 @@ export function filenameFromUrl(url: string): Filename | undefined {
 }
 
 /**
+ * Whether the url reached its bytes with a password.
+ *
+ * What such a download has to stay out of is the cache, which is addressed by digest and shared by
+ * everyone: a binary in it is handed to whoever names the right number, without their having to
+ * reach the url it came from. The caller was entitled to those bytes and the next person naming
+ * the digest may not be — and the digest is nobody's secret when a checksum published beside a
+ * download that is gated is the ordinary arrangement.
+ */
+export function carriesCredentials(url: string): boolean {
+  const parsed = parse(url);
+  return parsed !== undefined && (parsed.username !== '' || parsed.password !== '');
+}
+
+/**
  * The url with whatever a caller authenticated by taken out of it. This is the form that is written
  * down and read back in errors, and a password kept forever in a row — or answered to a browser —
  * is one nobody chose to store.

--- a/apps/api/src/repositories/artifacts.repository.ts
+++ b/apps/api/src/repositories/artifacts.repository.ts
@@ -13,6 +13,9 @@ export type InsertPendingArtifactInput = {
   // Only an artifact the api fetched has one, so the column it lands in is nullable and this is
   // how a caller says the bytes were sent instead.
   originalFileUrl: string | null;
+  // What the download was held to, where anybody said. Null is every upload, every url nobody
+  // vouched for, and every url whose bytes are not this api's to hand on.
+  sourceDigest: Sha256Digest | null;
 };
 
 export type CompleteArtifactInput = {
@@ -53,10 +56,11 @@ export class ArtifactsRepository extends Repository implements ArtifactsReposito
     ownerId,
     originalFileName,
     originalFileUrl,
+    sourceDigest,
   }: InsertPendingArtifactInput): Promise<PendingArtifactRow | null> {
     const [row] = await this.sql.InsertPendingArtifact`
-      INSERT INTO nibrun.artifacts (app_id, original_file_name, original_file_url)
-      SELECT a.id, ${originalFileName}, ${originalFileUrl}
+      INSERT INTO nibrun.artifacts (app_id, original_file_name, original_file_url, source_digest)
+      SELECT a.id, ${originalFileName}, ${originalFileUrl}, ${sourceDigest}
       FROM nibrun.live_apps a
       WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
       RETURNING id, app_id, original_file_name, original_file_url, created_at

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -27,7 +27,7 @@ import {
   inspectingPassThrough,
   RefusedArtifactError,
 } from '#lib/artifact-digest.ts';
-import { filenameFromUrl, withoutCredentials } from '#lib/binary-url.ts';
+import { carriesCredentials, filenameFromUrl, withoutCredentials } from '#lib/binary-url.ts';
 import { BadRequestError, NotFoundError, TooManyRequestsError } from '#lib/errors.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
 import type { AppsRepositoryContract } from '#repositories/apps.repository.ts';
@@ -286,6 +286,7 @@ export class ArtifactsService extends Service {
       ownerId,
       originalFileName: filename,
       originalFileUrl: null,
+      sourceDigest: null,
     });
     if (!pending) {
       throw new NotFoundError(NO_SUCH_APP);
@@ -408,6 +409,9 @@ export class ArtifactsService extends Service {
     sha256: Sha256Digest | undefined;
   }): Promise<Artifact> {
     const said = withoutCredentials(url);
+    // Written down only where the bytes are this api's to hand on. A download reached with a
+    // password is the caller's own, and a digest is all anybody would need to ask for it by.
+    const sourceDigest = sha256 !== undefined && !carriesCredentials(url) ? sha256 : null;
 
     const source = await this.sourceRepo.open({ url });
     if (source.outcome !== 'open') {
@@ -433,6 +437,7 @@ export class ArtifactsService extends Service {
       ownerId,
       originalFileName: held.filename,
       originalFileUrl: said,
+      sourceDigest,
     });
     if (!pending) {
       await release(held.body);

--- a/apps/api/tests/repositories/cached-binaries.test.ts
+++ b/apps/api/tests/repositories/cached-binaries.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { SQL } from 'bun';
+import { startTestDatabase, stopTestDatabase } from '#tests/support/database.ts';
+
+const DATABASE_START_TIMEOUT_MS = 180_000;
+
+const PROVEN = 'proven';
+const UNPROVEN = 'unproven';
+const UPLOADED = 'uploaded';
+
+const SHA256_LENGTH = 64;
+const PROVEN_DIGEST = 'a'.repeat(SHA256_LENGTH);
+const UNPROVEN_DIGEST = 'b'.repeat(SHA256_LENGTH);
+
+type SeededApp = {
+  sql: SQL;
+  slug: string;
+  sourceDigest: string | null;
+  activated: boolean;
+};
+
+/**
+ * `nibrun.cached_binaries` is the whole of what makes a second deploy of the same release skip
+ * the download, and every one of its clauses is load-bearing in a way only the real view can
+ * settle: what it leaves out is a binary handed to somebody on the strength of a fetch that was
+ * never shown to run, or bytes an app took with it when it was deleted.
+ */
+describe('a binary is remembered by the deployment that answered for it', () => {
+  let sql: SQL;
+
+  beforeAll(async () => {
+    sql = await startTestDatabase();
+    await seedOwner({ sql });
+    await seedApp({ sql, slug: PROVEN, sourceDigest: PROVEN_DIGEST, activated: true });
+    await seedApp({ sql, slug: UNPROVEN, sourceDigest: UNPROVEN_DIGEST, activated: false });
+    await seedApp({ sql, slug: UPLOADED, sourceDigest: null, activated: true });
+  }, DATABASE_START_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await stopTestDatabase(sql);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  async function cached(): Promise<{ source_digest: string; object_key: string }[]> {
+    return (await sql.unsafe(
+      'SELECT source_digest, object_key FROM nibrun.cached_binaries ORDER BY source_digest',
+    )) as { source_digest: string; object_key: string }[];
+  }
+
+  test('a url whose binary went on to serve is one the next fetch can skip', async () => {
+    expect(await cached()).toEqual([
+      { source_digest: PROVEN_DIGEST, object_key: `artifacts/${PROVEN}` },
+    ]);
+  });
+
+  // The distinction the whole view exists to draw. Fetching, storing and hashing a binary says
+  // the bytes arrived; only a microVM answering a health check says they were worth arriving.
+  test('a fetch no deployment ever answered for is not handed to the next person', async () => {
+    expect(await cached()).not.toContainEqual(
+      expect.objectContaining({ source_digest: UNPROVEN_DIGEST }),
+    );
+  });
+
+  test('and one deployed since is', async () => {
+    await activate({ sql, slug: UNPROVEN });
+
+    expect(await cached()).toContainEqual(
+      expect.objectContaining({ source_digest: UNPROVEN_DIGEST }),
+    );
+  });
+
+  /**
+   * The bytes outlive the row that names them only until the last app naming them is purged, so
+   * an app on its way out has to stop vouching for its binary first. A row left here would send
+   * the next fetch to an object key nothing is going to answer.
+   */
+  test('an app being deleted takes its binary out of everyone else’s reach', async () => {
+    await sql.unsafe(`UPDATE nibrun.apps SET state = 'deleted' WHERE slug = $1`, [PROVEN]);
+
+    expect(await cached()).not.toContainEqual(
+      expect.objectContaining({ source_digest: PROVEN_DIGEST }),
+    );
+  });
+});
+
+async function seedOwner({ sql }: { sql: SQL }): Promise<void> {
+  await sql.unsafe(
+    `INSERT INTO auth."user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+     VALUES ('owner', 'owner', 'owner@example.com', true, now(), now())`,
+  );
+}
+
+async function activate({ sql, slug }: { sql: SQL; slug: string }): Promise<void> {
+  await sql.unsafe(
+    `UPDATE nibrun.deployments d SET activated_at = now()
+     FROM nibrun.apps a WHERE a.id = d.app_id AND a.slug = $1`,
+    [slug],
+  );
+}
+
+/**
+ * An app deployed once. The artifact's object key is the slug's, so a row reaching the view is
+ * traceable to the app that put it there rather than to whichever seed happened to run first.
+ *
+ * An upload is seeded as the same shape with no `source_digest`, because that is exactly what
+ * distinguishes one: nothing was fetched, so there is no url anybody could ask for again.
+ */
+async function seedApp({ sql, slug, sourceDigest, activated }: SeededApp): Promise<void> {
+  await sql.unsafe(`INSERT INTO nibrun.apps (owner_id, slug) VALUES ('owner', $1)`, [slug]);
+  await sql.unsafe(
+    `INSERT INTO nibrun.artifacts
+       (app_id, digest, size_bytes, object_key, original_file_name, original_file_url, source_digest)
+     SELECT id, $2, 1, $3, 'app', $4, $5 FROM nibrun.apps WHERE slug = $1`,
+    [
+      slug,
+      `digest-${slug}`,
+      `artifacts/${slug}`,
+      sourceDigest === null ? null : `https://example.com/${slug}`,
+      sourceDigest,
+    ],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.app_configs (
+       app_id, http_port, args, vcpu_count, memory_mib,
+       health_check_interval_ms, health_check_timeout_ms, health_check_grace_period_ms,
+       health_check_healthy_threshold, health_check_unhealthy_threshold,
+       restart_max_restarts, restart_initial_backoff_ms, restart_max_backoff_ms,
+       restart_backoff_factor, restart_reset_after_ms)
+     SELECT id, 8080, '{}'::text[], 1, 512, 1000, 1000, 1000, 1, 3, 5, 500, 5000, 2, 60000
+     FROM nibrun.apps WHERE slug = $1`,
+    [slug],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.deployments (app_id, artifact_id, config_id, state, activated_at)
+     SELECT a.id, ar.id, c.id, 'running', $2
+     FROM nibrun.apps a
+     JOIN nibrun.artifacts ar ON ar.app_id = a.id
+     JOIN nibrun.app_configs c ON c.app_id = a.id
+     WHERE a.slug = $1`,
+    [slug, activated ? new Date() : null],
+  );
+}


### PR DESCRIPTION
A url fetched once is a url worth not fetching twice, and the digest of
what it served is the only name two links for the same release agree on.

`nibrun.cached_binaries` is a view rather than a table: every column of it
already belongs to the artifact, and membership is the same sentence as the
bytes being worth keeping. Nothing reads it yet.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>