### PR TITLE
perf(agent): an artifact image is stored rather than compressed

### DIFF
--- a/apps/agent/src/lib/vm/artifacts.ts
+++ b/apps/agent/src/lib/vm/artifacts.ts
@@ -8,14 +8,24 @@ const DIGEST_ALGORITHM = 'sha256';
 const HEX_ENCODING = 'hex';
 const SQUASHFS_FILENAME = 'artifact.squashfs';
 /**
- * The image is built once per digest on the path a deploy waits on, and read back off a local
- * disk by one guest — so the compressor's job here is to finish, not to be small. On a 57 MiB
- * release binary this measures 0.56s against 2.6s at the default level, for an image 8% larger.
+ * Stored rather than compressed. The image is built once per digest on the path a deploy waits
+ * on and is read back off a local disk by one guest, so nothing here crosses a network and the
+ * compressor was only ever spending a deploy's seconds to save a host's disk.
  *
- * gzip rather than something faster because that is the choice: `squashfs-tools` on the host
- * image is built with gzip, lzma and lzo only, and lzo measures slower than gzip at every level.
+ * Level 1 was already the fastest setting worth having — `squashfs-tools` on the host image
+ * carries gzip, lzma and lzo only, lzo measures slower than gzip at every level, and a larger
+ * block size moves neither. There is nothing left to tune, only the compression itself to drop:
+ * on a 78.7 MiB release binary level 1 measured 718ms of the 3.8s that deploy took.
+ *
+ * What it costs is the image, which roughly doubles — a 78.7 MiB binary goes from 39.8 MiB to
+ * 80.8 MiB — and `artifactCacheDir` is never swept, so a long-lived host accumulates twice what
+ * it did. Bounding that is worth doing on its own; the cache is only ever a copy of what the
+ * bucket still holds, so anything evicted costs a re-fetch and nothing else.
+ *
+ * The superblock still names gzip, because nothing here is what makes it uncompressed: a guest
+ * mounts one of these exactly as it mounts the ones every host already holds.
  */
-const SQUASHFS_COMPRESSION_LEVEL = '1';
+const SQUASHFS_STORE_UNCOMPRESSED = ['-noI', '-noD', '-noF', '-noX'];
 /** The path the guest's init execs, fixed by the boot contract. */
 const GUEST_BINARY_NAME = 'server';
 /** What a binary has to be to be one, wherever it lands — the guest's squashfs or an export. */
@@ -143,8 +153,7 @@ export const ensureArtifactImage = Effect.fn('ensureArtifactImage')(function* (
               stagedImage,
               '-no-progress',
               '-noappend',
-              '-Xcompression-level',
-              SQUASHFS_COMPRESSION_LEVEL,
+              ...SQUASHFS_STORE_UNCOMPRESSED,
             ],
           }),
         );


### PR DESCRIPTION
#451 measured this: `packMs` was 718ms of a 3.8s deploy for a 78.7 MiB binary. Level 1 was already the fastest setting worth having, so the only thing left was to stop compressing.

The image roughly doubles, 39.8 MiB → 80.8 MiB, and `artifactCacheDir` is never swept — a long-lived host accumulates twice what it did. Worth bounding on its own; the cache is only ever a copy of what the bucket still holds, so anything evicted costs a re-fetch and nothing else.

## Existing apps

- **Images already on a host are never rebuilt.** `ensureArtifactImage` returns early when `<digest>/artifact.squashfs` exists, so every image out there stays byte-identical and gzip-compressed.
- **Snapshots stay valid.** A `SnapshotStamp` does not cover the artifact image, and swapping one underneath a sleeping guest is the silent corruption `lib/vm/snapshot.ts` warns about. This cannot cause it: an image at a given digest is written once and never replaced.
- **The guest kernel needs nothing new.** The superblock still reports `Compression gzip` — the data simply is not compressed with it — so the kernel initialises zlib exactly as it does today, and `CONFIG_SQUASHFS_ZLIB=y` is unchanged.
- **Rollback is safe.** Reverting leaves uncompressed images in place and they keep mounting.

## Verified

`amazonlinux:2023` + `dnf install squashfs-tools`, the same install line as `app_host_user_data.sh.tftpl`, against the real 78.7 MiB binary:

| | build | image |
|---|---|---|
| gzip-1, 128K blocks (current) | 309ms | 39.8 MiB |
| gzip-1, 1M blocks | 303ms | — |
| **uncompressed** | **71ms** | **80.8 MiB** |

Those timings are emulated amd64 on arm64, so treat the ratio as indicative and the host's own `packMs` as the number that matters. `unsquashfs -stat` on the result confirms the gzip superblock.