### PR TITLE
fix(agent): the time a request took is not the name a state change already uses

### DIFF
--- a/apps/agent/src/services/app-activator.service.ts
+++ b/apps/agent/src/services/app-activator.service.ts
@@ -106,7 +106,7 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
         if (request.headers.get('upgrade') !== null) {
           return sayToComeBack();
         }
-        const [answered, response] = yield* Effect.timed(
+        const [served, response] = yield* Effect.timed(
           forwardToGuest({
             request,
             guestIpv4: woken.guestIpv4,
@@ -118,12 +118,16 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
          * long before it answers: `wokeMs` alone reads as the whole cost and is the smaller part
          * of it. What the visitor paid is the two added together, and which half moved is the
          * only way to tell a slower host from a tenant that takes longer to come back.
+         *
+         * `servedMs` and not `answeredMs`: a state change already annotates that name with the
+         * time from a start to the first probe it passed, which is a different quantity on a
+         * different scale — sharing the name makes any reading of either a mix of the two.
          */
         yield* Effect.logInfo('app answered the request that woke it').pipe(
           Effect.annotateLogs({
             appId,
             wokeMs: Duration.toMillis(woke),
-            answeredMs: Duration.toMillis(answered),
+            servedMs: Duration.toMillis(served),
           }),
         );
         return response;

--- a/apps/agent/tests/services/app-activator.test.ts
+++ b/apps/agent/tests/services/app-activator.test.ts
@@ -210,7 +210,10 @@ describe('an app that runs on request is started by the request that wanted it',
         expect(answered).toHaveLength(1);
         expect(answered[0]?.appId).toBe(APP_ID);
         expect(typeof answered[0]?.wokeMs).toBe('number');
-        expect(typeof answered[0]?.answeredMs).toBe('number');
+        expect(typeof answered[0]?.servedMs).toBe('number');
+        // A state change annotates `answeredMs` with a different quantity on a different scale,
+        // and one log stream carrying both under one name is unreadable either way round.
+        expect(answered[0]?.answeredMs).toBeUndefined();
       }).pipe(Effect.provide(capturing)),
     );
   });


### PR DESCRIPTION
`answeredMs` was already in use. A state change to `running` annotates it with the time from an instance's start to the first probe it passed — seconds, once per boot, at [instances.ts:358](https://github.com/ilbertt/nibrun/blob/main/apps/agent/src/lib/reconcile/instances.ts#L358). #448 then annotated the same name in the activator with the time one forwarded request took — milliseconds, once per wake.

Both go to the same log stream. Seen in production on a cold boot, four lines apart:

```
app answered the request that woke it   wokeMs=2426  answeredMs=24
instance state changed                  answeredMs=2619  from=starting to=running
```

The activator's field becomes `servedMs`. The older one keeps its name — it is the only record behind the wake history this work has been measured against, and renaming it would break that.

Found while investigating why `sharkord-68jmna` took 2.4s to wake: its snapshot was invalidated by a guest image roll, so it cold-booted. Unrelated cause, but the collision made the logs harder to read while chasing it.