### PR TITLE
chore(www): bump deploy presets

### DIFF
--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -33,8 +33,8 @@ export const DEPLOY_PRESETS = {
   gitea: {
     name: 'gitea',
     binary:
-      'https://github.com/ilbertt/gitea/releases/download/v1.28.0-dev-nibrun.2/gitea-nibrun-linux-amd64',
-    sha256: 'e74bef3081a046c6a3964dee49ca68b94316a69f0709a148ee6234c543a93bb5',
+      'https://github.com/ilbertt/gitea/releases/download/v1.28.0-dev-nibrun.3/gitea-nibrun-linux-amd64',
+    sha256: 'f7a3b71523a60be16772b82240a74e4fead1a5e7162008d6e5cf85cdd97ceff6',
     port: 3000,
     arg: ['nibrun'],
     minimal: true,

--- a/apps/www/deploy-presets.ts
+++ b/apps/www/deploy-presets.ts
@@ -61,16 +61,16 @@ export const DEPLOY_PRESETS = {
   pocketbase: {
     name: 'pocketbase',
     binary:
-      'https://github.com/pocketbase/pocketbase/releases/download/v0.40.1/pocketbase_0.40.1_linux_amd64.zip',
-    sha256: '0f3442d2e57b03b56fbff0d09289e4a30b4f561a44338c38d2dcd4a1a0cfa91e',
+      'https://github.com/pocketbase/pocketbase/releases/download/v0.40.2/pocketbase_0.40.2_linux_amd64.zip',
+    sha256: 'dd86b424a07f2bb5ac2b8ba8cdf013a37400a9cf56bd1f92e560981f7dd24244',
     port: 8090,
     arg: ['serve', '--http=0.0.0.0:8090', '--dir=./data/pb_data'],
     minimal: true,
   },
   sharkord: {
     name: 'sharkord',
-    binary: 'https://github.com/sharkord/sharkord/releases/download/v0.0.24/sharkord-linux-x64',
-    sha256: '92c5036ddf1951e14fe8359e03a3a66df9e20cee543837621ad47eccb3090d47',
+    binary: 'https://github.com/sharkord/sharkord/releases/download/v0.0.25/sharkord-linux-x64',
+    sha256: 'e381198decf43efe92b1b1e947dc220939a98ae3fb578f4d59b99b80a968fc58',
     port: 4991,
     'extra-public-port': true,
     env: [


### PR DESCRIPTION
Bumps the deploy presets to their latest upstream releases. Digests verified against the ones GitHub publishes for each asset.

| preset | from | to |
| --- | --- | --- |
| pocketbase | `v0.40.1` | `v0.40.2` |
| sharkord | `v0.0.24` | `v0.0.25` |
| gitea | `v1.28.0-dev-nibrun.2` | `v1.28.0-dev-nibrun.3` |

The gitea release is [cut from the fork](https://github.com/ilbertt/gitea/releases/tag/v1.28.0-dev-nibrun.3) and rolls in upstream Gitea changes; the nibrun integration itself is unchanged. Smoke-tested under linux/amd64 with the guest's own layout — it serves, creates `gitea-admin`, and the embedded git 2.51.2 runs.

boop `v1.3.0` and open-connector `v1.5.0` are already the newest releases, and context-use is pinned to a rolling tag with no version to bump.