### PR TITLE
feat(api): a release api that is rate limiting nibrun says so

### DIFF
--- a/apps/api/src/repositories/release-digest.repository.ts
+++ b/apps/api/src/repositories/release-digest.repository.ts
@@ -13,12 +13,35 @@ const USER_AGENT = 'nibrun';
 
 const DIGEST_PREFIX = 'sha256:';
 
+const REMAINING_HEADER = 'x-ratelimit-remaining';
+const RESET_HEADER = 'x-ratelimit-reset';
+const EXHAUSTED = '0';
+const MS_PER_SECOND = 1000;
+
 type ReleaseResponse = {
   assets?: { name?: unknown; digest?: unknown }[];
 };
 
+/**
+ * What the release had to say, rather than the digest alone.
+ *
+ * Only one of these is a digest, and the rest are all the same thing to the fetch that follows —
+ * it goes ahead unheld. They are told apart because one of them is worth somebody hearing about:
+ * being rate limited is the whole feature switched off, and it is indistinguishable from an
+ * ordinary quiet answer unless this end says which it was.
+ */
+export type PublishedDigest =
+  | { outcome: 'published'; digest: Sha256Digest }
+  // The url downloads no release asset, which is most urls and never worth a word.
+  | { outcome: 'not-a-release' }
+  | { outcome: 'rate-limited'; until: Date | undefined }
+  | { outcome: 'unavailable' }
+  // The release is there and says nothing about the asset: every one published before GitHub
+  // began computing these, and any url naming a file the release does not list.
+  | { outcome: 'undigested' };
+
 export abstract class ReleaseDigestRepositoryContract {
-  abstract publishedDigest(input: { url: string }): Promise<Sha256Digest | undefined>;
+  abstract publishedDigest(input: { url: string }): Promise<PublishedDigest>;
 }
 
 /**
@@ -45,29 +68,63 @@ export class ReleaseDigestRepository implements ReleaseDigestRepositoryContract 
     this.api = api;
   }
 
-  async publishedDigest({ url }: { url: string }): Promise<Sha256Digest | undefined> {
+  async publishedDigest({ url }: { url: string }): Promise<PublishedDigest> {
     const asset = releaseAsset(url);
     if (asset === undefined) {
-      return undefined;
+      return { outcome: 'not-a-release' };
     }
 
-    const release = await this.release({ url: `${this.api}/${releaseApiPath(asset)}` });
-    const published = release?.assets?.find((each) => each.name === asset.filename)?.digest;
+    const reached = await this.release({ url: `${this.api}/${releaseApiPath(asset)}` });
+    if (reached.outcome !== 'answered') {
+      return reached;
+    }
 
-    return typeof published === 'string' ? digestOf(published) : undefined;
+    const published = reached.release.assets?.find((each) => each.name === asset.filename)?.digest;
+    const digest = typeof published === 'string' ? digestOf(published) : undefined;
+
+    return digest === undefined ? { outcome: 'undigested' } : { outcome: 'published', digest };
   }
 
-  private async release({ url }: { url: string }): Promise<ReleaseResponse | undefined> {
+  private async release({ url }: { url: string }): Promise<Reached> {
     try {
       const response = await fetch(url, {
         headers: { accept: 'application/vnd.github+json', 'user-agent': USER_AGENT },
         signal: AbortSignal.timeout(DEADLINE_MS),
       });
-      return response.ok ? ((await response.json()) as ReleaseResponse) : undefined;
+      if (response.ok) {
+        return { outcome: 'answered', release: (await response.json()) as ReleaseResponse };
+      }
+      return refusal(response);
     } catch {
-      return undefined;
+      // A timeout, a name that does not resolve, a body that is not json. None of them is a
+      // verdict on the release, and all of them leave the download to happen as it would have.
+      return { outcome: 'unavailable' };
     }
   }
+}
+
+type Reached =
+  | { outcome: 'answered'; release: ReleaseResponse }
+  | { outcome: 'rate-limited'; until: Date | undefined }
+  | { outcome: 'unavailable' };
+
+/**
+ * A refusal read for whether it is the quota rather than the request.
+ *
+ * `x-ratelimit-remaining` is what tells them apart: GitHub spends 403 on both an exhausted quota
+ * and a request it will not answer, so the status alone would report the one thing worth acting on
+ * every time anything went wrong.
+ */
+function refusal(response: Response): Reached {
+  return response.headers.get(REMAINING_HEADER) === EXHAUSTED
+    ? { outcome: 'rate-limited', until: resetsAt(response.headers) }
+    : { outcome: 'unavailable' };
+}
+
+/** When the quota comes back, where the header saying so is one this end can read. */
+function resetsAt(headers: Headers): Date | undefined {
+  const reset = Number(headers.get(RESET_HEADER));
+  return Number.isFinite(reset) && reset > 0 ? new Date(reset * MS_PER_SECOND) : undefined;
 }
 
 /** The digest as this api spells one, or nothing where it is not a sha256 after all. */

