### PR TITLE
feat(www): context-use is a preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Open source projects that already ship a single binary. One click to deploy:
 | **[Boop](https://nibrun.com/deploy/boop)** | A self-hosted notification inbox for your own apps. |
 | **[Gitea](https://nibrun.com/deploy/gitea)** | A self-hosted Git service with repositories, issues, pull requests, packages and CI. |
 | **[OpenConnector](https://nibrun.com/deploy/open-connector)** | One OAuth hub for 1,000+ providers, with prebuilt actions your agents can call. |
+| **[Context Use](https://nibrun.com/deploy/context-use)** | A personal knowledge base your agents read and write over MCP, behind a passkey. |
 
 ## Why
 

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -20,6 +20,16 @@ export const DEPLOY_PRESETS = {
     ],
     minimal: true,
   },
+  'context-use': {
+    name: 'context-use',
+    // The only release is a rolling tag whose asset is replaced on every build, so a checksum
+    // written here would refuse the next one. Left out, the download is still held to something:
+    // the digest the release publishes for whatever the asset currently is.
+    binary:
+      'https://github.com/massimoalbarello/context-use/releases/download/nibrun-latest/context-use',
+    port: 3000,
+    minimal: true,
+  },
   gitea: {
     name: 'gitea',
     binary:


### PR DESCRIPTION
Adds a `context-use` deploy preset, copied from the deploy button [the project already carries in its README](https://github.com/massimoalbarello/context-use).

No `sha256`: its only release is the rolling `nibrun-latest` tag, whose asset is replaced on every build, so a checksum written into the preset would refuse the next one. The download is still held to something — the digest the release publishes for whatever the asset currently is.

No env either. The binary is already nibrun-aware: it binds `0.0.0.0`, reads `PORT`, defaults `DATA_FOLDER` to `/app/data` when `NIBRUN_HOSTNAME` is set, and derives its public origin from that same variable.

Deployed and checked end to end with `nib run` on the exact config:

- ready in 2.2s, 256 MiB guest, `listening on http://0.0.0.0:3000`
- the artifact resolved to the digest GitHub publishes for the asset, which is what the hashless link is held to
- `.better-auth-secret`, `app.db` and `objects/` land on the volume
- the origin interpolates: `/.well-known/oauth-protected-resource` comes back naming `https://<app>.nibrun.app/mcp`