### PR TITLE
feat(agent): a volume can be created holding an archive its owner uploaded

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -96,6 +96,12 @@ credentials, and the gap is wider than the test count suggests.
   are tested, and the export path, where the order the commands come in is the guarantee. In
   particular nothing has confirmed that a `truncate` onto a `zerofs` mount produces a device file
   ZeroFS then exports, which is the one step the whole volume path rests on.
+- **`mkfs.ext4 -d` has never written a seeded filesystem onto a real device.** The unpack is
+  exercised against a temp directory — every refusal, both ceilings, and who the tree ends up
+  belonging to — but who it belongs to is only provable as "whoever the caller said", because only
+  root may give a file away and none of this was run as root. That the tenant can then write to
+  their own `data/`, and that mke2fs is content with a tree behind an NBD device, are a host's
+  questions.
 - **S3 and IMDS** are tested against stubs; nothing has spoken to AWS. `ExportUploader` is the
   seam the export tests stand in front of, so what happens to a bundle's bytes after `writeBundle`
   is a recorded call and nothing more.

--- a/apps/agent/src/lib/exports/bundle.ts
+++ b/apps/agent/src/lib/exports/bundle.ts
@@ -4,6 +4,7 @@ import type { DesiredArtifact, TenantEnvironment } from '@repo/protocol';
 import { Data, Duration, Effect, Either } from 'effect';
 import { BINARY_MODE, downloadAndVerify } from '#lib/vm/artifacts.ts';
 import { MKFS_ROOT_ENTRIES } from '#lib/volumes/ext4.ts';
+import { AgentConfig } from '#services/agent-config.service.ts';
 import { stdoutOf } from '#services/command-runner.service.ts';
 
 const STAGING_MODE = 0o700;
