### PR TITLE
feat(api): a release nibrun already holds is not fetched twice

### DIFF
--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -581,6 +581,20 @@ export interface ISelectArtifactByIdResult {
     created_at: Date;
 }
 
+/** Result of query `SelectCachedBinary`. */
+export interface ISelectCachedBinaryResult {
+    /** The digest the url's own download was held to, which for an archive is the archive's. */
+    source_digest: NonNullable<IArtifactsColumns["source_digest"]>;
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row an artifact. */
+    digest: NonNullable<IArtifactsColumns["digest"]>;
+    /** Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    size_bytes: NonNullable<IArtifactsColumns["size_bytes"]>;
+    /** Where the verified bytes came to rest, so absent while they are still in a staging slot. Key within ARTIFACTS_BUCKET; which bucket is deploy configuration. */
+    object_key: NonNullable<IArtifactsColumns["object_key"]>;
+    /** The name the binary was uploaded under; a content-addressed key carries none. */
+    original_file_name: IArtifactsColumns["original_file_name"];
+}
+
 /** Result of query `SelectDeployableArtifact`. */
 export interface ISelectDeployableArtifactResult {
     id: IArtifactsColumns["id"];
@@ -868,6 +882,7 @@ export interface Queries {
     DeleteAbandonedArtifact: IDeleteAbandonedArtifactResult;
     SelectArtifactsByApp: ISelectArtifactsByAppResult;
     SelectArtifactById: ISelectArtifactByIdResult;
+    SelectCachedBinary: ISelectCachedBinaryResult;
     SelectDeployableArtifact: ISelectDeployableArtifactResult;
     InsertDeployment: IInsertDeploymentResult;
     SelectDeploymentToReplay: ISelectDeploymentToReplayResult;

--- a/apps/api/src/repositories/cached-binaries.repository.ts
+++ b/apps/api/src/repositories/cached-binaries.repository.ts
@@ -1,0 +1,49 @@
+import type { Sha256Digest } from '@repo/protocol';
+import type { Queries } from '#db/queries.gen.ts';
+import { Repository } from '#repositories/repository.ts';
+
+export type CachedBinaryRow = Queries['SelectCachedBinary'];
+
+export abstract class CachedBinariesRepositoryContract {
+  abstract findBySourceDigest(input: {
+    sourceDigest: Sha256Digest;
+  }): Promise<CachedBinaryRow | null>;
+}
+
+/**
+ * The one read here that names no owner, and the only one that must not.
+ *
+ * What it answers is "has this exact download already been fetched, stored and run", which is a
+ * question about bytes rather than about anybody's app — and the bytes are shared already: the
+ * store is content-addressed, so two owners deploying the same release have always pointed at one
+ * object. Scoping this to the caller would leave that sharing exactly as it is and only make each
+ * owner pay for the download separately, which is the cost this exists to remove.
+ *
+ * A digest is what the caller had to bring to ask, and they had to know it to write it down. What
+ * comes back is bytes they were already able to fetch for themselves — so the answer tells them
+ * nothing about who else deployed it, and `cached_binaries` leaves out every download that was
+ * reached with a password.
+ */
+export class CachedBinariesRepository
+  extends Repository
+  implements CachedBinariesRepositoryContract
+{
+  async findBySourceDigest({
+    sourceDigest,
+  }: {
+    sourceDigest: Sha256Digest;
+  }): Promise<CachedBinaryRow | null> {
+    const [row] = await this.sql.SelectCachedBinary`
+      /* @notNull source_digest */
+      /* @notNull digest */
+      /* @notNull size_bytes */
+      /* @notNull object_key */
+      /* @notNull original_file_name */
+      SELECT source_digest, digest, size_bytes, object_key, original_file_name
+      FROM nibrun.cached_binaries
+      WHERE source_digest = ${sourceDigest}
+      LIMIT 1
+    `;
+    return row ?? null;
+  }
+}

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -41,6 +41,10 @@ import {
   type BinarySourceRepositoryContract,
   InterruptedSourceError,
 } from '#repositories/binary-source.repository.ts';
+import type {
+  CachedBinariesRepositoryContract,
+  CachedBinaryRow,
+} from '#repositories/cached-binaries.repository.ts';
 import { Service } from '#services/service.ts';
 
 // An app the caller does not own has to be indistinguishable from one that does not exist: a
@@ -231,6 +235,7 @@ export class ArtifactsService extends Service {
   private readonly artifactsRepo: ArtifactsRepositoryContract;
   private readonly storageRepo: ArtifactStorageRepositoryContract;
   private readonly sourceRepo: BinarySourceRepositoryContract;
+  private readonly cachedRepo: CachedBinariesRepositoryContract;
   private readonly appsRepo: AppOwnership;
   private fetchesInFlight = 0;
 
@@ -238,17 +243,20 @@ export class ArtifactsService extends Service {
     artifactsRepo,
     storageRepo,
     sourceRepo,
+    cachedRepo,
     appsRepo,
   }: {
     artifactsRepo: ArtifactsRepositoryContract;
     storageRepo: ArtifactStorageRepositoryContract;
     sourceRepo: BinarySourceRepositoryContract;
+    cachedRepo: CachedBinariesRepositoryContract;
     appsRepo: AppOwnership;
   }) {
     super();
     this.artifactsRepo = artifactsRepo;
     this.storageRepo = storageRepo;
     this.sourceRepo = sourceRepo;
+    this.cachedRepo = cachedRepo;
     this.appsRepo = appsRepo;
   }
 
@@ -376,16 +384,109 @@ export class ArtifactsService extends Service {
     if (filename === undefined) {
       throw new BadRequestError(UNNAMED_BINARY);
     }
+    const said = withoutCredentials(url);
+    // Written down only where the bytes are this api's to hand on. A download reached with a
+    // password is the caller's own, and a digest is all anybody would need to ask for it by.
+    const sourceDigest = sha256 !== undefined && !carriesCredentials(url) ? sha256 : null;
+
+    const reused = await this.reuse({ appId, ownerId, url: said, sourceDigest });
+    if (reused) {
+      return reused;
+    }
+
+    // Counted only against a fetch that is going to happen. A release everyone is deploying would
+    // otherwise spend the slots it no longer needs, and turn its own popularity into the one
+    // answer nobody can act on.
     if (this.fetchesInFlight >= MAX_CONCURRENT_FETCHES) {
       throw new TooManyRequestsError(TOO_MANY_FETCHES);
     }
 
     this.fetchesInFlight += 1;
     try {
-      return await this.fetchInto({ appId, ownerId, url, filename, sha256 });
+      return await this.fetchInto({ appId, ownerId, url, said, filename, sha256, sourceDigest });
     } finally {
       this.fetchesInFlight -= 1;
     }
+  }
+
+  /**
+   * The artifact a url does not have to be followed for, where this api already holds what it
+   * serves and has watched it run.
+   *
+   * Only ever reached with a digest the caller brought, which is what makes the answer exact: the
+   * bytes are named by what they hash to rather than by where they were found, so this cannot
+   * hand back yesterday's release to a url that has since been rebuilt. A url nobody vouched for
+   * is fetched, every time — see `cached_binaries` for what it takes to get into it.
+   *
+   * The object is asked after because the view is a row and the bytes are not: an app purged
+   * between the two leaves a key nothing answers, and a deploy pointed at one would fail on the
+   * host rather than here. A miss costs one HEAD and the download that was going to happen anyway.
+   */
+  private async reuse({
+    appId,
+    ownerId,
+    url,
+    sourceDigest,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    url: string;
+    sourceDigest: Sha256Digest | null;
+  }): Promise<Artifact | undefined> {
+    if (sourceDigest === null) {
+      return undefined;
+    }
+    const cached = await this.cachedRepo.findBySourceDigest({ sourceDigest });
+    if (!cached || !(await this.storageRepo.exists({ objectKey: cached.object_key }))) {
+      return undefined;
+    }
+
+    this.logger.info('a url was served from what nibrun already holds', { url, sourceDigest });
+    return await this.stored({ appId, ownerId, url, cached });
+  }
+
+  /**
+   * The cached binary written down as this app's own artifact. A row per app either way: what is
+   * shared is the object, which is what being content-addressed has always meant here.
+   *
+   * The name comes from the cached row rather than from the url, because it is the name the
+   * binary actually has — an executable unwrapped from an archive is only ever named by the walk
+   * that found it, and the same download unwraps the same way every time.
+   */
+  private async stored({
+    appId,
+    ownerId,
+    url,
+    cached,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    url: string;
+    cached: CachedBinaryRow;
+  }): Promise<Artifact> {
+    const pending = await this.artifactsRepo.insertPending({
+      appId,
+      ownerId,
+      originalFileName: cached.original_file_name,
+      originalFileUrl: url,
+      sourceDigest: cached.source_digest,
+    });
+    if (!pending) {
+      throw new NotFoundError(NO_SUCH_APP);
+    }
+
+    const stored = await this.artifactsRepo.complete({
+      appId,
+      artifactId: pending.id,
+      ownerId,
+      digest: cached.digest,
+      sizeBytes: Number(cached.size_bytes),
+      objectKey: cached.object_key,
+    });
+
+    return stored
+      ? toArtifact(stored)
+      : await this.alreadyStored({ appId, artifactId: pending.id, ownerId });
   }
 
   /**
@@ -399,20 +500,19 @@ export class ArtifactsService extends Service {
     appId,
     ownerId,
     url,
+    said,
     filename,
     sha256,
+    sourceDigest,
   }: {
     appId: AppId;
     ownerId: OwnerId;
     url: string;
+    said: string;
     filename: Filename;
     sha256: Sha256Digest | undefined;
+    sourceDigest: Sha256Digest | null;
   }): Promise<Artifact> {
-    const said = withoutCredentials(url);
-    // Written down only where the bytes are this api's to hand on. A download reached with a
-    // password is the caller's own, and a digest is all anybody would need to ask for it by.
-    const sourceDigest = sha256 !== undefined && !carriesCredentials(url) ? sha256 : null;
-
     const source = await this.sourceRepo.open({ url });
     if (source.outcome !== 'open') {
       throw new BadRequestError(sourceRefusal({ url: said, source }));

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -13,6 +13,7 @@ import { ArtifactStorageRepository } from '#repositories/artifact-storage.reposi
 import { ArtifactsRepository } from '#repositories/artifacts.repository.ts';
 import { AssetsRepository } from '#repositories/assets.repository.ts';
 import { BinarySourceRepository } from '#repositories/binary-source.repository.ts';
+import { CachedBinariesRepository } from '#repositories/cached-binaries.repository.ts';
 import { CustomHostnamesRepository } from '#repositories/custom-hostnames.repository.ts';
 import { DeploymentsRepository } from '#repositories/deployments.repository.ts';
 import { ExportStorageRepository } from '#repositories/export-storage.repository.ts';
@@ -61,6 +62,7 @@ const artifactStorageRepository = new ArtifactStorageRepository({
   bucket: env.ARTIFACTS_BUCKET,
 });
 const binarySourceRepository = new BinarySourceRepository();
+const cachedBinariesRepository = new CachedBinariesRepository(sql);
 const exportsRepository = new ExportsRepository(sql);
 const exportStorageRepository = new ExportStorageRepository(exportsS3);
 const customHostnamesRepository = new CustomHostnamesRepository(cloudflareClient);
@@ -99,6 +101,7 @@ const artifactsService = new ArtifactsService({
   artifactsRepo: artifactsRepository,
   storageRepo: artifactStorageRepository,
   sourceRepo: binarySourceRepository,
+  cachedRepo: cachedBinariesRepository,
   appsRepo: appsRepository,
 });
 const agentService = new AgentService({

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -32,6 +32,10 @@ import {
   type BinarySourceRepositoryContract,
   InterruptedSourceError,
 } from '#repositories/binary-source.repository.ts';
+import type {
+  CachedBinariesRepositoryContract,
+  CachedBinaryRow,
+} from '#repositories/cached-binaries.repository.ts';
 import {
   type AppOwnership,
   ArtifactsService,
@@ -74,6 +78,9 @@ type StoredRow = Omit<ArtifactRow, 'digest' | 'size_bytes' | 'object_key'> & {
   digest: ArtifactRow['digest'] | null;
   size_bytes: ArtifactRow['size_bytes'] | null;
   object_key: ArtifactRow['object_key'] | null;
+  // Not on `ArtifactRow`, which is what a caller is shown: where the bytes were found is the
+  // control plane's own record, and the digest they were held to is read only by the view.
+  source_digest: Sha256Digest | null;
 };
 
 /**
@@ -100,6 +107,7 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
     ownerId,
     originalFileName,
     originalFileUrl,
+    sourceDigest,
   }: InsertPendingArtifactInput): Promise<PendingArtifactRow | null> {
     if (ownerId !== this.ownedBy || this.refuses) {
       return Promise.resolve(null);
@@ -112,6 +120,7 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
       object_key: null,
       original_file_name: originalFileName,
       original_file_url: originalFileUrl,
+      source_digest: sourceDigest,
       created_at: SEEDED_CREATED_AT,
     };
     this.rows.set(row.id, row);
@@ -240,6 +249,7 @@ class FakeArtifactsRepository implements ArtifactsRepositoryContract {
       object_key: Value.Parse(ObjectKeySchema, SEEDED_DIGEST),
       original_file_name: UPLOADED_NAME,
       original_file_url: null,
+      source_digest: null,
       created_at: SEEDED_CREATED_AT,
     };
     this.rows.set(row.id, row);
@@ -453,14 +463,45 @@ function stoppingPartWay(): ReadableStream<Uint8Array> {
   });
 }
 
+/**
+ * What `nibrun.cached_binaries` answers, as a map. Empty unless a test puts something in it: a
+ * download nobody has deployed is the ordinary case, and every other test here expects the fetch
+ * to happen.
+ */
+class FakeCachedBinaries implements CachedBinariesRepositoryContract {
+  readonly rows = new Map<Sha256Digest, CachedBinaryRow>();
+  readonly asked: Sha256Digest[] = [];
+
+  remember(row: CachedBinaryRow): void {
+    this.rows.set(row.source_digest, row);
+  }
+
+  findBySourceDigest({
+    sourceDigest,
+  }: {
+    sourceDigest: Sha256Digest;
+  }): Promise<CachedBinaryRow | null> {
+    this.asked.push(sourceDigest);
+    return Promise.resolve(this.rows.get(sourceDigest) ?? null);
+  }
+}
+
 function build(storageRepo: FakeStorage = new FakeStorage()) {
   const artifactsRepo = new FakeArtifactsRepository(OWNER_ID);
   const sourceRepo = new FakeBinarySource();
+  const cachedRepo = new FakeCachedBinaries();
   return {
     storage: storageRepo,
     artifactsRepo,
     sourceRepo,
-    service: new ArtifactsService({ artifactsRepo, storageRepo, sourceRepo, appsRepo }),
+    cachedRepo,
+    service: new ArtifactsService({
+      artifactsRepo,
+      storageRepo,
+      sourceRepo,
+      cachedRepo,
+      appsRepo,
+    }),
   };
 }
 
@@ -891,6 +932,176 @@ const A_TRANSFER_CHUNK = 65_536;
  * has to leave the app exactly as it was — an artifact half made is a deploy that cannot be
  * retried by following the same link again.
  */
+const CACHED_URL = 'https://releases.test/v1/my-server.tar.gz';
+const CREDENTIALLED_URL = 'https://someone:secret@releases.test/v1/my-server';
+const UNWRAPPED_NAME = Value.Parse(FilenameSchema, 'app');
+const CACHED_SIZE_BYTES = 128;
+
+/** A release this api has already fetched, stored and watched come up. */
+function alreadyDeployed(sourceDigest: Sha256Digest): CachedBinaryRow {
+  return {
+    source_digest: sourceDigest,
+    digest: Value.Parse(Sha256DigestSchema, BINARY_DIGEST),
+    size_bytes: String(CACHED_SIZE_BYTES),
+    object_key: Value.Parse(ObjectKeySchema, BINARY_DIGEST),
+    original_file_name: UNWRAPPED_NAME,
+  };
+}
+
+/**
+ * The whole point of the digest a link carries: the second person to follow it gets the binary
+ * without anybody going back to the release host for it.
+ */
+describe('a release nibrun already holds is not fetched twice', () => {
+  const SERVED_DIGEST = Value.Parse(Sha256DigestSchema, BINARY_DIGEST);
+
+  function readyToReuse() {
+    const built = build();
+    built.cachedRepo.remember(alreadyDeployed(SERVED_DIGEST));
+    built.storage.put({
+      objectKey: Value.Parse(ObjectKeySchema, BINARY_DIGEST),
+      text: BINARY_TEXT,
+    });
+    return built;
+  }
+
+  test('the url is never opened, and the artifact points at the bytes already stored', async () => {
+    const { service, sourceRepo, storage } = readyToReuse();
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: CACHED_URL,
+      sha256: SERVED_DIGEST,
+    });
+
+    expect(sourceRepo.opened).toEqual([]);
+    expect(artifact.digest).toBe(SERVED_DIGEST);
+    expect(artifact.objectKey).toBe(Value.Parse(ObjectKeySchema, BINARY_DIGEST));
+    expect(storage.objects.size).toBe(1);
+    expect(isValidMessage({ schema: ArtifactSchema, value: artifact })).toBe(true);
+  });
+
+  /**
+   * The name the binary has rather than the one the url has. An executable inside an archive is
+   * only ever named by the walk that found it, and a hit skips the walk — so the name has to come
+   * from the row, or every reuse of a packed release would be exported as `my-server.tar.gz`.
+   */
+  test('it carries the name the archive gave it, not the one the url did', async () => {
+    const { service } = readyToReuse();
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: CACHED_URL,
+      sha256: SERVED_DIGEST,
+    });
+
+    expect(artifact.originalFileName).toBe(UNWRAPPED_NAME);
+  });
+
+  // The row is per app, as it is for an upload: what two owners share is the object, which is
+  // what content addressing has always meant here.
+  test('the app gets an artifact of its own, addressed by the url it asked for', async () => {
+    const { service, artifactsRepo } = readyToReuse();
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: CACHED_URL,
+      sha256: SERVED_DIGEST,
+    });
+
+    expect(artifactsRepo.rows.get(artifact.id)?.app_id).toBe(APP_ID);
+    expect(artifactsRepo.rows.get(artifact.id)?.original_file_url).toBe(CACHED_URL);
+  });
+
+  /**
+   * The view is a row and the bytes are not. An app purged between the two leaves a key nothing
+   * answers, and an artifact pointed at one would fail on the host — where it costs a deployment
+   * that never converges rather than the download it was avoiding.
+   */
+  test('a row whose object has since gone is fetched again rather than handed on', async () => {
+    const { service, sourceRepo, cachedRepo } = build();
+    cachedRepo.remember(alreadyDeployed(SERVED_DIGEST));
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+      sha256: SERVED_DIGEST,
+    });
+
+    expect(sourceRepo.opened).toEqual([BINARY_URL]);
+    expect(artifact.digest).toBe(SERVED_DIGEST);
+  });
+
+  // The digest is the whole of what makes reuse exact, so a link without one is a link that has
+  // said nothing about what the url should be serving.
+  test('a url nobody said a digest for is followed every time', async () => {
+    const { service, sourceRepo, cachedRepo } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    await service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL });
+
+    expect(cachedRepo.asked).toEqual([]);
+    expect(sourceRepo.opened).toEqual([BINARY_URL]);
+  });
+
+  /**
+   * The url is written down without whatever a caller authenticated by, so a digest taken from
+   * one would stand for bytes anybody naming that digest could then ask for. Neither remembered
+   * nor answered from: the download belongs to whoever had the password.
+   */
+  test('a download reached with a password is neither reused nor remembered', async () => {
+    const { service, sourceRepo, cachedRepo, artifactsRepo } = build();
+    cachedRepo.remember(alreadyDeployed(SERVED_DIGEST));
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: CREDENTIALLED_URL,
+      sha256: SERVED_DIGEST,
+    });
+
+    expect(cachedRepo.asked).toEqual([]);
+    expect(sourceRepo.opened).toEqual([CREDENTIALLED_URL]);
+    expect(artifactsRepo.rows.get(artifact.id)?.source_digest).toBeNull();
+  });
+
+  /**
+   * The slots exist because a fetch passes through this process, and a hit does not — so a
+   * release everyone is deploying stops competing for them. Without this, a link going round
+   * would answer the ninth person with the one thing they cannot act on.
+   */
+  test('a hit costs no fetch slot, so a popular link cannot throttle itself', async () => {
+    const { service, sourceRepo, cachedRepo, storage } = build();
+    cachedRepo.remember(alreadyDeployed(SERVED_DIGEST));
+    storage.put({ objectKey: Value.Parse(ObjectKeySchema, BINARY_DIGEST), text: BINARY_TEXT });
+    sourceRepo.answers({ outcome: 'unreachable' });
+    const letThemGo = sourceRepo.holdsOpen();
+
+    const held = Array.from({ length: MAX_CONCURRENT_FETCHES }, () =>
+      service.createFromUrl({ appId: APP_ID, ownerId: OWNER_ID, url: BINARY_URL }),
+    );
+    await Bun.sleep(0);
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: CACHED_URL,
+      sha256: SERVED_DIGEST,
+    });
+
+    expect(artifact.digest).toBe(SERVED_DIGEST);
+
+    letThemGo();
+    await Promise.allSettled(held);
+  });
+});
+
 describe('a binary is fetched from the url it was given', () => {
   test('the bytes are stored under their digest, named and addressed by the url', async () => {
     const { service, sourceRepo, storage } = build();


### PR DESCRIPTION
The second person to follow a deploy link with a checksum in it gets the
binary without anybody going back to the release host for it.

Exact rather than quick: the bytes are named by what they hash to, so this
cannot hand back a release the url has since replaced. A link with no
checksum is followed every time, as is one whose bytes were reached with a
password.

The lookup happens before a fetch slot is taken, so a link going round
stops competing for the eight it no longer needs.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>