### PR TITLE
feat(api): a deployment can say what the app's data starts as

### DIFF
--- a/apps/api/src/db/migrations/0045_a_deployment_can_say_what_the_data_starts_as.sql
+++ b/apps/api/src/db/migrations/0045_a_deployment_can_say_what_the_data_starts_as.sql
@@ -1,0 +1,87 @@
+-- A deployment can name the archive the app's filesystem is created from, and the app records the
+-- moment it stopped being creatable.
+--
+-- On the deployment rather than a bespoke endpoint: a deployment is already the operation resource
+-- for a discrete recorded change to what this app runs, and it already stops the old microVM
+-- before starting the new one — which is the window a format needs. Not on `app_configs`, which
+-- carries standing configuration: this is a thing that happens once, not a setting.
+--
+-- `data_initialized_at` is what makes it once. A host formats a volume exactly once and skips a
+-- device that already carries a filesystem, so a second archive would be read and thrown away with
+-- nothing said about it; this is what turns that into a refused request. Stamped from the first
+-- `ready` a host reports for the volume, and never rewritten — which is also why an app deployed
+-- before any of this existed can never be seeded: its filesystem is already there.
+--
+-- Null for every app that has never had a host say so. That includes an app created after this and
+-- not yet deployed, which is exactly the one an archive may still be given to.
+
+ALTER TABLE nibrun.apps
+  ADD COLUMN data_initialized_at timestamptz;
+
+COMMENT ON COLUMN nibrun.apps.data_initialized_at IS 'When a host first reported this app''s filesystem ready. Its presence is what makes the data no longer creatable.';
+
+ALTER TABLE nibrun.deployments
+  ADD COLUMN initial_data_import_id uuid REFERENCES nibrun.imports (id) ON DELETE RESTRICT;
+
+COMMENT ON COLUMN nibrun.deployments.initial_data_import_id IS $c$The uploaded archive this release's filesystem is created from, where one was named. @type import('@repo/protocol').ImportId$c$;
+
+-- Not redundant with the primary key: this is the index the imports foreign key's own check reads,
+-- and without it deleting an import seq-scans every deployment.
+CREATE INDEX deployments_initial_data_idx ON nibrun.deployments (initial_data_import_id)
+  WHERE initial_data_import_id IS NOT NULL;
+
+-- Every statement resolving an app for its owner reads `live_apps` rather than the table, and
+-- refusing a deployment that names an archive is one of them.
+--
+-- Appended last, because CREATE OR REPLACE VIEW may only add columns at the end.
+CREATE OR REPLACE VIEW nibrun.live_apps AS
+  SELECT id, owner_id, slug, state, created_at, updated_at, activation, idle_timeout_ms,
+         data_initialized_at
+  FROM nibrun.apps
+  WHERE state <> 'deleted';
+
+-- The view a host reads its volumes out of, now carrying what the filesystem should be created
+-- holding. Read from the app's newest release rather than joined through `desired_deployments`,
+-- because a volume is desired for an app whose every deployment failed and that view drops none of
+-- those — but it is one row per app either way, so the seed is that row's or nothing.
+--
+-- `data_initialized_at IS NULL` inside the lateral, so the archive stops being sent the moment a
+-- host has said the filesystem exists. The host would ignore it anyway; not sending it is what
+-- keeps a gibibyte off the wire and out of a host's disk on every reconcile pass thereafter.
+--
+-- `digest IS NOT NULL` for the same reason it guards every other read of an upload: a row without
+-- one names bytes that may never arrive. `object_key IS NOT NULL` is the other end of the same
+-- sentence — the api removes the object once the archive can no longer be used — and the two
+-- conditions cannot both matter at once, which is the point: neither alone is relied on.
+--
+-- Appended last, because CREATE OR REPLACE VIEW may only add columns at the end.
+CREATE OR REPLACE VIEW nibrun.desired_volumes AS
+  SELECT a.id AS app_id,
+         a.state,
+         seed.digest AS seed_digest,
+         seed.size_bytes AS seed_size_bytes,
+         seed.object_key AS seed_object_key,
+         seed.original_file_name AS seed_original_file_name
+  FROM nibrun.apps a
+  LEFT JOIN LATERAL (
+    SELECT im.digest, im.size_bytes, im.object_key, im.original_file_name
+    FROM nibrun.deployments d
+    JOIN nibrun.imports im ON im.id = d.initial_data_import_id
+    WHERE d.app_id = a.id
+      AND d.state <> 'superseded'
+      AND im.digest IS NOT NULL
+      AND im.object_key IS NOT NULL
+      AND a.data_initialized_at IS NULL
+    ORDER BY d.id DESC
+    LIMIT 1
+  ) seed ON true
+  WHERE a.state <> 'deleted'
+    AND EXISTS (SELECT 1 FROM nibrun.deployments d WHERE d.app_id = a.id);
+
+-- A lateral join carries none of the column comments its columns pass through, so the types the
+-- rest of this schema is read through are said again here rather than degrading to `text` at the
+-- one place a host is told what to create a filesystem from.
+COMMENT ON COLUMN nibrun.desired_volumes.seed_digest IS $c$@type import('@repo/protocol').Sha256Digest$c$;
+COMMENT ON COLUMN nibrun.desired_volumes.seed_size_bytes IS 'A Postgres bigint, so it arrives as a string; the wire type is a number.';
+COMMENT ON COLUMN nibrun.desired_volumes.seed_object_key IS $c$@type import('@repo/protocol').ObjectKey$c$;
+COMMENT ON COLUMN nibrun.desired_volumes.seed_original_file_name IS $c$@type import('@repo/protocol').Filename$c$;

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -42,6 +42,14 @@ export interface ISelectDesiredDeploymentsResult {
 export interface ISelectDesiredVolumesResult {
     app_id: IAppsColumns["id"];
     state: IAppsColumns["state"];
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row usable. */
+    seed_digest: IDesiredVolumesColumns["seed_digest"];
+    /** A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    seed_size_bytes: IImportsColumns["size_bytes"];
+    /** Where the bytes are, present exactly while they are: absent before the upload has been read back, and absent again once the archive can no longer be used. Key within IMPORTS_BUCKET; which bucket is deploy configuration. */
+    seed_object_key: IDesiredVolumesColumns["seed_object_key"];
+    /** The name the archive was uploaded under; the key it lands under carries none. */
+    seed_original_file_name: IDesiredVolumesColumns["seed_original_file_name"];
 }
 
 /** Result of query `SelectDesiredHostnames`. */
@@ -775,6 +783,16 @@ export interface ISelectInsertedDeploymentResult {
     environment_names: string[];
 }
 
+/** Result of query `SelectAppAwaitingData`. */
+export interface ISelectAppAwaitingDataResult {
+    id: IAppsColumns["id"];
+}
+
+/** Result of query `SelectUsableImport`. */
+export interface ISelectUsableImportResult {
+    id: IImportsColumns["id"];
+}
+
 /** Result of query `InsertExport`. */
 export interface IInsertExportResult {
     id: IExportsColumns["id"];
@@ -915,6 +933,17 @@ export interface ISelectAbandonedImportsResult {
 export interface IDeleteAbandonedImportResult {
 }
 
+/** Result of query `SelectSpentImports`. */
+export interface ISelectSpentImportsResult {
+    id: IImportsColumns["id"];
+    /** Where the bytes are, present exactly while they are: absent before the upload has been read back, and absent again once the archive can no longer be used. Key within IMPORTS_BUCKET; which bucket is deploy configuration. */
+    object_key: NonNullable<IImportsColumns["object_key"]>;
+}
+
+/** Result of query `ForgetImportObject`. */
+export interface IForgetImportObjectResult {
+}
+
 export interface Queries {
     SelectDesiredDeployments: ISelectDesiredDeploymentsResult;
     SelectDesiredVolumes: ISelectDesiredVolumesResult;
@@ -979,6 +1008,8 @@ export interface Queries {
     FailDeployment: IFailDeploymentResult;
     SupersedeLiveDeployment: ISupersedeLiveDeploymentResult;
     SelectInsertedDeployment: ISelectInsertedDeploymentResult;
+    SelectAppAwaitingData: ISelectAppAwaitingDataResult;
+    SelectUsableImport: ISelectUsableImportResult;
     InsertExport: IInsertExportResult;
     SelectExportsByApp: ISelectExportsByAppResult;
     SelectExportById: ISelectExportByIdResult;
@@ -993,6 +1024,8 @@ export interface Queries {
     SelectImportById: ISelectImportByIdResult;
     SelectAbandonedImports: ISelectAbandonedImportsResult;
     DeleteAbandonedImport: IDeleteAbandonedImportResult;
+    SelectSpentImports: ISelectSpentImportsResult;
+    ForgetImportObject: IForgetImportObjectResult;
 }
 
 /** Columns of `account`. */
@@ -1266,6 +1299,8 @@ export interface IAppsColumns {
     updated_at: Date;
     activation: import("@repo/protocol").AppActivation;
     idle_timeout_ms: number;
+    /** When a host first reported this app's filesystem ready. Its presence is what makes the data no longer creatable. */
+    data_initialized_at: Date | null;
 }
 
 /** Schema of `apps`. */
@@ -1350,6 +1385,8 @@ export interface IDeploymentsColumns {
     public_ipv4: import("@repo/protocol").Ipv4Address | null;
     extra_public_port: import("@repo/protocol").HostPort | null;
     instance_state: import("@repo/protocol").InstanceState | null;
+    /** The uploaded archive this release's filesystem is created from, where one was named. */
+    initial_data_import_id: import("@repo/protocol").ImportId | null;
 }
 
 /** Schema of `deployments`. */
@@ -1483,6 +1520,14 @@ export interface IDesiredHostnamesTable {
 export interface IDesiredVolumesColumns {
     app_id: import("@repo/protocol").AppId | null;
     state: import("@repo/protocol").AppState | null;
+    /** Absent until the api has hashed the uploaded object; its presence is what makes the row usable. */
+    seed_digest: import("@repo/protocol").Sha256Digest | null;
+    /** A Postgres bigint, so it arrives as a string; the wire type is a number. */
+    seed_size_bytes: string | null;
+    /** Where the bytes are, present exactly while they are: absent before the upload has been read back, and absent again once the archive can no longer be used. Key within IMPORTS_BUCKET; which bucket is deploy configuration. */
+    seed_object_key: import("@repo/protocol").ObjectKey | null;
+    /** The name the archive was uploaded under; the key it lands under carries none. */
+    seed_original_file_name: import("@repo/protocol").Filename | null;
 }
 
 /** Schema of `desired_volumes`. */
@@ -1572,6 +1617,8 @@ export interface ILiveAppsColumns {
     updated_at: Date | null;
     activation: import("@repo/protocol").AppActivation | null;
     idle_timeout_ms: number | null;
+    /** When a host first reported this app's filesystem ready. Its presence is what makes the data no longer creatable. */
+    data_initialized_at: Date | null;
 }
 
 /** Schema of `live_apps`. */
@@ -1912,7 +1959,8 @@ export const schema = {
             created_at: { _columnName: "created_at", _foreignKeys: {} },
             updated_at: { _columnName: "updated_at", _foreignKeys: {} },
             activation: { _columnName: "activation", _foreignKeys: {} },
-            idle_timeout_ms: { _columnName: "idle_timeout_ms", _foreignKeys: {} }
+            idle_timeout_ms: { _columnName: "idle_timeout_ms", _foreignKeys: {} },
+            data_initialized_at: { _columnName: "data_initialized_at", _foreignKeys: {} }
         },
         _indexes: {
             apps_deleted_idx: { _indexName: "apps_deleted_idx" },
@@ -1989,13 +2037,15 @@ export const schema = {
             updated_at: { _columnName: "updated_at", _foreignKeys: {} },
             public_ipv4: { _columnName: "public_ipv4", _foreignKeys: {} },
             extra_public_port: { _columnName: "extra_public_port", _foreignKeys: {} },
-            instance_state: { _columnName: "instance_state", _foreignKeys: {} }
+            instance_state: { _columnName: "instance_state", _foreignKeys: {} },
+            initial_data_import_id: { _columnName: "initial_data_import_id", _foreignKeys: { deployments_initial_data_import_id_fkey: { _constraintName: "deployments_initial_data_import_id_fkey", _references: { _relationName: "imports", _columnName: "id" } } } }
         },
         _indexes: {
             deployments_activated_artifact_idx: { _indexName: "deployments_activated_artifact_idx" },
             deployments_app_id_idx: { _indexName: "deployments_app_id_idx" },
             deployments_artifact_id_idx: { _indexName: "deployments_artifact_id_idx" },
             deployments_config_id_idx: { _indexName: "deployments_config_id_idx" },
+            deployments_initial_data_idx: { _indexName: "deployments_initial_data_idx" },
             deployments_live_idx: { _indexName: "deployments_live_idx" },
             deployments_pkey: { _indexName: "deployments_pkey" },
             deployments_rollback_of_idx: { _indexName: "deployments_rollback_of_idx" }
@@ -2005,6 +2055,7 @@ export const schema = {
             deployments_artifact_id_fkey: { _constraintName: "deployments_artifact_id_fkey" },
             deployments_config_id_fkey: { _constraintName: "deployments_config_id_fkey" },
             deployments_extra_public_port_check: { _constraintName: "deployments_extra_public_port_check" },
+            deployments_initial_data_import_id_fkey: { _constraintName: "deployments_initial_data_import_id_fkey" },
             deployments_instance_state_check: { _constraintName: "deployments_instance_state_check" },
             deployments_pkey: { _constraintName: "deployments_pkey" },
             deployments_rollback_of_deployment_id_fkey: { _constraintName: "deployments_rollback_of_deployment_id_fkey" },
@@ -2101,7 +2152,11 @@ export const schema = {
         _relationType: "view",
         _columns: {
             app_id: { _columnName: "app_id", _foreignKeys: {} },
-            state: { _columnName: "state", _foreignKeys: {} }
+            state: { _columnName: "state", _foreignKeys: {} },
+            seed_digest: { _columnName: "seed_digest", _foreignKeys: {} },
+            seed_size_bytes: { _columnName: "seed_size_bytes", _foreignKeys: {} },
+            seed_object_key: { _columnName: "seed_object_key", _foreignKeys: {} },
+            seed_original_file_name: { _columnName: "seed_original_file_name", _foreignKeys: {} }
         },
         _indexes: {},
         _constraints: {}
@@ -2181,7 +2236,8 @@ export const schema = {
             created_at: { _columnName: "created_at", _foreignKeys: {} },
             updated_at: { _columnName: "updated_at", _foreignKeys: {} },
             activation: { _columnName: "activation", _foreignKeys: {} },
-            idle_timeout_ms: { _columnName: "idle_timeout_ms", _foreignKeys: {} }
+            idle_timeout_ms: { _columnName: "idle_timeout_ms", _foreignKeys: {} },
+            data_initialized_at: { _columnName: "data_initialized_at", _foreignKeys: {} }
         },
         _indexes: {},
         _constraints: {}

--- a/apps/api/src/lib/deployments/desired-state.ts
+++ b/apps/api/src/lib/deployments/desired-state.ts
@@ -37,6 +37,10 @@ export function volumeIdOf(appId: AppId): VolumeId {
  * A suspended app keeps its filesystem — that is what suspending it means — so deleting the app
  * is the only thing that asks for one to go, and it asks by saying so. A volume is never removed
  * by falling out of a list.
+ *
+ * The seed rides along only while the view still offers one, which is until a host has said the
+ * filesystem exists. A host that already has one ignores it, so this is about what crosses the
+ * wire rather than about what would happen if it did.
  */
 export function toDesiredVolume(row: DesiredVolumeRow): DesiredVolume {
   return {
@@ -44,6 +48,30 @@ export function toDesiredVolume(row: DesiredVolumeRow): DesiredVolume {
     appId: row.app_id,
     sizeBytes: DEFAULT_VOLUME_SIZE_BYTES,
     desiredState: row.state === 'deleting' ? 'absent' : 'present',
+    ...seedOf(row),
+  };
+}
+
+/**
+ * All four columns or none: the view fills them from one row of `imports` and leaves them all null
+ * where there is none, so a partly filled seed is not a state this can be handed.
+ */
+function seedOf(row: DesiredVolumeRow): Pick<DesiredVolume, 'seed'> {
+  if (
+    row.seed_digest === null ||
+    row.seed_size_bytes === null ||
+    row.seed_object_key === null ||
+    row.seed_original_file_name === null
+  ) {
+    return {};
+  }
+  return {
+    seed: {
+      digest: row.seed_digest,
+      sizeBytes: Number(row.seed_size_bytes),
+      objectKey: row.seed_object_key,
+      filename: row.seed_original_file_name,
+    },
   };
 }
 

--- a/apps/api/src/repositories/agent.repository.ts
+++ b/apps/api/src/repositories/agent.repository.ts
@@ -120,7 +120,9 @@ export class AgentRepository extends Repository implements AgentRepositoryContra
           FROM nibrun.desired_deployments
         `,
         this.sql.SelectDesiredVolumes`
-          SELECT app_id, state FROM nibrun.desired_volumes
+          SELECT app_id, state,
+                 seed_digest, seed_size_bytes, seed_object_key, seed_original_file_name
+          FROM nibrun.desired_volumes
         `,
         this.sql.SelectDesiredHostnames`
           SELECT app_id, hostname, kind FROM nibrun.desired_hostnames

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -74,6 +74,7 @@ export abstract class AppsRepositoryContract {
   abstract clearComputeUsage(input: { appIds: readonly AppId[] }): Promise<void>;
   abstract updateConfig(input: OwnedApp & { patch: SealedConfigPatch }): Promise<AppRow | null>;
   abstract updateState(input: StateChange): Promise<AppRow | null>;
+  abstract stampDataInitialized(input: { appIds: readonly AppId[] }): Promise<void>;
   abstract finishDeleting(input: { appId: AppId }): Promise<boolean>;
   abstract isDeletionFinishable(input: { appId: AppId }): Promise<boolean>;
   abstract listFinishableDeletions(input: { limit: number }): Promise<AppId[]>;
@@ -541,6 +542,25 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
       SELECT f.app_id FROM nibrun.finishable_deletions f LIMIT ${limit}
     `;
     return rows.map((row) => row.app_id);
+  }
+
+  /**
+   * The moment a host first said the filesystem exists, which is the moment it stops being
+   * creatable — and after which naming an archive to create it from is a refused request.
+   *
+   * `IS NULL` is what makes it once and what keeps it off the `set_updated_at` trigger. A volume
+   * reports `ready` on every pass, and an app whose `updated_at` moved every time a host spoke
+   * would look to its owner like somebody had just changed it.
+   */
+  async stampDataInitialized({ appIds }: { appIds: readonly AppId[] }): Promise<void> {
+    // Untagged, as `updateState` is: `sql.array` is a clause the generator blanks out before it
+    // parses the statement, and there is no row type to lose — this returns nothing.
+    await this.sql`
+      UPDATE nibrun.apps
+      SET data_initialized_at = now()
+      WHERE id = ANY(${this.sql.array([...appIds], TEXT_ARRAY)}::uuid[])
+        AND data_initialized_at IS NULL
+    `;
   }
 
   async finishDeleting({ appId }: { appId: AppId }): Promise<boolean> {

--- a/apps/api/src/repositories/deployments.repository.ts
+++ b/apps/api/src/repositories/deployments.repository.ts
@@ -5,6 +5,7 @@ import type {
   DeploymentId,
   DeploymentState,
   HostPort,
+  ImportId,
   InstanceState,
   Ipv4Address,
   OwnerId,
@@ -16,7 +17,28 @@ export type DeploymentRow = Queries['SelectDeploymentById'];
 
 export type OwnedApp = { appId: AppId; ownerId: OwnerId };
 
-export type CreateDeploymentInput = OwnedApp & { artifactId: ArtifactId };
+/**
+ * `initialDataFrom` is the archive the app's filesystem should be created holding, where one was
+ * named. Null is the ordinary case and the only one an app that has ever run can be in.
+ */
+export type CreateDeploymentInput = OwnedApp & {
+  artifactId: ArtifactId;
+  initialDataFrom: ImportId | null;
+};
+
+/**
+ * Why a deployment was not written, where "not found" would not be the truth.
+ *
+ * A rollback answers `null` because there is only one way it can fail — nothing of the caller's to
+ * replay — while this one can fail three, and two of them are about an archive rather than about
+ * anything being missing. An owner told "not found" about a filesystem that exists has been told
+ * the wrong thing.
+ */
+export type CreatedDeployment =
+  | { outcome: 'created'; row: DeploymentRow }
+  | { outcome: 'no-artifact' }
+  | { outcome: 'no-import' }
+  | { outcome: 'data-exists' };
 
 /**
  * Going back to a release is a new row naming the one it replays, rather than that one revived:
@@ -56,7 +78,7 @@ export type ReportedDeployment = {
 };
 
 export abstract class DeploymentsRepositoryContract {
-  abstract insert(input: CreateDeploymentInput): Promise<DeploymentRow | null>;
+  abstract insert(input: CreateDeploymentInput): Promise<CreatedDeployment>;
   abstract insertRollback(input: RollbackDeploymentInput): Promise<DeploymentRow | null>;
   abstract listByApp(input: DeploymentsByAppInput): Promise<DeploymentRow[]>;
   abstract findById(input: DeploymentByIdInput): Promise<DeploymentRow | null>;
@@ -82,8 +104,13 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
    * the app was running is superseded first. `deployments_live_idx` admits one live row per app,
    * so it has to leave in this same transaction or the insert meets it.
    */
-  insert({ appId, ownerId, artifactId }: CreateDeploymentInput): Promise<DeploymentRow | null> {
-    return this.sql.begin(async (tx) => {
+  insert({
+    appId,
+    ownerId,
+    artifactId,
+    initialDataFrom,
+  }: CreateDeploymentInput): Promise<CreatedDeployment> {
+    return this.sql.begin(async (tx): Promise<CreatedDeployment> => {
       // Asked before anything is superseded: returning from this callback commits, so an
       // artifact this owner does not have must leave the running deployment alone rather than
       // stand it down on behalf of a request that goes on to write nothing.
@@ -97,15 +124,22 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
           AND ar.digest IS NOT NULL
       `;
       if (!deployable) {
-        return null;
+        return { outcome: 'no-artifact' };
+      }
+      const refusal =
+        initialDataFrom === null
+          ? undefined
+          : await seedRefusal({ tx, appId, ownerId, initialDataFrom });
+      if (refusal) {
+        return refusal;
       }
       await this.supersedeLive({ tx, appId, ownerId });
 
       // INSERT … SELECT rather than VALUES, so the predicate that decides ownership is the one
       // the row is written through rather than one checked beside it.
       const [inserted] = await tx.InsertDeployment`
-        INSERT INTO nibrun.deployments (app_id, artifact_id, config_id)
-        SELECT a.id, ar.id, c.id
+        INSERT INTO nibrun.deployments (app_id, artifact_id, config_id, initial_data_import_id)
+        SELECT a.id, ar.id, c.id, ${initialDataFrom}
         FROM nibrun.live_apps a
         JOIN nibrun.artifacts ar ON ar.app_id = a.id
         JOIN LATERAL (
@@ -116,7 +150,11 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
           AND ar.digest IS NOT NULL
         RETURNING id
       `;
-      return inserted ? await this.selectDeployment({ tx, deploymentId: inserted.id }) : null;
+      if (!inserted) {
+        return { outcome: 'no-artifact' };
+      }
+      const row = await this.selectDeployment({ tx, deploymentId: inserted.id });
+      return row ? { outcome: 'created', row } : { outcome: 'no-artifact' };
     });
   }
 
@@ -327,4 +365,40 @@ export class DeploymentsRepository extends Repository implements DeploymentsRepo
     `;
     return row ?? null;
   }
+}
+
+/**
+ * Whether the archive named may create this app's filesystem, asked inside the transaction that
+ * would write the row: both answers can change between a read and a write, and one of them is a
+ * host reporting a volume ready.
+ *
+ * `digest IS NOT NULL` is what makes an upload an archive, and `data_initialized_at IS NULL` is
+ * the whole of "the filesystem does not exist yet". Refused rather than accepted and ignored: a
+ * host skips a device that already carries a filesystem, so a deployment written past this would
+ * be an owner told their data was replaced when nothing read the archive at all.
+ */
+async function seedRefusal({
+  tx,
+  appId,
+  ownerId,
+  initialDataFrom,
+}: OwnedApp & { tx: Transaction; initialDataFrom: ImportId }): Promise<
+  CreatedDeployment | undefined
+> {
+  const [app] = await tx.SelectAppAwaitingData`
+    SELECT a.id
+    FROM nibrun.live_apps a
+    WHERE a.id = ${appId} AND a.owner_id = ${ownerId} AND a.data_initialized_at IS NULL
+  `;
+  if (!app) {
+    return { outcome: 'data-exists' };
+  }
+  const [usable] = await tx.SelectUsableImport`
+    SELECT im.id
+    FROM nibrun.imports im
+    JOIN nibrun.live_apps a ON a.id = im.app_id
+    WHERE im.id = ${initialDataFrom} AND im.app_id = ${appId} AND a.owner_id = ${ownerId}
+      AND im.digest IS NOT NULL
+  `;
+  return usable ? undefined : { outcome: 'no-import' };
 }

--- a/apps/api/src/repositories/imports.repository.ts
+++ b/apps/api/src/repositories/imports.repository.ts
@@ -5,6 +5,7 @@ import { Repository } from '#repositories/repository.ts';
 export type ImportRow = Queries['SelectImportById'];
 export type PendingImportRow = Queries['SelectPendingImport'];
 export type AbandonedImportRow = Queries['SelectAbandonedImports'];
+export type SpentImportRow = Queries['SelectSpentImports'];
 
 export type CompleteImportInput = {
   appId: AppId;
@@ -35,6 +36,8 @@ export abstract class ImportsRepositoryContract {
   }): Promise<ImportRow | null>;
   abstract listAbandoned(input: { olderThanSeconds: number }): Promise<AbandonedImportRow[]>;
   abstract removeAbandoned(input: { importId: ImportId }): Promise<void>;
+  abstract listSpent(input: { limit: number }): Promise<SpentImportRow[]>;
+  abstract forgetObject(input: { importId: ImportId }): Promise<void>;
 }
 
 /**
@@ -165,6 +168,43 @@ export class ImportsRepository extends Repository implements ImportsRepositoryCo
     await this.sql.DeleteAbandonedImport`
       DELETE FROM nibrun.imports im
       WHERE im.id = ${importId} AND im.digest IS NULL
+    `;
+  }
+
+  /**
+   * Archives still holding an object that can no longer create a filesystem, because the app's
+   * already exists.
+   *
+   * Not only the ones that were used: an archive nobody ever deployed against an app whose data is
+   * now there is one `initialDataFrom` would refuse, so what it is holding is storage nothing can
+   * ever spend. Both are the same sentence — the archive can no longer be applied — which is why
+   * this asks that rather than asking which deployment named what.
+   *
+   * `object_key IS NOT NULL` is the whole of "there is still something to remove", so a row leaves
+   * this listing by having had it removed. That is what makes running it again the same code path
+   * as running it the first time.
+   */
+  listSpent({ limit }: { limit: number }): Promise<SpentImportRow[]> {
+    return this.sql.SelectSpentImports`
+      /* @notNull object_key */
+      SELECT im.id, im.object_key
+      FROM nibrun.imports im
+      JOIN nibrun.apps a ON a.id = im.app_id
+      WHERE im.object_key IS NOT NULL AND a.data_initialized_at IS NOT NULL
+      LIMIT ${limit}
+    `;
+  }
+
+  /**
+   * The row stops naming an object because there is no longer one to name. The digest stays: what
+   * the owner uploaded and what it hashed to is the app's history, and only where the bytes were
+   * has stopped being true.
+   */
+  async forgetObject({ importId }: { importId: ImportId }): Promise<void> {
+    await this.sql.ForgetImportObject`
+      UPDATE nibrun.imports im
+      SET object_key = NULL
+      WHERE im.id = ${importId} AND im.object_key IS NOT NULL
     `;
   }
 }

--- a/apps/api/src/routes/api/apps/[appId]/deployments/model.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/model.ts
@@ -1,4 +1,9 @@
-import { ArtifactIdSchema, DeploymentIdSchema, DeploymentSchema } from '@repo/protocol';
+import {
+  ArtifactIdSchema,
+  DeploymentIdSchema,
+  DeploymentSchema,
+  ImportIdSchema,
+} from '@repo/protocol';
 import { t } from 'elysia';
 import { PublicAppConfigSchema } from '#routes/api/apps/model.ts';
 
@@ -6,9 +11,17 @@ import { PublicAppConfigSchema } from '#routes/api/apps/model.ts';
  * An artifact to run, or a release to go back to — never both and never neither. A union rather
  * than two optional fields, so a request naming both is a schema error rather than a rule the
  * handler has to remember to apply.
+ *
+ * `initialDataFrom` rides on the first of the two and not the second: a rollback replays a release
+ * exactly as it ran, and creating the app's filesystem from an archive is not something that
+ * happened then. It is optional because it happens once in an app's life and never again — the
+ * moment a host says the filesystem exists, naming one is refused.
  */
 export const CreateDeploymentBodySchema = t.Union([
-  t.Object({ artifactId: ArtifactIdSchema }, { additionalProperties: false }),
+  t.Object(
+    { artifactId: ArtifactIdSchema, initialDataFrom: t.Optional(ImportIdSchema) },
+    { additionalProperties: false },
+  ),
   t.Object({ rollbackOf: DeploymentIdSchema }, { additionalProperties: false }),
 ]);
 

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -17,6 +17,7 @@ import type { ArtifactsService } from '#services/artifacts.service.ts';
 import type { DeploymentsService } from '#services/deployments.service.ts';
 import type { ExportsService } from '#services/exports.service.ts';
 import type { HostnamesService } from '#services/hostnames.service.ts';
+import type { ImportsService } from '#services/imports.service.ts';
 import { Service } from '#services/service.ts';
 
 const MS_PER_SECOND = 1000;
@@ -25,6 +26,9 @@ const SESSION_LIFETIME_MS = SECONDS_PER_HOUR * MS_PER_SECOND;
 
 /** What a report is borrowed for, and nothing else an upload's own service can do. */
 export type UploadSweep = Pick<ArtifactsService, 'sweepAbandoned'>;
+
+/** The same, plus the archives this report's own volume states have just made unusable. */
+export type ImportSweep = UploadSweep & Pick<ImportsService, 'sweepSpent'>;
 
 /** Likewise for hostnames: a report is the clock, not permission to add or remove one. */
 export type HostnameReconcile = Pick<HostnamesService, 'reconcile'>;
@@ -35,7 +39,7 @@ export class AgentService extends Service {
   private readonly appsService: AppsService;
   private readonly exportsService: ExportsService;
   private readonly artifactsService: UploadSweep;
-  private readonly importsService: UploadSweep;
+  private readonly importsService: ImportSweep;
   private readonly hostnamesService: HostnameReconcile;
 
   constructor({
@@ -52,7 +56,7 @@ export class AgentService extends Service {
     appsService: AppsService;
     exportsService: ExportsService;
     artifactsService: UploadSweep;
-    importsService: UploadSweep;
+    importsService: ImportSweep;
     hostnamesService: HostnameReconcile;
   }) {
     super();
@@ -133,6 +137,11 @@ export class AgentService extends Service {
     await this.agentRepo.observeReport({ reported });
     await this.deploymentsService.applyHostReport({ reported });
     await this.appsService.recordVolumeUsage({ volumes: reported.volumes });
+    // Before the deletions below, which read the same list for `deleted`: a filesystem that is
+    // ready and one that is gone are different volumes, so the order between them carries nothing
+    // — but a stamp is what stops the next deployment offering to create data that already exists,
+    // and the sooner it lands the smaller that window is.
+    await this.appsService.recordDataInitialized({ volumes: reported.volumes });
     await this.appsService.recordComputeUsage({ instances: reported.instances });
     await this.appsService.completeDeletions({ volumes: reported.volumes });
     await this.exportsService.applyHostReport({ reported });
@@ -144,6 +153,9 @@ export class AgentService extends Service {
     // upload nobody ever came back about is work that needs one.
     await this.artifactsService.sweepAbandoned();
     await this.importsService.sweepAbandoned();
+    // Not the same clock at all: this one reads what the report just wrote, because
+    // `recordDataInitialized` above is what makes an archive spent.
+    await this.importsService.sweepSpent();
     // The same clock, for the same reason: whether a custom hostname has been pointed at us is
     // decided in somebody else's DNS, so there is no moment to act on but a passing one.
     await this.hostnamesService.reconcile();

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -345,6 +345,21 @@ export class AppsService extends Service {
   }
 
   /**
+   * The first `ready` a host reports for an app's filesystem, which is the moment it stops being
+   * creatable — and the only moment anything on this end can learn it.
+   *
+   * Every `ready` in the report rather than the ones that just changed, because there is no such
+   * thing here: a host reports what it observes, and which of those is the first is the column's
+   * own question. `stampDataInitialized` answers it, and writes nothing for an app already stamped.
+   */
+  async recordDataInitialized({ volumes }: { volumes: readonly ReportedVolume[] }): Promise<void> {
+    const ready = volumes.filter((volume) => volume.state === 'ready').map((one) => one.appId);
+    if (ready.length > 0) {
+      await this.appsRepo.stampDataInitialized({ appIds: ready });
+    }
+  }
+
+  /**
    * The compute half, taken off the instances rather than the volumes: what a guest is spending
    * belongs to the microVM running the app, and a volume outlives every microVM that mounts it.
    *

--- a/apps/api/src/services/deployments.service.ts
+++ b/apps/api/src/services/deployments.service.ts
@@ -4,6 +4,7 @@ import type {
   DeploymentId,
   DeploymentState,
   HostReportedState,
+  ImportId,
   ReportedInstance,
   Timestamp,
 } from '@repo/protocol';
@@ -14,6 +15,7 @@ import { ConflictError, NotFoundError } from '#lib/errors.ts';
 import { isUniqueViolation } from '#lib/pg-errors.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
 import type {
+  CreatedDeployment,
   DeploymentByIdInput,
   DeploymentRow,
   DeploymentsByAppInput,
@@ -27,6 +29,15 @@ import { Service } from '#services/service.ts';
 const LIVE_DEPLOYMENT_CONSTRAINT = schema.deployments._indexes.deployments_live_idx._indexName;
 
 const NEVER_STARTED = 'No host started this deployment in time.';
+const ANOTHER_DEPLOYMENT = 'Another deployment for this app is being started.';
+const NOTHING_TO_DEPLOY = 'App, artifact or deployment not found.';
+const NO_SUCH_IMPORT = 'No uploaded import of that name is ready to be used.';
+/**
+ * Said as the app rather than as the request: nothing was wrong with what they asked for, it is
+ * simply too late to ask it. An app's filesystem is created once, and after that what replaces
+ * what is in it is the app's own business.
+ */
+const DATA_EXISTS = "This app's data already exists, so it cannot be created from an import.";
 
 export type PublicDeployment = Omit<Deployment, 'config'> & { config: PublicAppConfig };
 
@@ -35,7 +46,7 @@ export type PublicDeployment = Omit<Deployment, 'config'> & { config: PublicAppC
  * where the artifact and the config come from, and nothing else about it differs.
  */
 export type DeploymentSource =
-  | { artifactId: ArtifactId }
+  | { artifactId: ArtifactId; initialDataFrom?: ImportId }
   | Pick<RollbackDeploymentInput, 'rollbackOf'>;
 
 export class DeploymentsService extends Service {
@@ -62,7 +73,13 @@ export class DeploymentsService extends Service {
         this.deploymentsRepo.insertRollback({ ...owned, rollbackOf: source.rollbackOf }),
       );
     }
-    return this.published(this.deploymentsRepo.insert({ ...owned, artifactId: source.artifactId }));
+    return this.created(
+      this.deploymentsRepo.insert({
+        ...owned,
+        artifactId: source.artifactId,
+        initialDataFrom: source.initialDataFrom ?? null,
+      }),
+    );
   }
 
   async list(input: DeploymentsByAppInput): Promise<PublicDeployment[]> {
@@ -140,15 +157,38 @@ export class DeploymentsService extends Service {
    * callers racing meet `deployments_live_idx` rather than each other, so the loser is told to
    * retry instead of leaving the app with two live deployments.
    */
+  /**
+   * The same conflict handling as a rollback's, and three ways to be refused rather than one. An
+   * archive that cannot create the filesystem is said as what is wrong with it, because the caller
+   * has something to do about each: wait for the upload, or accept that the data is already there.
+   */
+  private async created(write: Promise<CreatedDeployment>): Promise<PublicDeployment> {
+    const outcome = await write.catch((error: unknown) => {
+      if (isUniqueViolation({ error, constraint: LIVE_DEPLOYMENT_CONSTRAINT })) {
+        throw new ConflictError(ANOTHER_DEPLOYMENT);
+      }
+      throw error;
+    });
+    if (outcome.outcome === 'created') {
+      return toPublicDeployment(outcome.row);
+    }
+    if (outcome.outcome === 'no-artifact') {
+      throw new NotFoundError(NOTHING_TO_DEPLOY);
+    }
+    throw outcome.outcome === 'no-import'
+      ? new NotFoundError(NO_SUCH_IMPORT)
+      : new ConflictError(DATA_EXISTS);
+  }
+
   private async published(write: Promise<DeploymentRow | null>): Promise<PublicDeployment> {
     const row = await write.catch((error: unknown) => {
       if (isUniqueViolation({ error, constraint: LIVE_DEPLOYMENT_CONSTRAINT })) {
-        throw new ConflictError('Another deployment for this app is being started.');
+        throw new ConflictError(ANOTHER_DEPLOYMENT);
       }
       throw error;
     });
     if (!row) {
-      throw new NotFoundError('App, artifact or deployment not found.');
+      throw new NotFoundError(NOTHING_TO_DEPLOY);
     }
     return toPublicDeployment(row);
   }

--- a/apps/api/src/services/imports.service.ts
+++ b/apps/api/src/services/imports.service.ts
@@ -52,6 +52,13 @@ const TOO_LARGE = `An import may be at most ${MAX_IMPORT_GIBIBYTES} GiB.`;
 /** Long enough that the signed url the row was handed has expired, so no bytes are still coming. */
 const ABANDONED_AFTER_SECONDS = 86_400;
 
+/**
+ * How many spent archives one host report clears. A gibibyte apiece and one delete each, on a path
+ * a host is waiting at the end of — so this drains rather than sweeps, exactly as the app purge
+ * does, and what it does not reach the next report finds still listed.
+ */
+const SPENT_BATCH = 8;
+
 const DIGEST_ALGORITHM = 'sha256';
 const HEX_ENCODING = 'hex';
 
@@ -235,6 +242,31 @@ export class ImportsService extends Service {
       await this.discard({ objectKey: importKey({ appId: row.app_id, importId: row.id }) });
       await this.importsRepo.removeAbandoned({ importId: row.id });
       this.logger.info('abandoned import swept', { appId: row.app_id, importId: row.id });
+    }
+  }
+
+  /**
+   * Archives that can no longer create a filesystem, because the app's already exists.
+   *
+   * The bucket's own expiry is the backstop for an upload nobody ever deployed; this is for the
+   * ones that have already done their job, and eventually is far too long to leave an owner's whole
+   * dataset lying in a bucket beside the filesystem it became. The row stays and keeps the digest;
+   * only the bytes go.
+   *
+   * Objects before rows, as everywhere else: a row that stopped naming its object first would leave
+   * an owner's dataset behind with nothing left to find it by.
+   */
+  async sweepSpent(): Promise<void> {
+    for (const row of await this.importsRepo.listSpent({ limit: SPENT_BATCH })) {
+      try {
+        await this.storageRepo.remove({ objectKey: row.object_key });
+        await this.importsRepo.forgetObject({ importId: row.id });
+        this.logger.info('spent import removed', { importId: row.id });
+      } catch (error) {
+        // The row goes on naming the object, so the next report finds it again. One bucket refusal
+        // is no reason to fail the report or to skip the archives queued behind it.
+        this.logger.error('a spent import could not be removed', { importId: row.id, error });
+      }
     }
   }
 

--- a/apps/api/tests/repositories/desired-volume-seed.test.ts
+++ b/apps/api/tests/repositories/desired-volume-seed.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { SQL } from 'bun';
+import { startTestDatabase, stopTestDatabase } from '#tests/support/database.ts';
+
+const DATABASE_START_TIMEOUT_MS = 180_000;
+
+const APP_SLUG = 'seeded';
+const ARCHIVE_DIGEST = 'sha256:archive';
+const ARCHIVE_KEY = 'imports/app/archive';
+const ARCHIVE_NAME = 'pb_data.tar.gz';
+
+type DesiredVolumeRow = {
+  seed_digest: string | null;
+  seed_size_bytes: string | null;
+  seed_object_key: string | null;
+  seed_original_file_name: string | null;
+};
+
+/**
+ * `nibrun.desired_volumes` is what a host is told to hold, and what a filesystem should be created
+ * holding reaches it by joining two tables the host never sees. Whether it stops being sent at the
+ * right moment is a question only the real view can answer.
+ */
+describe('what a filesystem is created from travels with the volume, once', () => {
+  let sql: SQL;
+
+  beforeAll(async () => {
+    sql = await startTestDatabase();
+    await seedApp(sql);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await stopTestDatabase(sql);
+  }, DATABASE_START_TIMEOUT_MS);
+
+  async function desired(): Promise<DesiredVolumeRow> {
+    const [row] = (await sql.unsafe(
+      `SELECT seed_digest, seed_size_bytes, seed_object_key, seed_original_file_name
+       FROM nibrun.desired_volumes`,
+    )) as DesiredVolumeRow[];
+    if (!row) {
+      throw new Error('the seeded app has no desired volume');
+    }
+    return row;
+  }
+
+  test('an app whose deployment named no archive is told to create an empty one', async () => {
+    expect(await desired()).toEqual({
+      seed_digest: null,
+      seed_size_bytes: null,
+      seed_object_key: null,
+      seed_original_file_name: null,
+    });
+  });
+
+  test('a deployment naming one carries every field a host needs to pull it', async () => {
+    await nameArchive(sql);
+
+    expect(await desired()).toEqual({
+      seed_digest: ARCHIVE_DIGEST,
+      seed_size_bytes: '4096',
+      seed_object_key: ARCHIVE_KEY,
+      seed_original_file_name: ARCHIVE_NAME,
+    });
+  });
+
+  // The host would ignore it — a device that already carries a filesystem is left alone — so this
+  // is about keeping a gibibyte off the wire on every pass for the rest of the app's life.
+  test('a host having said the filesystem exists is what stops it being sent', async () => {
+    await sql.unsafe('UPDATE nibrun.apps SET data_initialized_at = now() WHERE slug = $1', [
+      APP_SLUG,
+    ]);
+
+    expect((await desired()).seed_digest).toBeNull();
+  });
+
+  // An upload nobody has completed names bytes that may never arrive, and a host sent after them
+  // would find a key naming nothing.
+  test('an archive still awaiting its upload is not sent either', async () => {
+    await sql.unsafe('UPDATE nibrun.apps SET data_initialized_at = NULL WHERE slug = $1', [
+      APP_SLUG,
+    ]);
+    await sql.unsafe('UPDATE nibrun.imports SET digest = NULL');
+
+    expect((await desired()).seed_digest).toBeNull();
+  });
+
+  test('the volume is still desired whatever the archive is doing', async () => {
+    const rows = (await sql.unsafe('SELECT app_id FROM nibrun.desired_volumes')) as unknown[];
+
+    expect(rows).toHaveLength(1);
+  });
+});
+
+/** An app with one deployment, and one uploaded archive nothing has named yet. */
+async function seedApp(sql: SQL): Promise<void> {
+  await sql.unsafe(
+    `INSERT INTO auth."user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+     VALUES ('owner', 'owner', 'owner@example.com', true, now(), now())`,
+  );
+  await sql.unsafe(`INSERT INTO nibrun.apps (owner_id, slug) VALUES ('owner', $1)`, [APP_SLUG]);
+  await sql.unsafe(
+    `INSERT INTO nibrun.artifacts (app_id, digest, size_bytes, object_key, original_file_name)
+     SELECT id, 'sha256:a', 1, 'artifacts/a', 'app' FROM nibrun.apps WHERE slug = $1`,
+    [APP_SLUG],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.imports (app_id, digest, size_bytes, object_key, original_file_name)
+     SELECT id, $2, 4096, $3, $4 FROM nibrun.apps WHERE slug = $1`,
+    [APP_SLUG, ARCHIVE_DIGEST, ARCHIVE_KEY, ARCHIVE_NAME],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.app_configs (
+       app_id, http_port, args, vcpu_count, memory_mib,
+       health_check_interval_ms, health_check_timeout_ms, health_check_grace_period_ms,
+       health_check_healthy_threshold, health_check_unhealthy_threshold,
+       restart_max_restarts, restart_initial_backoff_ms, restart_max_backoff_ms,
+       restart_backoff_factor, restart_reset_after_ms)
+     SELECT id, 8080, '{}'::text[], 1, 512, 1000, 1000, 1000, 1, 3, 5, 500, 5000, 2, 60000
+     FROM nibrun.apps WHERE slug = $1`,
+    [APP_SLUG],
+  );
+  await sql.unsafe(
+    `INSERT INTO nibrun.deployments (app_id, artifact_id, config_id, state)
+     SELECT a.id, ar.id, c.id, 'running'
+     FROM nibrun.apps a
+     JOIN nibrun.artifacts ar ON ar.app_id = a.id
+     JOIN nibrun.app_configs c ON c.app_id = a.id
+     WHERE a.slug = $1`,
+    [APP_SLUG],
+  );
+}
+
+async function nameArchive(sql: SQL): Promise<void> {
+  await sql.unsafe(
+    `UPDATE nibrun.deployments d
+     SET initial_data_import_id = im.id
+     FROM nibrun.imports im
+     WHERE im.app_id = d.app_id`,
+  );
+}

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -12,7 +12,7 @@ import {
 import { AgentSessions } from '#lib/agent/sessions.ts';
 import { UnauthorizedError } from '#lib/errors.ts';
 import type { AgentRepositoryContract, HostObservation } from '#repositories/agent.repository.ts';
-import { AgentService, type HostnameReconcile, type UploadSweep } from '#services/agent.service.ts';
+import { AgentService, type HostnameReconcile, type ImportSweep } from '#services/agent.service.ts';
 import type { AppsService } from '#services/apps.service.ts';
 import type { DeploymentsService } from '#services/deployments.service.ts';
 import type { ExportsService } from '#services/exports.service.ts';
@@ -83,6 +83,11 @@ class FakeAppsService {
     return Promise.resolve();
   }
 
+  recordDataInitialized(): Promise<void> {
+    this.trace.push('recordDataInitialized');
+    return Promise.resolve();
+  }
+
   completeDeletions({ volumes }: { volumes: readonly ReportedVolume[] }): Promise<void> {
     this.volumes.push([...volumes]);
     this.trace.push('completeDeletions');
@@ -119,11 +124,17 @@ class FakeExportsService {
 }
 
 /** A report is the only clock this process has, so the sweep rides along on one. */
-class FakeUploadSweep implements UploadSweep {
+class FakeUploadSweep implements ImportSweep {
   swept = 0;
+  sweptSpent = 0;
 
   sweepAbandoned(): Promise<void> {
     this.swept += 1;
+    return Promise.resolve();
+  }
+
+  sweepSpent(): Promise<void> {
+    this.sweptSpent += 1;
     return Promise.resolve();
   }
 }
@@ -249,6 +260,7 @@ describe('a report is read by whatever owns what it talks about', () => {
 
     expect(apps.trace).toEqual([
       'recordVolumeUsage',
+      'recordDataInitialized',
       'recordComputeUsage',
       'completeDeletions',
       'finishDeletions',
@@ -271,6 +283,8 @@ describe('a report is read by whatever owns what it talks about', () => {
 
     expect(artifacts.swept).toBe(1);
     expect(imports.swept).toBe(1);
+    // The archives this report's own `ready` volumes just made unusable go on the same pass.
+    expect(imports.sweptSpent).toBe(1);
     expect(hostnames.reconciled).toBe(1);
   });
 });

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -161,6 +161,15 @@ class StubAppsRepository implements AppsRepositoryContract {
     );
   }
 
+  /** Every app a host has ever said `ready` about, in the order the stamps were asked for. */
+  readonly initialized: AppId[] = [];
+
+  stampDataInitialized({ appIds }: { appIds: readonly AppId[] }): Promise<void> {
+    // `IS NULL` in the statement, so an app already stamped is not stamped again.
+    this.initialized.push(...appIds.filter((appId) => !this.initialized.includes(appId)));
+    return Promise.resolve();
+  }
+
   finishDeleting({ appId }: { appId: AppId }): Promise<boolean> {
     if (!this.deleting.includes(appId)) {
       return Promise.resolve(false);
@@ -951,6 +960,49 @@ describe('how full a filesystem is, as the host that holds it last measured it',
     });
 
     expect(appsRepo.measured).toEqual([new Map([[APP_ID, MEASURED]])]);
+  });
+});
+
+/**
+ * The one thing on this end that can learn a filesystem exists is a host saying so, and the moment
+ * it does is the moment naming an archive to create it from stops being a request anybody can make.
+ */
+describe('an app records the moment its filesystem stopped being creatable', () => {
+  function reportedVolume(state: ReportedVolume['state']): ReportedVolume {
+    return { volumeId: VOLUME_ID, appId: APP_ID, state, sizeBytes: NO_BYTES };
+  }
+
+  test('a volume reported ready stamps the app it belongs to', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+
+    await serviceWith({ appsRepo }).recordDataInitialized({ volumes: [reportedVolume('ready')] });
+
+    expect(appsRepo.initialized).toEqual([APP_ID]);
+  });
+
+  // A volume this host is not serving says nothing about whether the filesystem exists, and one
+  // that failed to provision says the opposite.
+  test.each(['pending', 'detached', 'failed', 'deleted'] as const)(
+    'a volume reported %s stamps nothing',
+    async (state) => {
+      const appsRepo = new StubAppsRepository({ failures: 0 });
+
+      await serviceWith({ appsRepo }).recordDataInitialized({ volumes: [reportedVolume(state)] });
+
+      expect(appsRepo.initialized).toEqual([]);
+    },
+  );
+
+  // A volume reports ready on every pass, and `apps` carries a `set_updated_at` trigger — so an
+  // app stamped twice would look to its owner like somebody had just changed it.
+  test('an app already stamped is not stamped again', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    const apps = serviceWith({ appsRepo });
+
+    await apps.recordDataInitialized({ volumes: [reportedVolume('ready')] });
+    await apps.recordDataInitialized({ volumes: [reportedVolume('ready')] });
+
+    expect(appsRepo.initialized).toEqual([APP_ID]);
   });
 });
 

--- a/apps/api/tests/services/deployments.test.ts
+++ b/apps/api/tests/services/deployments.test.ts
@@ -21,6 +21,7 @@ import { STARTUP_DEADLINE_MS } from '#lib/deployments/lifecycle.ts';
 import { ConflictError, NotFoundError } from '#lib/errors.ts';
 import type {
   CreateDeploymentInput,
+  CreatedDeployment,
   DeploymentByIdInput,
   DeploymentRow,
   DeploymentsByAppInput,
@@ -36,6 +37,7 @@ import {
   configColumns,
   DEFAULT_CONFIG,
   DEPLOYMENT_ID,
+  IMPORT_ID,
   OWNER_ID,
 } from '#tests/services/support/fixtures.ts';
 import { uniqueViolation } from '#tests/support/postgres.ts';
@@ -107,6 +109,8 @@ type FakeBehaviour = {
   row?: DeploymentRow | null;
   live?: LiveDeploymentRow[];
   runError?: unknown;
+  /** What the insert decided, where a case is about a refusal rather than about the row. */
+  refusal?: Exclude<CreatedDeployment, { outcome: 'created' }>;
 };
 
 class FakeDeploymentsRepository implements DeploymentsRepositoryContract {
@@ -139,12 +143,16 @@ class FakeDeploymentsRepository implements DeploymentsRepositoryContract {
     return Promise.resolve();
   }
 
-  insert(input: CreateDeploymentInput): Promise<DeploymentRow | null> {
+  insert(input: CreateDeploymentInput): Promise<CreatedDeployment> {
     this.calls.push(input);
     if (this.#behaviour.runError) {
       return Promise.reject(this.#behaviour.runError);
     }
-    return Promise.resolve(this.#behaviour.row ?? null);
+    if (this.#behaviour.refusal) {
+      return Promise.resolve(this.#behaviour.refusal);
+    }
+    const row = this.#behaviour.row;
+    return Promise.resolve(row ? { outcome: 'created', row } : { outcome: 'no-artifact' });
   }
 
   listByApp(input: DeploymentsByAppInput): Promise<DeploymentRow[]> {
@@ -572,5 +580,76 @@ describe('going back to a release is a new deployment, not an old one revived', 
     const { service } = serviceWith({ runError: boom });
 
     await expect(service.createOrRollback(ROLLBACK_REQUEST)).rejects.toBe(boom);
+  });
+});
+
+/**
+ * The archive an app's filesystem is created from is named on the deployment, and refused where it
+ * could not be honoured. Every one of these is a refusal an owner has something to do about, which
+ * is why they are not all "not found".
+ */
+describe('a deployment can say what the app starts with, once', () => {
+  test('the archive named reaches the row that is written', async () => {
+    const { deploymentsRepo, service } = serviceWith({ row: deploymentRow() });
+
+    await service.createOrRollback({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      source: { artifactId: ARTIFACT_ID, initialDataFrom: IMPORT_ID },
+    });
+
+    expect(deploymentsRepo.calls[0]).toMatchObject({ initialDataFrom: IMPORT_ID });
+  });
+
+  test('a deployment that names none says so rather than leaving it unsaid', async () => {
+    const { deploymentsRepo, service } = serviceWith({ row: deploymentRow() });
+
+    await service.createOrRollback({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      source: { artifactId: ARTIFACT_ID },
+    });
+
+    expect(deploymentsRepo.calls[0]).toMatchObject({ initialDataFrom: null });
+  });
+
+  // Said as a conflict rather than a refusal of the request: nothing was wrong with what they
+  // asked for, it is simply too late to ask it.
+  test('an app whose filesystem already exists is a conflict', async () => {
+    const { service } = serviceWith({ refusal: { outcome: 'data-exists' } });
+
+    await expect(
+      service.createOrRollback({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        source: { artifactId: ARTIFACT_ID, initialDataFrom: IMPORT_ID },
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  test('an archive still awaiting its upload is not one this can be given', async () => {
+    const { service } = serviceWith({ refusal: { outcome: 'no-import' } });
+
+    await expect(
+      service.createOrRollback({
+        appId: APP_ID,
+        ownerId: OWNER_ID,
+        source: { artifactId: ARTIFACT_ID, initialDataFrom: IMPORT_ID },
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  // A rollback replays a release exactly as it ran, and creating the filesystem is not something
+  // that happened then. The body says so as a schema, so the service never sees the two together.
+  test('a rollback is written with no archive at all', async () => {
+    const { deploymentsRepo, service } = serviceWith({ row: deploymentRow() });
+
+    await service.createOrRollback({
+      appId: APP_ID,
+      ownerId: OWNER_ID,
+      source: { rollbackOf: DEPLOYMENT_ID },
+    });
+
+    expect(deploymentsRepo.calls[0]).not.toHaveProperty('initialDataFrom');
   });
 });

--- a/apps/api/tests/services/imports.test.ts
+++ b/apps/api/tests/services/imports.test.ts
@@ -22,6 +22,7 @@ import type {
   ImportRow,
   ImportsRepositoryContract,
   PendingImportRow,
+  SpentImportRow,
 } from '#repositories/imports.repository.ts';
 import { ImportsService, importKey, MAX_IMPORT_SIZE_BYTES } from '#services/imports.service.ts';
 import { APP_ID, OTHER_OWNER_ID, OWNER_ID } from '#tests/services/support/fixtures.ts';
@@ -167,6 +168,26 @@ class FakeImportsRepository implements ImportsRepositoryContract {
     return Promise.resolve();
   }
 
+  listSpent({ limit }: { limit: number }): Promise<SpentImportRow[]> {
+    return Promise.resolve(
+      [...this.rows.values()]
+        .filter((row) => row.object_key !== null && this.spentApps.includes(row.app_id))
+        .slice(0, limit)
+        .map((row) => ({ id: row.id, object_key: row.object_key as ObjectKey })),
+    );
+  }
+
+  forgetObject({ importId }: { importId: ImportId }): Promise<void> {
+    const row = this.rows.get(importId);
+    if (row && row.object_key !== null) {
+      this.rows.set(importId, { ...row, object_key: null });
+    }
+    return Promise.resolve();
+  }
+
+  /** The apps a host has said hold a filesystem, which is what makes their archives unusable. */
+  readonly spentApps: AppId[] = [];
+
   /** Pretends the row has been sitting there since before the sweep's cutoff. */
   age(importId: ImportId): void {
     const row = this.rows.get(importId);
@@ -192,6 +213,12 @@ class FakeStorage implements ArtifactStorageRepositoryContract {
   readonly objects = new Map<ObjectKey, Uint8Array>();
   readonly signed: { objectKey: ObjectKey; sizeBytes: number }[] = [];
   readonly removed: ObjectKey[] = [];
+  readonly refused = new Set<ObjectKey>();
+
+  /** A bucket turning one delete down, which must leave the row that names it alone. */
+  refuse(objectKey: ObjectKey): void {
+    this.refused.add(objectKey);
+  }
 
   signUpload(input: { objectKey: ObjectKey; sizeBytes: number }): Promise<string> {
     this.signed.push(input);
@@ -233,6 +260,9 @@ class FakeStorage implements ArtifactStorageRepositoryContract {
   }
 
   remove({ objectKey }: { objectKey: ObjectKey }): Promise<void> {
+    if (this.refused.has(objectKey)) {
+      return Promise.reject(new Error('the bucket refused the delete'));
+    }
     this.removed.push(objectKey);
     this.objects.delete(objectKey);
     return Promise.resolve();
@@ -559,5 +589,88 @@ describe('an upload that never lands leaves nothing behind', () => {
     await service.sweepAbandoned();
 
     expect(importsRepo.rows.size).toBe(1);
+  });
+});
+
+/**
+ * The bucket's own expiry is the backstop for an upload nobody deployed. This is for the archives
+ * that can no longer do anything: eventually is far too long to leave an owner's whole dataset
+ * lying in a bucket beside the filesystem it became.
+ */
+describe('an archive that can no longer create a filesystem stops being stored', () => {
+  test("an app whose data exists has its archive's bytes removed", async () => {
+    const { service, storage, importsRepo } = build();
+    const { begun } = await uploaded({ service, storage });
+    importsRepo.spentApps.push(APP_ID);
+
+    await service.sweepSpent();
+
+    expect(storage.removed).toEqual([importKey({ appId: APP_ID, importId: begun.importId })]);
+    expect(storage.objects.size).toBe(0);
+  });
+
+  // What the owner uploaded and what it hashed to is the app's history; only where the bytes were
+  // has stopped being true.
+  test('the row and its digest stay behind', async () => {
+    const { service, storage, importsRepo } = build();
+    const { begun, stored } = await uploaded({ service, storage });
+    importsRepo.spentApps.push(APP_ID);
+
+    await service.sweepSpent();
+
+    expect(importsRepo.rows.get(begun.importId)).toMatchObject({
+      digest: stored.digest,
+      object_key: null,
+    });
+  });
+
+  // Membership is having an object left, which is the same sentence as the work being done — so a
+  // second pass finds nothing rather than deleting twice.
+  test('a pass that has already run does nothing on the next report', async () => {
+    const { service, storage, importsRepo } = build();
+    await uploaded({ service, storage });
+    importsRepo.spentApps.push(APP_ID);
+
+    await service.sweepSpent();
+    await service.sweepSpent();
+
+    expect(storage.removed).toHaveLength(1);
+  });
+
+  test('an app whose filesystem does not exist yet keeps its archive', async () => {
+    const { service, storage } = build();
+    await uploaded({ service, storage });
+
+    await service.sweepSpent();
+
+    expect(storage.removed).toEqual([]);
+    expect(storage.objects.size).toBe(1);
+  });
+
+  /**
+   * Not only the ones that were used. An archive nobody ever deployed against an app whose data is
+   * now there is one `initialDataFrom` would refuse, so what it is holding is storage nothing can
+   * ever spend.
+   */
+  test('one nobody ever deployed is removed too, once the data exists', async () => {
+    const { service, storage, importsRepo } = build();
+    await uploaded({ service, storage });
+    importsRepo.spentApps.push(APP_ID);
+
+    await service.sweepSpent();
+
+    expect(storage.objects.size).toBe(0);
+  });
+
+  // A bucket refusing one delete leaves the row still naming it, so the next report finds it again.
+  test('an object that could not be removed is left to be found again', async () => {
+    const { service, storage, importsRepo } = build();
+    const { begun } = await uploaded({ service, storage });
+    importsRepo.spentApps.push(APP_ID);
+    storage.refuse(importKey({ appId: APP_ID, importId: begun.importId }));
+
+    await service.sweepSpent();
+
+    expect(importsRepo.rows.get(begun.importId)?.object_key).not.toBeNull();
   });
 });

--- a/apps/api/tests/services/support/fixtures.ts
+++ b/apps/api/tests/services/support/fixtures.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_RESTART_POLICY,
   DEFAULT_VOLUME_SIZE_BYTES,
   DeploymentIdSchema,
+  ImportIdSchema,
   OwnerIdSchema,
   Value,
 } from '@repo/protocol';
@@ -21,6 +22,7 @@ export const OWNER_ID = Value.Parse(OwnerIdSchema, 'owner-1');
 export const OTHER_OWNER_ID = Value.Parse(OwnerIdSchema, 'owner-2');
 export const APP_ID = Value.Parse(AppIdSchema, 'app-1');
 export const ARTIFACT_ID = Value.Parse(ArtifactIdSchema, 'artifact-1');
+export const IMPORT_ID = Value.Parse(ImportIdSchema, 'import-1');
 export const DEPLOYMENT_ID = Value.Parse(DeploymentIdSchema, 'deployment-1');
 
 export const APP_HOST_DOMAIN = 'apps.test';


### PR DESCRIPTION
`initialDataFrom` on the deployment body names an uploaded archive, and the app's filesystem is created holding it — refused once a host has reported the volume ready, or while the archive is still uploading.

Once that first ready report lands the api removes the archive's bytes, keeping the row and its digest: the bucket's expiry is the backstop for an upload nobody ever deployed, not what clears one that has already done its job.

Dashboard and CLI surfaces are not here. Written with no AWS and no hypervisor, so the seeded format is reasoned about rather than exercised — the gap `apps/agent/AGENTS.md` already records for the volume path.