@@ -139,10 +140,11 @@ export const writeBundle = Effect.fn('writeBundle')(function* ({
 }) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const config = yield* AgentConfig;
   const binaryName = yield* bundleBinaryName(artifact);
 
   const binaryPath = path.join(stagingDir, binaryName);
-  yield* downloadAndVerify({ artifact, destination: binaryPath });
+  yield* downloadAndVerify({ artifact, destination: binaryPath, bucket: config.artifactBucket });
   // A transfer writes what a transfer writes, and `tar` records the mode it finds. Without this
   // the bundle carries a binary the owner has to chmod before the copy they were handed will run.
   yield* fs.chmod(binaryPath, BINARY_MODE);

--- a/apps/agent/src/lib/vm/artifacts.ts
+++ b/apps/agent/src/lib/vm/artifacts.ts
@@ -46,13 +46,16 @@ export const artifactImagePath = ({
 export const downloadAndVerify = Effect.fn('downloadAndVerify')(function* ({
   artifact,
   destination,
+  bucket,
 }: {
   artifact: DesiredArtifact;
   destination: string;
+  bucket: string;
 }) {
   yield* Effect.annotateCurrentSpan({
     objectKey: artifact.objectKey,
     digest: artifact.digest,
+    bucket,
   });
   const fs = yield* FileSystem.FileSystem;
   const store = yield* ArtifactStore;
@@ -60,7 +63,7 @@ export const downloadAndVerify = Effect.fn('downloadAndVerify')(function* ({
   const written = yield* Ref.make(0);
 
   yield* Stream.unwrap(
-    Effect.map(store.open(artifact.objectKey), (readable) =>
+    Effect.map(store.open({ bucket, objectKey: artifact.objectKey }), (readable) =>
       Stream.fromReadableStream({
         evaluate: () => readable,
         onError: (cause) => new ArtifactTransferError({ cause }),

--- a/apps/agent/src/lib/volumes/ext4.ts
+++ b/apps/agent/src/lib/volumes/ext4.ts
@@ -1,5 +1,6 @@
 import { FileSystem } from '@effect/platform';
-import { Data, Duration, Effect } from 'effect';
+import { Data, Duration, Effect, Option } from 'effect';
+import type { CommandLine } from '#lib/exec.ts';
 import { stdoutOf } from '#services/command-runner.service.ts';
 
 const SUPERBLOCK_MAGIC_OFFSET = 1080;
@@ -75,19 +76,61 @@ export const isFormatted = (devicePath: string) =>
   });
 
 /**
- * Deliberately the defaults.
+ * A seeded format writes a whole directory tree through NBD to a log-structured store in S3, where
+ * an empty one writes almost nothing. What bounds it is the ceiling on the seed rather than
+ * anything about mke2fs, so the deadline is the export's rather than a subprocess's default.
+ */
+const SEEDED_FORMAT_TIMEOUT = Duration.hours(1);
+
+const mkfsCommand = ({
+  devicePath,
+  seedDir,
+}: {
+  devicePath: string;
+  seedDir: Option.Option<string>;
+}): CommandLine =>
+  Option.match(seedDir, {
+    onNone: (): CommandLine => ['mkfs.ext4', '-q', '-L', FILESYSTEM_LABEL, devicePath],
+    onSome: (dir): CommandLine => [
+      'mkfs.ext4',
+      '-q',
+      // The filesystem is created holding this tree, which is the only moment an app's data can be
+      // put there without the host mounting a tenant filesystem.
+      '-d',
+      dir,
+      '-L',
+      FILESYSTEM_LABEL,
+      devicePath,
+    ],
+  });
+
+/**
+ * Deliberately the defaults otherwise.
  *
  * Formatting an 8 GiB volume here measures 0.10s against a real ZeroFS, and ~0.09s of that is
  * recoverable only by `lazy_journal_init` — the one extended option that narrows what survives
  * an unclean shutdown. A log-structured store with compression is why: a fresh filesystem is
  * almost entirely zeroes, so what reaches S3 is a few hundred KiB whatever mke2fs is asked to
  * write. There is no time here worth buying.
+ *
+ * The guard is what makes a seed apply exactly once. A device that already carries a filesystem is
+ * left alone whatever it was asked to be created from, so a flaky NBD cannot turn a redeploy into
+ * a tenant's data being written over.
  */
-export const formatOnce = Effect.fn('formatOnce')(function* (devicePath: string) {
-  yield* Effect.annotateCurrentSpan({ devicePath });
+export const format = Effect.fn('format')(function* ({
+  devicePath,
+  seedDir,
+}: {
+  devicePath: string;
+  seedDir: Option.Option<string>;
+}) {
+  yield* Effect.annotateCurrentSpan({ devicePath, seeded: Option.isSome(seedDir) });
   if (yield* isFormatted(devicePath)) {
     return false;
   }
-  yield* stdoutOf({ command: ['mkfs.ext4', '-q', '-L', FILESYSTEM_LABEL, devicePath] });
+  yield* stdoutOf({
+    command: mkfsCommand({ devicePath, seedDir }),
+    ...(Option.isSome(seedDir) ? { timeout: SEEDED_FORMAT_TIMEOUT } : {}),
+  });
   return true;
 });

--- a/apps/agent/src/lib/volumes/seed.ts
+++ b/apps/agent/src/lib/volumes/seed.ts
@@ -1,0 +1,427 @@
+import { posix } from 'node:path';
+import { FileSystem, Path } from '@effect/platform';
+import type { PlatformError } from '@effect/platform/Error';
+import type { DesiredArtifact, VolumeId } from '@repo/protocol';
+import { Data, Effect, Option, Ref, Stream } from 'effect';
+import { downloadAndVerify } from '#lib/vm/artifacts.ts';
+import { format, isFormatted } from '#lib/volumes/ext4.ts';
+import { type TarEntry, tarEntries } from '#lib/volumes/tar.ts';
+import { AgentConfig } from '#services/agent-config.service.ts';
+
+/**
+ * Who the seed belongs to once it is inside the guest, from `apps/runtime/src/paths.h` — the boot
+ * contract, which this end cannot read and has to agree with.
+ *
+ * `mkfs.ext4 -d` keeps what it finds on the staging tree, and the guest chowns only the mount
+ * root, so this is the whole of what makes the tenant's own data writable to them.
+ */
+const TENANT: Owner = { uid: 65534, gid: 65534 };
+
+const ARCHIVE_FILENAME = 'archive.tar.gz';
+const TREE_DIRECTORY = 'tree';
+/** The staging tree is one owner's dataset in the clear on a shared host; nobody else may read it. */
+const STAGING_MODE = 0o700;
+const DIRECTORY_MODE = 0o755;
+/**
+ * What every unpacked directory carries beyond what the archive said about it.
+ *
+ * An archive may hold a directory its own owner cannot enter, and reproducing that faithfully
+ * would be a tree the unpack cannot write the next entry into and a `data/` the tenant cannot use.
+ * The tenant owns every one of these and is the only user in the guest, so the bits this adds are
+ * not a boundary anybody is on the other side of — where group and other are left exactly as the
+ * archive wrote them.
+ */
+const OWNER_ACCESS = 0o700;
+const GZIP = 'gzip';
+
+const BYTES_PER_GIB = 1_073_741_824;
+
+/** What an unpack will not go past, named by the caller so the bounds can be exercised. */
+export type SeedLimits = { readonly maxBytes: number; readonly maxEntries: number };
+
+/**
+ * `maxBytes` is how much an archive may come to once it is unpacked. The cap on the upload bounds
+ * what was *sent*; what it expands to is decided afterwards, and a quarter of a gibibyte of zeros
+ * is a 255 KB download — so the two are not the same bound at all, and this is the one that keeps
+ * a host's instance store out of it.
+ *
+ * Chosen against the room `DISK_RESERVE_GIB` already holds free in `lib/vm/snapshot.ts`: eight
+ * gibibytes, whose only other named claim is a checkpoint server's four while an export reads. The
+ * archive on disk is at most a gibibyte and the tree at most two, so the worst case is seven of the
+ * eight and the arithmetic there needs no change. The tree is transient where ZeroFS's cache is
+ * not, which is why it may borrow that room at all.
+ *
+ * `maxEntries` is what bounds an archive that is headers the whole way down, which the byte ceiling
+ * cannot: an entry declaring no data costs nothing against it. Inodes are the resource — a
+ * filesystem this size is made with about half a million of them, and an archive needing more would
+ * fail the format after the host had already spent the disk staging it.
+ */
+export const SEED_LIMITS: SeedLimits = { maxBytes: 2 * BYTES_PER_GIB, maxEntries: 200_000 };
+
+export class SeedTooLarge extends Data.TaggedError('SeedTooLarge')<{
+  readonly limitBytes: number;
+}> {
+  override get message() {
+    return `the archive holds more than the ${this.limitBytes} bytes an app may be seeded with`;
+  }
+}
+
+export class SeedTooManyEntries extends Data.TaggedError('SeedTooManyEntries')<{
+  readonly limit: number;
+}> {
+  override get message() {
+    return `the archive holds more than the ${this.limit} files an app may be seeded with`;
+  }
+}
+
+/**
+ * An entry the unpack will not write, named by what is wrong with it rather than by its path: a
+ * path is the tenant's own text, and this message reaches an operator's log.
+ */
+export class SeedEntryRefused extends Data.TaggedError('SeedEntryRefused')<{
+  readonly reason: string;
+}> {
+  override get message() {
+    return `the archive holds ${this.reason}`;
+  }
+}
+
+export class SeedUnreadable extends Data.TaggedError('SeedUnreadable')<{
+  readonly cause: unknown;
+}> {
+  override get message() {
+    return 'the archive could not be read as a gzipped tarball';
+  }
+}
+
+/** Who the unpacked tree belongs to, which is the tenant everywhere but a test with no root. */
+export type Owner = { readonly uid: number; readonly gid: number };
+
+const ABSOLUTE_PATH = 'an entry whose path starts at the root of a filesystem';
+const ESCAPING_PATH = 'an entry whose path climbs out of the archive';
+const THROUGH_A_SYMLINK = 'an entry reached through a symlink';
+const ESCAPING_LINK = 'a symlink pointing out of the archive';
+const NOT_A_FILE = 'something that is not a file, a directory or a symlink';
+
+/**
+ * What the unpack has written so far, and what it has to know to refuse the next entry.
+ *
+ * `symlinks` is what makes the containment check hold at all: an entry is refused for pointing out
+ * of the tree, and an entry underneath one that already does would reach the same place without
+ * ever saying so.
+ */
+type Unpacked = {
+  readonly bytes: number;
+  readonly entries: number;
+  readonly symlinks: ReadonlySet<string>;
+};
+
+const EMPTY: Unpacked = { bytes: 0, entries: 0, symlinks: new Set() };
+
+/**
+ * The archive's path as the segments of it that mean anything, or nothing where it is one the
+ * unpack will not write. Absolute and climbing are refused rather than corrected: what an owner
+ * uploaded is the root of `data/`, so either is an archive that was not made for this.
+ *
+ * No segments at all is the archive's own root, which `tar cf archive.tar .` writes as `./` and
+ * every path under it as `./…`. It names the tree rather than anything in it, so there is nothing
+ * to write for it and nothing wrong with it.
+ */
+function segmentsOf(path: string): Option.Option<readonly string[]> {
+  if (path.startsWith('/')) {
+    return Option.none();
+  }
+  const segments = path.split('/').filter((segment) => segment.length > 0 && segment !== '.');
+  return segments.some((segment) => segment === '..') ? Option.none() : Option.some(segments);
+}
+
+/** Whether anything above this entry is a symlink, which is the only way one could be followed. */
+function reachedThroughSymlink({
+  segments,
+  symlinks,
+}: {
+  segments: readonly string[];
+  symlinks: ReadonlySet<string>;
+}): boolean {
+  for (let depth = 1; depth < segments.length; depth += 1) {
+    if (symlinks.has(segments.slice(0, depth).join('/'))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Whether a symlink's target, read from where the symlink sits, lands back inside the archive. */
+function pointsInside({ segments, target }: { segments: readonly string[]; target: string }) {
+  if (target.startsWith('/')) {
+    return false;
+  }
+  const resolved = posix.normalize(posix.join(segments.slice(0, -1).join('/'), target));
+  return resolved !== '..' && !resolved.startsWith('../');
+}
+
+function refuse(reason: string) {
+  return Effect.fail(new SeedEntryRefused({ reason }));
+}
+
+/**
+ * Owned by the tenant as it is written, rather than chowned in a second pass.
+ *
+ * `mkfs.ext4 -d` copies what it finds, and the guest chowns only the mount root — so an unchowned
+ * tree is a `data/` the tenant can read and not write, which is the failure this exists to prevent
+ * and the one nothing on the host would notice.
+ */
+const owned = ({ path, owner }: { path: string; owner: Owner }) =>
+  Effect.flatMap(FileSystem.FileSystem, (fs) => fs.chown(path, owner.uid, owner.gid));
+
+const madeDirectory = ({ path, mode, owner }: { path: string; mode: number; owner: Owner }) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.makeDirectory(path, { recursive: true, mode });
+    yield* owned({ path, owner });
+  });
+
+/**
+ * A file's own bytes, written straight through rather than held: an entry is as large as the
+ * ceiling allows, and buffering one would be the whole of it in the agent's memory.
+ */
+const wroteFile = ({ entry, path, owner }: { entry: TarEntry; path: string; owner: Owner }) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* madeDirectory({ path: posix.dirname(path), mode: DIRECTORY_MODE, owner });
+    yield* Stream.fromAsyncIterable(entry.content(), (cause) => new SeedUnreadable({ cause })).pipe(
+      Stream.run(fs.sink(path)),
+    );
+    // Permissions only, and never the bits above them: a setuid file the host wrote would be one
+    // the host is briefly carrying, and one `mkfs.ext4 -d` would copy into the tenant's filesystem.
+    yield* fs.chmod(path, entry.mode);
+    yield* owned({ path, owner });
+  });
+
+/**
+ * A symlink is created rather than followed, and its ownership left alone: what a symlink permits
+ * is decided by what it points at, and chowning one would chown that instead.
+ */
+const wroteSymlink = ({ entry, path, owner }: { entry: TarEntry; path: string; owner: Owner }) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* madeDirectory({ path: posix.dirname(path), mode: DIRECTORY_MODE, owner });
+    yield* fs.symlink(entry.linkTarget, path);
+  });
+
+const wroteEntry = ({
+  entry,
+  segments,
+  destination,
+  owner,
+}: {
+  entry: TarEntry;
+  segments: readonly string[];
+  destination: string;
+  owner: Owner;
+}) => {
+  const path = posix.join(destination, ...segments);
+  if (entry.kind === 'directory') {
+    return madeDirectory({ path, mode: entry.mode | OWNER_ACCESS, owner });
+  }
+  return entry.kind === 'file'
+    ? wroteFile({ entry, path, owner })
+    : wroteSymlink({ entry, path, owner });
+};
+
+const advanced = ({
+  unpacked,
+  entry,
+  segments,
+}: {
+  unpacked: Unpacked;
+  entry: TarEntry;
+  segments: readonly string[];
+}): Unpacked => ({
+  bytes: unpacked.bytes + entry.sizeBytes,
+  entries: unpacked.entries + 1,
+  symlinks:
+    entry.kind === 'symlink'
+      ? new Set([...unpacked.symlinks, segments.join('/')])
+      : unpacked.symlinks,
+});
+
+/**
+ * One entry, refused or written.
+ *
+ * The ceilings are checked against what the header declares, before the bytes are spent: an entry
+ * cannot deliver more than it declared — the walk stops at the length it was given — so refusing
+ * on the declaration is refusing before the disk goes rather than after.
+ */
+const unpackedEntry = ({
+  unpacked,
+  entry,
+  destination,
+  owner,
+  limits,
+}: {
+  unpacked: Unpacked;
+  entry: TarEntry;
+  destination: string;
+  owner: Owner;
+  limits: SeedLimits;
+}): Effect.Effect<
+  Unpacked,
+  SeedEntryRefused | SeedTooLarge | SeedTooManyEntries | SeedUnreadable | PlatformError,
+  FileSystem.FileSystem
+> =>
+  Effect.gen(function* () {
+    if (entry.kind === 'unsupported') {
+      return yield* refuse(NOT_A_FILE);
+    }
+    const segments = yield* Option.match(segmentsOf(entry.path), {
+      onNone: () => refuse(refusalFor(entry.path)),
+      onSome: Effect.succeed,
+    });
+    if (segments.length === 0) {
+      return unpacked;
+    }
+    if (reachedThroughSymlink({ segments, symlinks: unpacked.symlinks })) {
+      return yield* refuse(THROUGH_A_SYMLINK);
+    }
+    if (entry.kind === 'symlink' && !pointsInside({ segments, target: entry.linkTarget })) {
+      return yield* refuse(ESCAPING_LINK);
+    }
+    const next = advanced({ unpacked, entry, segments });
+    if (next.bytes > limits.maxBytes) {
+      return yield* new SeedTooLarge({ limitBytes: limits.maxBytes });
+    }
+    if (next.entries > limits.maxEntries) {
+      return yield* new SeedTooManyEntries({ limit: limits.maxEntries });
+    }
+    yield* wroteEntry({ entry, segments, destination, owner });
+    return next;
+  });
+
+function refusalFor(path: string): string {
+  return path.startsWith('/') ? ABSOLUTE_PATH : ESCAPING_PATH;
+}
+
+/**
+ * The archive's root becomes the root of `data/`, so nothing is stripped and no leading directory
+ * is looked for. An export bundle nests its dataset under `data/` beside the binary, which is why
+ * one does not round-trip through here — restoring from an export is its own thing.
+ */
+export const unpackSeed = Effect.fn('unpackSeed')(function* ({
+  archivePath,
+  destination,
+  owner,
+  limits,
+}: {
+  archivePath: string;
+  destination: string;
+  owner: Owner;
+  limits: SeedLimits;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.makeDirectory(destination, { recursive: true, mode: STAGING_MODE });
+  yield* owned({ path: destination, owner });
+
+  const entries = yield* Effect.try({
+    try: () =>
+      tarEntries(Bun.file(archivePath).stream().pipeThrough(new DecompressionStream(GZIP))),
+    catch: (cause) => new SeedUnreadable({ cause }),
+  });
+
+  const progress = yield* Ref.make(EMPTY);
+  yield* Stream.fromAsyncIterable(entries, (cause) => new SeedUnreadable({ cause })).pipe(
+    Stream.runForEach((entry) =>
+      Ref.get(progress).pipe(
+        Effect.flatMap((unpacked) =>
+          unpackedEntry({ unpacked, entry, destination, owner, limits }),
+        ),
+        Effect.flatMap((next) => Ref.set(progress, next)),
+      ),
+    ),
+  );
+
+  const unpacked = yield* Ref.get(progress);
+  yield* Effect.annotateCurrentSpan({ entries: unpacked.entries, bytes: unpacked.bytes });
+  return unpacked;
+});
+
+/**
+ * A fresh filesystem with the owner's archive already in it, or nothing to do because there is
+ * already a filesystem here.
+ *
+ * The formatted check is asked before anything is downloaded, and `format` asks it again as the
+ * only thing that decides: what stands between them is a transfer of up to a gibibyte and a
+ * staging tree of up to two, and a device that already has a filesystem is worth answering before
+ * either is spent.
+ *
+ * Nothing is left behind on the way out, whichever way it goes. The archive and the tree it
+ * expands to are the owner's whole dataset in the clear on a host their app shares with others,
+ * and neither has any use once the filesystem carries it.
+ */
+export const formatFromSeed = Effect.fn('formatFromSeed')(function* ({
+  devicePath,
+  volumeId,
+  seed,
+}: {
+  devicePath: string;
+  volumeId: VolumeId;
+  seed: DesiredArtifact;
+}) {
+  yield* Effect.annotateCurrentSpan({ devicePath, volumeId });
+  const config = yield* AgentConfig;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  if (yield* isFormatted(devicePath)) {
+    return false;
+  }
+
+  const stagingDir = path.join(config.seedStagingDir, volumeId);
+  return yield* Effect.ensuring(
+    Effect.gen(function* () {
+      yield* fs.makeDirectory(stagingDir, { recursive: true, mode: STAGING_MODE });
+      const archivePath = path.join(stagingDir, ARCHIVE_FILENAME);
+      yield* downloadAndVerify({
+        artifact: seed,
+        destination: archivePath,
+        bucket: config.importBucket,
+      });
+      const tree = path.join(stagingDir, TREE_DIRECTORY);
+      const unpacked = yield* unpackSeed({
+        archivePath,
+        destination: tree,
+        owner: TENANT,
+        limits: SEED_LIMITS,
+      });
+      // Before the format rather than after it, so the disk the filesystem is written through is
+      // not also holding the copy it was written from.
+      yield* fs.remove(archivePath, { force: true });
+      yield* Effect.logInfo('volume seed unpacked').pipe(
+        Effect.annotateLogs({ volumeId, entries: unpacked.entries, bytes: unpacked.bytes }),
+      );
+      return yield* format({ devicePath, seedDir: Option.some(tree) });
+    }),
+    fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),
+  );
+});
+
+/**
+ * Cleanup that does not depend on this process having made the mess, for the reason the export
+ * staging tree is reaped the same way: ending the scope covers the seed that failed, and nothing
+ * in-process covers an agent killed between unpacking a tree and formatting from it — which is a
+ * tenant's whole dataset left in the clear on a shared host.
+ *
+ * At startup rather than every pass, because unlike an export checkpoint nothing else on the host
+ * is held hostage by one: what is left behind costs disk until the next restart and nothing else,
+ * and a pass that ran this would have to know it was not looking at a seed in progress.
+ */
+export const reapSeedStaging = Effect.gen(function* () {
+  const config = yield* AgentConfig;
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.remove(config.seedStagingDir, { recursive: true, force: true });
+}).pipe(
+  Effect.catchAll((error) =>
+    Effect.logError('volume seeds left behind could not be reaped', error),
+  ),
+  Effect.withSpan('reapSeedStaging'),
+);

--- a/apps/agent/src/lib/volumes/tar.ts
+++ b/apps/agent/src/lib/volumes/tar.ts
@@ -1,0 +1,302 @@
+// A tarball read forwards, once, which is the shape a decompressing stream hands it over in.
+//
+// Read here rather than by shelling out to `tar`, which is what every other host mechanic does.
+// What a seed needs of an archive is a set of refusals — nothing leaving the tree, no device node,
+// no ownership carried over, and a running total the unpack stops at — and `tar` has a flag for
+// none of them. Every entry is a 512-byte header, every length is in the header in front of its
+// data, and the data is padded out to the next block, so a walk is counting rather than seeking.
+
+import { Buffer } from 'node:buffer';
+
+const BLOCK_BYTES = 512;
+
+const NAME_AT = 0;
+const NAME_BYTES = 100;
+const MODE_AT = 100;
+const MODE_BYTES = 8;
+const SIZE_AT = 124;
+const SIZE_BYTES = 12;
+const TYPE_AT = 156;
+const LINK_AT = 157;
+const LINK_BYTES = 100;
+const PREFIX_AT = 345;
+const PREFIX_BYTES = 155;
+
+const TYPE_FILE = '0';
+/** Anything predating ustar writes a NUL where a modern tar writes the digit. */
+const TYPE_FILE_UNSET = '\0';
+const TYPE_DIRECTORY = '5';
+const TYPE_SYMLINK = '2';
+/** GNU's entries carrying the path, and the link target, of the one after them. */
+const TYPE_LONG_NAME = 'L';
+const TYPE_LONG_LINK = 'K';
+/** pax's own metadata, which annotates the header after it rather than describing a file. */
+const PAX_TYPES = new Set(['x', 'g']);
+
+/**
+ * As much of a long-name entry as will be held to read a path out of. Far longer than any path a
+ * filesystem will take, and far short of what the entry could claim: this one entry is read into
+ * memory, where every other is walked past a chunk at a time.
+ */
+const MAX_LONG_FIELD_BYTES = 4096;
+
+const OCTAL = 8;
+const OCTAL_DIGITS = /^[0-7]+$/;
+/** A number too wide for octal text sets the high bit and uses the rest of the field as base 256. */
+const BASE_256_MARKER = 0x80;
+const NUL = 0;
+const PATH_SEPARATOR = '/';
+const MODE_BITS = 0o777;
+
+/**
+ * What an unpack does with an entry. Everything that is not one of the first three is a refusal —
+ * a device node, a fifo, a hard link — so they are not told apart here: what a caller does with
+ * any of them is refuse the archive and name the entry.
+ */
+export type TarEntryKind = 'file' | 'directory' | 'symlink' | 'unsupported';
+
+export type TarEntry = {
+  readonly path: string;
+  readonly kind: TarEntryKind;
+  /** Permissions only. The bits above them say setuid, and nothing here carries those. */
+  readonly mode: number;
+  readonly sizeBytes: number;
+  /** Where a symlink points, as the archive wrote it; empty for everything else. */
+  readonly linkTarget: string;
+  /** The entry's own bytes, readable until the next entry is asked for. */
+  content(): AsyncGenerator<Uint8Array>;
+};
+
+/** What an archive that stops being followable is raised as, wherever it stops being one. */
+export class UnreadableTarball extends Error {
+  constructor(reason: string) {
+    super(`the archive ${reason}`);
+    this.name = 'UnreadableTarball';
+  }
+}
+
+type Header = {
+  readonly path: string;
+  readonly type: string;
+  readonly mode: number;
+  readonly sizeBytes: number;
+  readonly linkTarget: string;
+};
+
+/** What a long-name entry said about the entry after it, until that entry has taken it. */
+type Announced = { path?: string; linkTarget?: string };
+
+/**
+ * Every entry in the archive, in the order it was written.
+ *
+ * An entry's `content` is only readable until the next one is asked for: this is one pass over one
+ * stream, and the bytes behind it are gone once walked past. Whatever a caller leaves unread is
+ * walked past for it, so an entry it refuses costs it nothing to abandon.
+ */
+export async function* tarEntries(source: ReadableStream<Uint8Array>): AsyncGenerator<TarEntry> {
+  const chunks = source[Symbol.asyncIterator]();
+  let held = Buffer.alloc(0);
+  let ended = false;
+  let unread = 0;
+
+  async function pull(): Promise<boolean> {
+    if (ended) {
+      return false;
+    }
+    const { done, value } = await chunks.next();
+    if (done) {
+      ended = true;
+      return false;
+    }
+    held = held.length === 0 ? Buffer.from(value) : Buffer.concat([held, value]);
+    return true;
+  }
+
+  async function take(count: number): Promise<Buffer | undefined> {
+    while (held.length < count) {
+      if (!(await pull())) {
+        return undefined;
+      }
+    }
+    const taken = Buffer.from(held.subarray(0, count));
+    held = held.subarray(count);
+    return taken;
+  }
+
+  /** The next piece of the entry being read, or nothing once all of it has been handed over. */
+  async function pieceOfEntry(): Promise<Buffer | undefined> {
+    if (unread === 0) {
+      return undefined;
+    }
+    while (held.length === 0) {
+      if (!(await pull())) {
+        throw new UnreadableTarball('ended inside the entry it was describing');
+      }
+    }
+    const piece = held.subarray(0, Math.min(unread, held.length));
+    held = held.subarray(piece.length);
+    unread -= piece.length;
+    return piece;
+  }
+
+  async function* content(): AsyncGenerator<Uint8Array> {
+    let piece = await pieceOfEntry();
+    while (piece !== undefined) {
+      yield piece;
+      piece = await pieceOfEntry();
+    }
+  }
+
+  /** Whatever is left of the entry being read, and the padding out to the next header. */
+  async function walkPast(padding: number): Promise<void> {
+    let piece = await pieceOfEntry();
+    while (piece !== undefined) {
+      piece = await pieceOfEntry();
+    }
+    if (padding > 0 && (await take(padding)) === undefined) {
+      throw new UnreadableTarball('ended inside the padding after an entry');
+    }
+  }
+
+  /** The whole of a long-name entry, which is the one thing here read into memory. */
+  async function longFieldIn(sizeBytes: number): Promise<string> {
+    if (sizeBytes > MAX_LONG_FIELD_BYTES) {
+      throw new UnreadableTarball('carries a path longer than any filesystem would take');
+    }
+    unread = sizeBytes;
+    const pieces: Buffer[] = [];
+    let piece = await pieceOfEntry();
+    while (piece !== undefined) {
+      pieces.push(piece);
+      piece = await pieceOfEntry();
+    }
+    await walkPast(paddingAfter(sizeBytes));
+    return textIn(Buffer.concat(pieces));
+  }
+
+  let announced: Announced = {};
+
+  try {
+    while (true) {
+      const block = await take(BLOCK_BYTES);
+      if (block === undefined) {
+        throw new UnreadableTarball('ended before it said its entries had');
+      }
+      // A block of nothing is how a tar says its entries have stopped. What follows is padding
+      // out to a tape length, which nothing here reads.
+      if (isEnd(block)) {
+        return;
+      }
+
+      const header = headerIn(block);
+      if (header.type === TYPE_LONG_NAME || header.type === TYPE_LONG_LINK) {
+        const carried = await longFieldIn(header.sizeBytes);
+        announced =
+          header.type === TYPE_LONG_NAME
+            ? { ...announced, path: carried }
+            : { ...announced, linkTarget: carried };
+        continue;
+      }
+
+      unread = header.sizeBytes;
+      const padding = paddingAfter(header.sizeBytes);
+
+      // pax's records annotate the entry after this one rather than describing a file, and what
+      // this reads out of a header — the path, the mode, the length — a pax archive still writes
+      // in the header. So they are walked past, and the entry they annotate arrives next.
+      if (PAX_TYPES.has(header.type)) {
+        await walkPast(padding);
+        continue;
+      }
+
+      yield entryFrom({ header, announced, content });
+      announced = {};
+      await walkPast(padding);
+    }
+  } finally {
+    await chunks.return?.();
+  }
+}
+
+function entryFrom({
+  header,
+  announced,
+  content,
+}: {
+  header: Header;
+  announced: Announced;
+  content: () => AsyncGenerator<Uint8Array>;
+}): TarEntry {
+  return {
+    path: announced.path ?? header.path,
+    kind: kindOf(header.type),
+    mode: header.mode & MODE_BITS,
+    sizeBytes: header.sizeBytes,
+    linkTarget: announced.linkTarget ?? header.linkTarget,
+    content,
+  };
+}
+
+function kindOf(type: string): TarEntryKind {
+  if (type === TYPE_FILE || type === TYPE_FILE_UNSET) {
+    return 'file';
+  }
+  if (type === TYPE_DIRECTORY) {
+    return 'directory';
+  }
+  return type === TYPE_SYMLINK ? 'symlink' : 'unsupported';
+}
+
+function headerIn(block: Buffer): Header {
+  const name = textAt({ block, at: NAME_AT, bytes: NAME_BYTES });
+  // ustar splits a path too long for the name field, leading directories first. Joined back here,
+  // so a walk never sees the two halves.
+  const prefix = textAt({ block, at: PREFIX_AT, bytes: PREFIX_BYTES });
+  return {
+    path: prefix.length > 0 ? `${prefix}${PATH_SEPARATOR}${name}` : name,
+    type: String.fromCharCode(block[TYPE_AT] ?? NUL),
+    mode: octalAt({ block, at: MODE_AT, bytes: MODE_BYTES }),
+    sizeBytes: octalAt({ block, at: SIZE_AT, bytes: SIZE_BYTES }),
+    linkTarget: textAt({ block, at: LINK_AT, bytes: LINK_BYTES }),
+  };
+}
+
+/**
+ * A numeric field, which a tar writes as octal text.
+ *
+ * Read rather than parsed: `Number.parseInt` takes whatever digits a field opens with and stops at
+ * the first byte it cannot use, so a corrupt length would come back as a plausible shorter one and
+ * put the walk a few bytes out of step with the headers rather than ending it.
+ */
+function octalAt({ block, at, bytes }: { block: Buffer; at: number; bytes: number }): number {
+  const field = block.subarray(at, at + bytes);
+  if (((field[0] ?? NUL) & BASE_256_MARKER) !== 0) {
+    throw new UnreadableTarball('has a header field written in a form nibrun does not read');
+  }
+  const digits = field.toString('latin1').replaceAll('\0', ' ').trim();
+  if (digits.length === 0) {
+    return 0;
+  }
+  if (!OCTAL_DIGITS.test(digits)) {
+    throw new UnreadableTarball('has a header field that is not a number');
+  }
+  return Number.parseInt(digits, OCTAL);
+}
+
+function paddingAfter(sizeBytes: number): number {
+  return (BLOCK_BYTES - (sizeBytes % BLOCK_BYTES)) % BLOCK_BYTES;
+}
+
+function isEnd(block: Buffer): boolean {
+  return block.every((byte) => byte === NUL);
+}
+
+function textAt({ block, at, bytes }: { block: Buffer; at: number; bytes: number }): string {
+  return textIn(block.subarray(at, at + bytes));
+}
+
+/** A fixed-width field as what was written in it, which ends at the first NUL where there is one. */
+function textIn(field: Buffer): string {
+  const end = field.indexOf(NUL);
+  return field.subarray(0, end < 0 ? field.length : end).toString('utf8');
+}

--- a/apps/agent/src/services/agent-config.service.ts
+++ b/apps/agent/src/services/agent-config.service.ts
@@ -96,6 +96,9 @@ export class AgentConfig extends Effect.Service<AgentConfig>()('AgentConfig', {
       activityFile: inStateDir('activity.json'),
       desiredStateFile: inStateDir('desired-state.json'),
       exportStagingDir: inStateDir('exports'),
+      // Beside the export staging tree and reaped the same way, because it is the same thing:
+      // one tenant's dataset in the clear on a host they share with others.
+      seedStagingDir: inStateDir('seeds'),
       artifactCacheDir: inStateDir('artifacts'),
       vmDir: inStateDir('vm'),
       vmSnapshotDir: yield* optional({
@@ -140,6 +143,9 @@ export class AgentConfig extends Effect.Service<AgentConfig>()('AgentConfig', {
       zerofsStoragePrefix: yield* required('AGENT_ZEROFS_STORAGE_PREFIX'),
       artifactBucket: yield* required('AGENT_ARTIFACT_BUCKET'),
       exportBucket: yield* required('AGENT_EXPORT_BUCKET'),
+      // Read-only here, and read at most once per app: what an archive held is the tenant's
+      // filesystem from the format onwards, and nothing goes back for it.
+      importBucket: yield* required('AGENT_IMPORT_BUCKET'),
       awsRegion: yield* required('AGENT_AWS_REGION'),
       controlPlaneCidrsV4: yield* requiredList('AGENT_CONTROL_PLANE_CIDRS_V4'),
       controlPlaneCidrsV6: yield* requiredList('AGENT_CONTROL_PLANE_CIDRS_V6'),

--- a/apps/agent/src/services/artifact-images.service.ts
+++ b/apps/agent/src/services/artifact-images.service.ts
@@ -75,7 +75,7 @@ const imageFor = Effect.fn('ArtifactImages.imageFor')(function* (artifact: Desir
       Effect.gen(function* () {
         const binaryPath = path.join(stagedSource, GUEST_BINARY_NAME);
         const [fetching] = yield* Effect.timed(
-          downloadAndVerify({ artifact, destination: binaryPath }),
+          downloadAndVerify({ artifact, destination: binaryPath, bucket: config.artifactBucket }),
         );
         yield* fs.chmod(binaryPath, BINARY_MODE);
         const [packing] = yield* Effect.timed(

--- a/apps/agent/src/services/artifact-store.service.ts
+++ b/apps/agent/src/services/artifact-store.service.ts
@@ -17,13 +17,21 @@ export class ArtifactStore extends Effect.Service<ArtifactStore>()('ArtifactStor
     const config = yield* AgentConfig;
     const credentials = yield* AwsCredentialProvider;
     return {
-      open: (objectKey: string): Effect.Effect<ReadableStream<Uint8Array>, ArtifactTransferError> =>
+      // The bucket is named by the caller rather than fixed here: a host pulls binaries from one
+      // and seed archives from another, and which it is asking for is the caller's fact.
+      open: ({
+        bucket,
+        objectKey,
+      }: {
+        bucket: string;
+        objectKey: string;
+      }): Effect.Effect<ReadableStream<Uint8Array>, ArtifactTransferError> =>
         credentials.resolve.pipe(
           Effect.flatMap((resolved) =>
             Effect.try(
               () =>
                 new Bun.S3Client({
-                  bucket: config.artifactBucket,
+                  bucket,
                   region: config.awsRegion,
                   ...s3Credentials(resolved),
                 })

--- a/apps/agent/src/services/reconciler.service.ts
+++ b/apps/agent/src/services/reconciler.service.ts
@@ -19,6 +19,7 @@ import { readInstanceRecords } from '#lib/report/instance-record.ts';
 import * as Systemd from '#lib/vm/systemd.ts';
 import { UNKNOWN_UNIT } from '#lib/vm/unit-status.ts';
 import { readDeletedVolumes } from '#lib/volumes/manager.ts';
+import { reapSeedStaging } from '#lib/volumes/seed.ts';
 import { AgentConfig } from '#services/agent-config.service.ts';
 import { AgentState } from '#services/agent-state.service.ts';
 import { ReportSignal } from '#services/report-signal.service.ts';
@@ -68,6 +69,9 @@ export class Reconciler extends Effect.Service<Reconciler>()('Reconciler', {
       // Before the first poll has even been answered: an app this host stopped before the agent
       // restarted has no forward, so until something is listening its port refuses connections.
       yield* applyActivators;
+      // And before the first volume is provisioned: an unpacked seed the last agent was killed
+      // holding is a tenant's dataset in the clear, and nothing after this would go looking for it.
+      yield* reapSeedStaging;
     }).pipe(Effect.withSpan('Reconciler.load'));
 
     /**

--- a/apps/agent/src/services/volume-manager.service.ts
+++ b/apps/agent/src/services/volume-manager.service.ts
@@ -11,8 +11,9 @@ import { Array as Arr, Effect, Option } from 'effect';
 import type { AppSlot } from '#lib/network/slot.ts';
 import type { ObservedVolume } from '#lib/reconcile/plan.ts';
 import { devicePathFor, ensureDeviceFile, NBD_DIRECTORY } from '#lib/volumes/device-file.ts';
-import { formatOnce } from '#lib/volumes/ext4.ts';
+import { format } from '#lib/volumes/ext4.ts';
 import { detach, isUsable, reattach } from '#lib/volumes/nbd.ts';
+import { formatFromSeed } from '#lib/volumes/seed.ts';
 import type { ZerofsFilesystem } from '#lib/volumes/topology.ts';
 import { flush } from '#lib/volumes/zerofs.ts';
 import { SlotAllocator } from '#services/slot-allocator.service.ts';
@@ -140,9 +141,22 @@ export class VolumeManager extends Effect.Service<VolumeManager>()('VolumeManage
         });
       }
 
-      if (yield* formatOnce(slot.nbdDevicePath)) {
+      // The archive is only ever read on the way to creating the filesystem, so which of these
+      // runs is decided by desired state and the guard inside both is what makes it once.
+      const formatted = yield* desired.seed
+        ? formatFromSeed({
+            devicePath: slot.nbdDevicePath,
+            volumeId: desired.volumeId,
+            seed: desired.seed,
+          })
+        : format({ devicePath: slot.nbdDevicePath, seedDir: Option.none() });
+      if (formatted) {
         yield* Effect.logInfo('volume formatted').pipe(
-          Effect.annotateLogs({ volumeId: desired.volumeId, device: slot.nbdDevicePath }),
+          Effect.annotateLogs({
+            volumeId: desired.volumeId,
+            device: slot.nbdDevicePath,
+            seeded: desired.seed !== undefined,
+          }),
         );
       }
 

--- a/apps/agent/tests/lib/exports/bundle.test.ts
+++ b/apps/agent/tests/lib/exports/bundle.test.ts
@@ -7,6 +7,7 @@ import { Effect, Either, Layer } from 'effect';
 import { bundleBinaryName, dumpVolume, renderDotenv, writeBundle } from '#lib/exports/bundle.ts';
 import { artifactStore } from '#tests/support/artifacts.ts';
 import { recordingCommands, succeeding } from '#tests/support/commands.ts';
+import { agentConfig } from '#tests/support/config.ts';
 import { artifact, tenantEnvironment } from '#tests/support/fixtures.ts';
 import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
 
@@ -16,7 +17,7 @@ const PERMISSION_BITS = 0o777;
 const RUNNABLE_MODE = 0o755;
 const PRIVATE_MODE = 0o600;
 
-const run = provided(Layer.merge(artifactStore(), platform));
+const run = provided(Layer.mergeAll(artifactStore(), agentConfig(), platform));
 
 /** `lost+found` is written by `mkfs.ext4`, so a real `rdump` of any root always produces it. */
 const DUMPS = {

--- a/apps/agent/tests/lib/vm/artifacts.test.ts
+++ b/apps/agent/tests/lib/vm/artifacts.test.ts
@@ -11,6 +11,7 @@ import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
 const DIGEST_HEX_LENGTH = 64;
 const WRONG_DIGEST = Value.Parse(Sha256DigestSchema, 'b'.repeat(DIGEST_HEX_LENGTH));
 const CACHE_DIR = '/var/lib/nibrun/artifacts';
+const ARTIFACT_BUCKET = 'nibrun-artifacts';
 const HALF = Math.floor(ARTIFACT_BYTES.byteLength / 2);
 const SPLIT_CHUNKS = [ARTIFACT_BYTES.slice(0, HALF), ARTIFACT_BYTES.slice(HALF)];
 
@@ -33,7 +34,7 @@ function downloading({
     const destination = `${yield* temporaryDirectory}/server`;
     const result = yield* Effect.either(
       Effect.provide(
-        downloadAndVerify({ artifact: artifact(overrides), destination }),
+        downloadAndVerify({ artifact: artifact(overrides), destination, bucket: ARTIFACT_BUCKET }),
         artifactStore(chunks),
       ),
     );

--- a/apps/agent/tests/lib/volumes/ext4.test.ts
+++ b/apps/agent/tests/lib/volumes/ext4.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Effect, Option } from 'effect';
+import { FILESYSTEM_LABEL, format } from '#lib/volumes/ext4.ts';
+import { recordingCommands } from '#tests/support/commands.ts';
+import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
+
+const run = provided(platform);
+
+const SUPERBLOCK_MAGIC_OFFSET = 1080;
+const SUPERBLOCK_BYTES = 2048;
+/** `0xef53`, as ext4 writes it: little-endian, so the low byte comes first. */
+const EXT_MAGIC_LOW = 0x53;
+const EXT_MAGIC_HIGH = 0xef;
+
+/** A device as ZeroFS first exports one: the length is there, and nothing has been written to it. */
+function blank(): Buffer {
+  return Buffer.alloc(SUPERBLOCK_BYTES);
+}
+
+function alreadyFormatted(): Buffer {
+  const device = blank();
+  device.set([EXT_MAGIC_LOW, EXT_MAGIC_HIGH], SUPERBLOCK_MAGIC_OFFSET);
+  return device;
+}
+
+function formatting({ device, seedDir }: { device: Buffer; seedDir: Option.Option<string> }) {
+  return Effect.gen(function* () {
+    const directory = yield* temporaryDirectory;
+    const devicePath = join(directory, 'nbd0');
+    yield* Effect.promise(() => writeFile(devicePath, device));
+    const { commands, layer } = recordingCommands();
+    const formatted = yield* Effect.provide(format({ devicePath, seedDir }), layer);
+    return { formatted, commands, devicePath };
+  });
+}
+
+describe('a device is formatted once and only once', () => {
+  test('a blank device is given a filesystem', async () => {
+    const { formatted, commands, devicePath } = await run(
+      formatting({ device: blank(), seedDir: Option.none() }),
+    );
+
+    expect(formatted).toBe(true);
+    expect(commands.map(({ command }) => command)).toEqual([
+      ['mkfs.ext4', '-q', '-L', FILESYSTEM_LABEL, devicePath],
+    ]);
+  });
+
+  /**
+   * The whole of what makes a seed apply once. A device that already carries a filesystem is left
+   * alone whatever it was asked to be created from, so a redeploy naming an archive cannot write
+   * over what the tenant has since put there.
+   */
+  test('a device that already carries one is left alone, seed or no seed', async () => {
+    const { formatted, commands } = await run(
+      formatting({
+        device: alreadyFormatted(),
+        seedDir: Option.some('/var/lib/nibrun/seeds/tree'),
+      }),
+    );
+
+    expect(formatted).toBe(false);
+    expect(commands).toEqual([]);
+  });
+});
+
+test('a seed is handed to mkfs as the tree the filesystem is created from', async () => {
+  const seedDir = '/var/lib/nibrun/seeds/app-1/tree';
+  const { formatted, commands, devicePath } = await run(
+    formatting({ device: blank(), seedDir: Option.some(seedDir) }),
+  );
+
+  expect(formatted).toBe(true);
+  expect(commands[0]?.command).toEqual([
+    'mkfs.ext4',
+    '-q',
+    '-d',
+    seedDir,
+    '-L',
+    FILESYSTEM_LABEL,
+    devicePath,
+  ]);
+  // Nothing mounts the tenant's filesystem to put the data there, which is the point of `-d`.
+  expect(commands.some(({ command }) => command[0] === 'mount')).toBe(false);
+});
+
+test('a device nothing answers for stops the volume rather than being guessed at', async () => {
+  const failed = await run(
+    Effect.gen(function* () {
+      const directory = yield* temporaryDirectory;
+      const { layer } = recordingCommands();
+      return yield* Effect.provide(
+        format({ devicePath: join(directory, 'missing'), seedDir: Option.none() }),
+        layer,
+      ).pipe(Effect.isFailure);
+    }),
+  );
+
+  expect(failed).toBe(true);
+});

--- a/apps/agent/tests/lib/volumes/seed.test.ts
+++ b/apps/agent/tests/lib/volumes/seed.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, test } from 'bun:test';
+import { lstat, mkdir, readdir, readFile, readlink, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Effect, Either } from 'effect';
+import { type Owner, type SeedLimits, unpackSeed } from '#lib/volumes/seed.ts';
+import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
+import {
+  gzippedTarball,
+  type TarballEntry,
+  TYPE_CHAR_DEVICE,
+  TYPE_DIRECTORY,
+  TYPE_HARDLINK,
+  TYPE_SYMLINK,
+} from '#tests/support/tarball.ts';
+
+const run = provided(platform);
+
+const ALL_MODE_BITS = 0o7777;
+const PRIVATE_FILE_MODE = 0o640;
+const PRIVATE_DIRECTORY_MODE = 0o750;
+const RUNNABLE_MODE = 0o755;
+const SETUID_RUNNABLE_MODE = 0o4755;
+
+/**
+ * The process's own, not the tenant's. Only root may give a file away, so the thing a host does —
+ * hand the tree to uid 65534 — is not something a test can do; what it can prove is that every
+ * entry ends up owned by whoever the unpack was told to give it to.
+ */
+const OWNER: Owner = { uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 };
+
+/** Far below the host's, so a bound can be reached without staging what the real one allows. */
+const SMALL: SeedLimits = { maxBytes: 4096, maxEntries: 4 };
+
+/** Room for an ordinary archive, which is what every test not aiming at a bound wants. */
+const ROOMY: SeedLimits = { maxBytes: 1_048_576, maxEntries: 64 };
+
+type Written = {
+  readonly names: readonly string[];
+  readonly content: Readonly<Record<string, string>>;
+  readonly links: Readonly<Record<string, string>>;
+  readonly modes: Readonly<Record<string, number>>;
+  readonly owners: Readonly<Record<string, string>>;
+};
+
+/**
+ * Read inside the scope that owns the directory, as the export bundle's tests are: the tree is
+ * gone by the time an assertion runs.
+ */
+async function surveyed(destination: string): Promise<Written> {
+  const entries = await readdir(destination, { recursive: true, withFileTypes: true }).catch(
+    () => [],
+  );
+  const written: Written = { names: [], content: {}, links: {}, modes: {}, owners: {} };
+  const names: string[] = [];
+  const content: Record<string, string> = {};
+  const links: Record<string, string> = {};
+  const modes: Record<string, number> = {};
+  const owners: Record<string, string> = { '.': await ownerOf(destination) };
+  for (const entry of entries) {
+    const path = join(entry.parentPath, entry.name);
+    const name = path.slice(destination.length + 1);
+    names.push(name);
+    modes[name] = (await lstat(path)).mode & ALL_MODE_BITS;
+    owners[name] = await ownerOf(path);
+    if (entry.isSymbolicLink()) {
+      links[name] = await readlink(path);
+    } else if (entry.isFile()) {
+      content[name] = await readFile(path, 'utf8');
+    }
+  }
+  return { ...written, names: names.sort(), content, links, modes, owners };
+}
+
+async function ownerOf(path: string): Promise<string> {
+  const stats = await lstat(path);
+  return `${stats.uid}:${stats.gid}`;
+}
+
+function unpacking({
+  entries,
+  limits = ROOMY,
+}: {
+  entries: readonly TarballEntry[];
+  limits?: SeedLimits;
+}) {
+  return Effect.gen(function* () {
+    const directory = yield* temporaryDirectory;
+    const archivePath = join(directory, 'archive.tar.gz');
+    yield* Effect.promise(() => writeFile(archivePath, gzippedTarball(entries)));
+    const destination = join(directory, 'tree');
+    const result = yield* Effect.either(
+      unpackSeed({ archivePath, destination, owner: OWNER, limits }),
+    );
+    return {
+      refusal: refusalOf(result),
+      written: yield* Effect.promise(() => surveyed(destination)),
+    };
+  });
+}
+
+const NOTHING_REFUSED = 'nothing was refused';
+
+/** The refusal as an operator reads it, which is the message rather than the tag. */
+function refusalOf(result: Either.Either<unknown, { message: string }>): string {
+  return Either.isLeft(result) ? result.left.message : NOTHING_REFUSED;
+}
+
+describe("the archive's root becomes the root of the tree", () => {
+  test('files, directories and symlinks arrive where the archive put them', async () => {
+    const { refusal, written } = await run(
+      unpacking({
+        entries: [
+          { path: 'pb_data/', type: TYPE_DIRECTORY, mode: PRIVATE_DIRECTORY_MODE },
+          { path: 'pb_data/data.db', mode: PRIVATE_FILE_MODE, body: 'rows' },
+          { path: 'latest', type: TYPE_SYMLINK, linkTarget: 'pb_data/data.db' },
+        ],
+      }),
+    );
+
+    expect(refusal).toBe(NOTHING_REFUSED);
+    expect(written.content['pb_data/data.db']).toBe('rows');
+    expect(written.links.latest).toBe('pb_data/data.db');
+    expect(written.modes['pb_data/data.db']).toBe(PRIVATE_FILE_MODE);
+    expect(written.modes.pb_data).toBe(PRIVATE_DIRECTORY_MODE);
+  });
+
+  test('a parent the archive never declared is made anyway', async () => {
+    const { refusal, written } = await run(
+      unpacking({ entries: [{ path: 'deep/tree/data.db', body: 'rows' }] }),
+    );
+
+    expect(refusal).toBe(NOTHING_REFUSED);
+    expect(written.content['deep/tree/data.db']).toBe('rows');
+  });
+
+  test('everything written belongs to whoever the unpack was told to give it to', async () => {
+    const { written } = await run(
+      unpacking({
+        entries: [
+          { path: 'pb_data/', type: TYPE_DIRECTORY },
+          { path: 'pb_data/data.db', body: 'rows' },
+        ],
+      }),
+    );
+
+    const expected = `${OWNER.uid}:${OWNER.gid}`;
+    expect(written.owners).toEqual({
+      '.': expected,
+      pb_data: expected,
+      'pb_data/data.db': expected,
+    });
+  });
+
+  test('a setuid bit in the archive is not a setuid file on the host', async () => {
+    const { written } = await run(
+      unpacking({ entries: [{ path: 'helper', mode: SETUID_RUNNABLE_MODE }] }),
+    );
+
+    // Masked to every mode bit when it was read back, so this is also "and nothing above them".
+    expect(written.modes.helper).toBe(RUNNABLE_MODE);
+  });
+});
+
+describe('an entry that could reach outside the tree is refused', () => {
+  test('an absolute path', async () => {
+    const { refusal, written } = await run(
+      unpacking({ entries: [{ path: '/etc/passwd', body: 'root' }] }),
+    );
+
+    expect(refusal).toContain('starts at the root of a filesystem');
+    expect(written.names).toEqual([]);
+  });
+
+  test('a path that climbs out', async () => {
+    const { refusal } = await run(unpacking({ entries: [{ path: '../escaped', body: 'x' }] }));
+
+    expect(refusal).toContain('climbs out of the archive');
+  });
+
+  test('a symlink pointing out of the archive', async () => {
+    const { refusal } = await run(
+      unpacking({ entries: [{ path: 'escape', type: TYPE_SYMLINK, linkTarget: '../../etc' }] }),
+    );
+
+    expect(refusal).toContain('pointing out of the archive');
+  });
+
+  test('an absolute symlink', async () => {
+    const { refusal } = await run(
+      unpacking({ entries: [{ path: 'escape', type: TYPE_SYMLINK, linkTarget: '/etc' }] }),
+    );
+
+    expect(refusal).toContain('pointing out of the archive');
+  });
+
+  /**
+   * The one the containment check alone would not catch: `here` stays inside, and an entry written
+   * through it would land wherever it points once the tree is somewhere else.
+   */
+  test('an entry underneath a symlink the archive just made', async () => {
+    const { refusal, written } = await run(
+      unpacking({
+        entries: [
+          { path: 'here', type: TYPE_SYMLINK, linkTarget: 'pb_data' },
+          { path: 'here/data.db', body: 'rows' },
+        ],
+      }),
+    );
+
+    expect(refusal).toContain('reached through a symlink');
+    expect(written.links.here).toBe('pb_data');
+    expect(written.names).toEqual(['here']);
+  });
+
+  test('a symlink that stays inside is written', async () => {
+    const { refusal, written } = await run(
+      unpacking({
+        entries: [
+          { path: 'pb_data/data.db', body: 'rows' },
+          { path: 'pb_data/latest', type: TYPE_SYMLINK, linkTarget: '../pb_data/data.db' },
+        ],
+      }),
+    );
+
+    expect(refusal).toBe(NOTHING_REFUSED);
+    expect(written.links['pb_data/latest']).toBe('../pb_data/data.db');
+  });
+});
+
+describe('an entry that is not a file, a directory or a symlink is refused', () => {
+  test('a device node', async () => {
+    const { refusal } = await run(
+      unpacking({ entries: [{ path: 'dev/null', type: TYPE_CHAR_DEVICE }] }),
+    );
+
+    expect(refusal).toContain('not a file, a directory or a symlink');
+  });
+
+  test('a hard link, which would carry whatever it names into the filesystem', async () => {
+    const { refusal } = await run(
+      unpacking({ entries: [{ path: 'shadow', type: TYPE_HARDLINK, linkTarget: '/etc/shadow' }] }),
+    );
+
+    expect(refusal).toContain('not a file, a directory or a symlink');
+  });
+});
+
+describe('what the archive expands to is bounded, not just what it sent', () => {
+  test('a declared size past the ceiling ends the unpack before the bytes are spent', async () => {
+    const { refusal, written } = await run(
+      unpacking({
+        entries: [
+          { path: 'small', body: 'rows' },
+          { path: 'bomb', declaredSize: SMALL.maxBytes + 1 },
+        ],
+        limits: SMALL,
+      }),
+    );
+
+    expect(refusal).toContain('bytes an app may be seeded with');
+    expect(written.names).toEqual(['small']);
+  });
+
+  test('an archive that is headers the whole way down is bounded by their count', async () => {
+    const { refusal } = await run(
+      unpacking({
+        entries: [...Array(SMALL.maxEntries + 1).keys()].map((index) => ({
+          path: `d${index}`,
+          type: TYPE_DIRECTORY,
+        })),
+        limits: SMALL,
+      }),
+    );
+
+    expect(refusal).toContain('files an app may be seeded with');
+  });
+});
+
+test('bytes that are not a gzipped tarball are refused rather than half unpacked', async () => {
+  const refusal = await run(
+    Effect.gen(function* () {
+      const directory = yield* temporaryDirectory;
+      const archivePath = join(directory, 'archive.tar.gz');
+      yield* Effect.promise(() => writeFile(archivePath, 'not an archive'));
+      return refusalOf(
+        yield* Effect.either(
+          unpackSeed({
+            archivePath,
+            destination: join(directory, 'tree'),
+            owner: OWNER,
+            limits: SMALL,
+          }),
+        ),
+      );
+    }),
+  );
+
+  expect(refusal).not.toBe(NOTHING_REFUSED);
+});
+
+/**
+ * `tar cf archive.tar .` is how an owner is likeliest to make one, and it writes the tree's own
+ * root as `./` with every path under it as `./…`. Nothing here is spelled out block by block, so
+ * this is also the one test that proves the walk against a real tar's output end to end.
+ */
+test('an archive a real tar wrote from the tree root unpacks whole', async () => {
+  const { refusal, written } = await run(
+    Effect.gen(function* () {
+      const directory = yield* temporaryDirectory;
+      const source = join(directory, 'source');
+      yield* Effect.promise(async () => {
+        await mkdir(join(source, 'pb_data'), { recursive: true });
+        await writeFile(join(source, 'pb_data', 'data.db'), 'rows');
+        await symlink('pb_data/data.db', join(source, 'latest'));
+      });
+      const archivePath = join(directory, 'archive.tar.gz');
+      yield* Effect.promise(() => Bun.$`tar czf ${archivePath} -C ${source} .`.quiet());
+      const destination = join(directory, 'tree');
+      const result = yield* Effect.either(
+        unpackSeed({ archivePath, destination, owner: OWNER, limits: ROOMY }),
+      );
+      return {
+        refusal: refusalOf(result),
+        written: yield* Effect.promise(() => surveyed(destination)),
+      };
+    }),
+  );
+
+  expect(refusal).toBe(NOTHING_REFUSED);
+  expect(written.content['pb_data/data.db']).toBe('rows');
+  expect(written.links.latest).toBe('pb_data/data.db');
+});

--- a/apps/agent/tests/lib/volumes/tar.test.ts
+++ b/apps/agent/tests/lib/volumes/tar.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type TarEntry, tarEntries, UnreadableTarball } from '#lib/volumes/tar.ts';
+import {
+  TYPE_CHAR_DEVICE,
+  TYPE_DIRECTORY,
+  TYPE_LONG_NAME,
+  TYPE_SYMLINK,
+  tarballOf,
+} from '#tests/support/tarball.ts';
+
+const PRIVATE_FILE_MODE = 0o640;
+const PRIVATE_DIRECTORY_MODE = 0o750;
+const RUNNABLE_MODE = 0o755;
+const SETUID_RUNNABLE_MODE = 0o4755;
+/** What `tarballOf` writes where an entry says no mode of its own. */
+const DEFAULT_MODE = 0o644;
+/** Longer than one block, so the walk has to count rather than take what is in hand. */
+const SPANNING_BODY_BYTES = 1500;
+const ROWS_BYTES = 4;
+/** Longer than the 100-byte name field, which is what gnu's long-name entry exists for. */
+const LONG_DIRECTORY_BYTES = 120;
+const NAME_FIELD_BYTES = 99;
+const SIZE_FIELD_AT = 124;
+/** The high bit that says the rest of a numeric field is base 256 rather than octal text. */
+const BASE_256_MARKER = 0x80;
+const TRUNCATED_AT = 1024;
+
+type ReadEntry = Pick<TarEntry, 'path' | 'kind' | 'mode' | 'sizeBytes' | 'linkTarget'> & {
+  body: string;
+};
+
+function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new Response(bytes).body as ReadableStream<Uint8Array>;
+}
+
+async function entriesOf({
+  bytes,
+  reading = () => true,
+}: {
+  bytes: Uint8Array;
+  /** Whether this entry's content is read, so that abandoning one can be exercised too. */
+  reading?: (entry: TarEntry) => boolean;
+}): Promise<ReadEntry[]> {
+  const read: ReadEntry[] = [];
+  for await (const entry of tarEntries(streamOf(bytes))) {
+    const pieces: Uint8Array[] = [];
+    if (reading(entry)) {
+      for await (const piece of entry.content()) {
+        pieces.push(piece);
+      }
+    }
+    read.push({
+      path: entry.path,
+      kind: entry.kind,
+      mode: entry.mode,
+      sizeBytes: entry.sizeBytes,
+      linkTarget: entry.linkTarget,
+      body: new TextDecoder().decode(Buffer.concat(pieces)),
+    });
+  }
+  return read;
+}
+
+describe('an archive is walked forwards, once', () => {
+  test('every entry arrives with its header and its bytes', async () => {
+    const entries = await entriesOf({
+      bytes: tarballOf([
+        { path: 'pb_data/', type: TYPE_DIRECTORY, mode: PRIVATE_DIRECTORY_MODE },
+        { path: 'pb_data/data.db', mode: PRIVATE_FILE_MODE, body: 'rows' },
+        { path: 'latest', type: TYPE_SYMLINK, linkTarget: 'pb_data/data.db' },
+      ]),
+    });
+
+    expect(entries).toEqual([
+      {
+        path: 'pb_data/',
+        kind: 'directory',
+        mode: PRIVATE_DIRECTORY_MODE,
+        sizeBytes: 0,
+        linkTarget: '',
+        body: '',
+      },
+      {
+        path: 'pb_data/data.db',
+        kind: 'file',
+        mode: PRIVATE_FILE_MODE,
+        sizeBytes: ROWS_BYTES,
+        linkTarget: '',
+        body: 'rows',
+      },
+      {
+        path: 'latest',
+        kind: 'symlink',
+        mode: DEFAULT_MODE,
+        sizeBytes: 0,
+        linkTarget: 'pb_data/data.db',
+        body: '',
+      },
+    ]);
+  });
+
+  test('an entry nobody read is walked past, so the one after it still lines up', async () => {
+    const entries = await entriesOf({
+      bytes: tarballOf([
+        { path: 'skipped', body: 'x'.repeat(SPANNING_BODY_BYTES) },
+        { path: 'after', body: 'here' },
+      ]),
+      reading: (entry) => entry.path !== 'skipped',
+    });
+
+    expect(entries.map((entry) => entry.path)).toEqual(['skipped', 'after']);
+    expect(entries[1]?.body).toBe('here');
+  });
+
+  test('a device node is surfaced rather than hidden, so a caller can refuse the archive', async () => {
+    const entries = await entriesOf({
+      bytes: tarballOf([{ path: 'dev/null', type: TYPE_CHAR_DEVICE }]),
+    });
+
+    expect(entries[0]?.kind).toBe('unsupported');
+  });
+
+  test('the mode carries permissions and never the bits above them', async () => {
+    const entries = await entriesOf({
+      bytes: tarballOf([{ path: 'suid', mode: SETUID_RUNNABLE_MODE }]),
+    });
+
+    expect(entries[0]?.mode).toBe(RUNNABLE_MODE);
+  });
+});
+
+describe('a path a header cannot hold still arrives whole', () => {
+  test("gnu's long-name entry names the one after it", async () => {
+    const long = `${'d'.repeat(LONG_DIRECTORY_BYTES)}/data.db`;
+    const entries = await entriesOf({
+      bytes: tarballOf([
+        { path: '././@LongLink', type: TYPE_LONG_NAME, body: long },
+        { path: long.slice(0, NAME_FIELD_BYTES), body: 'rows' },
+      ]),
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.path).toBe(long);
+  });
+
+  test('a ustar prefix is joined back onto the name', async () => {
+    const entries = await entriesOf({
+      bytes: tarballOf([{ path: 'data.db', prefix: 'deep/tree' }]),
+    });
+
+    expect(entries[0]?.path).toBe('deep/tree/data.db');
+  });
+});
+
+describe('an archive that stops being followable ends the walk', () => {
+  test('a source that ends inside an entry is refused', async () => {
+    const whole = tarballOf([{ path: 'data.db', body: 'x'.repeat(SPANNING_BODY_BYTES) }]);
+
+    await expect(entriesOf({ bytes: whole.slice(0, TRUNCATED_AT) })).rejects.toBeInstanceOf(
+      UnreadableTarball,
+    );
+  });
+
+  test('a length that is not a number is refused rather than guessed at', async () => {
+    const bytes = tarballOf([{ path: 'data.db', body: 'rows' }]);
+    bytes.set(new TextEncoder().encode('99z99999999'), SIZE_FIELD_AT);
+
+    await expect(entriesOf({ bytes })).rejects.toBeInstanceOf(UnreadableTarball);
+  });
+
+  test('a length too wide for its own field is refused', async () => {
+    const bytes = tarballOf([{ path: 'data.db', body: 'rows' }]);
+    bytes.set([BASE_256_MARKER], SIZE_FIELD_AT);
+
+    await expect(entriesOf({ bytes })).rejects.toBeInstanceOf(UnreadableTarball);
+  });
+});
+
+/**
+ * The formats a real `tar` writes rather than the ones spelled out above — pax headers among them,
+ * which bsdtar emits routinely and which annotate the entry after them rather than describing a
+ * file of their own.
+ */
+test('a tarball a real tar wrote reads back as what went into it', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'nibrun-tar-'));
+  const source = join(directory, 'source');
+  await mkdir(join(source, 'pb_data'), { recursive: true });
+  await writeFile(join(source, 'pb_data', 'a name with spaces.db'), 'rows');
+  await symlink('pb_data/a name with spaces.db', join(source, 'latest'));
+  const archive = join(directory, 'archive.tar');
+  await Bun.$`tar cf ${archive} -C ${source} pb_data latest`.quiet();
+
+  const entries = await entriesOf({ bytes: new Uint8Array(await Bun.file(archive).arrayBuffer()) });
+  const byPath = new Map(entries.map((entry) => [entry.path.replace(/\/$/, ''), entry]));
+
+  expect(byPath.get('pb_data')?.kind).toBe('directory');
+  expect(byPath.get('pb_data/a name with spaces.db')?.body).toBe('rows');
+  expect(byPath.get('latest')).toMatchObject({
+    kind: 'symlink',
+    linkTarget: 'pb_data/a name with spaces.db',
+  });
+});

--- a/apps/agent/tests/support/config.ts
+++ b/apps/agent/tests/support/config.ts
@@ -14,6 +14,9 @@ export const AGENT_CONFIG = {
   zerofsCheckpointRuntimeDir: '/run/zerofs-checkpoint',
   zerofsBinary: '/opt/nibrun/bin/zerofs/zerofs',
   zerofsConfigFile: '/etc/zerofs/config.toml',
+  artifactBucket: 'nibrun-artifacts',
+  importBucket: 'nibrun-imports',
+  exportBucket: 'nibrun-exports',
 } as const;
 
 export function agentConfig(overrides: Partial<AgentConfig> = {}) {

--- a/apps/agent/tests/support/tarball.ts
+++ b/apps/agent/tests/support/tarball.ts
@@ -1,0 +1,100 @@
+import { Buffer } from 'node:buffer';
+
+/**
+ * Tarballs written block by block, because the archives worth testing against are the ones no
+ * `tar` will produce: an absolute path, a path climbing out, a device node, a length that lies.
+ * A real `tar` is used beside these for the formats it does write.
+ */
+
+const BLOCK_BYTES = 512;
+const CHECKSUM_AT = 148;
+const CHECKSUM_BYTES = 8;
+const CHECKSUM_DIGITS = 7;
+const HEADER_END = 500;
+const SPACE = 0x20;
+
+export const TYPE_FILE = '0';
+export const TYPE_DIRECTORY = '5';
+export const TYPE_SYMLINK = '2';
+export const TYPE_HARDLINK = '1';
+export const TYPE_CHAR_DEVICE = '3';
+export const TYPE_LONG_NAME = 'L';
+
+export type TarballEntry = {
+  path: string;
+  type?: string;
+  mode?: number;
+  linkTarget?: string;
+  body?: string;
+  /** What the header says the entry is, where that is not what follows it. */
+  declaredSize?: number;
+  /** The name field alone, for a path a ustar splits across the prefix. */
+  prefix?: string;
+};
+
+const DEFAULT_MODE = 0o644;
+
+function field({ value, at, size }: { value: string; at: number; size: number }) {
+  return { at, bytes: Buffer.from(value.slice(0, size - 1), 'utf8'), size };
+}
+
+const OCTAL = 8;
+
+function octalField({ value, at, size }: { value: number; at: number; size: number }) {
+  return field({ value: value.toString(OCTAL).padStart(size - 1, '0'), at, size });
+}
+
+function headerFor(entry: TarballEntry): Buffer {
+  const block = Buffer.alloc(BLOCK_BYTES);
+  const body = entry.body ?? '';
+  const parts = [
+    field({ value: entry.path, at: 0, size: 100 }),
+    octalField({ value: entry.mode ?? DEFAULT_MODE, at: 100, size: 8 }),
+    octalField({ value: 0, at: 108, size: 8 }),
+    octalField({ value: 0, at: 116, size: 8 }),
+    octalField({ value: entry.declaredSize ?? Buffer.byteLength(body), at: 124, size: 12 }),
+    octalField({ value: 0, at: 136, size: 12 }),
+    field({ value: entry.type ?? TYPE_FILE, at: 156, size: 2 }),
+    field({ value: entry.linkTarget ?? '', at: 157, size: 100 }),
+    field({ value: 'ustar', at: 257, size: 6 }),
+    field({ value: '00', at: 263, size: 3 }),
+    field({ value: entry.prefix ?? '', at: 345, size: 155 }),
+  ];
+  for (const part of parts) {
+    part.bytes.copy(block, part.at);
+  }
+  block.fill(SPACE, CHECKSUM_AT, CHECKSUM_AT + CHECKSUM_BYTES);
+  let checksum = 0;
+  for (const byte of block.subarray(0, HEADER_END)) {
+    checksum += byte;
+  }
+  octalField({ value: checksum, at: CHECKSUM_AT, size: CHECKSUM_DIGITS }).bytes.copy(
+    block,
+    CHECKSUM_AT,
+  );
+  return block;
+}
+
+function padded(body: Buffer): Buffer {
+  const padding = (BLOCK_BYTES - (body.byteLength % BLOCK_BYTES)) % BLOCK_BYTES;
+  return padding === 0 ? body : Buffer.concat([body, Buffer.alloc(padding)]);
+}
+
+const END_OF_ARCHIVE = Buffer.alloc(BLOCK_BYTES * 2);
+
+export function tarballOf(entries: readonly TarballEntry[]): Uint8Array {
+  const blocks = entries.flatMap((entry) => [
+    headerFor(entry),
+    padded(Buffer.from(entry.body ?? '', 'utf8')),
+  ]);
+  return new Uint8Array(Buffer.concat([...blocks, END_OF_ARCHIVE]));
+}
+
+export function gzippedTarball(entries: readonly TarballEntry[]): Uint8Array {
+  return Bun.gzipSync(new Uint8Array(tarballOf(entries)));
+}
+
+/** A file whose content is `size` bytes of nothing, which is what an expansion bomb is made of. */
+export function zeroFile({ path, size }: { path: string; size: number }): TarballEntry {
+  return { path, body: '\0'.repeat(size) };
+}


### PR DESCRIPTION
format() takes a seed directory and hands it to mkfs.ext4 -d, keeping the
superblock guard that makes it once. lib/volumes/seed.ts downloads and verifies
the archive, unpacks it under a staging tree bounded in bytes and entries, and
refuses anything that could reach out of it. Inert until the api sends a seed.

No hypervisor here, so `mkfs.ext4 -d` onto an NBD-backed ZeroFS device has not been run — the same gap `apps/agent/AGENTS.md` already documents for the volume path, and now recorded there for this too. The unpack itself is exercised against a temp directory: every refusal, both ceilings, and a real `tar`'s output.

