### PR TITLE
fix(api): a host session stops being honoured when the host was told it would

### DIFF
--- a/apps/api/src/lib/agent/sessions.ts
+++ b/apps/api/src/lib/agent/sessions.ts
@@ -1,0 +1,45 @@
+import type { HostId, SecretString } from '@repo/protocol';
+
+type OpenSession = {
+  hostId: HostId;
+  expiresAt: Date;
+};
+
+/**
+ * A host's identity between two polls. In memory, like the observation it goes with: a restarted
+ * api has admitted no host yet, and the next poll opens a session again.
+ *
+ * The lifetime the host is told about is the one enforced here, so a token the agent has already
+ * been told to stop presenting is one this end has already stopped honouring.
+ */
+export class AgentSessions {
+  readonly #byToken = new Map<string, OpenSession>();
+
+  open({
+    sessionToken,
+    hostId,
+    expiresAt,
+  }: {
+    sessionToken: SecretString;
+    hostId: HostId;
+    expiresAt: Date;
+  }): void {
+    this.#byToken.set(sessionToken, { hostId, expiresAt });
+  }
+
+  /**
+   * Expiry is settled on the way in rather than by a sweep: a token nobody presents again costs
+   * one entry, and one presented after it lapsed is the only case that has to be right.
+   */
+  hostFor({ sessionToken, now }: { sessionToken: string; now: Date }): HostId | undefined {
+    const session = this.#byToken.get(sessionToken);
+    if (session === undefined) {
+      return undefined;
+    }
+    if (session.expiresAt.getTime() <= now.getTime()) {
+      this.#byToken.delete(sessionToken);
+      return undefined;
+    }
+    return session.hostId;
+  }
+}

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -8,6 +8,7 @@ import type {
   Timestamp,
 } from '@repo/protocol';
 import type { Queries } from '#db/queries.gen.ts';
