### PR TITLE
perf(agent): a wake stops waiting on a grid to find out it is ready

### DIFF
--- a/apps/agent/src/lib/vm/firecracker-api.ts
+++ b/apps/agent/src/lib/vm/firecracker-api.ts
@@ -23,8 +23,13 @@ const MAX_DETAIL_LENGTH = 200;
 /** A 256 MiB guest measures ~1.7s to snapshot, and is paused for every millisecond of it. */
 const CALL_TIMEOUT = Duration.seconds(60);
 
-/** Firecracker binds its API socket after `exec`, and systemd calls a `Type=exec` unit started at it. */
-const BIND_POLL_INTERVAL = Duration.millis(10);
+/**
+ * Firecracker binds its API socket after `exec`, and systemd calls a `Type=exec` unit started at
+ * it — so the first call always races the bind, and whatever is left of an interval when the
+ * socket appears is added to the wake. Measured against the guest console, the socket is up ~3ms
+ * after the unit starts and a 10ms grid spent ~8ms of the wake waiting to ask again.
+ */
+const BIND_POLL_INTERVAL = Duration.millis(2);
 const BIND_TIMEOUT = Duration.seconds(10);
 
 export class FirecrackerUnreachable extends Data.TaggedError('FirecrackerUnreachable')<{

--- a/apps/agent/src/services/app-waker.service.ts
+++ b/apps/agent/src/services/app-waker.service.ts
@@ -21,10 +21,12 @@ import { VmManager } from '#services/vm-manager.service.ts';
 
 /**
  * Tighter than the startup grid the status loop probes on, because somebody is holding a browser
- * tab open on this one. The difference between finding out at 25ms and at 250ms is a quarter of
- * a second added to every cold start.
+ * tab open on this one — and tighter than it needs to be to find out, because on average half an
+ * interval is added to every wake purely by asking on a grid. A restore reaches its first accept
+ * in ~90ms, so 25ms spent a measured ~12ms of that on nothing; the probe is one loopback connect
+ * to a guest that either has the port open or does not, which is cheap enough to ask for often.
  */
-const PROBE_INTERVAL_MS = 25;
+const PROBE_INTERVAL_MS = 5;
 const PROBE_INTERVAL = Duration.millis(PROBE_INTERVAL_MS);
 
 const NO_SHORTFALL = 0;


### PR DESCRIPTION
Two polls sit between a snapshot restore and the request waiting on it, and both asked on intervals coarse enough to show up in the wake. Measured across 30 wakes on a production host, roughly 20ms of a ~250ms wake was spent on the gap between asks rather than on work.

`BIND_POLL_INTERVAL` 10ms → 2ms, `PROBE_INTERVAL_MS` 25ms → 5ms.

Not included: pinning the guest's neighbour entry `nud permanent` at tap creation to drop the per-wake `ip neigh replace`. `ensureTap` only runs from `boot`, so nothing would write the entry for taps that already exist — those apps would lose the refresh without gaining the pin and pay ARP re-resolution on every wake. It saves 1.2ms and risks ~1s, so it needs a migration path first.