### PR TITLE
feat(api): an owner can upload an archive an app can be given as its data

### DIFF
--- a/apps/api/src/db/migrations/0044_an_app_can_be_given_starting_data.sql
+++ b/apps/api/src/db/migrations/0044_an_app_can_be_given_starting_data.sql
@@ -1,0 +1,64 @@
+-- An archive an owner uploaded, which an app's filesystem can be created holding.
+--
+-- A noun with no notion of use. There is no `kind`, no `mode` and nothing here about what the
+-- archive is for: a deployment says that by naming this row, exactly as it says which binary to
+-- run by naming an artifact. Whoever needs a second thing to do with an uploaded archive — an
+-- overwrite of a filesystem that already exists, say — adds it where the asking happens rather
+-- than as a flag here.
+--
+-- Not a column on `artifacts` and not a key in that bucket. Its `object_key` is documented as a
+-- key within ARTIFACTS_BUCKET and its keys are content-addressed, which is exactly wrong for this:
+-- one key per row, so two owners uploading identical bytes never share an object and expiring one
+-- can never take the other's away. That table's service exists to reject anything that is not a
+-- Linux executable, and for an artifact an archive is a wrapper to unwrap and discard, where here
+-- the archive is the payload.
+--
+-- The row is written before its bytes exist, as `artifacts` has been since 0017, and for the same
+-- reason: the upload does not pass through the api, so the row is what it is addressed by. What
+-- the bytes decide stays absent until they have been read. `digest IS NULL` is the whole of "still
+-- coming" — no state column, because a row is complete when what completes it is present.
+
+CREATE TABLE nibrun.imports (
+  id                 uuid PRIMARY KEY DEFAULT uuidv7(),
+  app_id             uuid NOT NULL REFERENCES nibrun.apps (id) ON DELETE CASCADE,
+  digest             text,
+  size_bytes         bigint,
+  object_key         text,
+  original_file_name text NOT NULL,
+  created_at         timestamptz GENERATED ALWAYS AS (uuid_extract_timestamp(id)) VIRTUAL,
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE nibrun.imports IS 'An uploaded archive an app can be given as its starting data. What it is used for is said by whatever names it.';
+COMMENT ON COLUMN nibrun.imports.id IS $c$@type import('@repo/protocol').ImportId$c$;
+COMMENT ON COLUMN nibrun.imports.app_id IS $c$@type import('@repo/protocol').AppId$c$;
+COMMENT ON COLUMN nibrun.imports.digest IS $c$Absent until the api has hashed the uploaded object; its presence is what makes the row usable. @type import('@repo/protocol').Sha256Digest$c$;
+COMMENT ON COLUMN nibrun.imports.size_bytes IS 'Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number.';
+COMMENT ON COLUMN nibrun.imports.object_key IS $c$Where the bytes are, present exactly while they are: absent before the upload has been read back, and absent again once the archive can no longer be used. Key within IMPORTS_BUCKET; which bucket is deploy configuration. @type import('@repo/protocol').ObjectKey$c$;
+COMMENT ON COLUMN nibrun.imports.original_file_name IS $c$The name the archive was uploaded under; the key it lands under carries none. @type import('@repo/protocol').Filename$c$;
+COMMENT ON COLUMN nibrun.imports.created_at IS 'Derived from the uuidv7 id; the moment the row was created. @notNull';
+
+CREATE INDEX imports_app_id_idx ON nibrun.imports (app_id);
+
+-- An upload nobody ever completes leaves this row behind, and the bucket rule that expires the
+-- object cannot reach it. Partial, because the rows worth sweeping are always the few still
+-- pending rather than the many that are done.
+CREATE INDEX imports_pending_idx ON nibrun.imports (id) WHERE digest IS NULL;
+
+CREATE TRIGGER set_updated_at BEFORE UPDATE ON nibrun.imports
+  FOR EACH ROW EXECUTE FUNCTION nibrun.set_updated_at();
+
+-- An app whose filesystem is gone still has archives sitting in a bucket, and each one is an
+-- owner's whole dataset in the clear. The purge is driven off what is still there, so this is what
+-- makes it look.
+--
+-- Appended last, because CREATE OR REPLACE VIEW may only add columns at the end — there are none
+-- to add here, so this is the same shape said again with one more thing to look for.
+CREATE OR REPLACE VIEW nibrun.purgeable_apps AS
+  SELECT a.id AS app_id
+  FROM nibrun.apps a
+  WHERE a.state = 'deleted'
+    AND (EXISTS (SELECT 1 FROM nibrun.artifacts ar WHERE ar.app_id = a.id)
+      OR EXISTS (SELECT 1 FROM nibrun.exports e WHERE e.app_id = a.id)
+      OR EXISTS (SELECT 1 FROM nibrun.app_hostnames h WHERE h.app_id = a.id)
+      OR EXISTS (SELECT 1 FROM nibrun.imports im WHERE im.app_id = a.id));

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -440,12 +440,22 @@ export interface ISelectExportKeysByAppResult {
     object_key: IExportsColumns["object_key"];
 }
 
+/** Result of query `SelectImportKeysByApp`. */
+export interface ISelectImportKeysByAppResult {
+    /** Where the bytes are, present exactly while they are: absent before the upload has been read back, and absent again once the archive can no longer be used. Key within IMPORTS_BUCKET; which bucket is deploy configuration. */
+    object_key: NonNullable<IImportsColumns["object_key"]>;
+}
+
 /** Result of query `DeleteExportsByApp`. */
 export interface IDeleteExportsByAppResult {
 }
 
 /** Result of query `DeleteDeploymentsByApp`. */
 export interface IDeleteDeploymentsByAppResult {
+}
+
+/** Result of query `DeleteImportsByApp`. */
+export interface IDeleteImportsByAppResult {
 }
 
 /** Result of query `DeleteArtifactsByApp`. */
@@ -843,6 +853,68 @@ export interface ISelectHealthPingResult {
     ok: number | null;
 }
 
+/** Result of query `InsertPendingImport`. */
+export interface IInsertPendingImportResult {
+    id: IImportsColumns["id"];
+    app_id: IImportsColumns["app_id"];
+    /** The name the archive was uploaded under; the key it lands under carries none. */
+    original_file_name: IImportsColumns["original_file_name"];
+    /** Derived from the uuidv7 id; the moment the row was created. */
+    created_at: Date;
+}
+
+/** Result of query `CompleteImport`. */
+export interface ICompleteImportResult {
+    id: IImportsColumns["id"];
+    app_id: IImportsColumns["app_id"];
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row usable. */
+    digest: NonNullable<IImportsColumns["digest"]>;
+    /** Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    size_bytes: NonNullable<IImportsColumns["size_bytes"]>;
+    /** The name the archive was uploaded under; the key it lands under carries none. */
+    original_file_name: IImportsColumns["original_file_name"];
+    /** Derived from the uuidv7 id; the moment the row was created. */
+    created_at: Date;
+}
+
+/** Result of query `DeleteImport`. */
+export interface IDeleteImportResult {
+}
+
+/** Result of query `SelectPendingImport`. */
+export interface ISelectPendingImportResult {
+    id: IImportsColumns["id"];
+    app_id: IImportsColumns["app_id"];
+    /** The name the archive was uploaded under; the key it lands under carries none. */
+    original_file_name: IImportsColumns["original_file_name"];
+    /** Derived from the uuidv7 id; the moment the row was created. */
+    created_at: Date;
+}
+
+/** Result of query `SelectImportById`. */
+export interface ISelectImportByIdResult {
+    id: IImportsColumns["id"];
+    app_id: IImportsColumns["app_id"];
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row usable. */
+    digest: NonNullable<IImportsColumns["digest"]>;
+    /** Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    size_bytes: NonNullable<IImportsColumns["size_bytes"]>;
+    /** The name the archive was uploaded under; the key it lands under carries none. */
+    original_file_name: IImportsColumns["original_file_name"];
+    /** Derived from the uuidv7 id; the moment the row was created. */
+    created_at: Date;
+}
+
+/** Result of query `SelectAbandonedImports`. */
+export interface ISelectAbandonedImportsResult {
+    id: IImportsColumns["id"];
+    app_id: IImportsColumns["app_id"];
+}
+
+/** Result of query `DeleteAbandonedImport`. */
+export interface IDeleteAbandonedImportResult {
+}
+
 export interface Queries {
     SelectDesiredDeployments: ISelectDesiredDeploymentsResult;
     SelectDesiredVolumes: ISelectDesiredVolumesResult;
@@ -879,8 +951,10 @@ export interface Queries {
     SelectPurgeableApps: ISelectPurgeableAppsResult;
     SelectUnsharedArtifactKeys: ISelectUnsharedArtifactKeysResult;
     SelectExportKeysByApp: ISelectExportKeysByAppResult;
+    SelectImportKeysByApp: ISelectImportKeysByAppResult;
     DeleteExportsByApp: IDeleteExportsByAppResult;
     DeleteDeploymentsByApp: IDeleteDeploymentsByAppResult;
+    DeleteImportsByApp: IDeleteImportsByAppResult;
     DeleteArtifactsByApp: IDeleteArtifactsByAppResult;
     DeleteAppUsageByApp: IDeleteAppUsageByAppResult;
     SelectAppAfterStateChange: ISelectAppAfterStateChangeResult;
@@ -912,6 +986,13 @@ export interface Queries {
     FailInFlightExports: IFailInFlightExportsResult;
     SelectInFlightExport: ISelectInFlightExportResult;
     SelectHealthPing: ISelectHealthPingResult;
+    InsertPendingImport: IInsertPendingImportResult;
+    CompleteImport: ICompleteImportResult;
+    DeleteImport: IDeleteImportResult;
+    SelectPendingImport: ISelectPendingImportResult;
+    SelectImportById: ISelectImportByIdResult;
+    SelectAbandonedImports: ISelectAbandonedImportsResult;
+    DeleteAbandonedImport: IDeleteAbandonedImportResult;
 }
 
 /** Columns of `account`. */
@@ -1454,6 +1535,31 @@ export interface IFinishableDeletionsTable {
     relationType: (typeof schema)["finishable_deletions"]["_relationType"];
     indexes: keyof (typeof schema)["finishable_deletions"]["_indexes"];
     constraints: keyof (typeof schema)["finishable_deletions"]["_constraints"];
+}
+
+/** Columns of `imports`. */
+export interface IImportsColumns {
+    id: import("@repo/protocol").ImportId;
+    app_id: import("@repo/protocol").AppId;
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row usable. */
+    digest: import("@repo/protocol").Sha256Digest | null;
+    /** Counted off the uploaded bytes, so absent until they are there. A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    size_bytes: string | null;
+    /** Where the bytes are, present exactly while they are: absent before the upload has been read back, and absent again once the archive can no longer be used. Key within IMPORTS_BUCKET; which bucket is deploy configuration. */
+    object_key: import("@repo/protocol").ObjectKey | null;
+    /** The name the archive was uploaded under; the key it lands under carries none. */
+    original_file_name: import("@repo/protocol").Filename;
+    /** Derived from the uuidv7 id; the moment the row was created. */
+    created_at: Date;
+    updated_at: Date;
+}
+
+/** Schema of `imports`. */
+export interface IImportsTable {
+    columns: IImportsColumns;
+    relationType: (typeof schema)["imports"]["_relationType"];
+    indexes: keyof (typeof schema)["imports"]["_indexes"];
+    constraints: keyof (typeof schema)["imports"]["_constraints"];
 }
 
 /** Columns of `live_apps`. */
@@ -2041,6 +2147,29 @@ export const schema = {
         _indexes: {},
         _constraints: {}
     },
+    imports: {
+        _relationName: "imports",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            app_id: { _columnName: "app_id", _foreignKeys: { imports_app_id_fkey: { _constraintName: "imports_app_id_fkey", _references: { _relationName: "apps", _columnName: "id" } } } },
+            digest: { _columnName: "digest", _foreignKeys: {} },
+            size_bytes: { _columnName: "size_bytes", _foreignKeys: {} },
+            object_key: { _columnName: "object_key", _foreignKeys: {} },
+            original_file_name: { _columnName: "original_file_name", _foreignKeys: {} },
+            created_at: { _columnName: "created_at", _foreignKeys: {} },
+            updated_at: { _columnName: "updated_at", _foreignKeys: {} }
+        },
+        _indexes: {
+            imports_app_id_idx: { _indexName: "imports_app_id_idx" },
+            imports_pending_idx: { _indexName: "imports_pending_idx" },
+            imports_pkey: { _indexName: "imports_pkey" }
+        },
+        _constraints: {
+            imports_app_id_fkey: { _constraintName: "imports_app_id_fkey" },
+            imports_pkey: { _constraintName: "imports_pkey" }
+        }
+    },
     live_apps: {
         _relationName: "live_apps",
         _relationType: "view",
@@ -2113,6 +2242,7 @@ export interface Tables {
     desired_volumes: IDesiredVolumesTable;
     exports: IExportsTable;
     finishable_deletions: IFinishableDeletionsTable;
+    imports: IImportsTable;
     live_apps: ILiveAppsTable;
     profiles: IProfilesTable;
     purgeable_apps: IPurgeableAppsTable;

--- a/apps/api/src/lib/archive/gzipped-tarball.ts
+++ b/apps/api/src/lib/archive/gzipped-tarball.ts
@@ -1,0 +1,69 @@
+import { Buffer } from 'node:buffer';
+import { isTarball, TAR_IDENTITY_BYTES } from '#lib/archive/tar.ts';
+
+/** What a gzip opens with, whatever it turns out to be wrapped around. */
+const GZIP_MAGIC = Buffer.from('\x1f\x8b', 'latin1');
+
+const GZIP = 'gzip';
+
+/**
+ * How much of the source is held to answer this.
+ *
+ * A tar says what it is 262 bytes into its first header and gzip only ever shrinks, so this reaches
+ * that for anything but a pathologically incompressible one. Fixed whatever was uploaded, which is
+ * what keeps a decompression bomb out of it: nothing here reads past this many bytes of input, so
+ * what the source claims to expand to never costs this end anything.
+ */
+export const OPENING_BYTES = 4096;
+
+/**
+ * Whether the bytes open as a gzipped tarball, read from the front and no further.
+ *
+ * The envelope only. What is inside is the owner's business, and how much of it there is belongs to
+ * the host that unpacks it — this answers the one question the api is in a position to answer
+ * cheaply, so that sending the wrong kind of file is a refused upload rather than a filesystem that
+ * fails to provision later, where the reason reaches its owner as a broken app.
+ */
+export async function isGzippedTarball(opening: Uint8Array): Promise<boolean> {
+  if (!Buffer.from(opening).subarray(0, GZIP_MAGIC.length).equals(GZIP_MAGIC)) {
+    return false;
+  }
+  const header = await inflatedOpening(opening);
+  return header !== undefined && isTarball(header);
+}
+
+/**
+ * The front of what the gzip holds, or nothing where it does not hold that much.
+ *
+ * These bytes are a prefix of a stream, so the inflate ends by running out rather than by finishing
+ * — which is the ordinary case here and not a failure. What came out before it stopped is still the
+ * front of the archive, and the front is the whole question.
+ */
+async function inflatedOpening(opening: Uint8Array): Promise<Uint8Array | undefined> {
+  // Copied into a buffer of its own — at most `OPENING_BYTES` — because a decompression stream
+  // takes bytes that are not backed by shared memory, which a slice of somebody else's may be.
+  const compressed = new ReadableStream<Uint8Array<ArrayBuffer>>({
+    start(controller) {
+      controller.enqueue(new Uint8Array(opening));
+      controller.close();
+    },
+  });
+  const reader = compressed.pipeThrough(new DecompressionStream(GZIP)).getReader();
+  const pieces: Buffer[] = [];
+  let held = 0;
+  try {
+    while (held < TAR_IDENTITY_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      pieces.push(Buffer.from(value));
+      held += value.byteLength;
+    }
+  } catch {
+    // The prefix ran out mid-stream, which is what a prefix does.
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  return held >= TAR_IDENTITY_BYTES ? Buffer.concat(pieces) : undefined;
+}

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -11,6 +11,7 @@ interface CustomProcessEnv {
   readonly VICTORIALOGS_ENDPOINT: string;
   readonly ARTIFACTS_BUCKET: string;
   readonly EXPORTS_BUCKET: string;
+  readonly IMPORTS_BUCKET: string;
   readonly EXPORT_RETENTION_DAYS?: string;
   readonly S3_ACCESS_KEY_ID: string;
   readonly S3_SECRET_ACCESS_KEY: string;
@@ -58,6 +59,7 @@ type Env = {
   VICTORIALOGS_ENDPOINT: URL;
   ARTIFACTS_BUCKET: string;
   EXPORTS_BUCKET: string;
+  IMPORTS_BUCKET: string;
   EXPORT_RETENTION_DAYS: number;
   S3_ACCESS_KEY_ID: string;
   S3_SECRET_ACCESS_KEY: string;
@@ -80,6 +82,7 @@ function loadEnv(): Env {
     VICTORIALOGS_ENDPOINT: new URL(required('VICTORIALOGS_ENDPOINT')),
     ARTIFACTS_BUCKET: required('ARTIFACTS_BUCKET'),
     EXPORTS_BUCKET: required('EXPORTS_BUCKET'),
+    IMPORTS_BUCKET: required('IMPORTS_BUCKET'),
     EXPORT_RETENTION_DAYS: Number(
       optional({ name: 'EXPORT_RETENTION_DAYS', defaultValue: DEFAULT_EXPORT_RETENTION_DAYS }),
     ),

--- a/apps/api/src/lib/s3/client.ts
+++ b/apps/api/src/lib/s3/client.ts
@@ -12,12 +12,17 @@ export const artifactsS3 = new Bun.S3Client({ bucket: env.ARTIFACTS_BUCKET, ...c
 
 export const exportsS3 = new Bun.S3Client({ bucket: env.EXPORTS_BUCKET, ...credentials });
 
+export const importsS3 = new Bun.S3Client({ bucket: env.IMPORTS_BUCKET, ...credentials });
+
 /**
  * A client from another library for one thing Bun's cannot do: name `content-length` among the
  * headers a signature covers, which is what holds an upload to a size when the api is not the one
- * receiving it. Everything else still goes through the client above — see `signUpload`.
+ * receiving it. Everything else still goes through the clients above — see `signUpload`.
+ *
+ * Not bound to a bucket, unlike those: a `PutObjectCommand` names its own, so one signer serves
+ * every bucket this api hands an upload url out for.
  */
-export const artifactsSigner = new S3Client({
+export const uploadSigner = new S3Client({
   region: env.S3_REGION,
   endpoint: env.S3_ENDPOINT.origin,
   credentials: {

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -46,7 +46,7 @@ export type NewApp = {
  * one object — and deleting it for the app that is going would take the binary out from under the
  * one that stays. The last of them to be deleted is the one that finds it unreferenced.
  */
-export type Leftovers = { artifacts: ObjectKey[]; exports: ObjectKey[] };
+export type Leftovers = { artifacts: ObjectKey[]; exports: ObjectKey[]; imports: ObjectKey[] };
 
 type OwnedApp = { appId: AppId; ownerId: OwnerId };
 
@@ -570,7 +570,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
    * an app deployed a hundred times is a hundred rows over far fewer objects.
    */
   async listLeftovers({ appId }: { appId: AppId }): Promise<Leftovers> {
-    const [artifacts, exports] = await Promise.all([
+    const [artifacts, exports, imports] = await Promise.all([
       this.sql.SelectUnsharedArtifactKeys`
         /* @notNull object_key */
         SELECT DISTINCT ar.object_key
@@ -586,10 +586,19 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
       this.sql.SelectExportKeysByApp`
         SELECT e.object_key FROM nibrun.exports e WHERE e.app_id = ${appId}
       `,
+      // No `DISTINCT` and no shared-key check, unlike the artifacts above: a key here is one row's
+      // and no other's, which is what not content-addressing them buys.
+      this.sql.SelectImportKeysByApp`
+        /* @notNull object_key */
+        SELECT im.object_key
+        FROM nibrun.imports im
+        WHERE im.app_id = ${appId} AND im.object_key IS NOT NULL
+      `,
     ]);
     return {
       artifacts: artifacts.map((row) => row.object_key),
       exports: exports.map((row) => row.object_key),
+      imports: imports.map((row) => row.object_key),
     };
   }
 
@@ -609,6 +618,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
     return this.sql.begin(async (tx) => {
       await tx.DeleteExportsByApp`DELETE FROM nibrun.exports WHERE app_id = ${appId}`;
       await tx.DeleteDeploymentsByApp`DELETE FROM nibrun.deployments WHERE app_id = ${appId}`;
+      await tx.DeleteImportsByApp`DELETE FROM nibrun.imports WHERE app_id = ${appId}`;
       await tx.DeleteArtifactsByApp`DELETE FROM nibrun.artifacts WHERE app_id = ${appId}`;
       await tx.DeleteAppUsageByApp`DELETE FROM nibrun.app_usage WHERE app_id = ${appId}`;
     });

--- a/apps/api/src/repositories/imports.repository.ts
+++ b/apps/api/src/repositories/imports.repository.ts
@@ -1,0 +1,170 @@
+import type { AppId, Filename, ImportId, ObjectKey, OwnerId, Sha256Digest } from '@repo/protocol';
+import type { Queries } from '#db/queries.gen.ts';
+import { Repository } from '#repositories/repository.ts';
+
+export type ImportRow = Queries['SelectImportById'];
+export type PendingImportRow = Queries['SelectPendingImport'];
+export type AbandonedImportRow = Queries['SelectAbandonedImports'];
+
+export type CompleteImportInput = {
+  appId: AppId;
+  importId: ImportId;
+  ownerId: OwnerId;
+  digest: Sha256Digest;
+  sizeBytes: number;
+  objectKey: ObjectKey;
+};
+
+export abstract class ImportsRepositoryContract {
+  abstract insertPending(input: {
+    appId: AppId;
+    ownerId: OwnerId;
+    originalFileName: Filename;
+  }): Promise<PendingImportRow | null>;
+  abstract complete(input: CompleteImportInput): Promise<ImportRow | null>;
+  abstract remove(input: { appId: AppId; importId: ImportId; ownerId: OwnerId }): Promise<void>;
+  abstract findPending(input: {
+    appId: AppId;
+    importId: ImportId;
+    ownerId: OwnerId;
+  }): Promise<PendingImportRow | null>;
+  abstract findById(input: {
+    appId: AppId;
+    importId: ImportId;
+    ownerId: OwnerId;
+  }): Promise<ImportRow | null>;
+  abstract listAbandoned(input: { olderThanSeconds: number }): Promise<AbandonedImportRow[]>;
+  abstract removeAbandoned(input: { importId: ImportId }): Promise<void>;
+}
+
+/**
+ * `digest IS NOT NULL` is what separates an archive from an upload still in flight, so every read
+ * that returns one carries it. A row without it names bytes that may never arrive.
+ */
+export class ImportsRepository extends Repository implements ImportsRepositoryContract {
+  async insertPending({
+    appId,
+    ownerId,
+    originalFileName,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    originalFileName: Filename;
+  }): Promise<PendingImportRow | null> {
+    const [row] = await this.sql.InsertPendingImport`
+      INSERT INTO nibrun.imports (app_id, original_file_name)
+      SELECT a.id, ${originalFileName}
+      FROM nibrun.live_apps a
+      WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
+      RETURNING id, app_id, original_file_name, created_at
+    `;
+    return row ?? null;
+  }
+
+  /**
+   * Only ever the first time: the guard is what stops a second report of the same upload from
+   * rewriting an archive a deployment already points at.
+   */
+  async complete({
+    appId,
+    importId,
+    ownerId,
+    digest,
+    sizeBytes,
+    objectKey,
+  }: CompleteImportInput): Promise<ImportRow | null> {
+    const [row] = await this.sql.CompleteImport`
+      /* @notNull digest */
+      /* @notNull size_bytes */
+      UPDATE nibrun.imports im
+      SET digest = ${digest}, size_bytes = ${sizeBytes}, object_key = ${objectKey}
+      FROM nibrun.live_apps a
+      WHERE im.id = ${importId} AND im.app_id = ${appId} AND a.id = im.app_id
+        AND a.owner_id = ${ownerId} AND im.digest IS NULL
+      RETURNING im.id, im.app_id, im.digest, im.size_bytes, im.original_file_name, im.created_at
+    `;
+    return row ?? null;
+  }
+
+  async remove({
+    appId,
+    importId,
+    ownerId,
+  }: {
+    appId: AppId;
+    importId: ImportId;
+    ownerId: OwnerId;
+  }): Promise<void> {
+    await this.sql.DeleteImport`
+      DELETE FROM nibrun.imports im
+      USING nibrun.live_apps a
+      WHERE im.id = ${importId} AND im.app_id = ${appId} AND a.id = im.app_id
+        AND a.owner_id = ${ownerId} AND im.digest IS NULL
+    `;
+  }
+
+  async findPending({
+    appId,
+    importId,
+    ownerId,
+  }: {
+    appId: AppId;
+    importId: ImportId;
+    ownerId: OwnerId;
+  }): Promise<PendingImportRow | null> {
+    const [row] = await this.sql.SelectPendingImport`
+      SELECT im.id, im.app_id, im.original_file_name, im.created_at
+      FROM nibrun.imports im
+      JOIN nibrun.live_apps a ON a.id = im.app_id
+      WHERE im.id = ${importId} AND im.app_id = ${appId} AND a.owner_id = ${ownerId}
+        AND im.digest IS NULL
+    `;
+    return row ?? null;
+  }
+
+  async findById({
+    appId,
+    importId,
+    ownerId,
+  }: {
+    appId: AppId;
+    importId: ImportId;
+    ownerId: OwnerId;
+  }): Promise<ImportRow | null> {
+    const [row] = await this.sql.SelectImportById`
+      /* @notNull digest */
+      /* @notNull size_bytes */
+      SELECT im.id, im.app_id, im.digest, im.size_bytes, im.original_file_name, im.created_at
+      FROM nibrun.imports im
+      JOIN nibrun.live_apps a ON a.id = im.app_id
+      WHERE im.id = ${importId} AND im.app_id = ${appId} AND a.owner_id = ${ownerId}
+        AND im.digest IS NOT NULL
+    `;
+    return row ?? null;
+  }
+
+  /**
+   * An upload nobody ever reported on. Old enough that the signed URL it was handed has long
+   * expired, so nothing is still on its way to the key this row is addressed by.
+   */
+  listAbandoned({ olderThanSeconds }: { olderThanSeconds: number }): Promise<AbandonedImportRow[]> {
+    return this.sql.SelectAbandonedImports`
+      SELECT im.id, im.app_id
+      FROM nibrun.imports im
+      WHERE im.digest IS NULL
+        AND im.created_at < now() - make_interval(secs => ${olderThanSeconds})
+    `;
+  }
+
+  /**
+   * No owner, because no owner asked: this is the sweep, and the row it names came from a listing
+   * of what is still pending rather than from anybody's request. `digest IS NULL` is carried
+   * anyway, so a row completed since that listing is left alone.
+   */
+  async removeAbandoned({ importId }: { importId: ImportId }): Promise<void> {
+    await this.sql.DeleteAbandonedImport`
+      DELETE FROM nibrun.imports im
+      WHERE im.id = ${importId} AND im.digest IS NULL
+    `;
+  }
+}

--- a/apps/api/src/routes/api/apps/[appId]/imports/[importId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/imports/[importId]/controller.ts
@@ -1,0 +1,51 @@
+import { AppIdSchema, ImportIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
+import { Elysia, StatusMap, t } from 'elysia';
+import { authPlugin } from '#lib/auth/plugin.ts';
+import {
+  ImportResponseSchema,
+  UpdateImportBodySchema,
+} from '#routes/api/apps/[appId]/imports/model.ts';
+import { ImportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+
+export const AppsAppIdImportsImportIdController = new Elysia()
+  .use(loggerPlugin('appsAppIdImportsImportIdController'))
+  .use(authPlugin)
+  .use(ImportsServicePlugin)
+  .guard({ auth: true })
+  .get(
+    '/apps/:appId/imports/:importId',
+    async ({ importsService, params, user, status }) => {
+      const stored = await importsService.get({
+        appId: Value.Parse(AppIdSchema, params.appId),
+        importId: Value.Parse(ImportIdSchema, params.importId),
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
+      });
+      return status(StatusMap.OK, stored);
+    },
+    {
+      response: { [StatusMap.OK]: ImportResponseSchema },
+    },
+  )
+  .patch(
+    '/apps/:appId/imports/:importId',
+    async ({ importsService, params, body, user, status }) => {
+      const appId = Value.Parse(AppIdSchema, params.appId);
+      const importId = Value.Parse(ImportIdSchema, params.importId);
+      const ownerId = Value.Parse(OwnerIdSchema, user.id);
+
+      if (body.upload === 'failed') {
+        await importsService.failUpload({ appId, importId, ownerId });
+        return status(StatusMap['No Content'], undefined);
+      }
+
+      const stored = await importsService.completeUpload({ appId, importId, ownerId });
+      return status(StatusMap.OK, stored);
+    },
+    {
+      body: UpdateImportBodySchema,
+      response: {
+        [StatusMap.OK]: ImportResponseSchema,
+        [StatusMap['No Content']]: t.Void(),
+      },
+    },
+  );

--- a/apps/api/src/routes/api/apps/[appId]/imports/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/imports/controller.ts
@@ -1,0 +1,32 @@
+import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
+import { Elysia, StatusMap } from 'elysia';
+import { authPlugin } from '#lib/auth/plugin.ts';
+import {
+  CreateImportBodySchema,
+  CreateImportResponseSchema,
+} from '#routes/api/apps/[appId]/imports/model.ts';
+import { ImportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+
+export const AppsAppIdImportsController = new Elysia()
+  .use(loggerPlugin('appsAppIdImportsController'))
+  .use(authPlugin)
+  .use(ImportsServicePlugin)
+  .guard({ auth: true })
+  // Created rather than OK: the import exists from here on, and what is left to do with it is send
+  // the bytes to the url this answers with.
+  .post(
+    '/apps/:appId/imports',
+    async ({ importsService, params, body, user, status }) => {
+      const created = await importsService.create({
+        appId: Value.Parse(AppIdSchema, params.appId),
+        ownerId: Value.Parse(OwnerIdSchema, user.id),
+        filename: body.filename,
+        sizeBytes: body.sizeBytes,
+      });
+      return status(StatusMap.Created, created);
+    },
+    {
+      body: CreateImportBodySchema,
+      response: { [StatusMap.Created]: CreateImportResponseSchema },
+    },
+  );

--- a/apps/api/src/routes/api/apps/[appId]/imports/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/imports/model.ts
@@ -1,0 +1,25 @@
+import { ByteSizeSchema, FilenameSchema, ImportIdSchema, ImportSchema } from '@repo/protocol';
+import { t } from 'elysia';
+
+// The bytes the owner holds. The name is theirs, not the store's: keys here are assigned one per
+// row, so they carry none, and this is the only name anybody would recognise the archive by.
+//
+// The size is answered before anything is signed, and then signed into the url: the store holds
+// the upload to exactly it.
+export const CreateImportBodySchema = t.Object({
+  filename: FilenameSchema,
+  sizeBytes: ByteSizeSchema,
+});
+
+export const CreateImportResponseSchema = t.Object({
+  importId: ImportIdSchema,
+  url: t.String({ description: 'Where to PUT the archive, as the whole request body.' }),
+});
+
+// Said by the only end that knows: the upload happened between the caller and the store, so the
+// api learns how it went by being told.
+export const UpdateImportBodySchema = t.Object({
+  upload: t.Union([t.Literal('complete'), t.Literal('failed')]),
+});
+
+export const ImportResponseSchema = ImportSchema;

--- a/apps/api/src/routes/api/controller.ts
+++ b/apps/api/src/routes/api/controller.ts
@@ -10,6 +10,8 @@ import { AppsAppIdDeploymentsController } from '#routes/api/apps/[appId]/deploym
 import { AppsAppIdExportsExportIdController } from '#routes/api/apps/[appId]/exports/[exportId]/controller.ts';
 import { AppsAppIdExportsController } from '#routes/api/apps/[appId]/exports/controller.ts';
 import { AppsAppIdHostnamesController } from '#routes/api/apps/[appId]/hostnames/controller.ts';
+import { AppsAppIdImportsImportIdController } from '#routes/api/apps/[appId]/imports/[importId]/controller.ts';
+import { AppsAppIdImportsController } from '#routes/api/apps/[appId]/imports/controller.ts';
 import { AppsAppIdStateController } from '#routes/api/apps/[appId]/state/controller.ts';
 import { AppsController } from '#routes/api/apps/controller.ts';
 import { AuthController } from '#routes/api/auth/controller.ts';
@@ -28,5 +30,7 @@ export const ApiController = new Elysia({ prefix: RoutePrefix.Api })
   .use(AppsAppIdDeploymentsDeploymentIdLogsController)
   .use(AppsAppIdExportsController)
   .use(AppsAppIdExportsExportIdController)
+  .use(AppsAppIdImportsController)
+  .use(AppsAppIdImportsImportIdController)
   .use(AppsAppIdHostnamesController)
   .use(AppsAppIdStateController);

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -23,7 +23,7 @@ const MS_PER_SECOND = 1000;
 const SECONDS_PER_HOUR = 60 * 60;
 const SESSION_LIFETIME_MS = SECONDS_PER_HOUR * MS_PER_SECOND;
 
-/** What a report is borrowed for, and nothing else artifacts can do. */
+/** What a report is borrowed for, and nothing else an upload's own service can do. */
 export type UploadSweep = Pick<ArtifactsService, 'sweepAbandoned'>;
 
 /** Likewise for hostnames: a report is the clock, not permission to add or remove one. */
@@ -35,6 +35,7 @@ export class AgentService extends Service {
   private readonly appsService: AppsService;
   private readonly exportsService: ExportsService;
   private readonly artifactsService: UploadSweep;
+  private readonly importsService: UploadSweep;
   private readonly hostnamesService: HostnameReconcile;
 
   constructor({
@@ -43,6 +44,7 @@ export class AgentService extends Service {
     appsService,
     exportsService,
     artifactsService,
+    importsService,
     hostnamesService,
   }: {
     agentRepo: AgentRepositoryContract;
@@ -50,6 +52,7 @@ export class AgentService extends Service {
     appsService: AppsService;
     exportsService: ExportsService;
     artifactsService: UploadSweep;
+    importsService: UploadSweep;
     hostnamesService: HostnameReconcile;
   }) {
     super();
@@ -58,6 +61,7 @@ export class AgentService extends Service {
     this.appsService = appsService;
     this.exportsService = exportsService;
     this.artifactsService = artifactsService;
+    this.importsService = importsService;
     this.hostnamesService = hostnamesService;
   }
 
@@ -139,6 +143,7 @@ export class AgentService extends Service {
     // Nothing to do with this report. A report is simply the clock this process has, and an
     // upload nobody ever came back about is work that needs one.
     await this.artifactsService.sweepAbandoned();
+    await this.importsService.sweepAbandoned();
     // The same clock, for the same reason: whether a custom hostname has been pointed at us is
     // decided in somebody else's DNS, so there is no moment to act on but a passing one.
     await this.hostnamesService.reconcile();

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -108,6 +108,7 @@ export class AppsService extends Service {
   private readonly exportsRepo: ExportCancellation;
   private readonly artifactStorageRepo: ObjectRemoval;
   private readonly exportStorageRepo: ObjectRemoval;
+  private readonly importStorageRepo: ObjectRemoval;
   private readonly appHostDomain: string;
   private readonly secretsKey: TenantSecretsKey;
 
@@ -118,6 +119,7 @@ export class AppsService extends Service {
     exportsRepo,
     artifactStorageRepo,
     exportStorageRepo,
+    importStorageRepo,
     appHostDomain,
     secretsKey,
   }: {
@@ -127,6 +129,7 @@ export class AppsService extends Service {
     exportsRepo: ExportCancellation;
     artifactStorageRepo: ObjectRemoval;
     exportStorageRepo: ObjectRemoval;
+    importStorageRepo: ObjectRemoval;
     appHostDomain: string;
     secretsKey: TenantSecretsKey;
   }) {
@@ -137,6 +140,7 @@ export class AppsService extends Service {
     this.exportsRepo = exportsRepo;
     this.artifactStorageRepo = artifactStorageRepo;
     this.exportStorageRepo = exportStorageRepo;
+    this.importStorageRepo = importStorageRepo;
     this.appHostDomain = appHostDomain;
     this.secretsKey = secretsKey;
   }
@@ -399,8 +403,9 @@ export class AppsService extends Service {
 
   /**
    * Remove what a deleted app left behind: the binaries it was deployed from, the bundles it was
-   * exported into, and the rows naming them. The filesystem went with the host; these did not,
-   * and between them they are the tenant's code and every byte of their data.
+   * exported into, the archives it was given as starting data, and the rows naming them. The
+   * filesystem went with the host; these did not, and between them they are the tenant's code and
+   * every byte of their data.
    *
    * Driven off what is still there rather than off the moment an app became `deleted`, so a pass
    * that fails part way is retried by the next host report finding the same app still listed —
@@ -428,6 +433,7 @@ export class AppsService extends Service {
       await Promise.all([
         ...leftovers.exports.map((objectKey) => this.exportStorageRepo.remove({ objectKey })),
         ...leftovers.artifacts.map((objectKey) => this.artifactStorageRepo.remove({ objectKey })),
+        ...leftovers.imports.map((objectKey) => this.importStorageRepo.remove({ objectKey })),
       ]);
       await this.appsRepo.purge({ appId });
 
@@ -435,6 +441,7 @@ export class AppsService extends Service {
         appId,
         artifacts: leftovers.artifacts.length,
         exports: leftovers.exports.length,
+        imports: leftovers.imports.length,
       });
     } catch (error) {
       this.logger.error('purging a deleted app failed', { appId, error });

--- a/apps/api/src/services/imports.service.ts
+++ b/apps/api/src/services/imports.service.ts
@@ -1,0 +1,321 @@
+import { Buffer } from 'node:buffer';
+import {
+  type AppId,
+  type Filename,
+  type Import,
+  type ImportId,
+  type ObjectKey,
+  ObjectKeySchema,
+  type OwnerId,
+  type Sha256Digest,
+  Sha256DigestSchema,
+  Value,
+} from '@repo/protocol';
+import { isGzippedTarball, OPENING_BYTES } from '#lib/archive/gzipped-tarball.ts';
+import { BadRequestError, NotFoundError } from '#lib/errors.ts';
+import { toTimestamp } from '#lib/timestamp.ts';
+import type { AppsRepositoryContract } from '#repositories/apps.repository.ts';
+import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
+import type { ImportRow, ImportsRepositoryContract } from '#repositories/imports.repository.ts';
+import { Service } from '#services/service.ts';
+
+const NO_SUCH_APP = 'App not found.';
+const NO_SUCH_IMPORT = 'Import not found.';
+const NO_SUCH_UPLOAD = 'No upload is awaiting that import.';
+const NOTHING_UPLOADED = 'Nothing was uploaded against that import.';
+/**
+ * Said as the shape rather than as what was found: the upload happened between the caller and the
+ * store, so what they sent is a thing they can look at, and naming the format is what tells them
+ * `gzip data.db` is not `tar czf`.
+ */
+const NOT_AN_ARCHIVE =
+  "That upload is not a .tar.gz. An app's data is created from one archive, whose root becomes the root of data/.";
+
+const BYTES_PER_GIBIBYTE = 1_073_741_824;
+const MAX_IMPORT_GIBIBYTES = 1;
+
+/**
+ * What an owner may send as an app's starting data.
+ *
+ * Refused before anything is signed, and then signed into the url: the store holds the upload to
+ * exactly the size that was declared, so a larger body is not the request that was agreed to.
+ * Checked once more while hashing, because the store is not this api and a bucket that let
+ * something through is not an argument for keeping it.
+ *
+ * What the archive *expands* to is a different bound and not this one — the host holds it to a
+ * ceiling of its own while it unpacks, because a quarter of a gibibyte of zeros is a 255 KB
+ * upload.
+ */
+export const MAX_IMPORT_SIZE_BYTES = MAX_IMPORT_GIBIBYTES * BYTES_PER_GIBIBYTE;
+const TOO_LARGE = `An import may be at most ${MAX_IMPORT_GIBIBYTES} GiB.`;
+
+/** Long enough that the signed url the row was handed has expired, so no bytes are still coming. */
+const ABANDONED_AFTER_SECONDS = 86_400;
+
+const DIGEST_ALGORITHM = 'sha256';
+const HEX_ENCODING = 'hex';
+
+export type ImportUpload = {
+  importId: ImportId;
+  url: string;
+};
+
+/** What the bytes decided, which is everything about them the row does not have until now. */
+type UploadedArchive = { digest: Sha256Digest; sizeBytes: number; opening: Uint8Array };
+
+export class ImportsService extends Service {
+  private readonly importsRepo: ImportsRepositoryContract;
+  private readonly storageRepo: ArtifactStorageRepositoryContract;
+  private readonly appsRepo: AppsRepositoryContract;
+
+  constructor({
+    importsRepo,
+    storageRepo,
+    appsRepo,
+  }: {
+    importsRepo: ImportsRepositoryContract;
+    storageRepo: ArtifactStorageRepositoryContract;
+    appsRepo: AppsRepositoryContract;
+  }) {
+    super();
+    this.importsRepo = importsRepo;
+    this.storageRepo = storageRepo;
+    this.appsRepo = appsRepo;
+  }
+
+  /**
+   * Begin an import: a row with nothing the bytes decide, and somewhere to put them.
+   *
+   * The row comes first because it is what the upload is addressed by, exactly as an artifact's
+   * is. What differs is where the bytes land: an artifact is copied to the key its digest names
+   * once it has been hashed, and this is not content-addressed at all — one key per row, so the
+   * key is known before the upload and the object is written straight to it. Nothing reads it
+   * until the row carries a digest, and no second copy of an owner's dataset is ever made.
+   */
+  async create({
+    appId,
+    ownerId,
+    filename,
+    sizeBytes,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    filename: Filename;
+    sizeBytes: number;
+  }): Promise<ImportUpload> {
+    if (!(await this.appsRepo.isOwnedBy({ appId, ownerId }))) {
+      throw new NotFoundError(NO_SUCH_APP);
+    }
+    if (sizeBytes > MAX_IMPORT_SIZE_BYTES) {
+      throw new BadRequestError(TOO_LARGE);
+    }
+
+    const pending = await this.importsRepo.insertPending({
+      appId,
+      ownerId,
+      originalFileName: filename,
+    });
+    if (!pending) {
+      throw new NotFoundError(NO_SUCH_APP);
+    }
+
+    const url = await this.storageRepo.signUpload({
+      objectKey: importKey({ appId, importId: pending.id }),
+      sizeBytes,
+    });
+
+    return { importId: pending.id, url };
+  }
+
+  /**
+   * Take the caller's word that the bytes are there, and nothing else about them.
+   *
+   * They are read back and hashed rather than trusted, because the digest is what a host verifies
+   * before it will create a filesystem from one: a wrong digest accepted here becomes a volume
+   * that never provisions, which is the failure this end exists to turn into a rejected request.
+   *
+   * What is *inside* the archive is not asked about. An artifact is refused unless it is a Linux
+   * executable because a host has to run it; here the archive is the payload, and what it holds is
+   * the owner's business until the host unpacks it.
+   */
+  async completeUpload({
+    appId,
+    ownerId,
+    importId,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    importId: ImportId;
+  }): Promise<Import> {
+    const pending = await this.importsRepo.findPending({ appId, importId, ownerId });
+    if (!pending) {
+      return await this.alreadyStored({ appId, importId, ownerId });
+    }
+
+    const objectKey = importKey({ appId, importId });
+    if (!(await this.storageRepo.exists({ objectKey }))) {
+      throw new BadRequestError(NOTHING_UPLOADED);
+    }
+
+    const uploaded = await this.read({ objectKey });
+    if (!uploaded) {
+      await this.discard({ objectKey });
+      throw new BadRequestError(TOO_LARGE);
+    }
+    // The envelope, not the contents: a host has to be able to unpack this, and the front of the
+    // upload already went past on the way to the digest, so asking costs nothing that was not
+    // already spent. Everything else about the archive is the host's to refuse.
+    if (!(await isGzippedTarball(uploaded.opening))) {
+      await this.discard({ objectKey });
+      throw new BadRequestError(NOT_AN_ARCHIVE);
+    }
+
+    const stored = await this.importsRepo.complete({
+      appId,
+      importId,
+      ownerId,
+      objectKey,
+      ...uploaded,
+    });
+    if (!stored) {
+      return await this.alreadyStored({ appId, importId, ownerId });
+    }
+    this.logger.info('import stored', { appId, importId, sizeBytes: uploaded.sizeBytes });
+    return toImport(stored);
+  }
+
+  /**
+   * The caller says the upload will not be coming. Taken at face value: they are the only one who
+   * knows, and the row is theirs — so it goes now rather than waiting a day to be swept.
+   */
+  async failUpload({
+    appId,
+    ownerId,
+    importId,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    importId: ImportId;
+  }): Promise<void> {
+    const pending = await this.importsRepo.findPending({ appId, importId, ownerId });
+    if (!pending) {
+      throw new NotFoundError(NO_SUCH_UPLOAD);
+    }
+    await this.discard({ objectKey: importKey({ appId, importId }) });
+    await this.importsRepo.remove({ appId, importId, ownerId });
+  }
+
+  async get({
+    appId,
+    importId,
+    ownerId,
+  }: {
+    appId: AppId;
+    importId: ImportId;
+    ownerId: OwnerId;
+  }): Promise<Import> {
+    const row = await this.importsRepo.findById({ appId, importId, ownerId });
+    if (!row) {
+      throw new NotFoundError(NO_SUCH_IMPORT);
+    }
+    return toImport(row);
+  }
+
+  /**
+   * Uploads nobody ever came back about, driven off the rows still waiting rather than off the
+   * moment one was signed — so a pass that fails part way is retried by the next one finding the
+   * same rows. Objects before rows, as everywhere else: a row removed first leaves an owner's
+   * dataset sitting in a bucket with nothing naming it.
+   */
+  async sweepAbandoned(): Promise<void> {
+    const abandoned = await this.importsRepo.listAbandoned({
+      olderThanSeconds: ABANDONED_AFTER_SECONDS,
+    });
+    for (const row of abandoned) {
+      await this.discard({ objectKey: importKey({ appId: row.app_id, importId: row.id }) });
+      await this.importsRepo.removeAbandoned({ importId: row.id });
+      this.logger.info('abandoned import swept', { appId: row.app_id, importId: row.id });
+    }
+  }
+
+  /**
+   * What the object came to, or nothing where it came to more than may be stored. Streamed and
+   * hashed a chunk at a time: this is as large as a whole dataset, and holding one in memory is
+   * the cost signing the upload away was meant to avoid.
+   */
+  private async read({ objectKey }: { objectKey: ObjectKey }): Promise<UploadedArchive | null> {
+    const hasher = new Bun.CryptoHasher(DIGEST_ALGORITHM);
+    const opening: Uint8Array[] = [];
+    let held = 0;
+    let sizeBytes = 0;
+    for await (const chunk of this.storageRepo.read({ objectKey })) {
+      sizeBytes += chunk.byteLength;
+      // Leaving the loop cancels the read, so an object already past the cap costs one chunk
+      // rather than the whole of itself.
+      if (sizeBytes > MAX_IMPORT_SIZE_BYTES) {
+        return null;
+      }
+      // Kept on the way past rather than read again afterwards: this is the only pass over the
+      // object, and the front of it is what says whether it is an archive at all.
+      if (held < OPENING_BYTES) {
+        opening.push(chunk);
+        held += chunk.byteLength;
+      }
+      hasher.update(chunk);
+    }
+    return {
+      digest: Value.Parse(Sha256DigestSchema, hasher.digest(HEX_ENCODING)),
+      sizeBytes,
+      opening: Buffer.concat(opening).subarray(0, OPENING_BYTES),
+    };
+  }
+
+  /** A second report of the same upload, which is the row it already made rather than an error. */
+  private async alreadyStored({
+    appId,
+    importId,
+    ownerId,
+  }: {
+    appId: AppId;
+    importId: ImportId;
+    ownerId: OwnerId;
+  }): Promise<Import> {
+    const stored = await this.importsRepo.findById({ appId, importId, ownerId });
+    if (!stored) {
+      throw new NotFoundError(NO_SUCH_UPLOAD);
+    }
+    return toImport(stored);
+  }
+
+  /**
+   * The object is spent either way, and the bucket's own expiry is what guarantees it goes.
+   * Failing the request over it would report an upload that did not happen, so this is logged and
+   * left to the rule.
+   */
+  private async discard({ objectKey }: { objectKey: ObjectKey }): Promise<void> {
+    try {
+      await this.storageRepo.remove({ objectKey });
+    } catch (error) {
+      this.logger.warn('an uploaded import could not be removed', { objectKey, error });
+    }
+  }
+}
+
+/**
+ * One key per row, deliberately not the digest. Two owners uploading identical bytes must not
+ * share an object: expiring one would take the other's away, and neither of them agreed to that.
+ */
+export function importKey({ appId, importId }: { appId: AppId; importId: ImportId }): ObjectKey {
+  return Value.Parse(ObjectKeySchema, `imports/${appId}/${importId}`);
+}
+
+function toImport(row: ImportRow): Import {
+  return {
+    id: row.id,
+    appId: row.app_id,
+    digest: row.digest,
+    sizeBytes: Number(row.size_bytes),
+    originalFileName: row.original_file_name,
+    createdAt: toTimestamp(row.created_at),
+  };
+}

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -3,7 +3,7 @@ import { sql } from '#db/client.ts';
 import { CloudflareClient } from '#lib/cloudflare/client.ts';
 import { env } from '#lib/env.ts';
 import { createLogger } from '#lib/logger.ts';
-import { artifactsS3, artifactsSigner, exportsS3 } from '#lib/s3/client.ts';
+import { artifactsS3, exportsS3, importsS3, uploadSigner } from '#lib/s3/client.ts';
 import { readSecretsKey } from '#lib/tenant-secrets.ts';
 import { VictoriaLogsClient } from '#lib/victorialogs/client.ts';
 import { AgentRepository } from '#repositories/agent.repository.ts';
@@ -19,6 +19,7 @@ import { DeploymentsRepository } from '#repositories/deployments.repository.ts';
 import { ExportStorageRepository } from '#repositories/export-storage.repository.ts';
 import { ExportsRepository } from '#repositories/exports.repository.ts';
 import { HealthRepository } from '#repositories/health.repository.ts';
+import { ImportsRepository } from '#repositories/imports.repository.ts';
 import { LogsRepository } from '#repositories/logs.repository.ts';
 import { ReleaseDigestRepository } from '#repositories/release-digest.repository.ts';
 import { AgentService } from '#services/agent.service.ts';
@@ -30,6 +31,7 @@ import { ExportsService } from '#services/exports.service.ts';
 import { FilesystemService } from '#services/filesystem.service.ts';
 import { HealthService } from '#services/health.service.ts';
 import { HostnamesService } from '#services/hostnames.service.ts';
+import { ImportsService } from '#services/imports.service.ts';
 import { LogsService } from '#services/logs.service.ts';
 
 // Read once, where every other piece of the environment is read: a key of the wrong length is a
@@ -59,13 +61,19 @@ const artifactsRepository = new ArtifactsRepository(sql);
 const deploymentsRepository = new DeploymentsRepository(sql);
 const artifactStorageRepository = new ArtifactStorageRepository({
   client: artifactsS3,
-  signer: artifactsSigner,
+  signer: uploadSigner,
   bucket: env.ARTIFACTS_BUCKET,
+});
+const importStorageRepository = new ArtifactStorageRepository({
+  client: importsS3,
+  signer: uploadSigner,
+  bucket: env.IMPORTS_BUCKET,
 });
 const binarySourceRepository = new BinarySourceRepository();
 const cachedBinariesRepository = new CachedBinariesRepository(sql);
 const releaseDigestRepository = new ReleaseDigestRepository();
 const exportsRepository = new ExportsRepository(sql);
+const importsRepository = new ImportsRepository(sql);
 const exportStorageRepository = new ExportStorageRepository(exportsS3);
 const customHostnamesRepository = new CustomHostnamesRepository(cloudflareClient);
 const logsRepository = new LogsRepository(victoriaLogsClient);
@@ -78,6 +86,7 @@ const appsService = new AppsService({
   exportsRepo: exportsRepository,
   artifactStorageRepo: artifactStorageRepository,
   exportStorageRepo: exportStorageRepository,
+  importStorageRepo: importStorageRepository,
   appHostDomain: env.APP_HOST_DOMAIN,
   secretsKey,
 });
@@ -107,12 +116,18 @@ const artifactsService = new ArtifactsService({
   releaseRepo: releaseDigestRepository,
   appsRepo: appsRepository,
 });
+const importsService = new ImportsService({
+  importsRepo: importsRepository,
+  storageRepo: importStorageRepository,
+  appsRepo: appsRepository,
+});
 const agentService = new AgentService({
   agentRepo: agentRepository,
   deploymentsService,
   appsService,
   exportsService,
   artifactsService,
+  importsService,
   hostnamesService,
 });
 const logsService = new LogsService({
@@ -173,4 +188,9 @@ export const HostnamesServicePlugin = new Elysia({ name: 'service.hostnames' }).
 export const ExportsServicePlugin = new Elysia({ name: 'service.exports' }).decorate(
   'exportsService',
   exportsService,
+);
+
+export const ImportsServicePlugin = new Elysia({ name: 'service.imports' }).decorate(
+  'importsService',
+  importsService,
 );

--- a/apps/api/tests/controllers/imports.test.ts
+++ b/apps/api/tests/controllers/imports.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import { StatusMap } from 'elysia';
+import { ORIGIN, send, sendJson } from '#tests/controllers/support/api.ts';
+
+const APP_ID = '0199c0de-0000-7000-8000-000000000001';
+const IMPORT_ID = '0199c0de-0000-7000-8000-000000000003';
+const IMPORTS_URL = `${ORIGIN}/api/apps/${APP_ID}/imports`;
+
+function create(body: unknown) {
+  return sendJson({ method: 'POST', url: IMPORTS_URL, body });
+}
+
+function report(body: unknown) {
+  return sendJson({ method: 'PATCH', url: `${IMPORTS_URL}/${IMPORT_ID}`, body });
+}
+
+// Nothing here presents a session: better-auth needs a database and this suite has none. What it
+// does prove is that the routes exist — a 404 would mean the tree was never mounted — and that not
+// one of them answers anything to a caller who has not proven who they are.
+describe("an app's starting data is not somewhere strangers can write to", () => {
+  test('being given somewhere to upload requires a session', async () => {
+    const response = await create({ filename: 'pb_data.tar.gz', sizeBytes: 1 });
+
+    expect(response.status).toBe(StatusMap.Unauthorized);
+  });
+
+  test('saying how an upload went requires a session', async () => {
+    expect((await report({ upload: 'complete' })).status).toBe(StatusMap.Unauthorized);
+  });
+
+  test('reading one back requires a session', async () => {
+    expect((await send({ url: `${IMPORTS_URL}/${IMPORT_ID}` })).status).toBe(
+      StatusMap.Unauthorized,
+    );
+  });
+});
+
+// Body validation runs ahead of the session check, so these answer 400 rather than 401 — they say
+// nothing about the app, only that the request was never what it claimed.
+describe('a request that could not name an archive is not one', () => {
+  test('asking for somewhere to upload without saying what or how large is not asking', async () => {
+    expect((await create({})).status).toBe(StatusMap['Bad Request']);
+  });
+
+  test('a size that is not a size is not one', async () => {
+    const response = await create({ filename: 'pb_data.tar.gz', sizeBytes: 'large' });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
+  // The only name anybody would recognise the archive by, so one carrying a path is refused at
+  // the edge rather than sanitised into a different name.
+  test('a filename that is a path is not a filename', async () => {
+    const response = await create({ filename: '../../etc/passwd', sizeBytes: 1 });
+
+    expect(response.status).toBe(StatusMap['Bad Request']);
+  });
+
+  test('an upload outcome that is neither is not one', async () => {
+    expect((await report({ upload: 'maybe' })).status).toBe(StatusMap['Bad Request']);
+  });
+});

--- a/apps/api/tests/controllers/support/api.ts
+++ b/apps/api/tests/controllers/support/api.ts
@@ -14,6 +14,7 @@ Object.assign(process.env, {
   VICTORIALOGS_ENDPOINT: 'http://127.0.0.1:1',
   ARTIFACTS_BUCKET: 'test',
   EXPORTS_BUCKET: 'test-exports',
+  IMPORTS_BUCKET: 'test-imports',
   S3_ACCESS_KEY_ID: 'test',
   S3_SECRET_ACCESS_KEY: 'test',
   S3_REGION: 'test',

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -144,6 +144,7 @@ function build() {
   const apps = new FakeAppsService();
   const exports = new FakeExportsService();
   const artifacts = new FakeUploadSweep();
+  const imports = new FakeUploadSweep();
   const hostnames = new FakeHostnameReconcile();
   return {
     agentRepo,
@@ -151,6 +152,7 @@ function build() {
     deployments,
     exports,
     artifacts,
+    imports,
     hostnames,
     service: new AgentService({
       agentRepo,
@@ -158,6 +160,7 @@ function build() {
       appsService: apps as unknown as AppsService,
       exportsService: exports as unknown as ExportsService,
       artifactsService: artifacts,
+      importsService: imports,
       hostnamesService: hostnames,
     }),
   };
@@ -256,7 +259,7 @@ describe('a report is read by whatever owns what it talks about', () => {
   // Nothing in the report says anything about hostnames. It is borrowed as a clock, because
   // whether an owner has pointed their domain at us happens in DNS with nobody to announce it.
   test('and the clock it lends is what advances a custom hostname nobody announced', async () => {
-    const { artifacts, hostnames, service } = build();
+    const { artifacts, imports, hostnames, service } = build();
     const reported = {
       hostId: Value.Parse(HostIdSchema, 'host-1'),
       instances: [],
@@ -267,6 +270,7 @@ describe('a report is read by whatever owns what it talks about', () => {
     await service.acceptReport({ reported });
 
     expect(artifacts.swept).toBe(1);
+    expect(imports.swept).toBe(1);
     expect(hostnames.reconciled).toBe(1);
   });
 });

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -282,7 +282,7 @@ class StubAppsRepository implements AppsRepositoryContract {
   }
 
   listLeftovers({ appId }: { appId: AppId }): Promise<Leftovers> {
-    return Promise.resolve(this.leftovers.get(appId) ?? { artifacts: [], exports: [] });
+    return Promise.resolve(this.leftovers.get(appId) ?? NOTHING_LEFT);
   }
 
   // An app leaves the purgeable list by having nothing left, which is how the real view answers.
@@ -386,6 +386,7 @@ function serviceWith({
   exportsRepo = new StubExportCancellation(),
   artifactStorageRepo = new StubObjectStorage({ trace: [] }),
   exportStorageRepo = new StubObjectStorage({ trace: [] }),
+  importStorageRepo = new StubObjectStorage({ trace: [] }),
 }: {
   appsRepo: AppsRepositoryContract;
   hostnamesRepo?: AppHostnameAccess;
@@ -393,6 +394,7 @@ function serviceWith({
   exportsRepo?: ExportCancellation;
   artifactStorageRepo?: ObjectRemoval;
   exportStorageRepo?: ObjectRemoval;
+  importStorageRepo?: ObjectRemoval;
 }) {
   return new AppsService({
     appsRepo,
@@ -401,6 +403,7 @@ function serviceWith({
     exportsRepo,
     artifactStorageRepo,
     exportStorageRepo,
+    importStorageRepo,
     appHostDomain: APP_HOST_DOMAIN,
     secretsKey: TEST_SECRETS_KEY,
   });
@@ -1119,7 +1122,11 @@ const SECOND_APP_ID = Value.Parse(AppIdSchema, '01927e3a-0000-7000-8000-00000000
 
 const SOLO_BINARY = objectKey('solo-binary-digest');
 const BUNDLE = objectKey('exports/app/bundle.tar.gz');
+const ARCHIVE = objectKey('imports/app/archive');
 
+const NOTHING_LEFT: Leftovers = { artifacts: [], exports: [], imports: [] };
+
+/** Whatever kind the test is about; every other kind is what an app that had none of it leaves. */
 function purgeableApp({
   appsRepo,
   appId,
@@ -1127,31 +1134,34 @@ function purgeableApp({
 }: {
   appsRepo: StubAppsRepository;
   appId: AppId;
-  leftovers: Leftovers;
+  leftovers: Partial<Leftovers>;
 }): void {
   appsRepo.purgeable.push(appId);
-  appsRepo.leftovers.set(appId, leftovers);
+  appsRepo.leftovers.set(appId, { ...NOTHING_LEFT, ...leftovers });
 }
 
 describe('what a deleted app leaves behind is removed after it', () => {
-  test('the binaries and the bundles both go', async () => {
+  test('the binaries, the bundles and the uploaded archives all go', async () => {
     const appsRepo = new StubAppsRepository({ failures: 0 });
     const artifacts = new StubObjectStorage({ trace: appsRepo.trace });
     const exports = new StubObjectStorage({ trace: appsRepo.trace });
+    const imports = new StubObjectStorage({ trace: appsRepo.trace });
     purgeableApp({
       appsRepo,
       appId: APP_ID,
-      leftovers: { artifacts: [SOLO_BINARY], exports: [BUNDLE] },
+      leftovers: { artifacts: [SOLO_BINARY], exports: [BUNDLE], imports: [ARCHIVE] },
     });
 
     await serviceWith({
       appsRepo,
       artifactStorageRepo: artifacts,
       exportStorageRepo: exports,
+      importStorageRepo: imports,
     }).purgeDeleted();
 
     expect(artifacts.removed).toEqual([SOLO_BINARY]);
     expect(exports.removed).toEqual([BUNDLE]);
+    expect(imports.removed).toEqual([ARCHIVE]);
   });
 
   // A row deleted before its object is bytes nothing names; an object deleted before its row is

--- a/apps/api/tests/services/imports.test.ts
+++ b/apps/api/tests/services/imports.test.ts
@@ -1,0 +1,563 @@
+import { describe, expect, test } from 'bun:test';
+import { gzipSync } from 'node:zlib';
+import {
+  type AppId,
+  type Filename,
+  FilenameSchema,
+  type ImportId,
+  ImportIdSchema,
+  ImportSchema,
+  isValidMessage,
+  type ObjectKey,
+  type OwnerId,
+  type Sha256Digest,
+  Value,
+} from '@repo/protocol';
+import { BadRequestError, NotFoundError } from '#lib/errors.ts';
+import type { AppsRepositoryContract } from '#repositories/apps.repository.ts';
+import type { ArtifactStorageRepositoryContract } from '#repositories/artifact-storage.repository.ts';
+import type {
+  AbandonedImportRow,
+  CompleteImportInput,
+  ImportRow,
+  ImportsRepositoryContract,
+  PendingImportRow,
+} from '#repositories/imports.repository.ts';
+import { ImportsService, importKey, MAX_IMPORT_SIZE_BYTES } from '#services/imports.service.ts';
+import { APP_ID, OTHER_OWNER_ID, OWNER_ID } from '#tests/services/support/fixtures.ts';
+import { gzippedTarballOf, tarballOf } from '#tests/support/tarballs.ts';
+
+const ARCHIVE = gzippedTarballOf([{ name: 'pb_data/data.db', content: bytesOf('rows') }]);
+const UPLOADED_NAME = Value.Parse(FilenameSchema, 'pb_data.tar.gz');
+const SIGNED_URL = 'https://store.test/signed';
+
+const A_DAY_SECONDS = 86_400;
+const MS_PER_SECOND = 1_000;
+const AN_HOUR_MS = 3_600_000;
+const PAST_THE_SWEEP_MS = A_DAY_SECONDS * MS_PER_SECOND + AN_HOUR_MS;
+
+const NEXT_ID = { value: 0 };
+
+function anImportId(): ImportId {
+  NEXT_ID.value += 1;
+  return Value.Parse(ImportIdSchema, `import-${NEXT_ID.value}`);
+}
+
+function bytesOf(text: string): Uint8Array {
+  return Uint8Array.from(text, (character) => character.charCodeAt(0));
+}
+
+function digestOf(bytes: Uint8Array): string {
+  return new Bun.CryptoHasher('sha256').update(bytes).digest('hex');
+}
+
+type StoredRow = Omit<ImportRow, 'digest' | 'size_bytes'> & {
+  digest: ImportRow['digest'] | null;
+  size_bytes: ImportRow['size_bytes'] | null;
+  object_key: ObjectKey | null;
+};
+
+/**
+ * A row is an import once it has a digest and an upload still in flight until then, which is the
+ * distinction the SQL draws — so this fake draws it too rather than answering every read the same
+ * way and leaving the service to sort them out.
+ */
+class FakeImportsRepository implements ImportsRepositoryContract {
+  readonly rows = new Map<ImportId, StoredRow>();
+  private readonly ownedBy: OwnerId;
+
+  constructor(ownedBy: OwnerId) {
+    this.ownedBy = ownedBy;
+  }
+
+  insertPending({
+    appId,
+    ownerId,
+    originalFileName,
+  }: {
+    appId: AppId;
+    ownerId: OwnerId;
+    originalFileName: Filename;
+  }): Promise<PendingImportRow | null> {
+    if (ownerId !== this.ownedBy) {
+      return Promise.resolve(null);
+    }
+    const id = anImportId();
+    this.rows.set(id, {
+      id,
+      app_id: appId,
+      digest: null,
+      size_bytes: null,
+      object_key: null,
+      original_file_name: originalFileName,
+      created_at: new Date(),
+    });
+    return Promise.resolve(this.#pending(id));
+  }
+
+  complete({
+    importId,
+    ownerId,
+    digest,
+    sizeBytes,
+    objectKey,
+  }: CompleteImportInput): Promise<ImportRow | null> {
+    const row = this.rows.get(importId);
+    if (!row || ownerId !== this.ownedBy || row.digest !== null) {
+      return Promise.resolve(null);
+    }
+    const completed = {
+      ...row,
+      digest,
+      size_bytes: String(sizeBytes),
+      object_key: objectKey,
+    } satisfies StoredRow;
+    this.rows.set(importId, completed);
+    return Promise.resolve(completed as ImportRow);
+  }
+
+  remove({ importId, ownerId }: { importId: ImportId; ownerId: OwnerId }): Promise<void> {
+    const row = this.rows.get(importId);
+    if (row && ownerId === this.ownedBy && row.digest === null) {
+      this.rows.delete(importId);
+    }
+    return Promise.resolve();
+  }
+
+  findPending({
+    importId,
+    ownerId,
+  }: {
+    importId: ImportId;
+    ownerId: OwnerId;
+  }): Promise<PendingImportRow | null> {
+    const row = this.rows.get(importId);
+    return Promise.resolve(
+      row && ownerId === this.ownedBy && row.digest === null ? this.#pending(row.id) : null,
+    );
+  }
+
+  findById({
+    importId,
+    ownerId,
+  }: {
+    importId: ImportId;
+    ownerId: OwnerId;
+  }): Promise<ImportRow | null> {
+    const row = this.rows.get(importId);
+    return Promise.resolve(
+      row && ownerId === this.ownedBy && row.digest !== null ? (row as ImportRow) : null,
+    );
+  }
+
+  listAbandoned({ olderThanSeconds }: { olderThanSeconds: number }): Promise<AbandonedImportRow[]> {
+    const cutoff = Date.now() - olderThanSeconds * MS_PER_SECOND;
+    return Promise.resolve(
+      [...this.rows.values()]
+        .filter((row) => row.digest === null && row.created_at.getTime() < cutoff)
+        .map((row) => ({ id: row.id, app_id: row.app_id })),
+    );
+  }
+
+  removeAbandoned({ importId }: { importId: ImportId }): Promise<void> {
+    const row = this.rows.get(importId);
+    if (row && row.digest === null) {
+      this.rows.delete(importId);
+    }
+    return Promise.resolve();
+  }
+
+  /** Pretends the row has been sitting there since before the sweep's cutoff. */
+  age(importId: ImportId): void {
+    const row = this.rows.get(importId);
+    if (row) {
+      this.rows.set(importId, { ...row, created_at: new Date(Date.now() - PAST_THE_SWEEP_MS) });
+    }
+  }
+
+  #pending(id: ImportId): PendingImportRow | null {
+    const row = this.rows.get(id);
+    return row
+      ? {
+          id: row.id,
+          app_id: row.app_id,
+          original_file_name: row.original_file_name,
+          created_at: row.created_at,
+        }
+      : null;
+  }
+}
+
+class FakeStorage implements ArtifactStorageRepositoryContract {
+  readonly objects = new Map<ObjectKey, Uint8Array>();
+  readonly signed: { objectKey: ObjectKey; sizeBytes: number }[] = [];
+  readonly removed: ObjectKey[] = [];
+
+  signUpload(input: { objectKey: ObjectKey; sizeBytes: number }): Promise<string> {
+    this.signed.push(input);
+    return Promise.resolve(`${SIGNED_URL}/${input.objectKey}`);
+  }
+
+  async write({
+    objectKey,
+    body,
+  }: {
+    objectKey: ObjectKey;
+    body: ReadableStream<Uint8Array>;
+  }): Promise<void> {
+    const written: number[] = [];
+    for await (const chunk of body) {
+      written.push(...chunk);
+    }
+    this.objects.set(objectKey, Uint8Array.from(written));
+  }
+
+  read({ objectKey }: { objectKey: ObjectKey }): ReadableStream<Uint8Array> {
+    const bytes = this.objects.get(objectKey);
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (bytes !== undefined) {
+          controller.enqueue(bytes);
+        }
+        controller.close();
+      },
+    });
+  }
+
+  copy(): Promise<void> {
+    return Promise.reject(new Error('an import is never copied anywhere'));
+  }
+
+  exists({ objectKey }: { objectKey: ObjectKey }): Promise<boolean> {
+    return Promise.resolve(this.objects.has(objectKey));
+  }
+
+  remove({ objectKey }: { objectKey: ObjectKey }): Promise<void> {
+    this.removed.push(objectKey);
+    this.objects.delete(objectKey);
+    return Promise.resolve();
+  }
+
+  /** Stands in for the caller spending the signed url. */
+  put({ objectKey, bytes }: { objectKey: ObjectKey; bytes: Uint8Array }): void {
+    this.objects.set(objectKey, bytes);
+  }
+}
+
+class FakeAppsRepository {
+  isOwnedBy({ ownerId }: { appId: AppId; ownerId: OwnerId }): Promise<boolean> {
+    return Promise.resolve(ownerId === OWNER_ID);
+  }
+}
+
+function build() {
+  const importsRepo = new FakeImportsRepository(OWNER_ID);
+  const storage = new FakeStorage();
+  return {
+    importsRepo,
+    storage,
+    service: new ImportsService({
+      importsRepo,
+      storageRepo: storage,
+      appsRepo: new FakeAppsRepository() as unknown as AppsRepositoryContract,
+    }),
+  };
+}
+
+/** The whole round trip an owner makes: ask, PUT, say it landed. */
+async function uploaded({
+  service,
+  storage,
+  bytes = ARCHIVE,
+}: {
+  service: ImportsService;
+  storage: FakeStorage;
+  bytes?: Uint8Array;
+}) {
+  const begun = await service.create({
+    appId: APP_ID,
+    ownerId: OWNER_ID,
+    filename: UPLOADED_NAME,
+    sizeBytes: bytes.byteLength,
+  });
+  storage.put({ objectKey: importKey({ appId: APP_ID, importId: begun.importId }), bytes });
+  return {
+    begun,
+    stored: await service.completeUpload({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      importId: begun.importId,
+    }),
+  };
+}
+
+describe('an upload is addressed by the row it makes', () => {
+  test('the caller is handed a url signed for exactly the size they declared', async () => {
+    const { service, storage } = build();
+
+    const begun = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: ARCHIVE.byteLength,
+    });
+
+    expect(storage.signed).toEqual([
+      {
+        objectKey: importKey({ appId: APP_ID, importId: begun.importId }),
+        sizeBytes: ARCHIVE.byteLength,
+      },
+    ]);
+    expect(begun.url).toContain(SIGNED_URL);
+  });
+
+  /**
+   * The key is the row's, not the bytes'. Two owners uploading identical archives must not share
+   * an object: expiring one would take the other's away, and neither of them agreed to that.
+   */
+  test('two identical archives are two objects', async () => {
+    const { service, storage } = build();
+
+    const first = await uploaded({ service, storage });
+    const second = await uploaded({ service, storage });
+
+    expect(first.stored.digest).toBe(second.stored.digest);
+    expect(storage.signed.map(({ objectKey }) => objectKey)).toEqual([
+      importKey({ appId: APP_ID, importId: first.begun.importId }),
+      importKey({ appId: APP_ID, importId: second.begun.importId }),
+    ]);
+    expect(storage.objects.size).toBe(2);
+  });
+
+  test('an app the caller does not own is one that does not exist', async () => {
+    const { service } = build();
+
+    await expect(
+      service.create({
+        appId: APP_ID,
+        ownerId: OTHER_OWNER_ID,
+        filename: UPLOADED_NAME,
+        sizeBytes: ARCHIVE.byteLength,
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test('a declared size past the cap is refused before anything is signed', async () => {
+    const { service, storage } = build();
+
+    await expect(
+      service.create({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        filename: UPLOADED_NAME,
+        sizeBytes: MAX_IMPORT_SIZE_BYTES + 1,
+      }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(storage.signed).toEqual([]);
+  });
+});
+
+describe('the bytes are read back rather than taken on trust', () => {
+  test('the digest and the size come off what was stored', async () => {
+    const { service, storage } = build();
+    const bytes = ARCHIVE;
+
+    const { stored } = await uploaded({ service, storage, bytes });
+
+    expect(isValidMessage({ schema: ImportSchema, value: stored })).toBe(true);
+    expect(stored.digest).toBe(digestOf(bytes) as Sha256Digest);
+    expect(stored.sizeBytes).toBe(bytes.byteLength);
+    expect(stored.originalFileName).toBe(UPLOADED_NAME);
+  });
+
+  /**
+   * The envelope is asked about; what it holds is not. An artifact is refused unless it is a Linux
+   * executable because a host has to run it — here the archive is the payload, and what is inside
+   * it is the owner's business right up until the host unpacks it.
+   */
+  test('an archive holding anything at all is stored', async () => {
+    const { service, storage } = build();
+
+    const { stored } = await uploaded({
+      service,
+      storage,
+      bytes: gzippedTarballOf([
+        { name: 'notes.txt', content: bytesOf('nothing runnable in here') },
+        { name: 'pb_data/data.db', content: bytesOf('rows') },
+      ]),
+    });
+
+    expect(stored.sizeBytes).toBeGreaterThan(0);
+  });
+
+  test('saying an upload landed when it did not is refused', async () => {
+    const { service } = build();
+    const begun = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: ARCHIVE.byteLength,
+    });
+
+    await expect(
+      service.completeUpload({ appId: APP_ID, ownerId: OWNER_ID, importId: begun.importId }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  /**
+   * The store is not this api, and a bucket that let something through is not an argument for
+   * keeping it: the signature holds the upload to a length, and this is what happens if it did not.
+   */
+  test('an object longer than the cap is removed rather than recorded', async () => {
+    const { service, storage } = build();
+    const begun = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: ARCHIVE.byteLength,
+    });
+    const objectKey = importKey({ appId: APP_ID, importId: begun.importId });
+    storage.put({ objectKey, bytes: new Uint8Array(MAX_IMPORT_SIZE_BYTES + 1) });
+
+    await expect(
+      service.completeUpload({ appId: APP_ID, ownerId: OWNER_ID, importId: begun.importId }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(storage.objects.has(objectKey)).toBe(false);
+  });
+
+  test('a second report of the same upload is the import it already made', async () => {
+    const { service, storage } = build();
+    const { begun, stored } = await uploaded({ service, storage });
+
+    const again = await service.completeUpload({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      importId: begun.importId,
+    });
+
+    expect(again).toEqual(stored);
+  });
+
+  test('an import nobody uploaded is not found', async () => {
+    const { service } = build();
+
+    await expect(
+      service.get({ appId: APP_ID, ownerId: OWNER_ID, importId: anImportId() }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test('a refusal names the cap rather than the number that broke it', async () => {
+    const { service } = build();
+
+    const refusal = await service
+      .create({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        filename: UPLOADED_NAME,
+        sizeBytes: MAX_IMPORT_SIZE_BYTES + 1,
+      })
+      .catch((error: Error) => error.message);
+
+    expect(refusal).toBe('An import may be at most 1 GiB.');
+  });
+});
+
+/**
+ * The one thing the api is in a position to answer cheaply, and it answers it on the pass it was
+ * already making to hash the bytes. Without this the wrong kind of file is a request that succeeds,
+ * a deployment that is accepted, and a filesystem that fails to provision — where the reason
+ * reaches its owner as a broken app rather than as a refused upload.
+ */
+describe('an upload that is not a .tar.gz is refused where the owner can see it', () => {
+  async function sending(bytes: Uint8Array) {
+    const { service, storage } = build();
+    const begun = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: bytes.byteLength,
+    });
+    const objectKey = importKey({ appId: APP_ID, importId: begun.importId });
+    storage.put({ objectKey, bytes });
+    const refusal = await service
+      .completeUpload({ appId: APP_ID, ownerId: OWNER_ID, importId: begun.importId })
+      .then(() => null)
+      .catch((error: Error) => error);
+    return { refusal, storage, objectKey };
+  }
+
+  test('something that is not compressed at all', async () => {
+    const { refusal } = await sending(bytesOf('#!/bin/sh\necho hi\n'));
+
+    expect(refusal).toBeInstanceOf(BadRequestError);
+    expect(refusal?.message).toContain('.tar.gz');
+  });
+
+  // `gzip data.db` rather than `tar czf`, which is the mistake the magic bytes alone would miss.
+  test('a gzip of something that is not a tarball', async () => {
+    const { refusal } = await sending(gzipSync(bytesOf('rows and rows and rows')));
+
+    expect(refusal).toBeInstanceOf(BadRequestError);
+  });
+
+  test('a tarball nobody gzipped', async () => {
+    const { refusal } = await sending(tarballOf([{ name: 'data.db', content: bytesOf('rows') }]));
+
+    expect(refusal).toBeInstanceOf(BadRequestError);
+  });
+
+  // The object is spent either way, and leaving it would be an owner's upload sitting in a bucket
+  // with no row that will ever name it.
+  test('the bytes that were refused do not stay in the bucket', async () => {
+    const { storage, objectKey } = await sending(bytesOf('not an archive'));
+
+    expect(storage.objects.has(objectKey)).toBe(false);
+  });
+});
+
+describe('an upload that never lands leaves nothing behind', () => {
+  test('a caller saying it failed takes the row and the object with it', async () => {
+    const { service, storage, importsRepo } = build();
+    const begun = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: ARCHIVE.byteLength,
+    });
+    const objectKey = importKey({ appId: APP_ID, importId: begun.importId });
+    storage.put({ objectKey, bytes: ARCHIVE });
+
+    await service.failUpload({ appId: APP_ID, ownerId: OWNER_ID, importId: begun.importId });
+
+    expect(storage.objects.has(objectKey)).toBe(false);
+    expect(importsRepo.rows.size).toBe(0);
+  });
+
+  test('one nobody ever came back about is swept, object first', async () => {
+    const { service, storage, importsRepo } = build();
+    const begun = await service.create({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      filename: UPLOADED_NAME,
+      sizeBytes: ARCHIVE.byteLength,
+    });
+    const objectKey = importKey({ appId: APP_ID, importId: begun.importId });
+    storage.put({ objectKey, bytes: ARCHIVE });
+    importsRepo.age(begun.importId);
+
+    await service.sweepAbandoned();
+
+    expect(storage.removed).toEqual([objectKey]);
+    expect(importsRepo.rows.size).toBe(0);
+  });
+
+  test('a completed import is not swept out from under the app that names it', async () => {
+    const { service, storage, importsRepo } = build();
+    const { begun } = await uploaded({ service, storage });
+    importsRepo.age(begun.importId);
+
+    await service.sweepAbandoned();
+
+    expect(importsRepo.rows.size).toBe(1);
+  });
+});

--- a/packages/protocol/src/domain/import.ts
+++ b/packages/protocol/src/domain/import.ts
@@ -1,0 +1,28 @@
+import { Type } from '@sinclair/typebox';
+import { AppIdSchema, ImportIdSchema } from '#domain/identifiers.ts';
+import { ByteSizeSchema, FilenameSchema, Sha256DigestSchema, TimestampSchema } from '#lib/wire.ts';
+
+// An archive an owner uploaded, which an app's filesystem can be created holding. A noun with no
+// notion of use: what it is for is said by whatever names it, exactly as a deployment says which
+// binary to run by naming an artifact.
+//
+// The digest is what the host verifies after pulling, so it is the archive's identity as far as
+// one is concerned.
+//
+// Where the bytes are is deliberately absent, unlike an artifact's: an owner cannot read that key
+// and has no use for one, the api is the only thing that ever resolves it, and it stops naming
+// anything the moment the archive has been used.
+//
+// No state: the row is what an upload is addressed by, and one that appears here has had its bytes
+// read back and hashed.
+export const ImportSchema = Type.Object({
+  id: ImportIdSchema,
+  appId: AppIdSchema,
+  digest: Sha256DigestSchema,
+  sizeBytes: ByteSizeSchema,
+  // The only name anybody would recognise the archive by: nothing else here carries one.
+  originalFileName: FilenameSchema,
+  createdAt: TimestampSchema,
+});
+
+export type Import = typeof ImportSchema.static;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -180,6 +180,7 @@ export {
   type VolumeId,
   VolumeIdSchema,
 } from '#domain/identifiers.ts';
+export { type Import, ImportSchema } from '#domain/import.ts';
 export {
   DEFAULT_HEALTH_CHECK,
   DEFAULT_INSTANCE_RESOURCES,


### PR DESCRIPTION
nibrun.imports beside artifacts rather than a kind on it: keys are one per row
in a bucket of their own, and nothing here asks what is inside the archive.
POST /apps/:appId/imports signs the upload and PATCH says how it went; a
deleted app's archives go with its binaries and bundles. Nothing consumes one
yet.

The purge and the abandoned-upload sweep are here rather than left for later: without them an archive an owner uploaded outlives the app that named it.

