### PR TITLE
fix(cli): a backslash inside double quotes is an escape only where a shell would make it one

### DIFF
--- a/packages/cli/src/lib/command-line.ts
+++ b/packages/cli/src/lib/command-line.ts
@@ -6,6 +6,14 @@ const ESCAPE = '\\';
 const SINGLE = "'";
 const DOUBLE = '"';
 
+const DOUBLE_QUOTED_ESCAPES: Record<string, string> = {
+  $: '$',
+  '`': '`',
+  '"': '"',
+  '\\': '\\',
+  '\n': '',
+};
+
 export type CommandLine = {
   // A path on this machine or a url the api fetches; what it is, is decided where it is opened.
   binarySource: string;
@@ -47,9 +55,11 @@ function opensQuote({ char, quote }: { char: string; quote: string | null }): bo
 }
 
 /**
- * The character a backslash stands for, or `undefined` where it is only itself — as it is inside
- * single quotes, where nothing is special, which is what makes them the way to hand a Windows
- * path or a regex through untouched.
+ * The character a backslash stands for, or `undefined` where it is only itself. Inside single
+ * quotes nothing is special, which is what makes them the way to hand a Windows path or a regex
+ * through untouched. Inside double quotes only what the shell itself would escape is, so
+ * `"C:\Users"` keeps its backslash while `"\""` gives one up; before a newline it continues the
+ * line, and both are gone.
  */
 function escapedAt({
   line,
@@ -60,7 +70,11 @@ function escapedAt({
   index: number;
   quote: string | null;
 }): string | undefined {
-  return line[index] === ESCAPE && quote !== SINGLE ? line[index + 1] : undefined;
+  const next = line[index + 1];
+  if (line[index] !== ESCAPE || quote === SINGLE || next === undefined) {
+    return undefined;
+  }
+  return quote === DOUBLE ? DOUBLE_QUOTED_ESCAPES[next] : next;
 }
 
 /** `''` between two quotes is a token; never having started one is not. */

--- a/packages/cli/tests/lib/command-line.test.ts
+++ b/packages/cli/tests/lib/command-line.test.ts
@@ -37,8 +37,26 @@ test('single quotes pass their contents through untouched', () => {
   ]);
 });
 
-test('a backslash outside single quotes escapes what follows it', () => {
+test('a backslash outside quotes escapes what follows it', () => {
   expect(parseCommandLine('./my-server --name foo\\ bar').args).toEqual(['--name', 'foo bar']);
+});
+
+test('inside double quotes a backslash before what the shell would not escape is kept', () => {
+  expect(parseCommandLine('"C:\\Users\\foo\\bin.exe" --port 8080')).toEqual({
+    binarySource: 'C:\\Users\\foo\\bin.exe',
+    args: ['--port', '8080'],
+  });
+});
+
+test('a regex inside double quotes arrives with its backslashes', () => {
+  expect(parseCommandLine('./my-server --match "\\d+\\s"').args).toEqual(['--match', '\\d+\\s']);
+});
+
+test('inside double quotes a backslash still escapes a quote or another backslash', () => {
+  expect(parseCommandLine('./my-server --name "say \\"hi\\" \\\\ done"').args).toEqual([
+    '--name',
+    'say "hi" \\ done',
+  ]);
 });
 
 test('an argument may be deliberately empty', () => {


### PR DESCRIPTION
`escapedAt` treated every backslash outside single quotes as an escape of whatever followed it, so the tokenizer quietly dropped it:

```
nib run '"C:\Users\foo\bin.exe" --port 8080'   ->  binarySource C:Usersfoobin.exe
nib run './my-server --match "\d+\s"'          ->  args --match d+s
```

A shell escapes only `$`, a backtick, `"`, `\` and a newline inside double quotes and leaves everything else exactly as written. That table already exists in this repo, as `ESCAPED` in `packages/app-operations/src/env-file.ts`, and this now mirrors it. Single quoted and unquoted runs are unchanged and their tests still pass.

Double quotes are the instinct on Windows and around a regex, and what came back was a failure naming a path nobody typed.