### PR TITLE
feat(agent): what a visitor waited is recorded, not just what the wake did

### DIFF
--- a/apps/agent/src/services/app-activator.service.ts
+++ b/apps/agent/src/services/app-activator.service.ts
@@ -1,5 +1,5 @@
 import type { AppId, HostPort } from '@repo/protocol';
-import { Clock, Effect, Ref, Runtime } from 'effect';
+import { Clock, Duration, Effect, Ref, Runtime } from 'effect';
 import type { AppSlot } from '#lib/network/slot.ts';
 import { forwardToGuest } from '#lib/proxy/forward.ts';
 import { AgentState } from '#services/agent-state.service.ts';
@@ -97,7 +97,7 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
           return sayAppIsDown();
         }
         yield* AgentState.markActive({ appId, nowMs: yield* Clock.currentTimeMillis });
-        yield* waker.wake(appId);
+        const [woke] = yield* Effect.timed(waker.wake(appId));
 
         const woken = (yield* AgentState.snapshot).records.get(appId);
         if (!woken) {
@@ -106,11 +106,27 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
         if (request.headers.get('upgrade') !== null) {
           return sayToComeBack();
         }
-        return yield* forwardToGuest({
-          request,
-          guestIpv4: woken.guestIpv4,
-          httpPort: woken.httpPort,
-        });
+        const [answered, response] = yield* Effect.timed(
+          forwardToGuest({
+            request,
+            guestIpv4: woken.guestIpv4,
+            httpPort: woken.httpPort,
+          }),
+        );
+        /**
+         * Both halves, because a wake ends at the guest's first TCP accept and a guest accepts
+         * long before it answers: `wokeMs` alone reads as the whole cost and is the smaller part
+         * of it. What the visitor paid is the two added together, and which half moved is the
+         * only way to tell a slower host from a tenant that takes longer to come back.
+         */
+        yield* Effect.logInfo('app answered the request that woke it').pipe(
+          Effect.annotateLogs({
+            appId,
+            wokeMs: Duration.toMillis(woke),
+            answeredMs: Duration.toMillis(answered),
+          }),
+        );
+        return response;
       }).pipe(
         Effect.catchTag('HostHasNoRoom', (error) =>
           Effect.logWarning('a request could not be given an app', error)

--- a/apps/agent/tests/services/app-activator.test.ts
+++ b/apps/agent/tests/services/app-activator.test.ts
@@ -9,7 +9,7 @@ import {
   Ipv4AddressSchema,
   Value,
 } from '@repo/protocol';
-import { Duration, Effect, Either, Layer } from 'effect';
+import { Duration, Effect, Either, Layer, Logger } from 'effect';
 import { AgentState } from '#services/agent-state.service.ts';
 import { AppActivator } from '#services/app-activator.service.ts';
 import { AppWaker, HostHasNoRoom, WakeFailed } from '#services/app-waker.service.ts';
@@ -180,6 +180,38 @@ describe('an app that runs on request is started by the request that wanted it',
         expect(yield* Effect.promise(() => response.text())).toBe('served by the tenant');
         expect(waker.woken).toEqual([APP_ID]);
       }),
+    );
+  });
+
+  /**
+   * A wake finishes at the guest's first TCP accept, and a guest accepts well before it answers.
+   * Without the second number the larger half of what a visitor waited is not recorded anywhere,
+   * which is how a wake came to be reported as the cost of its restore alone.
+   */
+  test('what the guest spent answering is recorded beside what the wake spent', () => {
+    const answered: Record<string, unknown>[] = [];
+    const capturing = Logger.replace(
+      Logger.defaultLogger,
+      Logger.make(({ annotations, message }) => {
+        if (String(message).includes('app answered the request that woke it')) {
+          answered.push(Object.fromEntries(annotations));
+        }
+      }),
+    );
+    return activator(wakes().layer)(
+      Effect.gen(function* () {
+        const app = yield* AppActivator;
+        yield* guest(() => new Response('served by the tenant', { status: HTTP_OK }));
+        const hostPort = unusedPort();
+        yield* app.serve([{ appId: APP_ID, hostPort }]);
+
+        yield* get(hostPort);
+
+        expect(answered).toHaveLength(1);
+        expect(answered[0]?.appId).toBe(APP_ID);
+        expect(typeof answered[0]?.wokeMs).toBe('number');
+        expect(typeof answered[0]?.answeredMs).toBe('number');
+      }).pipe(Effect.provide(capturing)),
     );
   });
 


### PR DESCRIPTION
`waitedMs` closes at the guest's first TCP accept, and a guest accepts well before it answers. Measured on a production host, the accept lands ~90ms into a wake and the response ~100ms after that — so the larger half of what a visitor waits was recorded nowhere, and a wake was reported by the cost of its restore alone.

The activator times the forward it already performs and logs it beside the wake:

```
message="app answered the request that woke it" appId=… wokeMs=88 answeredMs=104
```

Kept as two numbers rather than one total because they fail differently — a slower host moves `wokeMs`, a tenant that takes longer to come back moves `answeredMs`.

Independent of #446; both touch the wake path but not the same files.