### PR TITLE
feat(api): a release that publishes its own digest is taken at its word

### DIFF
--- a/apps/api/src/lib/github-release.ts
+++ b/apps/api/src/lib/github-release.ts
@@ -1,0 +1,83 @@
+const RELEASE_HOST = 'github.com';
+const RELEASES = 'releases';
+const DOWNLOAD = 'download';
+const LATEST = 'latest';
+const RELEASE_PATH_SEGMENTS = 6;
+
+/** Where GitHub describes its own releases; see the note on the repository's constructor. */
+export const RELEASE_API = 'https://api.github.com';
+
+/**
+ * A release asset named the way GitHub addresses it, rather than the way it is downloaded. The tag
+ * is absent for the moving url a project points at from its README — the one that is whatever they
+ * released last, and so the one a digest is worth asking about rather than assuming.
+ */
+export type ReleaseAsset = {
+  owner: string;
+  repo: string;
+  tag: string | undefined;
+  filename: string;
+};
+
+/**
+ * The release asset a url downloads, where it is one.
+ *
+ * Both shapes GitHub serves are the same length and differ by one segment, so they are told apart
+ * by that segment rather than by counting: `/releases/download/<tag>/<file>` names a release, and
+ * `/releases/latest/download/<file>` names whichever is current.
+ *
+ * Undefined for every other url, which is most of them — a release host that is not GitHub, a
+ * repository page, an address that happens to be on the same domain. There is nothing to fall back
+ * to and nothing lost: not knowing a digest is the state everything here was already in.
+ */
+export function releaseAsset(url: string): ReleaseAsset | undefined {
+  const parsed = parse(url);
+  if (parsed === undefined || parsed.hostname !== RELEASE_HOST) {
+    return undefined;
+  }
+  const segments = parsed.pathname.split('/').filter((segment) => segment !== '');
+  if (segments.length !== RELEASE_PATH_SEGMENTS || segments[2] !== RELEASES) {
+    return undefined;
+  }
+
+  const [owner, repo, , kind, fourth, fifth] = segments;
+  if (owner === undefined || repo === undefined || fifth === undefined) {
+    return undefined;
+  }
+  if (kind === DOWNLOAD) {
+    return { owner, repo, tag: fourth, filename: decoded(fifth) };
+  }
+  return kind === LATEST && fourth === DOWNLOAD
+    ? { owner, repo, tag: undefined, filename: decoded(fifth) }
+    : undefined;
+}
+
+/**
+ * Where the release is described, below whichever address is answering for the api.
+ *
+ * Every segment is escaped on its way in. A tag reaches here as the path spelled it — still
+ * escaped — so one holding slashes is escaped again rather than becoming three segments of a
+ * different endpoint.
+ */
+export function releaseApiPath({ owner, repo, tag }: ReleaseAsset): string {
+  const release = tag === undefined ? LATEST : `tags/${encodeURIComponent(tag)}`;
+  return `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${RELEASES}/${release}`;
+}
+
+// A name with a space in it reaches the path escaped, and it is the unescaped one the release
+// describes. A malformed escape is a url naming no asset rather than one that throws.
+function decoded(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function parse(url: string): URL | undefined {
+  try {
+    return new URL(url);
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/api/src/repositories/release-digest.repository.ts
+++ b/apps/api/src/repositories/release-digest.repository.ts
@@ -1,0 +1,79 @@
+import { type Sha256Digest, Sha256DigestSchema, Value } from '@repo/protocol';
+import { RELEASE_API, releaseApiPath, releaseAsset } from '#lib/github-release.ts';
+
+/**
+ * Short, because this runs before a download rather than instead of one. Everything it could
+ * answer is an optimisation, so a release api that is slow to say costs the caller nothing beyond
+ * this and the fetch goes ahead the way it always did.
+ */
+const DEADLINE_MS = 5_000;
+
+// GitHub answers a request without one with a 403, and the name is the only thing it asks for.
+const USER_AGENT = 'nibrun';
+
+const DIGEST_PREFIX = 'sha256:';
+
+type ReleaseResponse = {
+  assets?: { name?: unknown; digest?: unknown }[];
+};
+
+export abstract class ReleaseDigestRepositoryContract {
+  abstract publishedDigest(input: { url: string }): Promise<Sha256Digest | undefined>;
+}
+
+/**
+ * What a release host says its own asset hashes to, asked before the bytes are fetched.
+ *
+ * This is what makes a link with no checksum in it as fast as one that has it: a digest is the
+ * only key that names a download exactly, and most deploy buttons point at a release rather than
+ * carrying a checksum somebody worked out by hand. Asking turns a url into that key — and unlike
+ * the url, it stops being the same key the moment the asset behind it is replaced.
+ *
+ * Unauthenticated, so it is rate limited to sixty an hour across everything sharing this address.
+ * Every failure is the same answer as an unknown digest: the download happens as it would have,
+ * and nothing a caller asked for depends on this having worked.
+ */
+export class ReleaseDigestRepository implements ReleaseDigestRepositoryContract {
+  private readonly api: string;
+
+  /**
+   * Which address answers for the release api, defaulting to the only one production has any
+   * business asking. It is an argument at all so that a test can point one of these at a server on
+   * the machine running it, and describe a release the way GitHub does.
+   */
+  constructor({ api = RELEASE_API }: { api?: string } = {}) {
+    this.api = api;
+  }
+
+  async publishedDigest({ url }: { url: string }): Promise<Sha256Digest | undefined> {
+    const asset = releaseAsset(url);
+    if (asset === undefined) {
+      return undefined;
+    }
+
+    const release = await this.release({ url: `${this.api}/${releaseApiPath(asset)}` });
+    const published = release?.assets?.find((each) => each.name === asset.filename)?.digest;
+
+    return typeof published === 'string' ? digestOf(published) : undefined;
+  }
+
+  private async release({ url }: { url: string }): Promise<ReleaseResponse | undefined> {
+    try {
+      const response = await fetch(url, {
+        headers: { accept: 'application/vnd.github+json', 'user-agent': USER_AGENT },
+        signal: AbortSignal.timeout(DEADLINE_MS),
+      });
+      return response.ok ? ((await response.json()) as ReleaseResponse) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+/** The digest as this api spells one, or nothing where it is not a sha256 after all. */
+function digestOf(published: string): Sha256Digest | undefined {
+  const hex = published.startsWith(DIGEST_PREFIX)
+    ? published.slice(DIGEST_PREFIX.length).toLowerCase()
+    : undefined;
+  return hex !== undefined && Value.Check(Sha256DigestSchema, hex) ? hex : undefined;
+}

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -45,6 +45,7 @@ import type {
   CachedBinariesRepositoryContract,
   CachedBinaryRow,
 } from '#repositories/cached-binaries.repository.ts';
+import type { ReleaseDigestRepositoryContract } from '#repositories/release-digest.repository.ts';
 import { Service } from '#services/service.ts';
 
 // An app the caller does not own has to be indistinguishable from one that does not exist: a
@@ -145,8 +146,20 @@ function wrongDigest({ expected, served }: { expected: string; served: string })
   return `The url served ${served}, not the ${expected} that was asked for.`;
 }
 
+/**
+ * The same surprise, where nobody asked for anything. Said as what the release publishes rather
+ * than as what was expected, because the caller never named a digest and would otherwise be shown
+ * two numbers they have never seen and no way to tell which of them is theirs.
+ */
+function wrongPublishedDigest({ expected, served }: { expected: string; served: string }): string {
+  return `The release publishes ${expected} for that asset and the url served ${served}, so what it is serving is not what was released.`;
+}
+
+/** A digest the download should come to, and who is in a position to have said so. */
+type Expectation = { digest: Sha256Digest; saidBy: 'caller' | 'release' };
+
 /** A digest somebody said the url would serve, and what it turned out to serve. */
-type DigestCheck = { expected: Sha256Digest; served: Promise<Sha256Digest> };
+type DigestCheck = { expected: Expectation; served: Promise<Sha256Digest> };
 
 /**
  * The source, hashed on its way past where there is something to hold it to. Untouched where
@@ -155,16 +168,16 @@ type DigestCheck = { expected: Sha256Digest; served: Promise<Sha256Digest> };
  */
 function checking({
   source,
-  sha256,
+  expected,
 }: {
   source: ReadableStream<Uint8Array>;
-  sha256: Sha256Digest | undefined;
+  expected: Expectation | undefined;
 }): { body: ReadableStream<Uint8Array>; check: DigestCheck | undefined } {
-  if (sha256 === undefined) {
+  if (expected === undefined) {
     return { body: source, check: undefined };
   }
   const { body, served } = digesting({ source });
-  return { body, check: { expected: sha256, served } };
+  return { body, check: { expected, served } };
 }
 
 /**
@@ -179,9 +192,12 @@ async function heldToDigest(check: DigestCheck | undefined): Promise<void> {
     return;
   }
   const served = await check.served;
-  if (served !== check.expected) {
-    throw new BadRequestError(wrongDigest({ expected: check.expected, served }));
+  const { digest, saidBy } = check.expected;
+  if (served === digest) {
+    return;
   }
+  const refusal = saidBy === 'caller' ? wrongDigest : wrongPublishedDigest;
+  throw new BadRequestError(refusal({ expected: digest, served }));
 }
 
 function unsupportedInterpreter(interpreter: string): string {
@@ -236,6 +252,7 @@ export class ArtifactsService extends Service {
   private readonly storageRepo: ArtifactStorageRepositoryContract;
   private readonly sourceRepo: BinarySourceRepositoryContract;
   private readonly cachedRepo: CachedBinariesRepositoryContract;
+  private readonly releaseRepo: ReleaseDigestRepositoryContract;
   private readonly appsRepo: AppOwnership;
   private fetchesInFlight = 0;
 
@@ -244,12 +261,14 @@ export class ArtifactsService extends Service {
     storageRepo,
     sourceRepo,
     cachedRepo,
+    releaseRepo,
     appsRepo,
   }: {
     artifactsRepo: ArtifactsRepositoryContract;
     storageRepo: ArtifactStorageRepositoryContract;
     sourceRepo: BinarySourceRepositoryContract;
     cachedRepo: CachedBinariesRepositoryContract;
+    releaseRepo: ReleaseDigestRepositoryContract;
     appsRepo: AppOwnership;
   }) {
     super();
@@ -257,6 +276,7 @@ export class ArtifactsService extends Service {
     this.storageRepo = storageRepo;
     this.sourceRepo = sourceRepo;
     this.cachedRepo = cachedRepo;
+    this.releaseRepo = releaseRepo;
     this.appsRepo = appsRepo;
   }
 
@@ -385,9 +405,11 @@ export class ArtifactsService extends Service {
       throw new BadRequestError(UNNAMED_BINARY);
     }
     const said = withoutCredentials(url);
+    const expected = await this.expected({ url, sha256 });
     // Written down only where the bytes are this api's to hand on. A download reached with a
     // password is the caller's own, and a digest is all anybody would need to ask for it by.
-    const sourceDigest = sha256 !== undefined && !carriesCredentials(url) ? sha256 : null;
+    const sourceDigest =
+      expected !== undefined && !carriesCredentials(url) ? expected.digest : null;
 
     const reused = await this.reuse({ appId, ownerId, url: said, sourceDigest });
     if (reused) {
@@ -403,10 +425,35 @@ export class ArtifactsService extends Service {
 
     this.fetchesInFlight += 1;
     try {
-      return await this.fetchInto({ appId, ownerId, url, said, filename, sha256, sourceDigest });
+      return await this.fetchInto({ appId, ownerId, url, said, filename, expected, sourceDigest });
     } finally {
       this.fetchesInFlight -= 1;
     }
+  }
+
+  /**
+   * What the download should come to, from whoever is in a position to say.
+   *
+   * The caller first, always: a checksum in a link was put there by somebody who knows what they
+   * published, and going and asking elsewhere would be second-guessing them. Where they said
+   * nothing, the release host's own word about its asset — which is what makes a link nobody wrote
+   * a checksum into exact anyway, and exact is the whole of what lets one be reused.
+   *
+   * It is also the difference between a hashless link being deployed unverified and being held to
+   * something: until now there was nothing to check such a download against.
+   */
+  private async expected({
+    url,
+    sha256,
+  }: {
+    url: string;
+    sha256: Sha256Digest | undefined;
+  }): Promise<Expectation | undefined> {
+    if (sha256 !== undefined) {
+      return { digest: sha256, saidBy: 'caller' };
+    }
+    const published = await this.releaseRepo.publishedDigest({ url });
+    return published === undefined ? undefined : { digest: published, saidBy: 'release' };
   }
 
   /**
@@ -502,7 +549,7 @@ export class ArtifactsService extends Service {
     url,
     said,
     filename,
-    sha256,
+    expected,
     sourceDigest,
   }: {
     appId: AppId;
@@ -510,7 +557,7 @@ export class ArtifactsService extends Service {
     url: string;
     said: string;
     filename: Filename;
-    sha256: Sha256Digest | undefined;
+    expected: Expectation | undefined;
     sourceDigest: Sha256Digest | null;
   }): Promise<Artifact> {
     const source = await this.sourceRepo.open({ url });
@@ -529,7 +576,7 @@ export class ArtifactsService extends Service {
     // a source that declares none is otherwise read for as long as it keeps sending. The bound is
     // on what the url sent rather than on what it came to, which for an archive is not the same.
     const bounded = boundedTo({ source: source.body, maxSizeBytes: MAX_ARTIFACT_SIZE_BYTES });
-    const { body: fetched, check } = checking({ source: bounded, sha256 });
+    const { body: fetched, check } = checking({ source: bounded, expected });
     const held = await unwrapped({ source: fetched, named: filename, url: said });
 
     const pending = await this.artifactsRepo.insertPending({

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -20,6 +20,7 @@ import { ExportStorageRepository } from '#repositories/export-storage.repository
 import { ExportsRepository } from '#repositories/exports.repository.ts';
 import { HealthRepository } from '#repositories/health.repository.ts';
 import { LogsRepository } from '#repositories/logs.repository.ts';
+import { ReleaseDigestRepository } from '#repositories/release-digest.repository.ts';
 import { AgentService } from '#services/agent.service.ts';
 import { AppsService } from '#services/apps.service.ts';
 import { ArtifactsService } from '#services/artifacts.service.ts';
@@ -63,6 +64,7 @@ const artifactStorageRepository = new ArtifactStorageRepository({
 });
 const binarySourceRepository = new BinarySourceRepository();
 const cachedBinariesRepository = new CachedBinariesRepository(sql);
+const releaseDigestRepository = new ReleaseDigestRepository();
 const exportsRepository = new ExportsRepository(sql);
 const exportStorageRepository = new ExportStorageRepository(exportsS3);
 const customHostnamesRepository = new CustomHostnamesRepository(cloudflareClient);
@@ -102,6 +104,7 @@ const artifactsService = new ArtifactsService({
   storageRepo: artifactStorageRepository,
   sourceRepo: binarySourceRepository,
   cachedRepo: cachedBinariesRepository,
+  releaseRepo: releaseDigestRepository,
   appsRepo: appsRepository,
 });
 const agentService = new AgentService({

--- a/apps/api/tests/lib/github-release.test.ts
+++ b/apps/api/tests/lib/github-release.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { releaseApiPath, releaseAsset } from '#lib/github-release.ts';
+
+const PINNED = 'https://github.com/pocketbase/pocketbase/releases/download/v0.40.1/pb_linux.zip';
+const MOVING = 'https://github.com/pocketbase/pocketbase/releases/latest/download/pb_linux.zip';
+
+describe('a release asset is recognised by the url that downloads it', () => {
+  test('a pinned download names the release it belongs to', () => {
+    expect(releaseAsset(PINNED)).toEqual({
+      owner: 'pocketbase',
+      repo: 'pocketbase',
+      tag: 'v0.40.1',
+      filename: 'pb_linux.zip',
+    });
+  });
+
+  /**
+   * The shape a README reaches for, and the one a url could never be a cache key on its own: it
+   * is whatever they released last. Asking what it currently is, is the whole point.
+   */
+  test('a moving download names no release, because it is whichever is current', () => {
+    expect(releaseAsset(MOVING)).toEqual({
+      owner: 'pocketbase',
+      repo: 'pocketbase',
+      tag: undefined,
+      filename: 'pb_linux.zip',
+    });
+  });
+
+  test('a name that reached the path escaped is the name the release describes', () => {
+    expect(
+      releaseAsset('https://github.com/me/app/releases/download/v1/my%20server')?.filename,
+    ).toBe('my server');
+  });
+
+  const NAMES_NOTHING = {
+    'a release host that is not GitHub': 'https://gitlab.com/me/app/releases/download/v1/app',
+    'a repository page': 'https://github.com/me/app',
+    'the releases index': 'https://github.com/me/app/releases',
+    'a path of the right length that is not a download': 'https://github.com/a/b/blob/c/d/e',
+    'a url that parses as nothing': 'not-a-url',
+  };
+
+  for (const [what, url] of Object.entries(NAMES_NOTHING)) {
+    test(`${what} names no asset`, () => {
+      expect(releaseAsset(url)).toBeUndefined();
+    });
+  }
+});
+
+describe('the release is asked about at an address built from what was parsed', () => {
+  test('a pinned download asks about its tag', () => {
+    expect(
+      releaseApiPath(releaseAsset(PINNED) as NonNullable<ReturnType<typeof releaseAsset>>),
+    ).toBe('repos/pocketbase/pocketbase/releases/tags/v0.40.1');
+  });
+
+  test('a moving one asks which is current', () => {
+    expect(
+      releaseApiPath(releaseAsset(MOVING) as NonNullable<ReturnType<typeof releaseAsset>>),
+    ).toBe('repos/pocketbase/pocketbase/releases/latest');
+  });
+
+  /**
+   * A tag reaches here as the path wrote it, still escaped — so the escaping is what has to
+   * survive being put in a second url. Escaped again rather than expanded: a tag holding slashes
+   * is one segment of the release api's path, not three.
+   */
+  test('a tag carrying escaped slashes stays one segment', () => {
+    expect(releaseApiPath({ owner: 'me', repo: 'app', tag: '..%2f..%2fzz', filename: 'app' })).toBe(
+      'repos/me/app/releases/tags/..%252f..%252fzz',
+    );
+  });
+});
+
+/**
+ * The url is parsed before any of it is read, and a path that climbs is resolved away by the
+ * parser — so a download url cannot name a release other than the one its own path spells.
+ */
+describe('a path that tries to climb never names an asset', () => {
+  const CLIMBS = {
+    'an escaped dot segment': 'https://github.com/a/b/releases/download/%2e%2e/x',
+    'a plain one': 'https://github.com/a/../releases/download/v1/x',
+  };
+
+  for (const [what, url] of Object.entries(CLIMBS)) {
+    test(`${what} is resolved away rather than followed`, () => {
+      expect(releaseAsset(url)).toBeUndefined();
+    });
+  }
+});

--- a/apps/api/tests/repositories/release-digest.repository.test.ts
+++ b/apps/api/tests/repositories/release-digest.repository.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { Sha256DigestSchema, Value } from '@repo/protocol';
+import { ReleaseDigestRepository } from '#repositories/release-digest.repository.ts';
+
+const ASSET = 'pocketbase_linux_amd64.zip';
+const PUBLISHED = Value.Parse(
+  Sha256DigestSchema,
+  '0f3442d2e57b03b56fbff0d09289e4a30b4f561a44338c38d2dcd4a1a0cfa91e',
+);
+
+/**
+ * Answered by a real server rather than a fake, because what is worth testing here is the shape
+ * GitHub replies in: a digest that arrives prefixed with its own algorithm, an asset matched out
+ * of a list of them, and a release old enough to have none. A stand-in returning a digest would
+ * only be restating what this repository is for.
+ */
+let releases: ReturnType<typeof Bun.serve>;
+let asked: string[] = [];
+
+beforeAll(() => {
+  releases = Bun.serve({ port: 0, fetch: answer });
+});
+
+afterAll(() => {
+  releases.stop(true);
+});
+
+function repo(): ReleaseDigestRepository {
+  return new ReleaseDigestRepository({ api: releases.url.origin });
+}
+
+function downloadOf(name: string): string {
+  return `https://github.com/pocketbase/pocketbase/releases/download/v0.40.1/${name}`;
+}
+
+/** The releases the server below knows about, keyed by the path GitHub describes them at. */
+const RELEASES: Record<string, unknown> = {
+  '/repos/pocketbase/pocketbase/releases/tags/v0.40.1': {
+    assets: [
+      { name: 'checksums.txt', digest: `sha256:${'c'.repeat(PUBLISHED.length)}` },
+      { name: ASSET, digest: `sha256:${PUBLISHED}` },
+    ],
+  },
+  // What every release published before GitHub began computing them looks like.
+  '/repos/pocketbase/pocketbase/releases/tags/v0.22.0': {
+    assets: [{ name: ASSET, digest: null }],
+  },
+  '/repos/pocketbase/pocketbase/releases/latest': {
+    assets: [{ name: ASSET, digest: `sha256:${PUBLISHED}` }],
+  },
+};
+
+function answer(request: Request): Response {
+  const { pathname } = new URL(request.url);
+  asked.push(pathname);
+  const release = RELEASES[pathname];
+  return release === undefined
+    ? new Response('no such release', { status: 404 })
+    : Response.json(release);
+}
+
+describe('a release is asked what its own asset hashes to', () => {
+  test('the asset is found by name and its digest read off the release', async () => {
+    expect(await repo().publishedDigest({ url: downloadOf(ASSET) })).toBe(PUBLISHED);
+  });
+
+  test('a moving download asks which release is current', async () => {
+    asked = [];
+
+    const digest = await repo().publishedDigest({
+      url: `https://github.com/pocketbase/pocketbase/releases/latest/download/${ASSET}`,
+    });
+
+    expect(digest).toBe(PUBLISHED);
+    expect(asked).toEqual(['/repos/pocketbase/pocketbase/releases/latest']);
+  });
+
+  /**
+   * GitHub began computing these part way through 2025, so every release older than that names
+   * its assets and says nothing about them. The download happens as it always did.
+   */
+  test('a release from before GitHub computed them says nothing', async () => {
+    const url =
+      'https://github.com/pocketbase/pocketbase/releases/download/v0.22.0/pocketbase_linux_amd64.zip';
+
+    expect(await repo().publishedDigest({ url })).toBeUndefined();
+  });
+
+  test('an asset the release does not list is not guessed at', async () => {
+    expect(await repo().publishedDigest({ url: downloadOf('pocketbase_windows.zip') })).toBe(
+      undefined,
+    );
+  });
+
+  /**
+   * Sixty an hour unauthenticated, so this is the ordinary answer rather than the exceptional
+   * one — and it has to be indistinguishable from not knowing, because that is what it is.
+   */
+  test('a release api that refuses is the same answer as one that never had a digest', async () => {
+    const url = 'https://github.com/pocketbase/pocketbase/releases/download/v9.9.9/app';
+
+    expect(await repo().publishedDigest({ url })).toBeUndefined();
+  });
+
+  test('a url that names no release asset is never asked about', async () => {
+    asked = [];
+
+    expect(
+      await repo().publishedDigest({ url: 'https://releases.example.com/v1/my-server' }),
+    ).toBeUndefined();
+    expect(asked).toEqual([]);
+  });
+});

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -36,6 +36,7 @@ import type {
   CachedBinariesRepositoryContract,
   CachedBinaryRow,
 } from '#repositories/cached-binaries.repository.ts';
+import type { ReleaseDigestRepositoryContract } from '#repositories/release-digest.repository.ts';
 import {
   type AppOwnership,
   ArtifactsService,
@@ -486,20 +487,41 @@ class FakeCachedBinaries implements CachedBinariesRepositoryContract {
   }
 }
 
+/**
+ * What a release host says about its own asset. Says nothing unless a test gives it something,
+ * which is also what an unreachable or rate-limited api answers with.
+ */
+class FakeReleaseDigests implements ReleaseDigestRepositoryContract {
+  readonly asked: string[] = [];
+  private published: Sha256Digest | undefined;
+
+  publishes(digest: Sha256Digest): void {
+    this.published = digest;
+  }
+
+  publishedDigest({ url }: { url: string }): Promise<Sha256Digest | undefined> {
+    this.asked.push(url);
+    return Promise.resolve(this.published);
+  }
+}
+
 function build(storageRepo: FakeStorage = new FakeStorage()) {
   const artifactsRepo = new FakeArtifactsRepository(OWNER_ID);
   const sourceRepo = new FakeBinarySource();
   const cachedRepo = new FakeCachedBinaries();
+  const releaseRepo = new FakeReleaseDigests();
   return {
     storage: storageRepo,
     artifactsRepo,
     sourceRepo,
     cachedRepo,
+    releaseRepo,
     service: new ArtifactsService({
       artifactsRepo,
       storageRepo,
       sourceRepo,
       cachedRepo,
+      releaseRepo,
       appsRepo,
     }),
   };
@@ -1099,6 +1121,124 @@ describe('a release nibrun already holds is not fetched twice', () => {
 
     letThemGo();
     await Promise.allSettled(held);
+  });
+});
+
+/**
+ * The half of the deploy button nobody writes a checksum into. A release says what its own asset
+ * hashes to, which is the only thing that turns such a url into a key exact enough to reuse — and
+ * the only thing a download from one was ever going to be checked against.
+ */
+describe('a release that publishes its own digest is taken at its word', () => {
+  const PUBLISHED = Value.Parse(Sha256DigestSchema, BINARY_DIGEST);
+
+  test('a link with no checksum is held to what the release publishes', async () => {
+    const { service, sourceRepo, releaseRepo } = build();
+    releaseRepo.publishes(PUBLISHED);
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+    });
+
+    expect(releaseRepo.asked).toEqual([BINARY_URL]);
+    expect(artifact.digest).toBe(PUBLISHED);
+  });
+
+  // Which is what makes the next one free: the digest is written down, so the same release asked
+  // for again is answered out of what is already stored.
+  test('and the digest it published is what the next deploy finds it by', async () => {
+    const { service, sourceRepo, artifactsRepo, releaseRepo } = build();
+    releaseRepo.publishes(PUBLISHED);
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+    });
+
+    expect(artifactsRepo.rows.get(artifact.id)?.source_digest).toBe(PUBLISHED);
+  });
+
+  test('a release nibrun already holds is not downloaded to find that out', async () => {
+    const { service, sourceRepo, cachedRepo, releaseRepo, storage } = build();
+    releaseRepo.publishes(PUBLISHED);
+    cachedRepo.remember(alreadyDeployed(PUBLISHED));
+    storage.put({ objectKey: Value.Parse(ObjectKeySchema, BINARY_DIGEST), text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+    });
+
+    expect(sourceRepo.opened).toEqual([]);
+    expect(artifact.digest).toBe(PUBLISHED);
+  });
+
+  /**
+   * The caller published the release. Going and asking the host what it thinks would be
+   * second-guessing the one person who knows, and would cost a round trip to be told the same
+   * thing — or, worse, something else.
+   */
+  test('a checksum in the link is used without asking anybody', async () => {
+    const { service, sourceRepo, releaseRepo } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+      sha256: PUBLISHED,
+    });
+
+    expect(releaseRepo.asked).toEqual([]);
+  });
+
+  /**
+   * Sixty an hour is what an unauthenticated caller gets, so being told nothing is the ordinary
+   * answer rather than the exceptional one. It has to cost exactly what it cost before any of
+   * this existed: the download, unverified, the way a link with no checksum always was.
+   */
+  test('a release that says nothing leaves the fetch exactly as it was', async () => {
+    const { service, sourceRepo, artifactsRepo } = build();
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+    });
+
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+    expect(artifactsRepo.rows.get(artifact.id)?.source_digest).toBeNull();
+  });
+
+  /**
+   * Said as what the release publishes rather than as what was asked for: nobody asked. A caller
+   * who wrote no checksum would otherwise be shown two numbers they have never seen, with nothing
+   * to say which of them was supposed to be theirs.
+   */
+  test('a url serving something other than what was released is refused, and says whose digest it was', async () => {
+    const { service, sourceRepo, releaseRepo, artifactsRepo, storage } = build();
+    releaseRepo.publishes(SEEDED_DIGEST);
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const refusal = service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+    });
+
+    await expect(refusal).rejects.toBeInstanceOf(BadRequestError);
+    await expect(refusal).rejects.toThrow('The release publishes');
+    await expect(refusal).rejects.toThrow(SEEDED_DIGEST);
+    await expect(refusal).rejects.toThrow(BINARY_DIGEST);
+    expect(artifactsRepo.rows.size).toBe(0);
+    expect(storage.objects.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
GitHub says what each release asset hashes to, which is the same number a
link's checksum carries. Asking turns a deploy button nobody wrote a
checksum into one exact enough to reuse — and, unlike the url, it stops
being the same key the moment the asset behind it is replaced.

It is also the first thing such a download is ever checked against.

Unauthenticated, so sixty an hour across everything sharing an address:
being told nothing is the ordinary answer and costs exactly what it cost
before, the download unverified the way it always was.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>