### PR TITLE
perf(protocol): a host asks for its desired state four times a second

### DIFF
--- a/packages/protocol/src/control/session.ts
+++ b/packages/protocol/src/control/session.ts
@@ -20,7 +20,23 @@ export const AgentPollSettingsSchema = Type.Object({
 
 export type AgentPollSettings = typeof AgentPollSettingsSchema.static;
 
-const DEFAULT_MIN_INTERVAL_MS = 1_000;
+/**
+ * A quarter of a second, because this is what a deploy waits out before anything has begun.
+ *
+ * A change lands at no particular point in the interval, so what it costs on average is half of
+ * one: at a second that was ~500ms on the front of every deploy, spent ahead of the artifact, the
+ * boot and the guest — and against a deploy measured at 1.6s for a small binary, the largest
+ * single thing the control plane was contributing.
+ *
+ * What a shorter one costs is polls, and the fleet is what decides whether that is dear rather
+ * than this number. It is the control plane's to set for precisely that reason: it can be raised
+ * again for every host at once without redeploying a single agent.
+ *
+ * Holding the request open is what stops notice-latency and request rate being the same dial at
+ * all, and is the answer at the point where lowering this stops being cheap. It is not that point
+ * while a host is something there is one of.
+ */
+const DEFAULT_MIN_INTERVAL_MS = 250;
 const DEFAULT_REPORT_INTERVAL_MS = 15_000;
 
 export const DEFAULT_AGENT_POLL_SETTINGS: AgentPollSettings = {


### PR DESCRIPTION
`minIntervalMs` is what a deploy waits out before anything has begun. A change lands at no particular point in the interval, so a second costs ~500ms on average — ahead of the artifact, the boot and the guest, and against the 1.6s a small binary took in #451, the largest single thing the control plane was contributing.

A quarter of a second takes ~375ms of that back, for one constant.

What it costs is polls: four requests a second from one host, and a handful of indexed selects behind each. The fleet is what decides whether that is dear rather than this number, and this is the control plane's to set for exactly that reason — it can be raised again for every host at once without redeploying a single agent, and agents pick it up from their next session.

Supersedes #457 for now, which does this properly by holding the request open. That is the right answer at the point where lowering this number stops being cheap, and the wrong size of solution while a host is something there is one of — 339 lines against this one. I've left it open as a draft rather than closing it: the design and its tests still stand, and `minIntervalMs` is the thing that tells you when to want it.