### PR TITLE
feat(www): gitea is the git forge on offer, in place of gogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Open source that already ships as a single binary. One click, nothing to fill in
 - **[Sharkord](https://nibrun.com/deploy/sharkord)** — a self-hosted chat server with voice,
   video and screen sharing.
 - **[Boop](https://nibrun.com/deploy/boop)** — a self-hosted notification inbox for your own apps.
-- **[Gogs](https://nibrun.com/deploy/gogs)** — a self-hosted Git service with repositories, issues
-  and pull requests.
 - **[Gitea](https://nibrun.com/deploy/gitea)** — a self-hosted Git service with repositories,
   issues, pull requests, packages and CI.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Open source that already ships as a single binary. One click, nothing to fill in
 - **[Boop](https://nibrun.com/deploy/boop)** — a self-hosted notification inbox for your own apps.
 - **[Gogs](https://nibrun.com/deploy/gogs)** — a self-hosted Git service with repositories, issues
   and pull requests.
+- **[Gitea](https://nibrun.com/deploy/gitea)** — a self-hosted Git service with repositories,
+  issues, pull requests, packages and CI.
 
 ## Deploy your own app
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Open source that already ships as a single binary. One click, nothing to fill in
 - **[Sharkord](https://nibrun.com/deploy/sharkord)** — a self-hosted chat server with voice,
   video and screen sharing.
 - **[Boop](https://nibrun.com/deploy/boop)** — a self-hosted notification inbox for your own apps.
+- **[Gogs](https://nibrun.com/deploy/gogs)** — a self-hosted Git service with repositories, issues
+  and pull requests.
 
 ## Deploy your own app
 

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -20,6 +20,18 @@ export const DEPLOY_PRESETS = {
     ],
     minimal: true,
   },
+  // Gitea, like Gogs, shells out to git and writes its hooks as bash scripts. This build
+  // carries a static git and native hooks inside the binary, which `nibrun` unpacks before
+  // serving. It comes up with an administrator whose password is printed to the log.
+  gitea: {
+    name: 'gitea',
+    binary:
+      'https://github.com/ilbertt/gitea/releases/download/v1.28.0-dev-nibrun.2/gitea-nibrun-linux-amd64',
+    sha256: 'e74bef3081a046c6a3964dee49ca68b94316a69f0709a148ee6234c543a93bb5',
+    port: 3000,
+    arg: ['nibrun'],
+    minimal: true,
+  },
   // Gogs shells out to git for every repository operation and the guest carries none, so
   // this build bundles a static one and unpacks it onto the volume. `nibrun` is the
   // subcommand that does that and then serves.

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -20,6 +20,18 @@ export const DEPLOY_PRESETS = {
     ],
     minimal: true,
   },
+  // Gogs shells out to git for every repository operation and the guest carries none, so
+  // this build bundles a static one and unpacks it onto the volume. `nibrun` is the
+  // subcommand that does that and then serves.
+  gogs: {
+    name: 'gogs',
+    binary:
+      'https://github.com/ilbertt/gogs/releases/download/v0.15.0-nibrun.2/gogs-nibrun-linux-amd64',
+    sha256: '2ccc30e5f0626239a1814d2b17244bfee366fbb3324025577e8fd77d81fea794',
+    port: 3000,
+    arg: ['nibrun'],
+    minimal: true,
+  },
   pocketbase: {
     name: 'pocketbase',
     binary:

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -20,26 +20,11 @@ export const DEPLOY_PRESETS = {
     ],
     minimal: true,
   },
-  // Gitea, like Gogs, shells out to git and writes its hooks as bash scripts. This build
-  // carries a static git and native hooks inside the binary, which `nibrun` unpacks before
-  // serving. It comes up with an administrator whose password is printed to the log.
   gitea: {
     name: 'gitea',
     binary:
       'https://github.com/ilbertt/gitea/releases/download/v1.28.0-dev-nibrun.2/gitea-nibrun-linux-amd64',
     sha256: 'e74bef3081a046c6a3964dee49ca68b94316a69f0709a148ee6234c543a93bb5',
-    port: 3000,
-    arg: ['nibrun'],
-    minimal: true,
-  },
-  // Gogs shells out to git for every repository operation and the guest carries none, so
-  // this build bundles a static one and unpacks it onto the volume. `nibrun` is the
-  // subcommand that does that and then serves.
-  gogs: {
-    name: 'gogs',
-    binary:
-      'https://github.com/ilbertt/gogs/releases/download/v0.15.0-nibrun.2/gogs-nibrun-linux-amd64',
-    sha256: '2ccc30e5f0626239a1814d2b17244bfee366fbb3324025577e8fd77d81fea794',
     port: 3000,
     arg: ['nibrun'],
     minimal: true,


### PR DESCRIPTION
Replaces the Gogs preset with Gitea, pointing at [v1.28.0-dev-nibrun.2](https://github.com/ilbertt/gitea/releases/tag/v1.28.0-dev-nibrun.2).

The binary carries a static git and native server-side hooks, so it serves in a guest with no git and no shell. It comes up with a `gitea-admin` account whose password is printed to the log, so there is nothing to fill in after the click.

Verified by deploying the linked asset and pushing to it over HTTPS. Note that `/deploy/gogs` stops resolving.