### PR TITLE
feat(dashboard): the mark on the deploy page leads home

### DIFF
--- a/apps/dashboard/src/components/handoff/handed-off-binary.tsx
+++ b/apps/dashboard/src/components/handoff/handed-off-binary.tsx
@@ -20,6 +20,7 @@ import { useFinishHandoff } from '#lib/hooks/use-finish-handoff.ts';
 import { useHandedOffBinary } from '#lib/hooks/use-handed-off-binary.ts';
 import { useSession } from '#lib/hooks/use-session.ts';
 import { DeployRunProvider } from '#lib/providers/deploy-run-provider.tsx';
+import { WWW_ORIGIN } from '#lib/www-origin.ts';
 import { Route as LoginRoute } from '#routes/(auth)/login.tsx';
 
 export function HandedOffBinary() {
@@ -28,7 +29,9 @@ export function HandedOffBinary() {
 
   return (
     <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
-      <BrandMark />
+      <a className="transition-opacity hover:opacity-80" href={WWW_ORIGIN}>
+        <BrandMark />
+      </a>
       <div className="flex w-full max-w-lg flex-col gap-6 lg:max-w-3xl">
         {loading ? <Spinner /> : <Waiting binary={binary} signedIn={session !== null} />}
       </div>

--- a/apps/dashboard/src/components/handoff/open-source-footer.tsx
+++ b/apps/dashboard/src/components/handoff/open-source-footer.tsx
@@ -1,20 +1,13 @@
 import { GithubMark } from '@repo/ui/custom/github-mark';
 import { GithubRepoLink } from '@repo/ui/custom/github-repo-link';
-import { WWW_ORIGIN } from '#lib/www-origin.ts';
 
-// Home stays in this tab: whoever is mid-deploy here has a binary in storage that only this tab
-// knows about, and home is the one place worth losing it for.
 export function OpenSourceFooter() {
   return (
-    <footer className="flex items-center gap-3 text-muted-foreground text-sm">
+    <footer className="mt-6 text-muted-foreground text-sm">
       <GithubRepoLink className="inline-flex items-center gap-1.5 hover:underline">
         <GithubMark className="size-4" />
         nibrun is fully open source
       </GithubRepoLink>
-      <span aria-hidden="true">·</span>
-      <a className="hover:underline" href={WWW_ORIGIN}>
-        Home
-      </a>
     </footer>
   );
 }


### PR DESCRIPTION
The footer's home link becomes the nibrun mark at the top, and what is left of the footer gets room from the card above it.