### PR TITLE
fix(cli): an export starts a partial over rather than writing into the one a killed run left

### DIFF
--- a/packages/cli/src/lib/exports.ts
+++ b/packages/cli/src/lib/exports.ts
@@ -126,6 +126,10 @@ async function download({ url, path }: { url: string; path: string }): Promise<v
  * download waits for good. A body that arrives at once is fine, which is why a local server does
  * not show it and every real transfer does. Reading the stream is the same thing said in a way
  * that finishes.
+ *
+ * Whatever is already at the path is removed first: a writer opened on an existing file writes
+ * over its head and keeps its tail, so a partial left by a run that was killed would otherwise
+ * outlive the run that finishes, longer than the bundle and renamed into place as if it were one.
  */
 export async function writeStream({
   stream,
@@ -134,6 +138,7 @@ export async function writeStream({
   stream: ReadableStream<Uint8Array>;
   path: string;
 }): Promise<void> {
+  await rm(path, { force: true });
   const sink = Bun.file(path).writer();
   try {
     for await (const chunk of stream) {

--- a/packages/cli/tests/lib/exports.test.ts
+++ b/packages/cli/tests/lib/exports.test.ts
@@ -104,3 +104,16 @@ describe('an export is a moment rather than an update', () => {
     );
   });
 });
+
+// A run that is killed cannot clean up after itself, so the next one finds its partial in place.
+describe('a partial left by an earlier run', () => {
+  test('one longer than the stream does not keep its tail in the delivered file', async () => {
+    const landed = join(root, 'stale.bin');
+    const longer = CHUNK_COUNT * CHUNK_BYTES + CHUNK_BYTES;
+    await Bun.write(landed, new Uint8Array(longer));
+
+    await writeStream({ stream: trickling(), path: landed });
+
+    expect(Bun.file(landed).size).toBe(CHUNK_COUNT * CHUNK_BYTES);
+  });
+});


### PR DESCRIPTION
`writeStream` opens `Bun.file(path).writer()` on the partial, and that writes over the head of an existing file while keeping whatever tail is longer than what it wrote. The partial is named after the bundle rather than freshly, and the guard before a download looks at the final path, not at that one.

So a run killed mid-download leaves a partial the next run writes into. The new bytes land in front of the old ones, the file is renamed into place, and the CLI reports success on an archive longer than the bundle it claims to be. The one feature whose point is a backup you can trust is the one that answers with something corrupt, and nothing on the way there notices.

The test writes a stale file one chunk longer than the stream and asserts the delivered file is the size of the stream. Reverting the fix turns it red.