+import { AgentSessions } from '#lib/agent/sessions.ts';
 import {
   environmentByDeployment,
   hostnamesByApp,
@@ -30,7 +31,11 @@ export type HostObservation = {
 };
 
 export abstract class AgentRepositoryContract {
-  abstract saveSession(input: { sessionToken: SecretString; hostId: HostId }): Promise<void>;
+  abstract saveSession(input: {
+    sessionToken: SecretString;
+    hostId: HostId;
+    expiresAt: Date;
+  }): Promise<void>;
   abstract hostForSession(input: { sessionToken: string }): Promise<HostId | undefined>;
   abstract desiredState(input: { hostId: HostId }): Promise<HostDesiredState>;
   abstract observeReport(input: { reported: HostReportedState }): Promise<void>;
@@ -38,7 +43,7 @@ export abstract class AgentRepositoryContract {
 }
 
 export class AgentRepository extends Repository implements AgentRepositoryContract {
-  readonly #hostBySession = new Map<string, HostId>();
+  readonly #sessions = new AgentSessions();
   readonly #secretsKey: TenantSecretsKey;
   #lastObservation: HostObservation | undefined;
 
@@ -50,16 +55,18 @@ export class AgentRepository extends Repository implements AgentRepositoryContra
   saveSession({
     sessionToken,
     hostId,
+    expiresAt,
   }: {
     sessionToken: SecretString;
     hostId: HostId;
+    expiresAt: Date;
   }): Promise<void> {
-    this.#hostBySession.set(sessionToken, hostId);
+    this.#sessions.open({ sessionToken, hostId, expiresAt });
     return Promise.resolve();
   }
 
   hostForSession({ sessionToken }: { sessionToken: string }): Promise<HostId | undefined> {
-    return Promise.resolve(this.#hostBySession.get(sessionToken));
+    return Promise.resolve(this.#sessions.hostFor({ sessionToken, now: new Date() }));
   }
 
   /**

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -74,7 +74,8 @@ export class AgentService extends Service {
     // identity across a reinstall. Nothing allocates one yet, so its own is honoured.
     const hostId = request.hostId ?? Value.Parse(HostIdSchema, crypto.randomUUID());
     const sessionToken = Value.Parse(SecretStringSchema, crypto.randomUUID());
-    await this.agentRepo.saveSession({ sessionToken, hostId });
+    const expiresAt = new Date(Date.now() + SESSION_LIFETIME_MS);
+    await this.agentRepo.saveSession({ sessionToken, hostId, expiresAt });
 
     this.logger.info('agent session opened', {
       hostId,
@@ -85,10 +86,7 @@ export class AgentService extends Service {
     return {
       hostId,
       sessionToken,
-      expiresAt: Value.Parse(
-        TimestampSchema,
-        new Date(Date.now() + SESSION_LIFETIME_MS).toISOString(),
-      ),
+      expiresAt: Value.Parse(TimestampSchema, expiresAt.toISOString()),
       poll: DEFAULT_AGENT_POLL_SETTINGS,
     };
   }

--- a/apps/api/tests/lib/agent/sessions.test.ts
+++ b/apps/api/tests/lib/agent/sessions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type HostId,
+  HostIdSchema,
+  type SecretString,
+  SecretStringSchema,
+  Value,
+} from '@repo/protocol';
+import { AgentSessions } from '#lib/agent/sessions.ts';
+
+const HOST: HostId = Value.Parse(HostIdSchema, 'host-1');
+const TOKEN: SecretString = Value.Parse(SecretStringSchema, 'token-1');
+
+const OPENED_AT = new Date('2026-01-01T00:00:00.000Z');
+const EXPIRES_AT = new Date('2026-01-01T01:00:00.000Z');
+
+function opened(): AgentSessions {
+  const sessions = new AgentSessions();
+  sessions.open({ sessionToken: TOKEN, hostId: HOST, expiresAt: EXPIRES_AT });
+  return sessions;
+}
+
+describe('a session is the host it was opened for until it lapses', () => {
+  test('a token presented before it expires resolves to its host', () => {
+    expect(opened().hostFor({ sessionToken: TOKEN, now: OPENED_AT })).toBe(HOST);
+  });
+
+  test('one presented after it expires resolves to nothing', () => {
+    expect(opened().hostFor({ sessionToken: TOKEN, now: EXPIRES_AT })).toBeUndefined();
+  });
+
+  test('a token nobody opened resolves to nothing', () => {
+    expect(opened().hostFor({ sessionToken: 'never-issued', now: OPENED_AT })).toBeUndefined();
+  });
+
+  // The lifetime the host was told about is the one that binds, so a lapsed token stays lapsed
+  // rather than being honoured again by a later clock reading.
+  test('one refused for having lapsed is not honoured by a reading taken earlier', () => {
+    const sessions = opened();
+
+    expect(sessions.hostFor({ sessionToken: TOKEN, now: EXPIRES_AT })).toBeUndefined();
+    expect(sessions.hostFor({ sessionToken: TOKEN, now: OPENED_AT })).toBeUndefined();
+  });
+
+  test('reopening a token gives it the lifetime it was reopened with', () => {
+    const sessions = opened();
+    const later = new Date('2026-01-01T02:00:00.000Z');
+    sessions.open({ sessionToken: TOKEN, hostId: HOST, expiresAt: later });
+
+    expect(sessions.hostFor({ sessionToken: TOKEN, now: EXPIRES_AT })).toBe(HOST);
+  });
+});

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -25,6 +25,7 @@ const SESSION_REQUEST = {
 class FakeAgentRepository implements AgentRepositoryContract {
   readonly #sessions = new AgentSessions();
   observed: HostObservation | undefined;
+  sessionExpiresAt: Date | undefined;
 
   saveSession({
     sessionToken,
@@ -35,6 +36,7 @@ class FakeAgentRepository implements AgentRepositoryContract {
     hostId: HostId;
     expiresAt: Date;
   }): Promise<void> {
+    this.sessionExpiresAt = expiresAt;
     this.#sessions.open({ sessionToken, hostId, expiresAt });
     return Promise.resolve();
   }
@@ -137,19 +139,21 @@ class FakeHostnameReconcile implements HostnameReconcile {
 }
 
 function build() {
+  const agentRepo = new FakeAgentRepository();
   const deployments = new FakeDeploymentsService();
   const apps = new FakeAppsService();
   const exports = new FakeExportsService();
   const artifacts = new FakeUploadSweep();
   const hostnames = new FakeHostnameReconcile();
   return {
+    agentRepo,
     apps,
     deployments,
     exports,
     artifacts,
     hostnames,
     service: new AgentService({
-      agentRepo: new FakeAgentRepository(),
+      agentRepo,
       deploymentsService: deployments as unknown as DeploymentsService,
       appsService: apps as unknown as AppsService,
       exportsService: exports as unknown as ExportsService,
@@ -180,6 +184,17 @@ describe('a session is the identity a host is answered as', () => {
     await expect(service.hostForSession({ sessionToken: 'not-a-session' })).rejects.toBeInstanceOf(
       UnauthorizedError,
     );
+  });
+});
+
+describe('a session is held for the lifetime its host was told about', () => {
+  // The lifetime used to be announced and never recorded, so nothing held the session to it.
+  test('the expiry the host is given is the one the session is saved under', async () => {
+    const { service, agentRepo } = build();
+
+    const session = await service.openSession(SESSION_REQUEST);
+
+    expect(agentRepo.sessionExpiresAt?.toISOString()).toBe(session.expiresAt);
   });
 });
 

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -9,6 +9,7 @@ import {
   type SecretString,
   Value,
 } from '@repo/protocol';
+import { AgentSessions } from '#lib/agent/sessions.ts';
 import { UnauthorizedError } from '#lib/errors.ts';
 import type { AgentRepositoryContract, HostObservation } from '#repositories/agent.repository.ts';
 import { AgentService, type HostnameReconcile, type UploadSweep } from '#services/agent.service.ts';
@@ -22,22 +23,24 @@ const SESSION_REQUEST = {
 } as unknown as AgentSessionRequest;
 
 class FakeAgentRepository implements AgentRepositoryContract {
-  readonly #hostBySession = new Map<string, HostId>();
+  readonly #sessions = new AgentSessions();
   observed: HostObservation | undefined;
 
   saveSession({
     sessionToken,
     hostId,
+    expiresAt,
   }: {
     sessionToken: SecretString;
     hostId: HostId;
+    expiresAt: Date;
   }): Promise<void> {
-    this.#hostBySession.set(sessionToken, hostId);
+    this.#sessions.open({ sessionToken, hostId, expiresAt });
     return Promise.resolve();
   }
 
   hostForSession({ sessionToken }: { sessionToken: string }): Promise<HostId | undefined> {
-    return Promise.resolve(this.#hostBySession.get(sessionToken));
+    return Promise.resolve(this.#sessions.hostFor({ sessionToken, now: new Date() }));
   }
 
   desiredState({ hostId }: { hostId: HostId }): Promise<HostDesiredState> {


### PR DESCRIPTION
`openSession` computes an hour of lifetime and hands it back as `expiresAt`, but `saveSession` kept only the host id and `hostForSession` only asked the map whether the token was in it. So the lifetime was advertised and never enforced: a token stayed good until the api process restarted, and the refusal read `Unknown or expired session.` for a condition nothing checked. The map also never lost an entry, so a host that reinstalls leaves its old token behind, still resolving.

The store moves next to `session-token.ts` as `AgentSessions`, which is what makes it testable without a database. It stays in memory and one host wide, as before. Expiry is settled when a token is presented rather than by a sweep, so a token nobody presents again costs one entry and the case that has to be right is the only one measured.