### PR TITLE
feat(dashboard): the deploy page says where the source is

### DIFF
--- a/apps/dashboard/src/components/handoff/handed-off-binary.tsx
+++ b/apps/dashboard/src/components/handoff/handed-off-binary.tsx
@@ -13,6 +13,7 @@ import { BrandMark } from '@repo/ui/custom/brand-mark';
 import { Link, useLocation } from '@tanstack/react-router';
 import { FileTerminalIcon } from 'lucide-react';
 import { HandoffDeploy } from '#components/handoff/handoff-deploy.tsx';
+import { OpenSourceFooter } from '#components/handoff/open-source-footer.tsx';
 import { formatBytes } from '#lib/format-bytes.ts';
 import { useDeployLink } from '#lib/hooks/use-deploy-link.ts';
 import { useFinishHandoff } from '#lib/hooks/use-finish-handoff.ts';
@@ -31,6 +32,7 @@ export function HandedOffBinary() {
       <div className="flex w-full max-w-lg flex-col gap-6 lg:max-w-3xl">
         {loading ? <Spinner /> : <Waiting binary={binary} signedIn={session !== null} />}
       </div>
+      <OpenSourceFooter />
     </div>
   );
 }

--- a/apps/dashboard/src/components/handoff/open-source-footer.tsx
+++ b/apps/dashboard/src/components/handoff/open-source-footer.tsx
@@ -1,0 +1,24 @@
+import { GithubIcon } from '#icons/github-icon.tsx';
+import { LANDING_ORIGIN, REPO_URL } from '#lib/site.ts';
+
+// A new tab for the repository and the same one for home: whoever is mid-deploy here has a
+// binary in storage that only this tab knows about, and only home is worth losing it for.
+export function OpenSourceFooter() {
+  return (
+    <footer className="flex items-center gap-3 text-muted-foreground text-sm">
+      <a
+        className="inline-flex items-center gap-1.5 hover:underline"
+        href={REPO_URL}
+        target="_blank"
+        rel="noreferrer"
+      >
+        <GithubIcon className="size-4" />
+        nibrun is fully open source
+      </a>
+      <span aria-hidden="true">·</span>
+      <a className="hover:underline" href={LANDING_ORIGIN}>
+        Home
+      </a>
+    </footer>
+  );
+}

--- a/apps/dashboard/src/lib/hooks/use-handoff-receiver.ts
+++ b/apps/dashboard/src/lib/hooks/use-handoff-receiver.ts
@@ -1,8 +1,7 @@
 import { HANDOFF_READY, HANDOFF_STORED, isHandoffOffer } from '@repo/binary-handoff';
 import { useEffect, useState } from 'react';
 import { storeHandedOffBinary } from '#lib/handoff-store.ts';
-
-const LANDING_ORIGIN = import.meta.env.DEV ? 'http://localhost:3002' : 'https://nibrun.com';
+import { LANDING_ORIGIN } from '#lib/site.ts';
 
 function framedByLandingPage(): boolean {
   return window.parent !== window;

--- a/apps/dashboard/src/lib/site.ts
+++ b/apps/dashboard/src/lib/site.ts
@@ -1,0 +1,3 @@
+export const LANDING_ORIGIN = import.meta.env.DEV ? 'http://localhost:3002' : 'https://nibrun.com';
+
+export const REPO_URL = 'https://github.com/ilbertt/nibrun';


### PR DESCRIPTION
A footer under the deploy card: the repository, and a way back to nibrun.com.