### PR TITLE
feat(dashboard): a failed deployment says why above the table it is a row of

### DIFF
--- a/apps/dashboard/src/components/apps/deployment-history.tsx
+++ b/apps/dashboard/src/components/apps/deployment-history.tsx
@@ -9,6 +9,7 @@ import {
 import { Skeleton } from '@repo/ui/components/skeleton';
 import { PackageIcon } from 'lucide-react';
 import { DeploymentsTable } from '#components/apps/deployments-table.tsx';
+import { FailedDeploymentNotice } from '#components/apps/failed-deployment-notice.tsx';
 import { FailureEmpty } from '#components/failure-empty.tsx';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
 import { useDeployments } from '#lib/hooks/use-deployments.ts';
@@ -25,7 +26,8 @@ export function DeploymentHistory() {
       <FailureEmpty title="Could not read the deployments" reason={deployments.error.message} />
     );
   }
-  if (deployments.data.length === 0) {
+  const newest = deployments.data[0];
+  if (newest === undefined) {
     return (
       <Empty className="border">
         <EmptyHeader>
@@ -47,6 +49,11 @@ export function DeploymentHistory() {
         <CardTitle>Deployments</CardTitle>
       </CardHeader>
       <CardContent className="px-0 pb-0">
+        {newest.state === 'failed' && (
+          <div className="px-4 pb-4">
+            <FailedDeploymentNotice deployment={newest} />
+          </div>
+        )}
         <DeploymentsTable deployments={deployments.data} />
       </CardContent>
     </Card>

--- a/apps/dashboard/src/components/apps/failed-deployment-notice.tsx
+++ b/apps/dashboard/src/components/apps/failed-deployment-notice.tsx
@@ -21,7 +21,7 @@ export function FailedDeploymentNotice({ deployment }: { deployment: DeploymentS
           search={{ timerange: DEFAULT_LOG_TIMERANGE }}
           className="font-medium underline underline-offset-4"
         >
-          The logs say more
+          Your logs may have more details
         </Link>
         .
       </span>

--- a/apps/dashboard/src/components/apps/failed-deployment-notice.tsx
+++ b/apps/dashboard/src/components/apps/failed-deployment-notice.tsx
@@ -1,0 +1,30 @@
+import { DEFAULT_LOG_TIMERANGE } from '@repo/protocol';
+import { Link } from '@tanstack/react-router';
+import { TriangleAlertIcon } from 'lucide-react';
+import { useAppId } from '#lib/hooks/use-app-id.ts';
+import type { DeploymentSummary } from '#queries/deployments.ts';
+import { Route as LogsRoute } from '#routes/(dashboard)/apps/$appId/logs.tsx';
+
+const UNEXPLAINED = 'It failed without saying why.';
+
+export function FailedDeploymentNotice({ deployment }: { deployment: DeploymentSummary }) {
+  const appId = useAppId();
+
+  return (
+    <p className="flex items-start gap-2 rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
+      <TriangleAlertIcon className="mt-0.5 size-4 shrink-0" />
+      <span className="wrap-anywhere">
+        {deployment.message ?? UNEXPLAINED}{' '}
+        <Link
+          to={LogsRoute.to}
+          params={{ appId }}
+          search={{ timerange: DEFAULT_LOG_TIMERANGE }}
+          className="font-medium underline underline-offset-4"
+        >
+          The logs say more
+        </Link>
+        .
+      </span>
+    </p>
+  );
+}


### PR DESCRIPTION
When the newest deployment is `failed`, its message now sits above the deployments table, with a link to the logs. Until now the reason was only behind a click on the state badge — a place to look for a reader who already suspects something is wrong.