### PR TITLE
fix(dashboard): the root path icon stops hanging off the left edge

### DIFF
--- a/apps/dashboard/src/components/files/path-breadcrumb.tsx
+++ b/apps/dashboard/src/components/files/path-breadcrumb.tsx
@@ -34,7 +34,7 @@ export function PathBreadcrumb() {
           {steps.length === 0 ? (
             <BreadcrumbPage
               aria-label={ROOT_LABEL}
-              className="-ml-1.5 flex size-7 items-center justify-center"
+              className="flex size-7 items-center justify-center"
               title={ROOT_LABEL}
             >
               <FolderRootIcon className="size-4" />
@@ -42,7 +42,6 @@ export function PathBreadcrumb() {
           ) : (
             <BreadcrumbLink
               className={buttonVariants({
-                className: '-ml-1.5',
                 size: 'icon-sm',
                 variant: 'ghost',
               })}


### PR DESCRIPTION
The breadcrumb's root icon carried a `-ml-1.5`, which pulled it 6px outside its row. `<main>` is `overflow-y-auto`, so the x-axis is `auto` rather than `visible` and that 6px was clipped into unreachable negative overflow — leaving the icon cut off and misaligned with the files card below.

Dropping the negative margin puts the button box flush with the card edge, mirroring the refresh button on the right.