### PR TITLE
fix: every outbound call on a request path now has a deadline

### DIFF
--- a/apps/agent/src/lib/proxy/forward.ts
+++ b/apps/agent/src/lib/proxy/forward.ts
@@ -1,5 +1,27 @@
 import type { HttpPort, Ipv4Address } from '@repo/protocol';
-import { Effect } from 'effect';
+import { Data, Duration, Effect } from 'effect';
+
+/**
+ * How long the guest has to begin answering. The answer itself is not under it: what comes back
+ * is streamed on to whoever asked, and a download or an event stream takes as long as the tenant
+ * takes. What is bounded is a guest that accepted the connection and then said nothing — `fetch`
+ * has no deadline of its own, so without this the visitor waits on it forever and so does the
+ * proxy connection they are holding.
+ *
+ * Long, because this is the one request that found no microVM: everything the tenant does lazily
+ * on its first request happens under it, and answering a working app with an error page is worse
+ * than the wait.
+ */
+const ANSWER_TIMEOUT = Duration.seconds(60);
+
+export class GuestDidNotAnswer extends Data.TaggedError('GuestDidNotAnswer')<{
+  readonly guestIpv4: Ipv4Address;
+  readonly httpPort: HttpPort;
+}> {
+  override get message() {
+    return `${this.guestIpv4}:${this.httpPort} took the request that woke it and did not answer within ${Duration.toSeconds(ANSWER_TIMEOUT)}s`;
+  }
+}
 
 /**
  * Headers describing one hop of a connection rather than the message travelling on it. Copying
@@ -51,7 +73,7 @@ export const forwardToGuest = Effect.fn('forwardToGuest')(
     guestIpv4: Ipv4Address;
     httpPort: HttpPort;
   }) =>
-    Effect.tryPromise(async () => {
+    Effect.tryPromise(async (signal) => {
       const target = new URL(request.url);
       target.protocol = 'http:';
       target.hostname = guestIpv4;
@@ -63,6 +85,9 @@ export const forwardToGuest = Effect.fn('forwardToGuest')(
         body: request.body,
         redirect: 'manual',
         duplex: 'half',
+        // Giving up here has to reach the socket too, or the guest goes on being asked for an
+        // answer nobody is waiting for and the connection to it is never released.
+        signal,
       } as RequestInit);
 
       const headers = without({
@@ -71,5 +96,10 @@ export const forwardToGuest = Effect.fn('forwardToGuest')(
       });
       headers.set('connection', 'close');
       return new Response(upstream.body, { status: upstream.status, headers });
-    }),
+    }).pipe(
+      Effect.timeoutFail({
+        duration: ANSWER_TIMEOUT,
+        onTimeout: () => new GuestDidNotAnswer({ guestIpv4, httpPort }),
+      }),
+    ),
 );

--- a/apps/agent/src/services/app-activator.service.ts
+++ b/apps/agent/src/services/app-activator.service.ts
@@ -34,6 +34,13 @@ const sayAppIsDown = () => say('This app is not running.');
 const sayAppWouldNotStart = () => say('This app could not be started.');
 
 /**
+ * Not the sentence above, because the microVM did come up: it took the request and then said
+ * nothing for as long as the forward is willing to wait. An owner told their app would not start
+ * would go and read a boot that worked.
+ */
+const sayAppDidNotAnswer = () => say('This app started but did not answer.');
+
+/**
  * Its own sentence rather than the one above. An app that could not be woken because its host had
  * no memory left is not a broken app, and telling its visitor otherwise would have its owner
  * reading a binary that is fine — while the repair, moving the app, is not something either of
@@ -132,6 +139,11 @@ export class AppActivator extends Effect.Service<AppActivator>()('AppActivator',
         );
         return response;
       }).pipe(
+        Effect.catchTag('GuestDidNotAnswer', (error) =>
+          Effect.logWarning('an app did not answer the request that woke it', error)
+            .pipe(Effect.annotateLogs({ appId }))
+            .pipe(Effect.as(sayAppDidNotAnswer())),
+        ),
         Effect.catchTag('HostHasNoRoom', (error) =>
           Effect.logWarning('a request could not be given an app', error)
             .pipe(Effect.annotateLogs({ appId }))

--- a/apps/agent/tests/lib/proxy/forward.test.ts
+++ b/apps/agent/tests/lib/proxy/forward.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import { HttpPortSchema, Ipv4AddressSchema, Value } from '@repo/protocol';
+import { Duration, Effect, Fiber, TestClock, TestContext } from 'effect';
+import { forwardToGuest, GuestDidNotAnswer } from '#lib/proxy/forward.ts';
+import { runScoped } from '#tests/support/run.ts';
+import { HTTP_OK, serving } from '#tests/support/server.ts';
+
+const LOOPBACK = '127.0.0.1';
+const GUEST_IPV4 = Value.Parse(Ipv4AddressSchema, LOOPBACK);
+const VISITED = 'http://app.example.dev/';
+
+/** Virtual, so the deadline is what the test waits out rather than the test's own patience. */
+const LONGER_THAN_ANY_DEADLINE_MINUTES = 5;
+const LONGER_THAN_ANY_DEADLINE = Duration.minutes(LONGER_THAN_ANY_DEADLINE_MINUTES);
+
+/**
+ * A guest that accepts the connection and answers nothing, which is the one this deadline is for:
+ * a refused connection fails on its own, and only an accepted one waits forever.
+ *
+ * The accept is handed back because the clock here is virtual — moved before the forward had
+ * registered anything against it, it would pass over a deadline nobody was waiting on yet.
+ */
+function silentGuest() {
+  const accepted = Promise.withResolvers<void>();
+  return Effect.map(
+    Effect.acquireRelease(
+      Effect.sync(() =>
+        Bun.listen({
+          hostname: LOOPBACK,
+          port: 0,
+          socket: { open: () => accepted.resolve(), data: () => undefined },
+        }),
+      ),
+      (listener) => Effect.sync(() => listener.stop(true)),
+    ),
+    (listener) => ({
+      httpPort: Value.Parse(HttpPortSchema, listener.port),
+      accepted: Effect.promise(() => accepted.promise),
+    }),
+  );
+}
+
+describe('a guest that took the request that woke it and said nothing is given up on', () => {
+  test('the wait is the deadline rather than however long the guest stays silent', () =>
+    runScoped(
+      Effect.gen(function* () {
+        const guest = yield* silentGuest();
+        const forwarding = yield* Effect.fork(
+          forwardToGuest({
+            request: new Request(VISITED),
+            guestIpv4: GUEST_IPV4,
+            httpPort: guest.httpPort,
+          }),
+        );
+        yield* guest.accepted;
+
+        yield* TestClock.adjust(LONGER_THAN_ANY_DEADLINE);
+
+        const failure = yield* Effect.flip(Fiber.join(forwarding));
+        expect(failure).toBeInstanceOf(GuestDidNotAnswer);
+      }).pipe(Effect.provide(TestContext.TestContext)),
+    ));
+
+  test('and one that does answer is still answered from', () =>
+    runScoped(
+      Effect.gen(function* () {
+        const guest = yield* serving(() => new Response('served by the tenant'));
+
+        const response = yield* forwardToGuest({
+          request: new Request(VISITED),
+          guestIpv4: GUEST_IPV4,
+          httpPort: Value.Parse(HttpPortSchema, guest.port),
+        });
+
+        expect(response.status).toBe(HTTP_OK);
+        expect(yield* Effect.promise(() => response.text())).toBe('served by the tenant');
+      }),
+    ));
+});

