### PR TITLE
fix(agent): a start systemd refuses leaves a cold boot rather than a snapshot nothing will load

### DIFF
--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -367,8 +367,9 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
      *
      * The stamp is checked before anything starts, and a snapshot that fails the check is thrown
      * away rather than left: it is unloadable from here on, and a stamp on disk is what a start
-     * reads to decide it is a restore. The start itself consumes the stamp, so every way this can
-     * fail past that point leaves the next start a cold boot.
+     * reads to decide it is a restore. Past the check, every way this can fail leaves the next
+     * start a cold boot — the start consumes the stamp where it runs, and the snapshot is
+     * discarded below where it does not.
      */
     const wake = Effect.fn('VmManager.wake')(function* ({
       appId,
@@ -387,10 +388,10 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       // caused this is waiting on — the stamp check above it happens before anything is asked
       // of the VMM and costs a file read.
       const [restoring] = yield* Effect.timed(
-        Effect.gen(function* () {
-          yield* Systemd.start(appId);
-          yield* Effect.ensuring(
-            Effect.onError(
+        Effect.ensuring(
+          Effect.gen(function* () {
+            yield* Systemd.start(appId);
+            yield* Effect.onError(
               Effect.gen(function* () {
                 yield* Firecracker.loadSnapshot({
                   socketPath,
@@ -407,17 +408,21 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
               // The start already consumed the stamp, so this Firecracker holds no guest and never
               // will: stopping it is what leaves a cold boot rather than a process in the way of one.
               () => Effect.ignore(Systemd.stop(appId)),
-            ),
-            // Every way out, so no retry of a restore that failed halfway can find the files it did
-            // not finish with. The stamp is already gone and would stop a second load on its own;
-            // this is what keeps at-most-once from resting on that single fact.
-            //
-            // Unlinking while Firecracker still has the memory file mapped keeps the mapping alive
-            // and hands the disk back the moment the microVM exits, so the successful path pays
-            // nothing for it either.
-            forgetSnapshot(appId),
-          );
-        }),
+            );
+          }),
+          // Every way out, the start included. A unit systemd would not start — its burst limit
+          // hit, its runtime directory gone — never reached the stamp, so nothing consumed it: left
+          // there, the next wake reads the same stamp and retries the same start, with no way down
+          // to a cold boot because the failure is not `SnapshotUnusable`, while the files beside it
+          // count against every other app's budget. Past the start the stamp is already gone and
+          // would stop a second load on its own; this is what keeps at-most-once from resting on
+          // that single fact.
+          //
+          // Unlinking while Firecracker still has the memory file mapped keeps the mapping alive
+          // and hands the disk back the moment the microVM exits, so the successful path pays
+          // nothing for it either.
+          forgetSnapshot(appId),
+        ),
       );
       yield* Effect.logInfo('instance awake').pipe(
         Effect.annotateLogs({ appId, slot: slot.slot, restoreMs: Duration.toMillis(restoring) }),

--- a/apps/agent/tests/services/vm-manager.test.ts
+++ b/apps/agent/tests/services/vm-manager.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'bun:test';
+import { FileSystem } from '@effect/platform';
+import type { HostVersions } from '@repo/protocol';
+import { Effect, Either, Layer } from 'effect';
+import { writeJsonFile } from '#lib/json-store.ts';
+import { describeSlot, FIRST_SLOT } from '#lib/network/slot.ts';
+import { type SnapshotStamp, snapshotPaths } from '#lib/vm/snapshot.ts';
+import { AgentState } from '#services/agent-state.service.ts';
+import { TenantLogReceiver } from '#services/tenant-log-receiver.service.ts';
+import { VmManager } from '#services/vm-manager.service.ts';
+import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
+import { recordingCommands, succeeding } from '#tests/support/commands.ts';
+import { agentConfig } from '#tests/support/config.ts';
+import { APP_ID, DEPLOYMENT_ID } from '#tests/support/fixtures.ts';
+import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
+
+const run = provided(platform);
+
+const RUNTIME_DIR = '/nonexistent/nibrun-test/run';
+const SLOT = describeSlot({ slot: FIRST_SLOT, appId: APP_ID });
+
+/** Where `readHostBootId` reads, answered here so the stamp can match on a host with no such file. */
+const HOST_BOOT_ID_PATH = '/proc/sys/kernel/random/boot_id';
+const HOST_BOOT_ID = 'b6b8f0d2-0000-4000-8000-000000000001';
+
+const versions: HostVersions = {
+  agent: 'abc1234',
+  guestImage: '2026.08.01',
+  zerofs: '0.5.0',
+  firecracker: '1.16.1',
+};
+
+const stamp: SnapshotStamp = {
+  deploymentId: DEPLOYMENT_ID,
+  guestImageVersion: versions.guestImage,
+  hostBootId: HOST_BOOT_ID,
+  slot: SLOT.slot,
+};
+
+function hostBooted(bootId: string) {
+  return Layer.effect(
+    FileSystem.FileSystem,
+    Effect.map(FileSystem.FileSystem, (fs) => ({
+      ...fs,
+      readFileString: (...read: Parameters<FileSystem.FileSystem['readFileString']>) => {
+        const [path] = read;
+        return path === HOST_BOOT_ID_PATH ? Effect.succeed(bootId) : fs.readFileString(...read);
+      },
+    })),
+  );
+}
+
+const VERB_ARGUMENT = 1;
+const START_REFUSED = 1;
+
+/** systemd refusing the unit — a burst limit hit, a runtime directory gone — and nothing else failing. */
+function systemctlRefusingStart() {
+  return recordingCommands(({ command }) =>
+    succeeding(
+      command[VERB_ARGUMENT] === 'start'
+        ? { code: START_REFUSED, stderr: 'Start request repeated too quickly.' }
+        : {},
+    ),
+  );
+}
+
+/**
+ * A host holding a snapshot this wake may load — the stamp matching, the files beside it — and a
+ * systemd that will not start the unit. What is on disk is read back afterwards rather than
+ * remembered, because what the wake left there is the whole question.
+ */
+function hostAsleepAndRefusing() {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const snapshotDir = yield* temporaryDirectory;
+    const versionsFile = `${yield* temporaryDirectory}/versions.json`;
+    yield* writeJsonFile({ path: versionsFile, value: versions });
+    const paths = snapshotPaths({ snapshotDir, appId: APP_ID });
+    yield* fs.makeDirectory(paths.directory, { recursive: true });
+    yield* fs.writeFileString(paths.statePath, 'the vmm as it was');
+    yield* fs.writeFileString(paths.memoryPath, 'the guest as it was');
+    yield* writeJsonFile({ path: paths.stampPath, value: stamp });
+
+    const systemctl = systemctlRefusingStart();
+    const host = Layer.mergeAll(
+      agentConfig({ vmSnapshotDir: snapshotDir, versionsFile, runtimeDir: RUNTIME_DIR }),
+      systemctl.layer,
+      hostBooted(HOST_BOOT_ID),
+    ).pipe(Layer.provideMerge(platform));
+    const services = VmManager.DefaultWithoutDependencies.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          AgentState.Default,
+          TenantLogReceiver.Default,
+          ZerofsTopology.DefaultWithoutDependencies,
+        ),
+      ),
+      Layer.provideMerge(host),
+    );
+    const wake = Effect.flatMap(VmManager, (vms) =>
+      vms.wake({ appId: APP_ID, deploymentId: DEPLOYMENT_ID, slot: SLOT }),
+    ).pipe(Effect.either, Effect.provide(services));
+    const kept = Effect.all({
+      stamp: fs.exists(paths.stampPath),
+      snapshot: fs.exists(paths.directory),
+    });
+    return { wake, kept, commands: systemctl.commands };
+  });
+}
+
+/**
+ * `resumeInstance` falls back to a cold boot on `SnapshotUnusable` and on nothing else, so a
+ * start that fails past the stamp check is recoverable only if it leaves nothing loadable behind.
+ */
+describe('a wake whose unit systemd would not start', () => {
+  test('fails with the start, having asked for nothing after it', async () => {
+    const { outcome, commands } = await run(
+      Effect.gen(function* () {
+        const host = yield* hostAsleepAndRefusing();
+        return { outcome: yield* host.wake, commands: host.commands };
+      }),
+    );
+
+    expect(Either.isLeft(outcome) && outcome.left._tag).toBe('CommandFailed');
+    expect(commands.map(({ command }) => command[VERB_ARGUMENT])).toEqual(['start']);
+  });
+
+  // The stamp and the files beside it used to outlive this: the snapshot was forgotten only once
+  // the start had returned, so the next wake read the same stamp and retried the same start, and
+  // the snapshot held its budget against every other app on the host for as long as that went on.
+  test('discards the snapshot it could not restore', async () => {
+    const kept = await run(
+      Effect.gen(function* () {
+        const host = yield* hostAsleepAndRefusing();
+        yield* host.wake;
+        return yield* host.kept;
+      }),
+    );
+
+    expect(kept).toEqual({ stamp: false, snapshot: false });
+  });
+
+  test('leaves the wake after it nothing to restore, which is the cold boot', async () => {
+    const outcome = await run(
+      Effect.gen(function* () {
+        const host = yield* hostAsleepAndRefusing();
+        yield* host.wake;
+        return yield* host.wake;
+      }),
+    );
+
+    expect(Either.isLeft(outcome) && outcome.left._tag).toBe('SnapshotUnusable');
+  });
+});


### PR DESCRIPTION
`forgetSnapshot` sat in the `ensuring` that wrapped everything after `Systemd.start`, so a start systemd itself refused never reached it. Its burst limit hit, its runtime directory gone: the generator fails first, the stamp is never consumed and the snapshot files are never discarded.

That failure is not `SnapshotUnusable`, so `resumeInstance` has no way down to a cold boot. The next wake reads the same stamp, decides it is a restore, and asks systemd for the same unit it just refused. The app stays down for as long as that holds, and the snapshot beside it goes on counting against every other app's `snapshotBudget` on the host.

Moving the start inside the ensured block makes the comment above the function true as written: past the stamp check, every way this can fail leaves the next start a cold boot. The `Systemd.stop` compensation still wraps only what follows the start, and the error tags are unchanged.

Three cases, over the real `VmManager` with a `CommandRunner` that answers `systemctl start` with exit 1: the wake fails with `CommandFailed` having asked for nothing after the start, the stamp and the snapshot directory are gone afterwards, and the wake after it fails with `SnapshotUnusable`, which is the tag `resumeInstance` catches to cold boot. With the original block put back the second and third go red.

`apps/agent`: 540 pass, tsc clean. Six failures there are pre-existing on a Windows checkout, all path separator and file mode comparisons in files this does not touch; the same six fail on `main`.