### PR TITLE
ci: a pull request from a fork skips the plan it was never able to run

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -3,6 +3,11 @@ name: infra
 # No paths filter: infra-passed is a required check, and a check gated by a path
 # filter never reports on the PRs it skips, leaving them unmergeable. The plan
 # script decides for itself whether anything under infra/terraform changed.
+#
+# A pull request from a fork is the one case the plan cannot run in: GitHub issues
+# no OIDC token to it, so the role cannot be assumed and the step fails before
+# terraform is reached. Skipping is what leaves infra-passed green there, because a
+# job that was skipped is neither a failure nor a cancellation.
 on: pull_request
 
 concurrency:
@@ -34,6 +39,7 @@ jobs:
         run: bun run --filter @repo/internal-scripts terraform-check
 
   terraform-plan:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
`infra:required` is red on every pull request I have open, and it is red for a reason none of them can do anything about. GitHub issues no OIDC token to a workflow running on a fork's pull request, so `configure-aws-credentials` never gets one to exchange:

```
Retry validateCredentials: attempt 12 of 12 failed: Credentials could not be loaded,
please check your action inputs: Could not load credentials from any providers.
Retry validateCredentials: reached max retries (12); giving up.
##[error]Credentials could not be loaded, please check your action inputs
```

`terraform-plan` fails there, `infra-passed` aggregates the failure, and since `infra:required` is a required check, a pull request opened from a fork is unmergeable whatever it changes. Everything else is green on all of them: `checks:required`, `build:required`, `check-pr-title:required` and `terraform-check`.

The comment above `on:` already says why there is no paths filter, that a check gated by one never reports and leaves a PR unmergeable. A fork is the same outcome reached the other way, so the note now covers both.

Skipping is the whole fix, because `infra-passed` already reads a skip correctly: it fails on `failure` and `cancelled`, and a skipped job is neither. `terraform-check` keeps running, so a fork's infra changes are still checked for formatting and validity. What a fork does not get is a plan against real state, which is the same sentence as it does not get the role.

This runs from the pull request's own workflow file, so the check on this PR is the test.