### PR TITLE
fix(runtime): a tenant filling tmpfs is told so rather than killed

### DIFF
--- a/apps/runtime/src/init.c
+++ b/apps/runtime/src/init.c
@@ -125,7 +125,7 @@ static bool prepare_tenant_filesystem(void) {
   }
   /* The tenant's working directory is a tmpfs it does not own: the only path it
    * can write is the data filesystem mounted inside it. */
-  if (!mounts_tmpfs(APP_DIR, "mode=0755")) {
+  if (!mounts_tmpfs(APP_DIR, "mode=0755," RUNTIME_TMPFS_SIZE)) {
     return false;
   }
   return mounts_tenant_data(&(struct tenant_data_mount){

--- a/apps/runtime/src/mounts.c
+++ b/apps/runtime/src/mounts.c
@@ -86,17 +86,17 @@ bool mounts_pseudo_filesystems(void) {
        .target = "/run",
        .filesystem = "tmpfs",
        .flags = MS_NOSUID | MS_NODEV,
-       .options = "mode=0755"},
+       .options = "mode=0755," RUNTIME_TMPFS_SIZE},
       {.source = "tmpfs",
        .target = "/tmp",
        .filesystem = "tmpfs",
        .flags = MS_NOSUID | MS_NODEV,
-       .options = "mode=1777"},
+       .options = "mode=1777," TENANT_TMPFS_SIZE},
       {.source = "tmpfs",
        .target = "/dev/shm",
        .filesystem = "tmpfs",
        .flags = MS_NOSUID | MS_NODEV,
-       .options = "mode=1777"},
+       .options = "mode=1777," TENANT_TMPFS_SIZE},
   };
 
   /* Every other mount point here is a directory the image carries. /dev is a

--- a/apps/runtime/src/mounts.h
+++ b/apps/runtime/src/mounts.h
@@ -14,6 +14,32 @@ bool mounts_dev(void);
  * VM, so every writable path in the guest is one of these. */
 bool mounts_pseudo_filesystems(void);
 
+/* A tmpfs is guest memory wearing a filesystem, and one mounted without a size gets
+ * half of it. That default is why a tenant filling /tmp is OOM-killed rather than told
+ * ENOSPC: the pages are unevictable with no swap, so the write competes with the heap
+ * of the process making it and the killer arrives before the filesystem is full.
+ *
+ * A percentage because guest memory is configurable from 128 MiB to 16 GiB and the
+ * kernel resolves the fraction itself; a byte count here would mean reading
+ * /proc/meminfo to arrive at the same number. Whole ones only — it parses the figure
+ * with memparse and refuses size=12.5%.
+ *
+ * A quarter each — 64 MiB apiece at the 256 MiB default, and the two of them full still
+ * leave the tenant half its memory. Room deliberately left: a ceiling low enough to stop
+ * a leak early is also low enough to break an app writing honestly to the TMPDIR it was
+ * handed, and only one of those two is a fault of ours.
+ *
+ * What the room costs is worth knowing, because nothing here is ever emptied. A snapshot
+ * is exactly the guest's RAM, so what a tenant leaves in /tmp is restored with it on
+ * every wake and outlives everything short of a redeploy: memory spent rather than
+ * scratch returned, and an app can take months of sleeps to reach a ceiling it would
+ * have met in an afternoon. */
+#define TENANT_TMPFS_SIZE "size=25%"
+
+/* /app and /run are mode 0755 owned by root, and hold two mount points and a
+ * resolv.conf. Nothing a tenant does grows them, so they do not scale with the guest. */
+#define RUNTIME_TMPFS_SIZE "size=1M"
+
 bool mounts_tmpfs(const char *target, const char *options);
 
 /* The instance config drive: squashfs, read-only, and nothing on it is ever run. */

--- a/apps/runtime/test.sh
+++ b/apps/runtime/test.sh
@@ -88,6 +88,16 @@ require 'the artifact is read-only and the data filesystem is not' \
 require 'the tenant volume is mounted noatime' contains "$mounts" '/app/data ext4 rw,nosuid,nodev,noatime'
 require 'the config drive, which carries the secrets, is gone' lacks "$mounts" /run/config
 
+# The percentage resolves against this container's memory and against the microVM's in
+# production, so the number here is not the guest's. What is worth asserting is that a
+# ceiling arrived at all: a tmpfs mounted without one gets half the machine, which is
+# what turns a tenant filling TMPDIR into an OOM kill instead of an ENOSPC it can read.
+require 'the filesystems the tenant can write are capped' \
+  contains "$mounts" '/tmp tmpfs rw,nosuid,nodev,relatime,size='
+require 'and so is its shared memory' contains "$mounts" '/dev/shm tmpfs rw,nosuid,nodev,relatime,size='
+require 'the two the runtime owns are held to what the runtime puts on them' \
+  contains "$mounts" '/app tmpfs rw,nosuid,nodev,relatime,size=1024k'
+
 echo "PID 1 memory: $(docker exec "$container" grep VmRSS /proc/1/status)"
 
 docker kill --signal TERM "$container" >/dev/null

