### PR TITLE
fix(agent): one build per digest, so two callers cannot pack a half written binary into the cache

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -8,6 +8,7 @@ import { AgentSessionHolder } from '#services/agent-session-holder.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { AppActivator } from '#services/app-activator.service.ts';
 import { AppWaker } from '#services/app-waker.service.ts';
+import { ArtifactImages } from '#services/artifact-images.service.ts';
 import { ArtifactStore } from '#services/artifact-store.service.ts';
 import { CaddyProxy } from '#services/caddy-proxy.service.ts';
 import { CommandRunner } from '#services/command-runner.service.ts';
@@ -44,6 +45,7 @@ const agent = Layer.mergeAll(
   ControlPlane.Default,
   LogStore.Default,
   ArtifactStore.Default,
+  ArtifactImages.Default,
   SlotAllocator.Default,
   ZerofsTopology.Default,
   HostFirewall.Default,

--- a/apps/agent/src/lib/reconcile/instances.ts
+++ b/apps/agent/src/lib/reconcile/instances.ts
@@ -27,11 +27,11 @@ import {
   NO_START_ATTEMPTS,
   newInstanceRecord,
 } from '#lib/report/instance-record.ts';
-import { ensureArtifactImage } from '#lib/vm/artifacts.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { UNKNOWN_UNIT, type UnitStatus } from '#lib/vm/unit-status.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
+import { ArtifactImages } from '#services/artifact-images.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
 import { VmManager } from '#services/vm-manager.service.ts';
@@ -250,8 +250,8 @@ function isStartable({
 }
 
 /**
- * One entry per digest: two apps deploying the same bytes share the image, and fetching it
- * twice at once would have them race for the same staging directory.
+ * One entry per digest: two apps deploying the same bytes share the image, so a batch that named
+ * it twice would only be two fibers joining one build and two warnings for one failed fetch.
  */
 function artifactsToStart(plan: ReconcilePlan) {
   return new Map(
@@ -271,20 +271,19 @@ function artifactsToStart(plan: ReconcilePlan) {
  * Best-effort: `startInstance` asks for the same image and is the one that reports a fetch that
  * could not be made, so a failure here is only a head start that was not taken.
  */
-export const prefetchArtifacts = Effect.fn('prefetchArtifacts')((plan: ReconcilePlan) =>
-  Effect.forEach(
+export const prefetchArtifacts = Effect.fn('prefetchArtifacts')(function* (plan: ReconcilePlan) {
+  const images = yield* ArtifactImages;
+  yield* Effect.forEach(
     artifactsToStart(plan),
     (artifact) =>
-      ensureArtifactImage(artifact).pipe(
-        Effect.catchAll((error) =>
-          Effect.logWarning('artifact prefetch failed', error).pipe(
-            Effect.annotateLogs({ digest: artifact.digest }),
-          ),
+      Effect.catchAll(images.ensure(artifact), (error) =>
+        Effect.logWarning('artifact prefetch failed', error).pipe(
+          Effect.annotateLogs({ digest: artifact.digest }),
         ),
       ),
     { discard: true, concurrency: 'unbounded' },
-  ),
-);
+  );
+});
 
 /**
  * What desired state says about an app, as the record's own fields. Named once because a start

--- a/apps/agent/src/lib/vm/artifacts.ts
+++ b/apps/agent/src/lib/vm/artifacts.ts
@@ -1,48 +1,12 @@
-import { FileSystem, Path } from '@effect/platform';
+import { FileSystem, type Path } from '@effect/platform';
 import type { DesiredArtifact, Sha256Digest } from '@repo/protocol';
-import { Data, Duration, Effect, Ref, Stream } from 'effect';
-import { AgentConfig } from '#services/agent-config.service.ts';
-import { stdoutOf } from '#services/command-runner.service.ts';
+import { Data, Effect, Ref, Stream } from 'effect';
 
 const DIGEST_ALGORITHM = 'sha256';
 const HEX_ENCODING = 'hex';
-const SQUASHFS_FILENAME = 'artifact.squashfs';
-/**
- * Stored rather than compressed. The image is built once per digest on the path a deploy waits
- * on and is read back off a local disk by one guest, so nothing here crosses a network and the
- * compressor was only ever spending a deploy's seconds to save a host's disk.
- *
- * Level 1 was already the fastest setting worth having — `squashfs-tools` on the host image
- * carries gzip, lzma and lzo only, lzo measures slower than gzip at every level, and a larger
- * block size moves neither. There is nothing left to tune, only the compression itself to drop:
- * on a 78.7 MiB release binary level 1 measured 718ms of the 3.8s that deploy took.
- *
- * What it costs is the image, which roughly doubles — a 78.7 MiB binary goes from 39.8 MiB to
- * 80.8 MiB — and `artifactCacheDir` is never swept, so a long-lived host accumulates twice what
- * it did. Bounding that is worth doing on its own; the cache is only ever a copy of what the
- * bucket still holds, so anything evicted costs a re-fetch and nothing else.
- *
- * The superblock still names gzip, because nothing here is what makes it uncompressed: a guest
- * mounts one of these exactly as it mounts the ones every host already holds.
- */
-const SQUASHFS_STORE_UNCOMPRESSED = ['-noI', '-noD', '-noF', '-noX'];
-/**
- * What gets squashed, one level inside the staging directory rather than being it.
- *
- * mksquashfs writes its output beside its input and never into it, so the two cannot be the same
- * directory — and while the image was a *sibling* of the staging directory, the release below
- * removed the directory and left the image. Every way a build can end between mksquashfs and the
- * rename then leaked one, and only a later build of the same digest ever cleared it.
- *
- * Nesting both under one directory is what makes that unleakable rather than remembered: there is
- * a single path to remove, and it is the one already being removed.
- */
-const STAGED_SOURCE_DIRNAME = 'source';
-/** The path the guest's init execs, fixed by the boot contract. */
-const GUEST_BINARY_NAME = 'server';
+export const SQUASHFS_FILENAME = 'artifact.squashfs';
 /** What a binary has to be to be one, wherever it lands — the guest's squashfs or an export. */
 export const BINARY_MODE = 0o755;
-const CACHE_DIR_MODE = 0o755;
 
 export class DigestMismatch extends Data.TaggedError('DigestMismatch')<{
   readonly expected: Sha256Digest;
@@ -125,74 +89,4 @@ export const downloadAndVerify = Effect.fn('downloadAndVerify')(function* ({
     yield* fs.remove(destination, { force: true }).pipe(Effect.ignore);
     return yield* mismatch;
   }
-});
-
-/** The read-only squashfs the guest attaches as `vdb`, built if this host has not seen the digest. */
-export const ensureArtifactImage = Effect.fn('ensureArtifactImage')(function* (
-  artifact: DesiredArtifact,
-) {
-  yield* Effect.annotateCurrentSpan({ digest: artifact.digest });
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const config = yield* AgentConfig;
-  const cacheDir = config.artifactCacheDir;
-  const imagePath = artifactImagePath({ cacheDir, digest: artifact.digest, path });
-  if (yield* fs.exists(imagePath)) {
-    // Marks it used, which is the whole of what `sweepArtifactCache` orders by. Left alone the
-    // timestamp says when the image was *built*, so the digest this host starts every day would
-    // be evicted ahead of one fetched once last week and never wanted again. Ignored on failure:
-    // a cache entry that cannot be touched is one that ages, not one that fails a deploy.
-    yield* Effect.ignore(fs.utimes(imagePath, new Date(), new Date()));
-    return imagePath;
-  }
-
-  const stagingDir = path.join(cacheDir, `.staging-${artifact.digest}`);
-  const stagedSource = path.join(stagingDir, STAGED_SOURCE_DIRNAME);
-  const stagedImage = path.join(stagingDir, SQUASHFS_FILENAME);
-  return yield* Effect.acquireUseRelease(
-    fs
-      .remove(stagingDir, { recursive: true, force: true })
-      .pipe(
-        Effect.andThen(fs.makeDirectory(stagedSource, { recursive: true, mode: CACHE_DIR_MODE })),
-      ),
-    () =>
-      Effect.gen(function* () {
-        const binaryPath = path.join(stagedSource, GUEST_BINARY_NAME);
-        const [fetching] = yield* Effect.timed(
-          downloadAndVerify({ artifact, destination: binaryPath }),
-        );
-        yield* fs.chmod(binaryPath, BINARY_MODE);
-        const [packing] = yield* Effect.timed(
-          stdoutOf({
-            command: [
-              'mksquashfs',
-              stagedSource,
-              stagedImage,
-              '-no-progress',
-              '-noappend',
-              ...SQUASHFS_STORE_UNCOMPRESSED,
-            ],
-          }),
-        );
-        yield* fs.makeDirectory(path.dirname(imagePath), {
-          recursive: true,
-          mode: CACHE_DIR_MODE,
-        });
-        yield* fs.rename(stagedImage, imagePath);
-        // Only where the image was built, which is the only time it cost anything: a host that
-        // already holds the digest returns above and has nothing to say. The two halves are
-        // apart because they answer to different things — the transfer to the bucket and the
-        // size of the release, the compression to what this host's CPU is doing.
-        yield* Effect.logInfo('artifact image built').pipe(
-          Effect.annotateLogs({
-            digest: artifact.digest,
-            sizeBytes: artifact.sizeBytes,
-            fetchMs: Duration.toMillis(fetching),
-            packMs: Duration.toMillis(packing),
-          }),
-        );
-        return imagePath;
-      }),
-    () => fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),
-  );
 });

--- a/apps/agent/src/services/app-waker.service.ts
+++ b/apps/agent/src/services/app-waker.service.ts
@@ -12,7 +12,6 @@ import {
 import type { InstanceRecord } from '#lib/report/instance-record.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
-import { ArtifactStore } from '#services/artifact-store.service.ts';
 import { CommandRunner } from '#services/command-runner.service.ts';
 import { DesiredStateCache } from '#services/desired-state-cache.service.ts';
 import { RefreshSignal } from '#services/refresh-signal.service.ts';
@@ -247,7 +246,6 @@ export class AppWaker extends Effect.Service<AppWaker>()('AppWaker', {
   dependencies: [
     AgentConfig.Default,
     AgentState.Default,
-    ArtifactStore.Default,
     CommandRunner.Default,
     DesiredStateCache.Default,
     RefreshSignal.Default,

--- a/apps/agent/src/services/artifact-images.service.ts
+++ b/apps/agent/src/services/artifact-images.service.ts
@@ -1,0 +1,176 @@
+import { FileSystem, Path } from '@effect/platform';
+import type { DesiredArtifact, Sha256Digest } from '@repo/protocol';
+import { Deferred, Duration, Effect, Option, Ref } from 'effect';
+import {
+  artifactImagePath,
+  BINARY_MODE,
+  downloadAndVerify,
+  SQUASHFS_FILENAME,
+} from '#lib/vm/artifacts.ts';
+import { AgentConfig } from '#services/agent-config.service.ts';
+import { ArtifactStore } from '#services/artifact-store.service.ts';
+import { CommandRunner, stdoutOf } from '#services/command-runner.service.ts';
+
+/**
+ * Stored rather than compressed. The image is built once per digest on the path a deploy waits
+ * on and is read back off a local disk by one guest, so nothing here crosses a network and the
+ * compressor was only ever spending a deploy's seconds to save a host's disk.
+ *
+ * Level 1 was already the fastest setting worth having — `squashfs-tools` on the host image
+ * carries gzip, lzma and lzo only, lzo measures slower than gzip at every level, and a larger
+ * block size moves neither. There is nothing left to tune, only the compression itself to drop:
+ * on a 78.7 MiB release binary level 1 measured 718ms of the 3.8s that deploy took.
+ *
+ * What it costs is the image, which roughly doubles — a 78.7 MiB binary goes from 39.8 MiB to
+ * 80.8 MiB — and `artifactCacheDir` is never swept, so a long-lived host accumulates twice what
+ * it did. Bounding that is worth doing on its own; the cache is only ever a copy of what the
+ * bucket still holds, so anything evicted costs a re-fetch and nothing else.
+ *
+ * The superblock still names gzip, because nothing here is what makes it uncompressed: a guest
+ * mounts one of these exactly as it mounts the ones every host already holds.
+ */
+const SQUASHFS_STORE_UNCOMPRESSED = ['-noI', '-noD', '-noF', '-noX'];
+/**
+ * What gets squashed, one level inside the staging directory rather than being it.
+ *
+ * mksquashfs writes its output beside its input and never into it, so the two cannot be the same
+ * directory — and while the image was a *sibling* of the staging directory, the release below
+ * removed the directory and left the image. Every way a build can end between mksquashfs and the
+ * rename then leaked one, and only a later build of the same digest ever cleared it.
+ *
+ * Nesting both under one directory is what makes that unleakable rather than remembered: there is
+ * a single path to remove, and it is the one already being removed.
+ */
+const STAGED_SOURCE_DIRNAME = 'source';
+/** The path the guest's init execs, fixed by the boot contract. */
+const GUEST_BINARY_NAME = 'server';
+const CACHE_DIR_MODE = 0o755;
+
+/** The read-only squashfs the guest attaches as `vdb`, built if this host has not seen the digest. */
+const imageFor = Effect.fn('ArtifactImages.imageFor')(function* (artifact: DesiredArtifact) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const config = yield* AgentConfig;
+  const cacheDir = config.artifactCacheDir;
+  const imagePath = artifactImagePath({ cacheDir, digest: artifact.digest, path });
+  if (yield* fs.exists(imagePath)) {
+    // Marks it used, which is the whole of what `sweepArtifactCache` orders by. Left alone the
+    // timestamp says when the image was *built*, so the digest this host starts every day would
+    // be evicted ahead of one fetched once last week and never wanted again. Ignored on failure:
+    // a cache entry that cannot be touched is one that ages, not one that fails a deploy.
+    yield* Effect.ignore(fs.utimes(imagePath, new Date(), new Date()));
+    return imagePath;
+  }
+
+  const stagingDir = path.join(cacheDir, `.staging-${artifact.digest}`);
+  const stagedSource = path.join(stagingDir, STAGED_SOURCE_DIRNAME);
+  const stagedImage = path.join(stagingDir, SQUASHFS_FILENAME);
+  return yield* Effect.acquireUseRelease(
+    fs
+      .remove(stagingDir, { recursive: true, force: true })
+      .pipe(
+        Effect.andThen(fs.makeDirectory(stagedSource, { recursive: true, mode: CACHE_DIR_MODE })),
+      ),
+    () =>
+      Effect.gen(function* () {
+        const binaryPath = path.join(stagedSource, GUEST_BINARY_NAME);
+        const [fetching] = yield* Effect.timed(
+          downloadAndVerify({ artifact, destination: binaryPath }),
+        );
+        yield* fs.chmod(binaryPath, BINARY_MODE);
+        const [packing] = yield* Effect.timed(
+          stdoutOf({
+            command: [
+              'mksquashfs',
+              stagedSource,
+              stagedImage,
+              '-no-progress',
+              '-noappend',
+              ...SQUASHFS_STORE_UNCOMPRESSED,
+            ],
+          }),
+        );
+        yield* fs.makeDirectory(path.dirname(imagePath), {
+          recursive: true,
+          mode: CACHE_DIR_MODE,
+        });
+        yield* fs.rename(stagedImage, imagePath);
+        // Only where the image was built, which is the only time it cost anything: a host that
+        // already holds the digest returns above and has nothing to say. The two halves are
+        // apart because they answer to different things — the transfer to the bucket and the
+        // size of the release, the compression to what this host's CPU is doing.
+        yield* Effect.logInfo('artifact image built').pipe(
+          Effect.annotateLogs({
+            digest: artifact.digest,
+            sizeBytes: artifact.sizeBytes,
+            fetchMs: Duration.toMillis(fetching),
+            packMs: Duration.toMillis(packing),
+          }),
+        );
+        return imagePath;
+      }),
+    () => fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),
+  );
+});
+
+type ImagePath = Effect.Effect.Success<ReturnType<typeof imageFor>>;
+type BuildFailure = Effect.Effect.Error<ReturnType<typeof imageFor>>;
+type BuildContext = Effect.Effect.Context<ReturnType<typeof imageFor>>;
+type Building = Deferred.Deferred<ImagePath, BuildFailure>;
+
+/**
+ * The one way to a digest's image on this host, and one build of it at a time for the process.
+ *
+ * The staging directory is named by the digest alone, which is what makes a build killed halfway
+ * self-healing — the next build of those bytes removes what the last one left, and
+ * `artifact-cache.ts` sweeps digest directories and never `.staging-*`. It also means two builds
+ * of one digest share a directory: the second's acquire removes the tree the first is still
+ * downloading into, and the first writes on through unlinked handles while `chmod` and
+ * `mksquashfs` re-resolve the shared path onto whatever the second has written so far. The digest
+ * is checked against the download rather than against the packed image, so a squashfs built over
+ * half a binary is renamed into the cache and every app that references that digest boots it.
+ *
+ * Nothing else serialises those callers: the reconcile loop prefetches on its own fiber while a
+ * wake cold-boots on the request fiber that asked for it. Joining the build in flight rather than
+ * racing it is what lets the staging name stay fixed, and costs the second caller nothing it was
+ * not already going to wait for.
+ *
+ * The first caller in owns the build, as in `AppWaker.wake`, so an interrupt reaches its joiners.
+ */
+export class ArtifactImages extends Effect.Service<ArtifactImages>()('ArtifactImages', {
+  effect: Effect.gen(function* () {
+    const context = yield* Effect.context<BuildContext>();
+    const building = yield* Ref.make(new Map<Sha256Digest, Building>());
+
+    return {
+      ensure: Effect.fn('ArtifactImages.ensure')(function* (artifact: DesiredArtifact) {
+        yield* Effect.annotateCurrentSpan({ digest: artifact.digest });
+        const claim = yield* Deferred.make<ImagePath, BuildFailure>();
+        const held = yield* Ref.modify(building, (current) => {
+          const existing = current.get(artifact.digest);
+          return existing
+            ? ([Option.some(existing), current] as const)
+            : ([Option.none<Building>(), new Map(current).set(artifact.digest, claim)] as const);
+        });
+        if (Option.isSome(held)) {
+          return yield* Deferred.await(held.value);
+        }
+        return yield* imageFor(artifact).pipe(
+          Effect.provide(context),
+          Effect.onExit((exit) =>
+            Deferred.done(claim, exit).pipe(
+              Effect.andThen(
+                Ref.update(building, (current) => {
+                  const remaining = new Map(current);
+                  remaining.delete(artifact.digest);
+                  return remaining;
+                }),
+              ),
+            ),
+          ),
+        );
+      }),
+    };
+  }),
+  dependencies: [AgentConfig.Default, ArtifactStore.Default, CommandRunner.Default],
+}) {}

--- a/apps/agent/src/services/vm-manager.service.ts
+++ b/apps/agent/src/services/vm-manager.service.ts
@@ -7,7 +7,6 @@ import type { AppSlot } from '#lib/network/slot.ts';
 import { ensureTap, refreshNeighbour } from '#lib/network/tap.ts';
 import { readFilesystemSpace } from '#lib/report/capacity.ts';
 import { readHostVersions } from '#lib/report/versions.ts';
-import * as Artifacts from '#lib/vm/artifacts.ts';
 import * as Firecracker from '#lib/vm/firecracker-api.ts';
 import { renderFirecrackerConfig } from '#lib/vm/firecracker-config.ts';
 import { buildInstanceConfigImage } from '#lib/vm/instance-env.ts';
@@ -29,6 +28,7 @@ import { GUEST_VSOCK_FILENAME, vmWorkingDir } from '#lib/vm/vsock.ts';
 import { readCacheDiskBytes } from '#lib/volumes/zerofs.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
+import { ArtifactImages } from '#services/artifact-images.service.ts';
 import { TenantLogReceiver } from '#services/tenant-log-receiver.service.ts';
 import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
 
@@ -51,6 +51,7 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
     const config = yield* AgentConfig;
     const path = yield* Path.Path;
     const fs = yield* FileSystem.FileSystem;
+    const images = yield* ArtifactImages;
     const logs = yield* TenantLogReceiver;
     const zerofs = yield* ZerofsTopology;
     const agentState = yield* AgentState;
@@ -211,9 +212,7 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
       // taken against — and a start that still found a stamp would restore the old guest onto
       // the new deployment's disk rather than boot the new one.
       yield* discardSnapshot(desired.appId);
-      const [fetching, artifactImagePath] = yield* Effect.timed(
-        Artifacts.ensureArtifactImage(desired.artifact),
-      );
+      const [fetching, artifactImagePath] = yield* Effect.timed(images.ensure(desired.artifact));
       const [staging] = yield* Effect.timed(
         stage({ desired, slot, dataDevicePath, artifactImagePath }),
       );
@@ -446,6 +445,7 @@ export class VmManager extends Effect.Service<VmManager>()('VmManager', {
   dependencies: [
     AgentConfig.Default,
     AgentState.Default,
+    ArtifactImages.Default,
     TenantLogReceiver.Default,
     ZerofsTopology.Default,
   ],

--- a/apps/agent/tests/lib/reconcile/instances.test.ts
+++ b/apps/agent/tests/lib/reconcile/instances.test.ts
@@ -4,7 +4,6 @@ import { Deferred, Effect, Fiber, Layer } from 'effect';
 import { refreshStates, resumeInstance, suspendInstance } from '#lib/reconcile/instances.ts';
 import { SleepRefused, SnapshotUnusable } from '#lib/vm/snapshot.ts';
 import { AgentState } from '#services/agent-state.service.ts';
-import { ArtifactStore, ArtifactTransferError } from '#services/artifact-store.service.ts';
 import { CommandRunner } from '#services/command-runner.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
@@ -206,17 +205,6 @@ function recordingVms({
   };
 }
 
-/**
- * A stubbed `VmManager` still asks for what a real boot would fetch, so this stands in for the
- * bucket the artifact would come from. Reaching it is the failure: nothing here boots anything.
- */
-const noArtifacts = Layer.succeed(
-  ArtifactStore,
-  ArtifactStore.make({
-    open: () => new ArtifactTransferError({ cause: 'no artifact store in a test' }),
-  }),
-);
-
 function onHost({ vms, unit }: { vms: ReturnType<typeof recordingVms>; unit: string }) {
   const host = Layer.mergeAll(
     agentConfig({ vmDir: VM_DIR }),
@@ -228,7 +216,6 @@ function onHost({ vms, unit }: { vms: ReturnType<typeof recordingVms>; unit: str
       ReportSignal.Default,
       SlotAllocator.DefaultWithoutDependencies,
       ZerofsTopology.DefaultWithoutDependencies,
-      noArtifacts,
       vms.layer,
     ).pipe(Layer.provideMerge(host), Layer.provideMerge(platform)),
   );

--- a/apps/agent/tests/lib/vm/artifacts.test.ts
+++ b/apps/agent/tests/lib/vm/artifacts.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { FileSystem, Path } from '@effect/platform';
+import { Path } from '@effect/platform';
 import { BunPath } from '@effect/platform-bun';
 import { type DesiredArtifact, Sha256DigestSchema, Value } from '@repo/protocol';
-import { Effect, Either, Layer } from 'effect';
-import { artifactImagePath, downloadAndVerify, ensureArtifactImage } from '#lib/vm/artifacts.ts';
+import { Effect, Either } from 'effect';
+import { artifactImagePath, downloadAndVerify } from '#lib/vm/artifacts.ts';
 import { ARTIFACT_BYTES, ARTIFACT_DIGEST, artifactStore } from '#tests/support/artifacts.ts';
-import { recordingCommands } from '#tests/support/commands.ts';
-import { agentConfig } from '#tests/support/config.ts';
 import { artifact } from '#tests/support/fixtures.ts';
 import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
 
@@ -90,58 +88,4 @@ test('the cache path depends only on the digest, so a redeploy of the same bytes
   expect(artifactImagePath({ cacheDir: CACHE_DIR, digest: ARTIFACT_DIGEST, path })).toBe(
     `${CACHE_DIR}/${ARTIFACT_DIGEST}/artifact.squashfs`,
   );
-});
-
-/**
- * mksquashfs as it behaves when it fails: the output file exists by the time it gives up, which
- * is what used to be left in the cache. `command[2]` is the destination it was asked to write.
- */
-const DESTINATION_ARGUMENT = 2;
-
-function mksquashfsThat({ code }: { code: number }) {
-  return recordingCommands((request) =>
-    Effect.promise(async () => {
-      await Bun.write(request.command[DESTINATION_ARGUMENT] ?? '', 'a squashfs image');
-      return { code, stdout: '', stderr: '' };
-    }),
-  );
-}
-
-function buildingInto({ code }: { code: number }) {
-  return Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const cacheDir = yield* temporaryDirectory;
-    const result = yield* Effect.either(
-      Effect.provide(
-        ensureArtifactImage(artifact()),
-        Layer.mergeAll(
-          agentConfig({ artifactCacheDir: cacheDir }),
-          artifactStore(),
-          mksquashfsThat({ code }).layer,
-        ),
-      ),
-    );
-    return { result, entries: yield* fs.readDirectory(cacheDir) };
-  });
-}
-
-const MKFS_FAILED = 1;
-const MKFS_OK = 0;
-
-describe('a build leaves the cache holding finished images and nothing else', () => {
-  // Every way a build can end between mksquashfs and the rename used to leave the image behind,
-  // and only a later build of the same digest ever cleared it.
-  test('one that fails after writing its image leaves nothing at all', async () => {
-    const { result, entries } = await run(buildingInto({ code: MKFS_FAILED }));
-
-    expect(Either.isLeft(result)).toBe(true);
-    expect(entries).toEqual([]);
-  });
-
-  test('one that succeeds leaves the image under its digest and no staging beside it', async () => {
-    const { result, entries } = await run(buildingInto({ code: MKFS_OK }));
-
-    expect(Either.isRight(result)).toBe(true);
-    expect(entries).toEqual([ARTIFACT_DIGEST]);
-  });
 });

--- a/apps/agent/tests/services/artifact-images.test.ts
+++ b/apps/agent/tests/services/artifact-images.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from 'bun:test';
+import { FileSystem } from '@effect/platform';
+import { Deferred, Duration, Effect, Either, Fiber, Layer, Ref, Schedule } from 'effect';
+import { ArtifactImages } from '#services/artifact-images.service.ts';
+import { ArtifactStore, ArtifactTransferError } from '#services/artifact-store.service.ts';
+import type { CommandRunner } from '#services/command-runner.service.ts';
+import { ARTIFACT_BYTES, ARTIFACT_DIGEST, artifactStore } from '#tests/support/artifacts.ts';
+import { recordingCommands } from '#tests/support/commands.ts';
+import { agentConfig } from '#tests/support/config.ts';
+import { artifact } from '#tests/support/fixtures.ts';
+import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
+
+const run = provided(platform);
+
+/**
+ * mksquashfs as it behaves when it fails: the output file exists by the time it gives up, which
+ * is what used to be left in the cache. `command[2]` is the destination it was asked to write.
+ */
+const DESTINATION_ARGUMENT = 2;
+
+const MKFS_FAILED = 1;
+const MKFS_OK = 0;
+
+const ONE_BUILD = 1;
+const NOT_STARTED = 0;
+const FIRST_ATTEMPT = 1;
+const POLL_INTERVAL = Duration.millis(1);
+
+function mksquashfsThat({ code }: { code: number }) {
+  return recordingCommands((request) =>
+    Effect.promise(async () => {
+      await Bun.write(request.command[DESTINATION_ARGUMENT] ?? '', 'a squashfs image');
+      return { code, stdout: '', stderr: '' };
+    }),
+  );
+}
+
+function artifactBytes() {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(ARTIFACT_BYTES);
+      controller.close();
+    },
+  });
+}
+
+/** The bucket as a build in flight: it counts its callers and hands out nothing until released. */
+function heldStore({
+  opens,
+  released,
+}: {
+  opens: Ref.Ref<number>;
+  released: Deferred.Deferred<void>;
+}) {
+  return Layer.succeed(
+    ArtifactStore,
+    ArtifactStore.make({
+      open: () =>
+        Ref.update(opens, (started) => started + 1).pipe(
+          Effect.andThen(Deferred.await(released)),
+          Effect.map(artifactBytes),
+        ),
+    }),
+  );
+}
+
+/** A bucket that is unreachable exactly once, so what a failed build left behind is visible. */
+function unreachableOnceStore(opens: Ref.Ref<number>) {
+  return Layer.succeed(
+    ArtifactStore,
+    ArtifactStore.make({
+      open: () =>
+        Ref.updateAndGet(opens, (started) => started + 1).pipe(
+          Effect.flatMap((attempt) =>
+            attempt === FIRST_ATTEMPT
+              ? Effect.fail(new ArtifactTransferError({ cause: 'the bucket was unreachable' }))
+              : Effect.sync(artifactBytes),
+          ),
+        ),
+    }),
+  );
+}
+
+function imagesOver(host: Layer.Layer<ArtifactStore | CommandRunner>) {
+  return Effect.gen(function* () {
+    const cacheDir = yield* temporaryDirectory;
+    return {
+      cacheDir,
+      layer: ArtifactImages.DefaultWithoutDependencies.pipe(
+        Layer.provide(Layer.merge(agentConfig({ artifactCacheDir: cacheDir }), host)),
+      ),
+    };
+  });
+}
+
+const ensuring = Effect.flatMap(ArtifactImages, (images) => images.ensure(artifact()));
+
+function buildingInto({ code }: { code: number }) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const commands = mksquashfsThat({ code });
+    const { cacheDir, layer } = yield* imagesOver(Layer.merge(artifactStore(), commands.layer));
+    const result = yield* Effect.either(Effect.provide(ensuring, layer));
+    return { result, entries: yield* fs.readDirectory(cacheDir) };
+  });
+}
+
+describe('a build leaves the cache holding finished images and nothing else', () => {
+  // Every way a build can end between mksquashfs and the rename used to leave the image behind,
+  // and only a later build of the same digest ever cleared it.
+  test('one that fails after writing its image leaves nothing at all', async () => {
+    const { result, entries } = await run(buildingInto({ code: MKFS_FAILED }));
+
+    expect(Either.isLeft(result)).toBe(true);
+    expect(entries).toEqual([]);
+  });
+
+  test('one that succeeds leaves the image under its digest and no staging beside it', async () => {
+    const { result, entries } = await run(buildingInto({ code: MKFS_OK }));
+
+    expect(Either.isRight(result)).toBe(true);
+    expect(entries).toEqual([ARTIFACT_DIGEST]);
+  });
+});
+
+/** Racing here means one caller's acquire removing the directory the other is downloading into. */
+const racingBuilds = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const opens = yield* Ref.make(NOT_STARTED);
+  const released = yield* Deferred.make<void>();
+  const commands = mksquashfsThat({ code: MKFS_OK });
+  const { cacheDir, layer } = yield* imagesOver(
+    Layer.merge(heldStore({ opens, released }), commands.layer),
+  );
+
+  const paths = yield* Effect.provide(
+    Effect.gen(function* () {
+      const first = yield* Effect.fork(ensuring);
+      // The second caller arrives only once the first is downloading, which is the window the
+      // shared `.staging-<digest>` name made destructive.
+      yield* Effect.repeat(Ref.get(opens), {
+        schedule: Schedule.spaced(POLL_INTERVAL),
+        until: (started) => started > NOT_STARTED,
+      });
+      const second = yield* Effect.fork(ensuring);
+      yield* Deferred.succeed(released, undefined);
+      return [yield* Fiber.join(first), yield* Fiber.join(second)] as const;
+    }),
+    layer,
+  );
+
+  return {
+    paths,
+    opens: yield* Ref.get(opens),
+    packed: commands.commands.length,
+    entries: yield* fs.readDirectory(cacheDir),
+  };
+});
+
+describe('one digest is built once for the process, not once per caller', () => {
+  test('a second caller joins the build in flight instead of racing it', async () => {
+    const { paths, opens, packed, entries } = await run(racingBuilds);
+
+    expect(opens).toBe(ONE_BUILD);
+    expect(packed).toBe(ONE_BUILD);
+    expect(paths[0]).toBe(paths[1]);
+    expect(entries).toEqual([ARTIFACT_DIGEST]);
+  });
+
+  test('a build that fails leaves the digest buildable rather than holding its failure', async () => {
+    const { failed, retried, opens } = await run(
+      Effect.gen(function* () {
+        const opens = yield* Ref.make(NOT_STARTED);
+        const commands = mksquashfsThat({ code: MKFS_OK });
+        const { layer } = yield* imagesOver(
+          Layer.merge(unreachableOnceStore(opens), commands.layer),
+        );
+        return yield* Effect.provide(
+          Effect.gen(function* () {
+            const failed = yield* Effect.either(ensuring);
+            const retried = yield* Effect.either(ensuring);
+            return { failed, retried, opens: yield* Ref.get(opens) };
+          }),
+          layer,
+        );
+      }),
+    );
+
+    expect(Either.isLeft(failed)).toBe(true);
+    expect(Either.isRight(retried)).toBe(true);
+    expect(opens).toBe(FIRST_ATTEMPT + ONE_BUILD);
+  });
+});

--- a/apps/agent/tests/services/vm-manager.test.ts
+++ b/apps/agent/tests/services/vm-manager.test.ts
@@ -6,6 +6,8 @@ import { writeJsonFile } from '#lib/json-store.ts';
 import { describeSlot, FIRST_SLOT } from '#lib/network/slot.ts';
 import { type SnapshotStamp, snapshotPaths } from '#lib/vm/snapshot.ts';
 import { AgentState } from '#services/agent-state.service.ts';
+import { ArtifactImages } from '#services/artifact-images.service.ts';
+import { ArtifactTransferError } from '#services/artifact-store.service.ts';
 import { TenantLogReceiver } from '#services/tenant-log-receiver.service.ts';
 import { VmManager } from '#services/vm-manager.service.ts';
 import { ZerofsTopology } from '#services/zerofs-topology.service.ts';
@@ -50,6 +52,14 @@ function hostBooted(bootId: string) {
   );
 }
 
+/** A wake restores what is already on the host, so reaching the image builder is the failure. */
+const noArtifactImages = Layer.succeed(
+  ArtifactImages,
+  ArtifactImages.make({
+    ensure: () => new ArtifactTransferError({ cause: 'no artifact images in a test' }),
+  }),
+);
+
 const VERB_ARGUMENT = 1;
 const START_REFUSED = 1;
 
@@ -91,6 +101,7 @@ function hostAsleepAndRefusing() {
       Layer.provide(
         Layer.mergeAll(
           AgentState.Default,
+          noArtifactImages,
           TenantLogReceiver.Default,
           ZerofsTopology.DefaultWithoutDependencies,
         ),


### PR DESCRIPTION
`ensureArtifactImage` becomes `ArtifactImages.ensure`: a service that dedupes builds in flight by digest for the whole process, so a second caller joins the first rather than removing the `.staging-<digest>` directory it is downloading into. The staging name stays fixed, so a killed build still cleans up after itself.

The image cache half of `lib/vm/artifacts.ts` moves with it; the transfer half — which `lib/exports/bundle.ts` also uses — stays. Every caller now reaches the builder through the service, which is what makes the guarantee hold rather than the batch dedupe in `artifactsToStart` that only covered one prefetch.

Closes #489