### PR TITLE
feat(agent): a cold start says what it spent, and stops spending it on ARP

### DIFF
--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -337,6 +337,28 @@ export const sleepInstance = Effect.fn('sleepInstance')(function* (desired: Desi
   }
 });
 
+/**
+ * How long the guest took to answer, on the pass that first finds it answering.
+ *
+ * The other half of what a cold start costs, and the half no host-side timing can see:
+ * `startedAt` is written when the VMM was asked to start, so this is the kernel, the guest's init
+ * and the tenant's own startup together. `VmManager.boot` accounts for everything before it, and
+ * a start that grew is one or the other.
+ */
+function answeredAfter({
+  record,
+  state,
+  nowMs,
+}: {
+  record: InstanceRecord;
+  state: InstanceState;
+  nowMs: number;
+}) {
+  return state === 'running' && record.startedAt !== undefined
+    ? { answeredMs: nowMs - Date.parse(record.startedAt) }
+    : {};
+}
+
 /** A microVM that has just come up is not left waiting on a delay measured for the one before it. */
 function probeAtOnce(appId: AppId) {
   return AgentState.modify((current) => {
@@ -616,6 +638,7 @@ function settle({
         appId: record.appId,
         from: record.state,
         to: state,
+        ...answeredAfter({ record, state, nowMs }),
       }),
     );
     yield* ReportSignal.raise;

--- a/apps/agent/src/lib/vm/artifacts.ts
+++ b/apps/agent/src/lib/vm/artifacts.ts
@@ -1,6 +1,6 @@
 import { FileSystem, Path } from '@effect/platform';
 import type { DesiredArtifact, Sha256Digest } from '@repo/protocol';
-import { Data, Effect, Ref, Stream } from 'effect';
+import { Data, Duration, Effect, Ref, Stream } from 'effect';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { stdoutOf } from '#services/command-runner.service.ts';
 
@@ -130,25 +130,41 @@ export const ensureArtifactImage = Effect.fn('ensureArtifactImage')(function* (
     () =>
       Effect.gen(function* () {
         const binaryPath = path.join(stagingDir, GUEST_BINARY_NAME);
-        yield* downloadAndVerify({ artifact, destination: binaryPath });
+        const [fetching] = yield* Effect.timed(
+          downloadAndVerify({ artifact, destination: binaryPath }),
+        );
         yield* fs.chmod(binaryPath, BINARY_MODE);
         yield* fs.remove(stagedImage, { force: true });
-        yield* stdoutOf({
-          command: [
-            'mksquashfs',
-            stagingDir,
-            stagedImage,
-            '-no-progress',
-            '-noappend',
-            '-Xcompression-level',
-            SQUASHFS_COMPRESSION_LEVEL,
-          ],
-        });
+        const [packing] = yield* Effect.timed(
+          stdoutOf({
+            command: [
+              'mksquashfs',
+              stagingDir,
+              stagedImage,
+              '-no-progress',
+              '-noappend',
+              '-Xcompression-level',
+              SQUASHFS_COMPRESSION_LEVEL,
+            ],
+          }),
+        );
         yield* fs.makeDirectory(path.dirname(imagePath), {
           recursive: true,
           mode: CACHE_DIR_MODE,
         });
         yield* fs.rename(stagedImage, imagePath);
+        // Only where the image was built, which is the only time it cost anything: a host that
+        // already holds the digest returns above and has nothing to say. The two halves are
+        // apart because they answer to different things — the transfer to the bucket and the
+        // size of the release, the compression to what this host's CPU is doing.
+        yield* Effect.logInfo('artifact image built').pipe(
+          Effect.annotateLogs({
+            digest: artifact.digest,
+            sizeBytes: artifact.sizeBytes,
+            fetchMs: Duration.toMillis(fetching),
+            packMs: Duration.toMillis(packing),
+          }),
+        );
         return imagePath;
       }),
     () => fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -103,30 +103,38 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
     }
 
     /**
-     * The agent never becomes the VM's parent: it stages the files, asks init to start the unit,
-     * and stops caring.
+     * Everything a cold boot puts on disk and in the kernel before the VMM is asked for anything:
+     * the tap, the host's view of the guest behind it, the config drive and the machine
+     * description Firecracker reads.
+     *
+     * Apart from the start it precedes because the two are paid by different things. This is the
+     * host's own work and shortening it is this end's to do; what follows is the guest's kernel
+     * and the tenant's own startup, which is not.
      */
-    const boot = Effect.fn('VmManager.boot')(function* ({
+    const stage = Effect.fn('VmManager.stage')(function* ({
       desired,
       slot,
       dataDevicePath,
+      artifactImagePath,
     }: {
       desired: DesiredInstance;
       slot: AppSlot;
       dataDevicePath: string;
+      artifactImagePath: string;
     }) {
-      yield* Effect.annotateCurrentSpan({
-        appId: desired.appId,
-      });
-      // Ahead of everything, because everything below replaces what a snapshot of this app was
-      // taken against — and a start that still found a stamp would restore the old guest onto
-      // the new deployment's disk rather than boot the new one.
-      yield* discardSnapshot(desired.appId);
-      const artifactImagePath = yield* Artifacts.ensureArtifactImage(desired.artifact);
       yield* ensureTap({
         tapName: slot.tapName,
         hostIpv4: slot.hostIpv4,
         subnetPrefixLength: slot.subnetPrefixLength,
+      });
+      // Written before the guest exists rather than after it answers, because nothing has to ask
+      // the guest for it: the MAC is the slot's, and the config below is what hands it over. Left
+      // to ARP, the host's first probe of a new guest pays the resolution `refreshNeighbour`
+      // documents — the same second a wake already knows not to spend.
+      yield* refreshNeighbour({
+        guestIpv4: slot.guestIpv4,
+        guestMac: slot.guestMac,
+        tapName: slot.tapName,
       });
 
       const directory = workingDir(desired.appId);
@@ -175,8 +183,53 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
         },
         socketPath: tenantLogSocketPath({ workingDir: directory }),
       });
-      yield* Effect.onError(Systemd.start(desired.appId), () =>
-        Effect.ignore(logs.detach(desired.appId)),
+    });
+
+    /**
+     * The agent never becomes the VM's parent: it stages the files, asks init to start the unit,
+     * and stops caring.
+     *
+     * The three costs are timed apart because a cold start is the one thing here with no other
+     * account of itself: what the control plane records is the whole of it, and a deploy that
+     * grew by a second says nothing about which of these grew. `artifactMs` is nearly nothing
+     * where the prefetch already built the image and the whole download where it did not, which
+     * is the difference between a host that has seen these bytes and one that has not.
+     */
+    const boot = Effect.fn('VmManager.boot')(function* ({
+      desired,
+      slot,
+      dataDevicePath,
+    }: {
+      desired: DesiredInstance;
+      slot: AppSlot;
+      dataDevicePath: string;
+    }) {
+      yield* Effect.annotateCurrentSpan({
+        appId: desired.appId,
+      });
+      // Ahead of everything, because everything below replaces what a snapshot of this app was
+      // taken against — and a start that still found a stamp would restore the old guest onto
+      // the new deployment's disk rather than boot the new one.
+      yield* discardSnapshot(desired.appId);
+      const [fetching, artifactImagePath] = yield* Effect.timed(
+        Artifacts.ensureArtifactImage(desired.artifact),
+      );
+      const [staging] = yield* Effect.timed(
+        stage({ desired, slot, dataDevicePath, artifactImagePath }),
+      );
+      const [starting] = yield* Effect.timed(
+        Effect.onError(Systemd.start(desired.appId), () =>
+          Effect.ignore(logs.detach(desired.appId)),
+        ),
+      );
+      yield* Effect.logInfo('instance booting').pipe(
+        Effect.annotateLogs({
+          appId: desired.appId,
+          slot: slot.slot,
+          artifactMs: Duration.toMillis(fetching),
+          stagedMs: Duration.toMillis(staging),
+          vmmMs: Duration.toMillis(starting),
+        }),
       );
     });
 

--- a/apps/agent/tests/lib/network/tap.test.ts
+++ b/apps/agent/tests/lib/network/tap.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, test } from 'bun:test';
 import { Ipv4AddressSchema, Value } from '@repo/protocol';
 import { Effect } from 'effect';
 import type { CommandRequest } from '#lib/exec.ts';
-import { ensureTap } from '#lib/network/tap.ts';
+import { ensureTap, refreshNeighbour } from '#lib/network/tap.ts';
 import { recordingCommands, succeeding } from '#tests/support/commands.ts';
 
 const tap = {
   tapName: 'nbr7',
   hostIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.29'),
   subnetPrefixLength: 30,
+};
+
+const guest = {
+  guestIpv4: Value.Parse(Ipv4AddressSchema, '10.201.0.30'),
+  guestMac: '02:00:0a:c9:00:1e',
+  tapName: tap.tapName,
 };
 
 // The only command whose output is read back; every tap looks absent so the create path is taken.
@@ -37,5 +43,40 @@ describe('a tap is usable the moment it is up', () => {
     const sysctl = (await issuedCommands()).find(([command]) => command === 'sysctl')?.join(' ');
     expect(sysctl).toContain(tap.tapName);
     expect(sysctl).not.toContain('conf.all');
+  });
+});
+
+async function neighbourCommand() {
+  const { commands, layer } = recordingCommands();
+  await Effect.runPromise(Effect.provide(refreshNeighbour(guest), layer));
+  return commands.map(({ command }) => [...command]).at(0);
+}
+
+/**
+ * Both a cold boot and a wake write this entry, and neither has anything to notice its absence
+ * by: an unprimed host resolves the address by ARP and the app comes up a second later, which
+ * reads as a slow tenant rather than as a command that did nothing.
+ */
+describe('the host knows where a guest is before it asks', () => {
+  test('the pairing is written against the tap the guest is behind', async () => {
+    expect(await neighbourCommand()).toEqual([
+      'ip',
+      'neigh',
+      'replace',
+      guest.guestIpv4,
+      'lladdr',
+      guest.guestMac,
+      'dev',
+      guest.tapName,
+      'nud',
+      'reachable',
+    ]);
+  });
+
+  // `replace` rather than `add`, because a boot onto a slot that has held a guest before finds
+  // the entry already there — and `add` fails on one that exists, which would leave the stale
+  // pairing in place on exactly the hosts that have been up longest.
+  test('an entry already there is overwritten rather than refused', async () => {
+    expect(await neighbourCommand()).toContain('replace');
   });
 });


### PR DESCRIPTION
New apps got measurably slower to start the week of Aug 31 — first deploys moved from 2.9s to 4.3s at p50 while redeploys stayed flat. The end-to-end number is already in `deployments` (`activated_at - created_at`), but every stage underneath it was untimed, so there was nothing to attribute the second to.

A cold start now accounts for itself: `fetchMs`/`packMs` for the artifact image, `artifactMs`/`stagedMs`/`vmmMs` for the boot, and `answeredMs` for the guest's own startup. `artifactMs` near zero is a prefetch that worked; the whole download is one that did not.

`refreshNeighbour` also moves onto the boot path, where it was only ever on the wake path. Not the regression — `boot` never primed the entry, including in the baseline — but it is ~1s of ARP resolution on every first deploy that a wake already knows to avoid.