### PR TITLE
feat(www): openconnector is a preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Open source projects that already ship a single binary. One click to deploy:
 | **[Sharkord](https://nibrun.com/deploy/sharkord)** | A self-hosted chat server with voice, video and screen sharing. |
 | **[Boop](https://nibrun.com/deploy/boop)** | A self-hosted notification inbox for your own apps. |
 | **[Gitea](https://nibrun.com/deploy/gitea)** | A self-hosted Git service with repositories, issues, pull requests, packages and CI. |
+| **[OpenConnector](https://nibrun.com/deploy/open-connector)** | One OAuth hub for 1,000+ providers, with prebuilt actions your agents can call. |
 
 ## Why
 

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -29,19 +29,19 @@ export const DEPLOY_PRESETS = {
     arg: ['nibrun'],
     minimal: true,
   },
-  // The one preset without a pinned tag and a checksum: openconnector attaches a linux binary to
-  // its releases as of oomol-lab/open-connector#488, and there is no published one to hold this to
-  // until the release after it merges. Pin it and add the digest then.
   'open-connector': {
     name: 'open-connector',
     binary:
-      'https://github.com/oomol-lab/open-connector/releases/latest/download/open-connector-linux-x64',
+      'https://github.com/oomol-lab/open-connector/releases/download/v1.5.0/open-connector-linux-x64',
+    sha256: '127c17d6dcdbd646733ddcb714509996e75cbede1f0eaca6ded9b26fa9115ee2',
     port: 3000,
     env: [
       'HOST=0.0.0.0',
-      `PORT=${interpolableRuntimeValue(RUNTIME_VALUES.HTTP_PORT.name)}`,
       `OOMOL_CONNECT_DATA_DIR=${interpolableRuntimeValue(RUNTIME_VALUES.DATA_DIR.name)}`,
       `OOMOL_CONNECT_ORIGIN=https://${interpolableRuntimeValue(RUNTIME_VALUES.HOSTNAME.name)}`,
+      // The catalog held in memory is the largest allocation openconnector makes, and upstream
+      // names the 256 MiB machine as the case for reading its schemas off disk instead.
+      'OOMOL_CONNECT_CATALOG_LAZY_SCHEMAS=true',
       'OOMOL_CONNECT_ENCRYPTION_KEY',
       'OOMOL_CONNECT_ADMIN_TOKEN',
       'OOMOL_CONNECT_RUNTIME_TOKEN',

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -29,6 +29,25 @@ export const DEPLOY_PRESETS = {
     arg: ['nibrun'],
     minimal: true,
   },
+  // The one preset without a pinned tag and a checksum: openconnector attaches a linux binary to
+  // its releases as of oomol-lab/open-connector#488, and there is no published one to hold this to
+  // until the release after it merges. Pin it and add the digest then.
+  'open-connector': {
+    name: 'open-connector',
+    binary:
+      'https://github.com/oomol-lab/open-connector/releases/latest/download/open-connector-linux-x64',
+    port: 3000,
+    env: [
+      'HOST=0.0.0.0',
+      `PORT=${interpolableRuntimeValue(RUNTIME_VALUES.HTTP_PORT.name)}`,
+      `OOMOL_CONNECT_DATA_DIR=${interpolableRuntimeValue(RUNTIME_VALUES.DATA_DIR.name)}`,
+      `OOMOL_CONNECT_ORIGIN=https://${interpolableRuntimeValue(RUNTIME_VALUES.HOSTNAME.name)}`,
+      'OOMOL_CONNECT_ENCRYPTION_KEY',
+      'OOMOL_CONNECT_ADMIN_TOKEN',
+      'OOMOL_CONNECT_RUNTIME_TOKEN',
+    ],
+    minimal: true,
+  },
   pocketbase: {
     name: 'pocketbase',
     binary:


### PR DESCRIPTION
Adds an `open-connector` deploy preset, following [oomol-lab/open-connector#488](https://github.com/oomol-lab/open-connector/pull/488), which lists nibrun as a deployment option. That PR's release workflow has landed, so `v1.5.0` publishes `open-connector-linux-x64` alongside a `SHA256SUMS` — the preset pins that tag and holds the download to its digest, as the others do.

Deployed and checked end to end with `nib run` on the exact config:

- serves on the issued hostname, ready in 4.3s, 256 MiB guest
- `OOMOL_CONNECT_DATA_DIR` lands `connect.sqlite` on the volume
- `OOMOL_CONNECT_ORIGIN` interpolates: `expectedRedirectUri` comes back as `https://<app>.nibrun.app/oauth/callback`
- `OOMOL_CONNECT_ADMIN_TOKEN` gates the admin api (401 without, 200 with)
- `OOMOL_CONNECT_RUNTIME_TOKEN` gates `/mcp` (401 without, initializes with)

No `PORT` variable: the guest runtime already exports it as an alias of `NIBRUN_HTTP_PORT`, so the binary follows the port the form is deployed with. Confirmed by deploying on 8080 — `connect server listening` at `http://0.0.0.0:8080` with nothing else set.