### PR TITLE
fix(cli): the port prompt asks for a whole number above zero and means it

### DIFF
--- a/packages/cli/src/lib/plan.ts
+++ b/packages/cli/src/lib/plan.ts
@@ -98,9 +98,14 @@ async function askPort(): Promise<number> {
   const answer = await text({
     message: 'Which HTTP port does the binary listen on?',
     initialValue: String(DEFAULT_HTTP_PORT),
-    validate: (value) => (Number.isInteger(Number(value)) ? undefined : 'Ports are whole numbers.'),
+    validate: validatePort,
   });
   return Number(answered(answer));
+}
+
+export function validatePort(value: string | undefined): string | undefined {
+  const port = Number(value);
+  return Number.isInteger(port) && port > 0 ? undefined : 'Ports are whole numbers above zero.';
 }
 
 async function confirmPlan({ options, binarySource, args }: Plan): Promise<void> {

--- a/packages/cli/tests/lib/plan.test.ts
+++ b/packages/cli/tests/lib/plan.test.ts
@@ -4,7 +4,7 @@ import { recordingPrompts } from '#tests/support/prompts.ts';
 
 const prompts = await recordingPrompts();
 
-const { completeOptions } = await import('#lib/plan.ts');
+const { completeOptions, validatePort } = await import('#lib/plan.ts');
 
 beforeEach(() => {
   prompts.reset();
@@ -128,4 +128,17 @@ test('declining the confirmation cancels rather than deploying', async () => {
   });
 
   await expect(attempt).rejects.toThrow('Cancelled.');
+});
+
+test('a port is a whole number above zero, so nothing, zero and a negative are refused', () => {
+  const refused = 'Ports are whole numbers above zero.';
+
+  expect(validatePort('')).toBe(refused);
+  expect(validatePort(' ')).toBe(refused);
+  expect(validatePort('0')).toBe(refused);
+  expect(validatePort('-5')).toBe(refused);
+});
+
+test('a port typed as one is passed', () => {
+  expect(validatePort('8080')).toBeUndefined();
 });


### PR DESCRIPTION
`Number('')` and `Number(' ')` are both `0`, and `Number('-5')` is an integer, so clearing the field or typing a negative number satisfied `Number.isInteger` and went through to the deploy as the port.

`asPort` in `packages/deploy-link/src/link.ts` is the sibling of this rule and already requires a positive integer. The check moves out of the prompt options so a test can reach it: `tests/support/prompts.ts` stubs `text` without ever calling `validate`, so inline it is unreachable.