### PR TITLE
fix(dashboard): a dropped binary stops outliving the visit that dropped it

### DIFF
--- a/apps/dashboard/src/components/deploy/deploy-binary-field.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-binary-field.tsx
@@ -2,23 +2,21 @@ import { Field, FieldError, FieldLabel } from '@repo/ui/components/field';
 import { BINARY_INPUT_ID } from '#components/deploy/binary-drop-zone.tsx';
 import { BinarySourcePicker } from '#components/deploy/binary-source-picker.tsx';
 import {
-  type DeployFormApi,
+  type DeployFormState,
   validateBinary,
   validateKeptBinary,
 } from '#lib/hooks/use-deploy-form.ts';
-import type { AppSummary } from '#queries/apps.ts';
 
-export function DeployBinaryField({
-  api,
-  replacing,
-}: {
-  api: DeployFormApi;
-  replacing: AppSummary | undefined;
-}) {
+export function DeployBinaryField({ form }: { form: DeployFormState }) {
+  const { api, binaryListeners, replacing } = form;
   const validate = replacing === undefined ? validateBinary : validateKeptBinary;
 
   return (
-    <api.Field name="binary" validators={{ onMount: validate, onChange: validate }}>
+    <api.Field
+      name="binary"
+      validators={{ onMount: validate, onChange: validate }}
+      listeners={binaryListeners}
+    >
       {(field) => {
         const rejected = field.state.value !== undefined && field.state.meta.errors.length > 0;
         return (

--- a/apps/dashboard/src/components/deploy/deploy-form.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-form.tsx
@@ -36,9 +36,9 @@ export function DeployForm({
       }}
     >
       {stripped ? (
-        <MinimalBinaryField api={api} appName={suggested?.name} />
+        <MinimalBinaryField form={form} appName={suggested?.name} />
       ) : (
-        <DeployBinaryField api={api} replacing={replacing} />
+        <DeployBinaryField form={form} />
       )}
 
       {!stripped && <DeployConfiguration form={form} suggested={suggested} />}

--- a/apps/dashboard/src/components/deploy/minimal-binary-field.tsx
+++ b/apps/dashboard/src/components/deploy/minimal-binary-field.tsx
@@ -5,7 +5,7 @@ import { FileTerminalIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { BINARY_INPUT_ID } from '#components/deploy/binary-drop-zone.tsx';
 import { fetchedUrl, pickedFile } from '#lib/binary-source.ts';
-import { type DeployFormApi, validateBinary } from '#lib/hooks/use-deploy-form.ts';
+import { type DeployFormState, validateBinary } from '#lib/hooks/use-deploy-form.ts';
 
 /**
  * The binary, asked for the way the landing page asks: a link carries everything else, so the one
@@ -15,14 +15,20 @@ import { type DeployFormApi, validateBinary } from '#lib/hooks/use-deploy-form.t
  * for — the binary is named rather than dropped, and the button below is the whole of it.
  */
 export function MinimalBinaryField({
-  api,
+  form,
   appName,
 }: {
-  api: DeployFormApi;
+  form: DeployFormState;
   appName: string | undefined;
 }) {
+  const { api, binaryListeners } = form;
+
   return (
-    <api.Field name="binary" validators={{ onMount: validateBinary, onChange: validateBinary }}>
+    <api.Field
+      name="binary"
+      validators={{ onMount: validateBinary, onChange: validateBinary }}
+      listeners={binaryListeners}
+    >
       {(field) => {
         const rejected = field.state.value !== undefined && field.state.meta.errors.length > 0;
         const file = pickedFile(field.state.value);

--- a/apps/dashboard/src/components/handoff/handed-off-binary.tsx
+++ b/apps/dashboard/src/components/handoff/handed-off-binary.tsx
@@ -8,7 +8,6 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@repo/ui/components/empty';
-import { Spinner } from '@repo/ui/components/spinner';
 import { BrandMark } from '@repo/ui/custom/brand-mark';
 import { Link, useLocation } from '@tanstack/react-router';
 import { FileTerminalIcon } from 'lucide-react';
@@ -24,7 +23,7 @@ import { WWW_ORIGIN } from '#lib/www-origin.ts';
 import { Route as LoginRoute } from '#routes/(auth)/login.tsx';
 
 export function HandedOffBinary() {
-  const { binary, loading } = useHandedOffBinary();
+  const binary = useHandedOffBinary();
   const session = useSession();
 
   return (
@@ -33,7 +32,7 @@ export function HandedOffBinary() {
         <BrandMark />
       </a>
       <div className="flex w-full max-w-lg flex-col gap-6 lg:max-w-3xl">
-        {loading ? <Spinner /> : <Waiting binary={binary} signedIn={session !== null} />}
+        <Waiting binary={binary} signedIn={session !== null} />
       </div>
       <OpenSourceFooter />
     </div>

--- a/apps/dashboard/src/lib/handoff-store.ts
+++ b/apps/dashboard/src/lib/handoff-store.ts
@@ -7,6 +7,15 @@ const DB_VERSION = 1;
 const STORE_NAME = 'binaries';
 const BINARY_KEY = 'dropped';
 
+const MS_PER_HOUR = 3_600_000;
+const HOURS_OFFERED = 12;
+
+/**
+ * A drop, and when it happened. Nothing here consumes the binary, so without the second half a
+ * visit weeks later would be answered by whatever the last one left behind.
+ */
+type HandedOff = { binary: File; storedAt: number };
+
 function openDatabase(): Promise<IDBDatabase> {
   const { promise, resolve, reject } = Promise.withResolvers<IDBDatabase>();
   const open = indexedDB.open(DB_NAME, DB_VERSION);
@@ -45,15 +54,80 @@ async function commitWrite(change: (binaries: IDBObjectStore) => void): Promise<
 }
 
 export function storeHandedOffBinary(binary: File): Promise<void> {
-  return commitWrite((binaries) => binaries.put(binary, BINARY_KEY));
+  const handedOff: HandedOff = { binary, storedAt: Date.now() };
+  return commitWrite((binaries) => binaries.put(handedOff, BINARY_KEY));
 }
 
-/** A binary is spent once it has been deployed; left here it would be offered again. */
-export function forgetHandedOffBinary(): Promise<void> {
+/**
+ * Throws the drop away without waiting to hear whether it worked.
+ *
+ * Which is all any caller wants: a binary is spent once it has been deployed, given up once the
+ * form holds something else, and beside the point once the link being followed names its own —
+ * and in none of the three is there anything to do about a browser that says no.
+ */
+export function discardHandedOffBinary(): void {
+  void forgetHandedOffBinary().catch(ignoreRefusal);
+}
+
+/**
+ * The drop still waiting, if there is one this visit would have made itself.
+ *
+ * A browser that will not open storage — a private window, a blocked origin — is answered as
+ * none, since there is nothing here that could tell the difference or act on it.
+ */
+export async function readHandedOffBinary(): Promise<File | undefined> {
+  try {
+    return await stillWaiting();
+  } catch {
+    return undefined;
+  }
+}
+
+async function stillWaiting(): Promise<File | undefined> {
+  const stored = await readStored();
+  if (stored === undefined) {
+    return undefined;
+  }
+
+  const offered = offeredBinary(stored);
+  if (offered !== undefined) {
+    return offered;
+  }
+
+  // Nobody is going to be offered it, and it is megabytes of somebody's quota.
+  await forgetHandedOffBinary();
+  return undefined;
+}
+
+function forgetHandedOffBinary(): Promise<void> {
   return commitWrite((binaries) => binaries.delete(BINARY_KEY));
 }
 
-export async function readHandedOffBinary(): Promise<File | undefined> {
+function ignoreRefusal(): void {}
+
+/**
+ * What a stored record still offers. Nothing where the drop has gone stale, and nothing where it
+ * was written in the shape a past release used — which is the same answer for the same reason,
+ * since neither is a binary anyone standing here today asked for.
+ */
+export function offeredBinary(stored: unknown): File | undefined {
+  const handedOff = asHandedOff(stored);
+  if (handedOff === undefined) {
+    return undefined;
+  }
+  const age = Date.now() - handedOff.storedAt;
+  return age < HOURS_OFFERED * MS_PER_HOUR ? handedOff.binary : undefined;
+}
+
+function asHandedOff(stored: unknown): HandedOff | undefined {
+  if (typeof stored !== 'object' || stored === null) {
+    return undefined;
+  }
+  const { binary, storedAt } = stored as Partial<HandedOff>;
+  return binary instanceof File && typeof storedAt === 'number' ? { binary, storedAt } : undefined;
+}
+
+async function readStored(): Promise<unknown> {
   const database = await openDatabase();
   const { promise, resolve, reject } = Promise.withResolvers<unknown>();
 
@@ -66,8 +140,7 @@ export async function readHandedOffBinary(): Promise<File | undefined> {
     read.onsuccess = () => resolve(read.result);
     read.onerror = () => reject(read.error ?? new Error('The browser refused the read.'));
 
-    const stored = await promise;
-    return stored instanceof File ? stored : undefined;
+    return await promise;
   } finally {
     database.close();
   }

--- a/apps/dashboard/src/lib/hooks/use-deploy-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy-form.ts
@@ -22,6 +22,7 @@ import {
   storedNames,
   unfilledAsked,
 } from '#lib/environment-variables.ts';
+import { discardHandedOffBinary } from '#lib/handoff-store.ts';
 import { useApps } from '#lib/hooks/use-apps.ts';
 import type { ReleaseRequest } from '#lib/hooks/use-deploy.ts';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
@@ -51,8 +52,12 @@ export type DeployFormApi = ReactFormExtendedApi<
   undefined
 >;
 
+/** What a change to the binary field does besides changing it. */
+export type BinaryFieldListeners = { onChange?: () => void };
+
 export type DeployFormState = {
   api: DeployFormApi;
+  binaryListeners: BinaryFieldListeners;
   locked: boolean;
   replacing: AppSummary | undefined;
   targetResolved: boolean;
@@ -167,6 +172,7 @@ export function useDeployForm({
 
   return {
     api,
+    binaryListeners: spendsHandoff(binary),
     locked,
     replacing,
     targetResolved,
@@ -174,6 +180,16 @@ export function useDeployForm({
     defaultExtraPublicPort: replacing?.config.hasExtraPublicPort ?? false,
     defaultArgs: replacing?.config.args.join('\n') ?? '',
   };
+}
+
+/**
+ * Storage keeps a dropped binary so that signing in and reloading do not lose it, which is the
+ * same property that would offer it again on a visit that never chose it. So the drop is spent
+ * the moment this form holds anything else — cleared with the x, replaced by another file, given
+ * up for a url — and a form that was never handed one has nothing to spend.
+ */
+function spendsHandoff(binary: File | undefined): BinaryFieldListeners {
+  return binary === undefined ? {} : { onChange: discardHandedOffBinary };
 }
 
 /**

--- a/apps/dashboard/src/lib/hooks/use-finish-handoff.ts
+++ b/apps/dashboard/src/lib/hooks/use-finish-handoff.ts
@@ -1,22 +1,18 @@
 import type { Deployed } from '@repo/app-operations';
 import { useNavigate } from '@tanstack/react-router';
-import { forgetHandedOffBinary } from '#lib/handoff-store.ts';
+import { discardHandedOffBinary } from '#lib/handoff-store.ts';
 import { Route as AppRoute } from '#routes/(dashboard)/apps/$appId/index.tsx';
 
 /**
  * What to do once a handed-off binary has been deployed. The page it ran on is outside the
  * dashboard, opened by a drop on another origin, and the binary it exists for is spent the moment
  * it lands — so what is left of it is thrown away and the app it became is where this goes.
- *
- * Leaving is not conditional on the forgetting: a browser that refuses the delete is no reason
- * to strand someone on a page whose work is done.
  */
 export function useFinishHandoff(): (deployed: Deployed) => void {
   const navigate = useNavigate();
 
   return function finish(deployed: Deployed): void {
-    void forgetHandedOffBinary().finally(() =>
-      navigate({ to: AppRoute.to, params: { appId: deployed.appId } }),
-    );
+    discardHandedOffBinary();
+    void navigate({ to: AppRoute.to, params: { appId: deployed.appId } });
   };
 }

--- a/apps/dashboard/src/lib/hooks/use-handed-off-binary.ts
+++ b/apps/dashboard/src/lib/hooks/use-handed-off-binary.ts
@@ -1,35 +1,5 @@
-import { useEffect, useState } from 'react';
-import { readHandedOffBinary } from '#lib/handoff-store.ts';
+import { Route as DeployRoute } from '#routes/deploy.tsx';
 
-export type HandedOffBinary = {
-  binary: File | undefined;
-  loading: boolean;
-};
-
-export function useHandedOffBinary(): HandedOffBinary {
-  const [binary, setBinary] = useState<File>();
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let live = true;
-
-    readHandedOffBinary()
-      .then(function keep(stored) {
-        if (live) {
-          setBinary(stored);
-          setLoading(false);
-        }
-      })
-      .catch(function giveUp() {
-        if (live) {
-          setLoading(false);
-        }
-      });
-
-    return () => {
-      live = false;
-    };
-  }, []);
-
-  return { binary, loading };
+export function useHandedOffBinary(): File | undefined {
+  return DeployRoute.useLoaderData();
 }

--- a/apps/dashboard/src/routes/deploy.tsx
+++ b/apps/dashboard/src/routes/deploy.tsx
@@ -1,14 +1,37 @@
 import { deployLink } from '@repo/deploy-link';
 import { createFileRoute } from '@tanstack/react-router';
 import { HandedOffBinary } from '#components/handoff/handed-off-binary.tsx';
+import { discardHandedOffBinary, readHandedOffBinary } from '#lib/handoff-store.ts';
 import { useHandoffReceiver } from '#lib/hooks/use-handoff-receiver.ts';
 
 // Outside `(auth)` and `(dashboard)` on purpose: the landing page frames this route, and a
 // hidden frame should render neither the signed-in chrome nor the auth card.
 export const Route = createFileRoute('/deploy')({
   validateSearch: deployLink,
+  loaderDeps: ({ search }) => ({ linkedBinary: search.binary }),
+  loader: ({ deps }) => waitingBinary(deps),
   component: RouteComponent,
 });
+
+/**
+ * The drop this page is for, settled before anything renders rather than arriving into a form
+ * that has already been built out of not having it.
+ *
+ * A link that names its own binary says what to deploy, so a drop left behind by some earlier
+ * visit is not it. Thrown away rather than passed over: passed over, it would still be there to
+ * answer the next visit that arrives without a link.
+ */
+function waitingBinary({
+  linkedBinary,
+}: {
+  linkedBinary: string | undefined;
+}): Promise<File | undefined> {
+  if (linkedBinary === undefined) {
+    return readHandedOffBinary();
+  }
+  discardHandedOffBinary();
+  return Promise.resolve(undefined);
+}
 
 function RouteComponent() {
   const framed = useHandoffReceiver();

--- a/apps/dashboard/tests/lib/handoff-store.test.ts
+++ b/apps/dashboard/tests/lib/handoff-store.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test';
+import { offeredBinary } from '#lib/handoff-store.ts';
+
+const MS_PER_HOUR = 3_600_000;
+const JUST_INSIDE_HOURS = 11;
+const JUST_PAST_HOURS = 13;
+const NEXT_WEEK_HOURS = 168;
+
+const BINARY = new File([], 'my-server');
+
+function droppedHoursAgo(hours: number): unknown {
+  return { binary: BINARY, storedAt: Date.now() - hours * MS_PER_HOUR };
+}
+
+test('a drop is offered while it is still the one this visit would have made', () => {
+  expect(offeredBinary(droppedHoursAgo(0))).toBe(BINARY);
+  expect(offeredBinary(droppedHoursAgo(JUST_INSIDE_HOURS))).toBe(BINARY);
+});
+
+test('a drop nobody came back for is not offered to whoever arrives next', () => {
+  expect(offeredBinary(droppedHoursAgo(JUST_PAST_HOURS))).toBeUndefined();
+  expect(offeredBinary(droppedHoursAgo(NEXT_WEEK_HOURS))).toBeUndefined();
+});
+
+// The bare `File` a release before this one wrote. Undatable, so unofferable — the alternative is
+// offering it forever, which is the whole reason there is a date beside it now.
+test('a record written the way a past release wrote it is not offered either', () => {
+  expect(offeredBinary(BINARY)).toBeUndefined();
+  expect(offeredBinary({ binary: BINARY })).toBeUndefined();
+  expect(offeredBinary(undefined)).toBeUndefined();
+});


### PR DESCRIPTION
The handoff store kept a dropped binary forever, and only a successful deploy from `/deploy` ever took it out. So a visit days later — including one whose link named its own `?binary=` url — deployed whatever the last drop left behind, and clearing the field with the x left the row sitting there.

The record now carries when it was dropped and is only offered for 12 hours, a link naming a binary throws it away instead of losing to it, and the form forgets it the moment it holds something else.