--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -45,7 +45,10 @@ import type {
   CachedBinariesRepositoryContract,
   CachedBinaryRow,
 } from '#repositories/cached-binaries.repository.ts';
-import type { ReleaseDigestRepositoryContract } from '#repositories/release-digest.repository.ts';
+import type {
+  PublishedDigest,
+  ReleaseDigestRepositoryContract,
+} from '#repositories/release-digest.repository.ts';
 import { Service } from '#services/service.ts';
 
 // An app the caller does not own has to be indistinguishable from one that does not exist: a
@@ -453,7 +456,35 @@ export class ArtifactsService extends Service {
       return { digest: sha256, saidBy: 'caller' };
     }
     const published = await this.releaseRepo.publishedDigest({ url });
-    return published === undefined ? undefined : { digest: published, saidBy: 'release' };
+    if (published.outcome === 'published') {
+      return { digest: published.digest, saidBy: 'release' };
+    }
+
+    this.saidNothing({ url, published });
+    return undefined;
+  }
+
+  /**
+   * A release that gave no digest, said out loud only where somebody could act on it.
+   *
+   * Being rate limited is this whole feature switched off — every hashless link goes back to being
+   * fetched unverified — and it is indistinguishable from a quiet afternoon unless it is said. The
+   * quota is sixty an hour for a caller with no token, so the sentence names the way out of it.
+   *
+   * The other two outcomes are the ordinary shape of the world: most urls are not releases, and
+   * every release published before GitHub began computing digests has none.
+   */
+  private saidNothing({ url, published }: { url: string; published: PublishedDigest }): void {
+    if (published.outcome === 'rate-limited') {
+      this.logger.warn(
+        'the release api is rate limiting nibrun, so binaries fetched from it go unverified and are not reused. A GitHub token raises the quota from 60 an hour to 5000.',
+        { url, until: published.until },
+      );
+      return;
+    }
+    if (published.outcome === 'unavailable') {
+      this.logger.info('the release api said nothing about this url', { url });
+    }
   }
 
   /**

--- a/apps/api/tests/repositories/release-digest.repository.test.ts
+++ b/apps/api/tests/repositories/release-digest.repository.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { Sha256DigestSchema, Value } from '@repo/protocol';
 import { ReleaseDigestRepository } from '#repositories/release-digest.repository.ts';
 
@@ -17,8 +17,21 @@ const PUBLISHED = Value.Parse(
 let releases: ReturnType<typeof Bun.serve>;
 let asked: string[] = [];
 
+/** What the api is doing with the caller's quota, which every path below answers through. */
+type Quota = 'available' | 'exhausted' | 'exhausted-without-reset' | 'refused';
+let quota: Quota = 'available';
+
+const RESETS_AT = 1_788_350_550;
+const MS_PER_SECOND = 1000;
+const REFUSED = 403;
+const REMAINING_WHEN_REFUSED = '59';
+
 beforeAll(() => {
   releases = Bun.serve({ port: 0, fetch: answer });
+});
+
+beforeEach(() => {
+  quota = 'available';
 });
 
 afterAll(() => {
@@ -53,15 +66,36 @@ const RELEASES: Record<string, unknown> = {
 function answer(request: Request): Response {
   const { pathname } = new URL(request.url);
   asked.push(pathname);
+  if (quota !== 'available') {
+    return refusal();
+  }
   const release = RELEASES[pathname];
   return release === undefined
     ? new Response('no such release', { status: 404 })
     : Response.json(release);
 }
 
+/** A 403, spent the two ways GitHub spends one: on an empty quota, and on anything else. */
+function refusal(): Response {
+  if (quota === 'refused') {
+    return new Response('forbidden', {
+      status: REFUSED,
+      headers: { 'x-ratelimit-remaining': REMAINING_WHEN_REFUSED },
+    });
+  }
+  const headers: Record<string, string> = { 'x-ratelimit-remaining': '0' };
+  if (quota === 'exhausted') {
+    headers['x-ratelimit-reset'] = String(RESETS_AT);
+  }
+  return new Response('rate limit exceeded', { status: REFUSED, headers });
+}
+
 describe('a release is asked what its own asset hashes to', () => {
   test('the asset is found by name and its digest read off the release', async () => {
-    expect(await repo().publishedDigest({ url: downloadOf(ASSET) })).toBe(PUBLISHED);
+    expect(await repo().publishedDigest({ url: downloadOf(ASSET) })).toEqual({
+      outcome: 'published',
+      digest: PUBLISHED,
+    });
   });
 
   test('a moving download asks which release is current', async () => {
@@ -71,7 +105,7 @@ describe('a release is asked what its own asset hashes to', () => {
       url: `https://github.com/pocketbase/pocketbase/releases/latest/download/${ASSET}`,
     });
 
-    expect(digest).toBe(PUBLISHED);
+    expect(digest).toEqual({ outcome: 'published', digest: PUBLISHED });
     expect(asked).toEqual(['/repos/pocketbase/pocketbase/releases/latest']);
   });
 
@@ -83,23 +117,19 @@ describe('a release is asked what its own asset hashes to', () => {
     const url =
       'https://github.com/pocketbase/pocketbase/releases/download/v0.22.0/pocketbase_linux_amd64.zip';
 
-    expect(await repo().publishedDigest({ url })).toBeUndefined();
+    expect(await repo().publishedDigest({ url })).toEqual({ outcome: 'undigested' });
   });
 
   test('an asset the release does not list is not guessed at', async () => {
-    expect(await repo().publishedDigest({ url: downloadOf('pocketbase_windows.zip') })).toBe(
-      undefined,
-    );
+    expect(await repo().publishedDigest({ url: downloadOf('pocketbase_windows.zip') })).toEqual({
+      outcome: 'undigested',
+    });
   });
 
-  /**
-   * Sixty an hour unauthenticated, so this is the ordinary answer rather than the exceptional
-   * one — and it has to be indistinguishable from not knowing, because that is what it is.
-   */
-  test('a release api that refuses is the same answer as one that never had a digest', async () => {
+  test('a release the api does not have is unavailable rather than undigested', async () => {
     const url = 'https://github.com/pocketbase/pocketbase/releases/download/v9.9.9/app';
 
-    expect(await repo().publishedDigest({ url })).toBeUndefined();
+    expect(await repo().publishedDigest({ url })).toEqual({ outcome: 'unavailable' });
   });
 
   test('a url that names no release asset is never asked about', async () => {
@@ -107,7 +137,44 @@ describe('a release is asked what its own asset hashes to', () => {
 
     expect(
       await repo().publishedDigest({ url: 'https://releases.example.com/v1/my-server' }),
-    ).toBeUndefined();
+    ).toEqual({ outcome: 'not-a-release' });
     expect(asked).toEqual([]);
+  });
+});
+
+/**
+ * Sixty an hour is what an unauthenticated caller gets, so this is the state nibrun spends most of
+ * its time in — and the one outcome anybody can act on. It has to be told apart from a quiet
+ * afternoon, which is the whole of why the outcome is not just `undefined`.
+ */
+describe('a quota that has run out says so rather than going quiet', () => {
+  test('an exhausted quota is named, with when it comes back', async () => {
+    quota = 'exhausted';
+
+    expect(await repo().publishedDigest({ url: downloadOf(ASSET) })).toEqual({
+      outcome: 'rate-limited',
+      until: new Date(RESETS_AT * MS_PER_SECOND),
+    });
+  });
+
+  /**
+   * GitHub spends 403 on an exhausted quota and on a request it will not answer, so the status
+   * alone would report the actionable one every time anything at all went wrong.
+   */
+  test('a refusal that is not the quota is not reported as one', async () => {
+    quota = 'refused';
+
+    expect(await repo().publishedDigest({ url: downloadOf(ASSET) })).toEqual({
+      outcome: 'unavailable',
+    });
+  });
+
+  test('a quota that is exhausted without saying when says only that much', async () => {
+    quota = 'exhausted-without-reset';
+
+    expect(await repo().publishedDigest({ url: downloadOf(ASSET) })).toEqual({
+      outcome: 'rate-limited',
+      until: undefined,
+    });
   });
 });

--- a/apps/api/tests/services/artifacts.test.ts
+++ b/apps/api/tests/services/artifacts.test.ts
@@ -36,7 +36,10 @@ import type {
   CachedBinariesRepositoryContract,
   CachedBinaryRow,
 } from '#repositories/cached-binaries.repository.ts';
-import type { ReleaseDigestRepositoryContract } from '#repositories/release-digest.repository.ts';
+import type {
+  PublishedDigest,
+  ReleaseDigestRepositoryContract,
+} from '#repositories/release-digest.repository.ts';
 import {
   type AppOwnership,
   ArtifactsService,
@@ -493,15 +496,19 @@ class FakeCachedBinaries implements CachedBinariesRepositoryContract {
  */
 class FakeReleaseDigests implements ReleaseDigestRepositoryContract {
   readonly asked: string[] = [];
-  private published: Sha256Digest | undefined;
+  private answer: PublishedDigest = { outcome: 'not-a-release' };
 
   publishes(digest: Sha256Digest): void {
-    this.published = digest;
+    this.answer = { outcome: 'published', digest };
   }
 
-  publishedDigest({ url }: { url: string }): Promise<Sha256Digest | undefined> {
+  answers(answer: PublishedDigest): void {
+    this.answer = answer;
+  }
+
+  publishedDigest({ url }: { url: string }): Promise<PublishedDigest> {
     this.asked.push(url);
-    return Promise.resolve(this.published);
+    return Promise.resolve(this.answer);
   }
 }
 
@@ -1213,6 +1220,27 @@ describe('a release that publishes its own digest is taken at its word', () => {
       url: BINARY_URL,
     });
 
+    expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
+    expect(artifactsRepo.rows.get(artifact.id)?.source_digest).toBeNull();
+  });
+
+  /**
+   * The quota is sixty an hour for a caller with no token, so this is not the exceptional path —
+   * it is where nibrun spends most of its time. The deploy has to go through regardless: being
+   * unable to look a digest up is not a reason to refuse a url that was always fetchable.
+   */
+  test('a quota that has run out still deploys, by fetching the url as before', async () => {
+    const { service, sourceRepo, releaseRepo, artifactsRepo } = build();
+    releaseRepo.answers({ outcome: 'rate-limited', until: undefined });
+    sourceRepo.serves({ text: BINARY_TEXT });
+
+    const artifact = await service.createFromUrl({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      url: BINARY_URL,
+    });
+
+    expect(sourceRepo.opened).toEqual([BINARY_URL]);
     expect(artifact.digest).toBe(Value.Parse(Sha256DigestSchema, BINARY_DIGEST));
     expect(artifactsRepo.rows.get(artifact.id)?.source_digest).toBeNull();
   });


### PR DESCRIPTION
Falling back to fetching the url on a rate limit already happened; what was missing was any way to tell an exhausted quota from a release that simply has no digest — so the feature can be switched off in production with nothing saying it went.

The repository answers with which of the four outcomes it was, and the service logs the one anybody can act on.