--- a/apps/api/src/lib/cloudflare/client.ts
+++ b/apps/api/src/lib/cloudflare/client.ts
@@ -4,6 +4,16 @@ const MAX_ERROR_BODY = 256;
 const HTTP_NOT_FOUND = 404;
 
 /**
+ * How long the edge has to answer one call. `fetch` has no deadline of its own, so an edge that
+ * takes the connection and never answers holds whoever is waiting on it — and somebody is: adding
+ * a hostname makes two of these before its owner is handed the record they have to go and place.
+ *
+ * A call given up on is the case the reconcile pass already finishes, which is why the number can
+ * be this short: a row written with no `cloudflare_id` is attached to the edge on a later pass.
+ */
+const REQUEST_DEADLINE_MS = 10_000;
+
+/**
  * Where Cloudflare answers the challenge on the owner's behalf. They point `_acme-challenge` at
  * this once and the edge renews against it forever, which is the whole reason to prefer it over
  * handing them a TXT value that changes on every issuance.
@@ -117,6 +127,7 @@ export class CloudflareClient {
         ...(body === undefined ? {} : { 'content-type': 'application/json' }),
       },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(REQUEST_DEADLINE_MS),
     });
 
     const text = await response.text();

--- a/apps/api/src/lib/cloudflare/client.ts
+++ b/apps/api/src/lib/cloudflare/client.ts
@@ -5,13 +5,18 @@ const HTTP_NOT_FOUND = 404;
 
 /**
  * How long the edge has to answer one call. `fetch` has no deadline of its own, so an edge that
- * takes the connection and never answers holds whoever is waiting on it — and somebody is: adding
- * a hostname makes two of these before its owner is handed the record they have to go and place.
+ * takes the connection and never answers holds whoever is waiting on it open forever.
  *
- * A call given up on is the case the reconcile pass already finishes, which is why the number can
- * be this short: a row written with no `cloudflare_id` is attached to the edge on a later pass.
+ * It has to expire far enough below the ceiling that adding a hostname fits under it twice over:
+ * that path makes one call to create the hostname and one to read the zone's delegation uuid,
+ * with the owner waiting on the pair, and Bun drops a connection nothing has travelled on for 30s.
+ * A deadline that outlived the connection it answers on would leave them the dropped connection
+ * and no reason for it.
+ *
+ * Short is affordable because a call given up on is the case the reconcile pass already finishes:
+ * a row written with no `cloudflare_id` is attached to the edge on a later one.
  */
