### PR TITLE
fix(www): a blog post's markdown alternate points at the post, not at llms.txt

### DIFF
--- a/apps/www/src/lib/page-head.ts
+++ b/apps/www/src/lib/page-head.ts
@@ -1,9 +1,10 @@
-import { WWW_SITE } from '@repo/global-constants';
+import { PRODUCT_NAME, WWW_SITE } from '@repo/global-constants';
 
 /**
- * The tags that differ per page, kept in one place because one of them cannot be repeated:
+ * The tags that differ per page, kept in one place because some of them cannot be repeated:
  * the router dedupes `meta` by name, so a route overriding the root's is free, but it renders
- * every `link` a match contributes — two routes each declaring a canonical would emit both.
+ * every `link` a match contributes — a canonical or a Markdown alternate declared by both the
+ * root and a route would emit both, and a post would advertise the site's Markdown beside its own.
  */
 export function pageHead({
   path,
@@ -11,6 +12,7 @@ export function pageHead({
   description,
   publishedAt,
   image,
+  markdown = { path: '/llms.txt', title: `${PRODUCT_NAME} for agents` },
 }: {
   path: string;
   title: string;
@@ -18,6 +20,8 @@ export function pageHead({
   publishedAt?: string;
   /** Root-relative, and 1200x630 to match the dimensions the root route declares. */
   image?: string;
+  /** The Markdown this page reads as, for agents; the site-wide entry point unless a page has one. */
+  markdown?: { path: string; title: string };
 }) {
   const url = `${WWW_SITE.url}${path}`;
   const card =
@@ -45,6 +49,14 @@ export function pageHead({
         : [{ property: 'article:published_time', content: publishedAt }]),
       ...card,
     ],
-    links: [{ rel: 'canonical', href: url }],
+    links: [
+      { rel: 'canonical', href: url },
+      {
+        rel: 'alternate',
+        type: 'text/markdown',
+        href: `${WWW_SITE.url}${markdown.path}`,
+        title: markdown.title,
+      },
+    ],
   };
 }

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -24,12 +24,6 @@ export const Route = createRootRoute({
     ],
     links: [
       { rel: 'stylesheet', href: appCss },
-      {
-        rel: 'alternate',
-        type: 'text/markdown',
-        href: `${WWW_SITE.url}/llms.txt`,
-        title: `${PRODUCT_NAME} for agents`,
-      },
       { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' },
     ],
   }),

--- a/apps/www/src/routes/blog/$slug.tsx
+++ b/apps/www/src/routes/blog/$slug.tsx
@@ -1,4 +1,3 @@
-import { WWW_SITE } from '@repo/global-constants';
 import { Button } from '@repo/ui/components/button';
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { ArrowLeftIcon, FileTextIcon } from 'lucide-react';
@@ -26,26 +25,14 @@ export const Route = createFileRoute('/blog/$slug')({
     if (post === undefined) {
       return {};
     }
-    const head = pageHead({
+    return pageHead({
       path: `/blog/${post.slug}`,
       title: pageTitle(post.title),
       description: post.description,
       publishedAt: post.date,
       image: post.image,
+      markdown: { path: markdownPath(post), title: 'This post in Markdown' },
     });
-
-    return {
-      ...head,
-      links: [
-        ...head.links,
-        {
-          rel: 'alternate',
-          type: 'text/markdown',
-          href: markdownPath(post),
-          title: 'This post in Markdown',
-        },
-      ],
-    };
   },
   component: RouteComponent,
 });
@@ -92,7 +79,7 @@ function ArticleBody({ post }: { post: BlogPost }) {
 }
 
 function markdownPath(post: BlogPost): string {
-  return `${WWW_SITE.url}/blog/${post.slug}.md`;
+  return `/blog/${post.slug}.md`;
 }
 
 function RouteComponent() {
@@ -123,7 +110,7 @@ function RouteComponent() {
               variant="outline"
               size="sm"
               className="self-start"
-              render={<a href={`/blog/${post.slug}.md`} />}
+              render={<a href={markdownPath(post)} />}
             >
               <FileTextIcon data-icon="inline-start" />
               View markdown


### PR DESCRIPTION
A post page emitted two `rel=alternate type=text/markdown` links: the root's site-wide `llms.txt` one plus its own. The alternate moves into `pageHead`, where a route can supply its own.