--- a/apps/runtime/tests/test-mounts.c
+++ b/apps/runtime/tests/test-mounts.c
@@ -11,12 +11,14 @@
 #include <fcntl.h>
 #include <sched.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/sysinfo.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -27,8 +29,12 @@
 
 #define SQUASHFS_MOUNT "/run/test-artifact"
 #define DATA_MOUNT "/run/test-data"
+#define TENANT_TMPFS_MOUNT "/run/test-tenant-tmpfs"
 #define FREEZE_HOLD_TEST_MS 200
 #define GRANT_BYTES 8
+#define KIBIBYTE_BYTES 1024
+#define MEBIBYTE_BYTES (1024 * 1024)
+#define UNBOUNDED_SHARE 2
 
 /**
  * Drives the real control-channel loop over a socketpair, standing in for the vsock a
@@ -92,6 +98,49 @@ static bool mounted_with(const char *target, const char *option) {
   }
   fclose(table);
   return found;
+}
+
+/**
+ * The ceiling tmpfs actually applied, which it reports as `size=<n>k` already resolved
+ * from whatever the mount asked for. Reading it back is the only way to see what a
+ * percentage came out as — and 0, the answer for a mount carrying no size at all, is
+ * the unbounded default this exists to keep off the tenant-writable ones.
+ */
+static uint64_t mounted_size_bytes(const char *target) {
+  FILE *table = fopen("/proc/self/mounts", "r");
+  if (table == NULL) {
+    return 0;
+  }
+  char line[1024];
+  uint64_t bytes = 0;
+  while (fgets(line, sizeof(line), table) != NULL) {
+    char device[256];
+    char point[256];
+    char type[64];
+    char options[256];
+    if (sscanf(line, "%255s %255s %63s %255s", device, point, type, options) != 4) {
+      continue;
+    }
+    if (strcmp(point, target) != 0) {
+      continue;
+    }
+    for (char *cursor = strtok(options, ","); cursor != NULL; cursor = strtok(NULL, ",")) {
+      unsigned long long kilobytes = 0;
+      if (sscanf(cursor, "size=%lluk", &kilobytes) == 1) {
+        bytes = (uint64_t)kilobytes * KIBIBYTE_BYTES;
+      }
+    }
+  }
+  fclose(table);
+  return bytes;
+}
+
+static uint64_t total_memory_bytes(void) {
+  struct sysinfo information;
+  if (sysinfo(&information) < 0) {
+    return 0;
+  }
+  return (uint64_t)information.totalram * information.mem_unit;
 }
 
 static bool is_of_type(const char *target, const char *filesystem) {
@@ -168,10 +217,22 @@ int main(int argc, char **argv) {
     return 64;
   }
 
-  EXPECT(mounts_tmpfs("/run", "mode=0755"));
+  EXPECT(mounts_tmpfs("/run", "mode=0755," RUNTIME_TMPFS_SIZE));
   EXPECT(is_of_type("/run", "tmpfs"));
   EXPECT(mounted_with("/run", "nosuid"));
   EXPECT(mounted_with("/run", "nodev"));
+  EXPECT(mounted_size_bytes("/run") == MEBIBYTE_BYTES);
+
+  /* The percentage form, resolved by the kernel and not by anything here. The way this
+   * fails silently is a size= the kernel does not parse: the mount still succeeds, and
+   * what it gets is the unbounded default this exists to keep off a tenant's /tmp. So
+   * what is asserted is a ceiling that arrived and came in under that default. */
+  EXPECT(mkdir(TENANT_TMPFS_MOUNT, 0755) == 0);
+  EXPECT(mounts_tmpfs(TENANT_TMPFS_MOUNT, "mode=1777," TENANT_TMPFS_SIZE));
+  EXPECT(mounted_size_bytes(TENANT_TMPFS_MOUNT) > 0);
+  EXPECT(mounted_size_bytes(TENANT_TMPFS_MOUNT) < total_memory_bytes() / UNBOUNDED_SHARE);
+  /* Unlike /app and /run: /tmp is the tenant's, and a ceiling on it is not a lock. */
+  EXPECT(can_write_as_tenant(TENANT_TMPFS_MOUNT));
 
   EXPECT(mounts_artifact(squashfs_device, SQUASHFS_MOUNT));
   EXPECT(is_of_type(SQUASHFS_MOUNT, "squashfs"));


### PR DESCRIPTION
Every writable path in the guest but `/app/data` is a tmpfs, and none carried a `size=` — so each defaulted to half of guest memory. A tenant writing to the `TMPDIR` we hand it competes with its own heap and meets the OOM killer before the filesystem it is filling ever reports full. What reaches the logs is an OOM on the first attempt and `ENOSPC` on every restart after it, landing on a tmpfs the first one already filled.

Nothing empties these. A snapshot is exactly the guest's RAM, so what a tenant leaves in `/tmp` is restored with it on every wake and outlives everything short of a redeploy. The ceiling bounds memory the tenant has spent for the life of a deployment, not scratch it gets back.

`/tmp` and `/dev/shm` are held to a quarter of guest memory, `/app` and `/run` to a fixed 1 MiB. A percentage because guest memory is configurable from 128 MiB to 16 GiB and the kernel resolves it — whole ones only, it refuses `size=12.5%`. The two the runtime owns hold two mount points and a `resolv.conf`, so they do not scale with the guest.

Needs a guest image release to reach hosts.