### PR TITLE
docs: the staged-upload expiry and the sweep that beats it to it name each other

### DIFF
--- a/apps/api/src/services/artifacts.service.ts
+++ b/apps/api/src/services/artifacts.service.ts
@@ -232,6 +232,12 @@ function refusalMessage(inspection: Exclude<ArtifactInspection, { outcome: 'stor
  * Long enough that no upload is still on its way to a row this old — the signed policy expires
  * far sooner — and no longer than the bucket rule that expires the staged object, so a row and
  * the bytes it was waiting for are not left outliving each other.
+ *
+ * That rule is `expire-staged-uploads` in `infra/terraform/s3.tf`, one day over the `uploads/`
+ * prefix, and nothing compares the two — so shortening it there is shortening this here. Which way
+ * they may differ is not symmetric: this sweep is what removes the object and the row together,
+ * and the rule is the backstop for an object whose delete was refused, so a rule longer than this
+ * costs nothing and a rule shorter than it is what leaves a row waiting on bytes already gone.
  */
 const ABANDONED_AFTER_SECONDS = 86_400;
 

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -166,6 +166,13 @@ resource "aws_s3_bucket_cors_configuration" "artifacts" {
 # the ones where it never happens: an upload nobody registers is bytes no row will
 # ever name, and without a rule they would sit here at full size forever.
 #
+# The api sweeps those rows on the same schedule and deletes the object itself as
+# it goes — `ABANDONED_AFTER_SECONDS` in apps/api/src/services/artifacts.service.ts,
+# one day, and nothing compares the two numbers. So this is the backstop for an
+# object whose delete was refused rather than the thing that usually removes one,
+# and shortening it below that number is what leaves rows waiting on bytes already
+# gone.
+#
 # Scoped to the prefix, because everything outside it is what users deployed.
 #
 # Noncurrent versions too: the bucket is versioned, so deleting a staging object


### PR DESCRIPTION
`expire-staged-uploads` in `infra/terraform/s3.tf` and `ABANDONED_AFTER_SECONDS` in `apps/api/src/services/artifacts.service.ts` are both one day, and nothing compares them — the api's comment referred to "the bucket rule" without saying where it lives, and the terraform rule did not mention the sweep at all.

Comments rather than a shared terraform variable: the api never tells anyone this number, so unlike `EXPORT_RETENTION_DAYS` there is no promise that could outlive the rule, and the drift is one-directional and mild. Naming the other side is what the eleven `nothing compares the two` comments elsewhere in the repo already do for this.

Independent of the imports stack (#499–#503); touches no behaviour.