### PR TITLE
perf(agent): a status pass settles every app at once, not one after another

### DIFF
--- a/apps/agent/src/lib/health/probe.ts
+++ b/apps/agent/src/lib/health/probe.ts
@@ -32,6 +32,12 @@ const unhealthyUnless = ({
   timeoutMs: number;
 }) =>
   probe.pipe(
+    // As in `CommandRunner` and `isFormatted`: the connect is a promise this side cannot recall,
+    // so without this the deadline is the moment the *socket* gives up rather than the moment this
+    // stops waiting — an address nothing answers on is bounded by the kernel's connect timeout,
+    // not by `timeoutMs`. A guest whose tap has gone is exactly that address, and a pass waiting
+    // on one is a pass reporting nothing about any app on the host.
+    Effect.disconnect,
     Effect.timeoutTo({
       duration: Duration.millis(timeoutMs),
       onSuccess: (healthy: boolean) => healthy,

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -338,24 +338,30 @@ export const sleepInstance = Effect.fn('sleepInstance')(function* (desired: Desi
 });
 
 /**
- * How long the guest took to answer, on the pass that first finds it answering.
+ * How long the guest took to answer, measured to the moment that is written down.
  *
  * The other half of what a cold start costs, and the half no host-side timing can see:
  * `startedAt` is written when the VMM was asked to start, so this is the kernel, the guest's init
  * and the tenant's own startup together. `VmManager.boot` accounts for everything before it, and
  * a start that grew is one or the other.
+ *
+ * `atMs` is read here rather than taken from the pass, and the difference is the whole point. A
+ * guest is not up as far as anything else is concerned until this record says so — the report goes
+ * out on it, and the deploy ends on the report. Measured from the pass's own clock it read 69ms
+ * for a start that took 1145ms to be written down, which is a number that hides exactly the delay
+ * it exists to find.
  */
 function answeredAfter({
   record,
   state,
-  nowMs,
+  atMs,
 }: {
   record: InstanceRecord;
   state: InstanceState;
-  nowMs: number;
+  atMs: number;
 }) {
   return state === 'running' && record.startedAt !== undefined
-    ? { answeredMs: nowMs - Date.parse(record.startedAt) }
+    ? { answeredMs: atMs - Date.parse(record.startedAt) }
     : {};
 }
 
@@ -638,14 +644,28 @@ function settle({
         appId: record.appId,
         from: record.state,
         to: state,
-        ...answeredAfter({ record, state, nowMs }),
+        ...answeredAfter({ record, state, atMs: yield* Clock.currentTimeMillis }),
       }),
     );
     yield* ReportSignal.raise;
   });
 }
 
-/** Probes the tenants that are due, then settles each state from systemd and the probe together. */
+/**
+ * Probes the tenants that are due, then settles each state from systemd and the probe together.
+ *
+ * Concurrently, because what takes any time here is the probe, and sequentially that is one probe
+ * ceiling per instance in front of every instance behind it — including the one that has just
+ * booted and is waiting to be called `running`. Nothing reports a start until this pass reaches
+ * it, and the deploy ends on that report, so an app's own boot time is only half of what its owner
+ * waits: measured on this host, a guest that answered 69ms after its VMM started was written down
+ * 1145ms after it, the whole of the difference spent settling other apps first.
+ *
+ * The reasoning `VolumeManager.observe` already gives for its own probes, and the same bound makes
+ * it safe: the records are one per slot, so the fan-out is what the kernel's NBD minors allow.
+ * Every write below merges into the record as it stands rather than replacing it, which is what
+ * lets two of these land at once.
+ */
 export const refreshStates = Effect.gen(function* () {
   const current = yield* AgentState.snapshot;
   const statuses = yield* Systemd.statuses([...current.records.keys()]);
@@ -661,6 +681,6 @@ export const refreshStates = Effect.gen(function* () {
         snapshotting: current.snapshotting.has(record.appId),
         nowMs,
       }),
-    { discard: true },
+    { discard: true, concurrency: 'unbounded' },
   );
 });


### PR DESCRIPTION
Measured on the prod host, decomposing a deploy that took 2204ms end to end:

| | guest answered | written down as `running` | gap |
|---|---|---|---|
| probe-small2 | 69ms after start | **1145ms** after start | **1076ms** |
| probe-large2 | 735ms | 736ms | 1ms |
| probe-s3 / s4 / s5 | 609 / 591 / 418ms | 610 / 592 / 419ms | ~1ms |

The guest was up and answering in 69ms. The host did not record it for another second.

`refreshStates` walked its records sequentially, and what takes any time in one is the probe — up to `healthCheck.timeoutMs`, 2s by default. A newly booted app waited out a probe ceiling for every app in front of it. Nothing reports a start until the pass reaches it, and the deploy ends on that report, so this was the owner's wait rather than the app's. It also grows with whatever else the host is carrying, which is why it gets worse over time with no code change and why it is erratic rather than uniformly slow — what you pay depends on where you land in the order.

`VolumeManager.observe` already gives exactly this reasoning for its own probes: *"Sequentially that is one probe ceiling per volume before the host reports anything, and a host that reports nothing is a host the control plane cannot see."* The instance health loop never got the same treatment.

## Safety

- Every mutation goes through `Ref.update`, which is atomic.
- `settle` merges into the record as it stands rather than replacing it — already deliberate, and what lets two land at once.
- Fan-out is one record per slot, so it is bounded by the kernel's NBD minors, the same bound `VolumeManager.observe` relies on.

## `answeredMs`

Also fixed, and it is why this took so long to find. It measured from the pass's own clock, so it read **69ms for a start that took 1145ms to be written down** — hiding the delay it was added to find. It now measures to the moment the state is recorded.

## No test

`VolumeManager.observe`'s equivalent has none, and `probeInstance` is a direct import rather than an injected dependency, so pinning this would mean restructuring production code for a timing-based test that could flake. The reasoning and the measured numbers are in the comment instead.