### PR TITLE
feat(protocol): a desired volume can name the archive it is created from

### DIFF
--- a/packages/protocol/src/control/desired-state.ts
+++ b/packages/protocol/src/control/desired-state.ts
@@ -80,11 +80,20 @@ export const DesiredInstanceSchema = Type.Object({
 
 export type DesiredInstance = typeof DesiredInstanceSchema.static;
 
+/**
+ * `seed` is the archive the filesystem is created from, read at exactly one moment: the format. A
+ * host that finds the device already formatted does nothing with it, which is what makes this
+ * once-only without a second fact anywhere saying whether it has been applied.
+ *
+ * Absent is the ordinary case — a volume is created empty unless somebody uploaded something to
+ * create it from.
+ */
 export const DesiredVolumeSchema = Type.Object({
   volumeId: VolumeIdSchema,
   appId: AppIdSchema,
   sizeBytes: ByteSizeSchema,
   desiredState: DesiredPresenceSchema,
+  seed: Type.Optional(DesiredArtifactSchema),
 });
 
 export type DesiredVolume = typeof DesiredVolumeSchema.static;

--- a/packages/protocol/src/domain/identifiers.ts
+++ b/packages/protocol/src/domain/identifiers.ts
@@ -30,6 +30,11 @@ export const CheckpointIdSchema = identifierSchema<CheckpointId>(
   'A point-in-time view of a volume, readable while the owning host still has it open.',
 );
 
+export type ImportId = Identifier<'ImportId'>;
+export const ImportIdSchema = identifierSchema<ImportId>(
+  'One uploaded archive an app can be given as its starting data.',
+);
+
 export type ExportId = Identifier<'ExportId'>;
 export const ExportIdSchema = identifierSchema<ExportId>(
   'One request for a downloadable copy of an app.',

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -173,6 +173,8 @@ export {
   FilesystemQueryIdSchema,
   type HostId,
   HostIdSchema,
+  type ImportId,
+  ImportIdSchema,
   type OwnerId,
   OwnerIdSchema,
   type VolumeId,


### PR DESCRIPTION
An ImportId, and an optional seed on DesiredVolume carrying the same four
things a host needs of any object it pulls.
