### PR TITLE
fix(dashboard): an app is not offered a release while it is coming back

### DIFF
--- a/apps/dashboard/src/lib/app-actions.ts
+++ b/apps/dashboard/src/lib/app-actions.ts
@@ -36,6 +36,16 @@ const UNTIL_RESUMED: AppActionAvailability = {
 };
 
 /**
+ * Creating a release supersedes whatever the app was on, and while an app is resuming that is the
+ * release the host is in the middle of bringing back — so an owner who pressed resume and then
+ * deployed would get the app back on the new binary rather than the one that went away.
+ */
+const UNTIL_UP: AppActionAvailability = {
+  kind: 'disabled',
+  reason: 'This app is resuming, so a new release would replace the one coming back. Wait for it.',
+};
+
+/**
  * Every status against every button, written out rather than derived, because there is no rule
  * underneath: export needs a release to have ever existed, suspend needs one that is running,
  * delete needs the app to not already be going. A status added to `AppStatusKey` is a row missing
@@ -110,9 +120,11 @@ const AVAILABILITY: Record<AppStatusKey, AppActions> = {
     suspend: DISABLED,
     delete: DISABLED,
   },
-  // Deploying is offered back the moment the app row asks to run again, which is what resuming is.
+  // Both buttons that change what is running are held for the seconds a resume takes: suspend is
+  // the one the owner just pressed the other way, and a release is the one that would land on top
+  // of the release coming back. Everything that only reads the app is offered as usual.
   resuming: {
-    deploy: ENABLED,
+    deploy: UNTIL_UP,
     redeploy: HIDDEN,
     export: ENABLED,
     suspend: DISABLED,

--- a/apps/dashboard/tests/lib/app-actions.test.ts
+++ b/apps/dashboard/tests/lib/app-actions.test.ts
@@ -72,6 +72,13 @@ describe('an app the host has not caught up with yet', () => {
     expect(actions({ deploymentState: 'stopped' }).suspend).toEqual(DISABLED);
   });
 
+  test('nor offered a release while it is coming back, and says why', () => {
+    expect(actions({ deploymentState: 'stopped' }).deploy).toEqual({
+      kind: 'disabled',
+      reason: expect.any(String),
+    });
+  });
+
   test('and one on its way down offers nothing to press at all', () => {
     expect(actions({ appState: 'suspended', deploymentState: 'running' })).toEqual({
       deploy: { kind: 'disabled', reason: expect.any(String) },
@@ -108,8 +115,8 @@ describe('a suspended app', () => {
     });
   }
 
-  test('is offered one again the moment it is asked to run, before the host has started it', () => {
-    expect(actions({ deploymentState: 'stopped' }).deploy).toEqual(ENABLED);
+  test('is offered one again once the host has it running', () => {
+    expect(actions({ deploymentState: 'running' }).deploy).toEqual(ENABLED);
   });
 });
 


### PR DESCRIPTION
Deploying onto a resuming app supersedes the release the host is in the middle of bringing back, so an owner who pressed resume and then Update got the app back on the new binary rather than the one that went away.

The button matrix greys `deploy` for `resuming`, with the sentence saying why — the same window over which suspend is already greyed. Saving environment variables follows it, being a release.

The CLI table is untouched: `@repo/app-operations` refuses a release with "a new release would never start", which is true of a suspended app and not of a resuming one — its row already asks to run.