### PR TITLE
build: a checkout on windows keeps the line endings the tools expect

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 charset = utf-8
+end_of_line = lf
 indent_style = space
 indent_size = 2
 insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.png binary


### PR DESCRIPTION
Nothing declares how the working tree should be written, so a clone on a machine with `core.autocrlf` left at the Windows default lands 965 of the 975 tracked files with CRLF. On that checkout, before a line is changed, all three required checks fail:

| Check | What happens |
| --- | --- |
| `bun check:codestyle` | 752 errors, every one of them the line ending |
| `bun check:types` | `bun-sqlgen --check` reads `queries.gen.ts` as stale and exits 1 |
| `bun run test` | `packages/cli/install.sh` arrives with carriage returns in it, and it is the file the install tests run through `sh` |

`text=auto` leaves the blobs as they already are, so `git add --renormalize .` is a no op and nothing in the index moves. `eol=lf` is what the working tree gets whatever the platform default says. `.editorconfig` gains the matching `end_of_line` so an editor agrees with git.

Verified by cloning the branch fresh on Windows: `install.sh` comes back as a POSIX shell script with no CR, and the only files still holding a CR byte are the nine PNGs.