### PR TITLE
feat(www): /deploy sends you to the deploy screen the presets already reach

### DIFF
--- a/apps/www/src/lib/deploy-redirect.ts
+++ b/apps/www/src/lib/deploy-redirect.ts
@@ -2,24 +2,35 @@ import { defaultStringifySearch } from '@tanstack/react-router';
 import { findPreset } from '#deploy-presets.ts';
 import { APP_ORIGIN } from '#lib/app-origin.ts';
 
-const PRESET_PATH = /^\/deploy\/([a-z0-9-]+)\/?$/;
+const DEPLOY_PATH = /^\/deploy(?:\/([a-z0-9-]+))?\/?$/;
 
 // Temporary rather than permanent: a preset is edited in place, and a browser holding a permanent
 // move would keep following the version of it that it first saw.
 const MOVED_FOR_NOW = 302;
 
 /**
- * A preset is an address rather than a page, so the worker answers it with the move itself. A
- * prerendered file could only have carried a redirect a browser performs after rendering it,
+ * The deploy screen is the dashboard's, so the worker answers its addresses with the move itself.
+ * A prerendered file could only have carried a redirect a browser performs after rendering it,
  * which is a page nobody asked to see on the way to one they did.
  *
- * The search is written by the router that reads it on the far side: the deploy screen takes it
- * back apart with `JSON.parse`, so a value spelled out here would be a value it read as something
- * other than what the preset holds.
+ * A preset's search is written by the router that reads it on the far side: the deploy screen
+ * takes it back apart with `JSON.parse`, so a value spelled out here would be a value it read as
+ * something other than what the preset holds.
  */
 export function deployRedirect(request: Request): Response | undefined {
-  const slug = PRESET_PATH.exec(new URL(request.url).pathname)?.[1];
-  const preset = slug === undefined ? undefined : findPreset(slug);
+  const match = DEPLOY_PATH.exec(new URL(request.url).pathname);
+
+  if (match === null) {
+    return undefined;
+  }
+
+  const slug = match[1];
+
+  if (slug === undefined) {
+    return Response.redirect(`${APP_ORIGIN}/deploy`, MOVED_FOR_NOW);
+  }
+
+  const preset = findPreset(slug);
 
   return preset === undefined
     ? undefined


### PR DESCRIPTION
`nibrun.com/deploy` was a 404 while every `/deploy/<preset>` under it redirected. The worker's slug is now optional, so the bare path lands on `app.nibrun.com/deploy` with no preset attached.