### PR TITLE
fix(dashboard): where signing in lands you is a path on this origin or it is home

### DIFF
--- a/apps/dashboard/src/lib/hooks/use-sign-in.ts
+++ b/apps/dashboard/src/lib/hooks/use-sign-in.ts
@@ -1,14 +1,17 @@
 import { type UseMutationResult, useMutation } from '@tanstack/react-query';
 import { authClient } from '#lib/auth.ts';
+import { sameOriginPath } from '#lib/same-origin-path.ts';
+import { Route as IndexRoute } from '#routes/(dashboard)/index.tsx';
 
 type SignInResult = Awaited<ReturnType<typeof authClient.signIn.social>>;
 
 // better-auth answers with the provider URL and the client follows it, so a
 // resolved mutation means the browser is already on its way to GitHub.
 export function useSignIn(callbackURL: string): UseMutationResult<SignInResult, Error, void> {
+  const landing = sameOriginPath(callbackURL) ?? IndexRoute.to;
   return useMutation({
     mutationFn: async () => {
-      const result = await authClient.signIn.social({ provider: 'github', callbackURL });
+      const result = await authClient.signIn.social({ provider: 'github', callbackURL: landing });
       if (result.error) {
         throw result.error;
       }

--- a/apps/dashboard/src/lib/same-origin-path.ts
+++ b/apps/dashboard/src/lib/same-origin-path.ts
@@ -1,0 +1,7 @@
+// A leading slash alone still leaves the origin: `//host` and `/\host` are protocol-relative, and
+// the URL parser drops tabs and newlines before it looks, so `/<tab>/host` is one of them too.
+const SAME_ORIGIN_PATH = /^\/(?![/\\])[^\s\\]*$/;
+
+export function sameOriginPath(candidate: unknown): string | undefined {
+  return typeof candidate === 'string' && SAME_ORIGIN_PATH.test(candidate) ? candidate : undefined;
+}

--- a/apps/dashboard/src/routes/(auth)/login.tsx
+++ b/apps/dashboard/src/routes/(auth)/login.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { LoginForm } from '#components/login/login-form.tsx';
+import { sameOriginPath } from '#lib/same-origin-path.ts';
 import { Route as IndexRoute } from '#routes/(dashboard)/index.tsx';
 
 type LoginSearch = {
@@ -8,7 +9,7 @@ type LoginSearch = {
 
 export const Route = createFileRoute('/(auth)/login')({
   validateSearch: (search: Record<string, unknown>): LoginSearch => ({
-    redirect: typeof search.redirect === 'string' ? search.redirect : undefined,
+    redirect: sameOriginPath(search.redirect),
   }),
   beforeLoad: ({ context, search }) => {
     if (context.session) {

--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { createRootRouteWithContext, Outlet, redirect } from '@tanstack/react-router';
 import { AppDevtools } from '#components/app-devtools.tsx';
+import { sameOriginPath } from '#lib/same-origin-path.ts';
 import { sessionQueryOptions } from '#queries/session.ts';
 import { Route as LoginRoute } from '#routes/(auth)/login.tsx';
 import { Route as IndexRoute } from '#routes/(dashboard)/index.tsx';
@@ -26,12 +27,13 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     const session = await context.queryClient.ensureQueryData(sessionQueryOptions);
 
     if (!session && !isPublic(location.pathname)) {
+      const destination = sameOriginPath(location.href);
       // Home is where signing in lands you with no destination, so saying so
       // would only put a `?redirect=%2F` in front of the user.
-      const isHome = location.href === IndexRoute.to;
+      const landsHome = destination === undefined || destination === IndexRoute.to;
       throw redirect({
         to: LoginRoute.to,
-        search: isHome ? {} : { redirect: location.href },
+        search: landsHome ? {} : { redirect: destination },
       });
     }
 

--- a/apps/dashboard/tests/lib/same-origin-path.test.ts
+++ b/apps/dashboard/tests/lib/same-origin-path.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'bun:test';
+import { sameOriginPath } from '#lib/same-origin-path.ts';
+
+test('a path of its own is where the visitor came from', () => {
+  expect(sameOriginPath('/')).toBe('/');
+  expect(sameOriginPath('/apps')).toBe('/apps');
+  expect(sameOriginPath('/apps?tab=logs')).toBe('/apps?tab=logs');
+  expect(sameOriginPath('/evil.example')).toBe('/evil.example');
+});
+
+test('a scheme of any kind is refused, even one that would point back here', () => {
+  expect(sameOriginPath('https://evil.example/phish')).toBeUndefined();
+  expect(sameOriginPath('http://localhost:3000/apps')).toBeUndefined();
+  expect(sameOriginPath('javascript:alert(1)')).toBeUndefined();
+});
+
+test('a leading slash is not enough once what follows hands the browser a host', () => {
+  expect(sameOriginPath('//evil.example')).toBeUndefined();
+  expect(sameOriginPath('/\\evil.example')).toBeUndefined();
+  expect(sameOriginPath('\\\\evil.example')).toBeUndefined();
+});
+
+// The parser drops them before it reads, so a path carrying one is read as something else.
+test('a tab or a newline inside it is refused rather than dropped and read again', () => {
+  expect(sameOriginPath('/\t/evil.example')).toBeUndefined();
+  expect(sameOriginPath('/\n/evil.example')).toBeUndefined();
+  expect(sameOriginPath('/apps /evil.example')).toBeUndefined();
+});
+
+test('nothing to come back to is left for the caller to decide', () => {
+  expect(sameOriginPath(undefined)).toBeUndefined();
+  expect(sameOriginPath(['/apps'])).toBeUndefined();
+});


### PR DESCRIPTION
`validateSearch` on `/login` accepted `?redirect=` as any string, and TanStack Router follows an absolute `href` as a full document navigation rather than a route change. Two ways out of the domain followed from that:

* someone already signed in who opens `https://app.nibrun.com/login?redirect=https://evil.example` is bounced there by the site they trusted
* the same unchecked value is what `useSignIn` passes GitHub as `callbackURL`, so a signed out visitor is handed to the attacker's origin after authenticating

A leading slash is not the check. `//host` and `/\host` are protocol relative, and the URL parser drops a tab or a newline before it reads, so `/<tab>/host` is the same thing spelled differently. `sameOriginPath` accepts a path on this origin and nothing else, and it runs where the value enters, so no consumer downstream can be handed one that was never checked.

`apps/dashboard`: 81 pass, 0 fail; `tsc --noEmit` clean.