-const REQUEST_DEADLINE_MS = 10_000;
+const REQUEST_DEADLINE_MS = 5_000;
 
 /**
  * Where Cloudflare answers the challenge on the owner's behalf. They point `_acme-challenge` at

--- a/apps/api/src/lib/victorialogs/client.ts
+++ b/apps/api/src/lib/victorialogs/client.ts
@@ -9,14 +9,22 @@ const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded';
 const MAX_ERROR_BODY = 256;
 
 /**
- * How long the store has to answer one request. `fetch` has no deadline of its own, so a store
- * that takes the connection and never answers holds the reader waiting on it — and the log stream
- * asks again every second, so it is a wait nobody is watching for.
+ * How long a window has to come back. `fetch` has no deadline of its own, so a store that takes
+ * the connection and never answers holds the reader waiting on it — and the log stream asks again
+ * every second, so it is a wait nobody is watching for.
  *
  * The whole exchange rather than the first byte: what is read after the headers is one window,
  * capped by its own `limit`, and not something anyone follows.
  */
-const REQUEST_DEADLINE_MS = 10_000;
+const QUERY_DEADLINE_MS = 10_000;
+
+/**
+ * Shorter, because the answer is only ever wanted inside a budget that is shorter: health gives
+ * every probe 2s and calls the component down when one overruns it. Left on the window's
+ * deadline the socket would outlive that verdict by the rest of it — on every probe, on every
+ * poll of every open dashboard — which is the wait that budget exists to not have.
+ */
+const HEALTH_DEADLINE_MS = 2_000;
 
 export class VictoriaLogsError extends Error {
   constructor({ status, body }: { status: number; body: string }) {
@@ -30,19 +38,22 @@ export class VictoriaLogsError extends Error {
  *
  * Subclassed per endpoint rather than switched on a path, so what a caller may ask for is what
  * the type offers: `query.run(…)` names the endpoint and what it does in the same phrase,
- * and an endpoint added later inherits the base URL rather than re-deriving it.
+ * and an endpoint added later inherits the base URL rather than re-deriving it. How long it may
+ * take is the endpoint's too — what waits on a window is not what waits on a health probe.
  */
 abstract class VictoriaLogsEndpoint {
   private readonly url: string;
+  private readonly deadlineMs: number;
 
-  constructor({ baseUrl, path }: { baseUrl: URL; path: string }) {
+  constructor({ baseUrl, path, deadlineMs }: { baseUrl: URL; path: string; deadlineMs: number }) {
     this.url = new URL(path, baseUrl).toString();
+    this.deadlineMs = deadlineMs;
   }
 
   protected async send(init: RequestInit): Promise<Response> {
     const response = await fetch(this.url, {
       ...init,
-      signal: AbortSignal.timeout(REQUEST_DEADLINE_MS),
+      signal: AbortSignal.timeout(this.deadlineMs),
     });
     if (!response.ok) {
       throw new VictoriaLogsError({
@@ -85,7 +96,7 @@ export type QueryRequest = {
  */
 export class VictoriaLogsQuery extends VictoriaLogsEndpoint {
   constructor(baseUrl: URL) {
-    super({ baseUrl, path: QUERY_PATH });
+    super({ baseUrl, path: QUERY_PATH, deadlineMs: QUERY_DEADLINE_MS });
   }
 
   async run({ query, start }: QueryRequest): Promise<LogRow[]> {
@@ -110,7 +121,7 @@ export class VictoriaLogsQuery extends VictoriaLogsEndpoint {
  */
 export class VictoriaLogsHealth extends VictoriaLogsEndpoint {
   constructor(baseUrl: URL) {
-    super({ baseUrl, path: HEALTH_PATH });
+    super({ baseUrl, path: HEALTH_PATH, deadlineMs: HEALTH_DEADLINE_MS });
   }
 
   async check(): Promise<void> {

--- a/apps/api/src/lib/victorialogs/client.ts
+++ b/apps/api/src/lib/victorialogs/client.ts
@@ -8,6 +8,16 @@ const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded';
 
 const MAX_ERROR_BODY = 256;
 
+/**
+ * How long the store has to answer one request. `fetch` has no deadline of its own, so a store
+ * that takes the connection and never answers holds the reader waiting on it — and the log stream
+ * asks again every second, so it is a wait nobody is watching for.
+ *
+ * The whole exchange rather than the first byte: what is read after the headers is one window,
+ * capped by its own `limit`, and not something anyone follows.
+ */
+const REQUEST_DEADLINE_MS = 10_000;
+
 export class VictoriaLogsError extends Error {
   constructor({ status, body }: { status: number; body: string }) {
     super(`the log store answered ${status}: ${body}`);
@@ -30,7 +40,10 @@ abstract class VictoriaLogsEndpoint {
   }
 
   protected async send(init: RequestInit): Promise<Response> {
-    const response = await fetch(this.url, init);
+    const response = await fetch(this.url, {
+      ...init,
+      signal: AbortSignal.timeout(REQUEST_DEADLINE_MS),
+    });
     if (!response.ok) {
       throw new VictoriaLogsError({
         status: response.status,
@@ -63,10 +76,12 @@ export type QueryRequest = {
 /**
  * One window of the store, read and finished with.
  *
- * An ordinary request, and nothing here can cancel one. The endpoint that follows a stream instead
- * exists and would need that — it is held open for as long as someone is reading, so abandoning
- * one without saying so leaks it. A window is bounded by its own `limit` and answers in the time a
- * query takes, which is short enough that a reader who has left costs a reply nobody reads.
+ * An ordinary request, and no reader here can cancel one. The endpoint that follows a stream
+ * instead exists and would need that — it is held open for as long as someone is reading, so
+ * abandoning one without saying so leaks it. A window is bounded by its own `limit` and answers in
+ * the time a query takes, which is short enough that a reader who has left costs a reply nobody
+ * reads. A store that answers nothing at all is the other question, and `send`'s deadline is what
+ * bounds that one.
  */
 export class VictoriaLogsQuery extends VictoriaLogsEndpoint {
   constructor(baseUrl: URL) {


### PR DESCRIPTION
Closes #486.

Bun's `fetch` has no deadline of its own, so a peer that accepts the connection and never answers holds the caller open indefinitely. The three call sites the issue names are on a path a visitor or a tenant waits on, and none of them had one.

The forward bounds the guest's *answer*, not the whole exchange — a download or an event stream is still the tenant's to take as long as it takes — and a guest that woke and then went silent gets its own sentence rather than being reported as one that would not start.