### PR TITLE
fix(runtime): lost+found belongs to the tenant, like the rest of their volume

### DIFF
--- a/apps/runtime/src/mounts.c
+++ b/apps/runtime/src/mounts.c
@@ -1,6 +1,8 @@
 #include "mounts.h"
 
 #include <errno.h>
+#include <limits.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
@@ -130,6 +132,27 @@ bool mounts_artifact(const char *device, const char *target) {
   return mount_squashfs(device, target, 0);
 }
 
+/* mkfs.ext4 makes this on every volume and keeps it for root at 0700, so it is the one
+ * thing in the tenant's own data/ they cannot read — and a recursive walk of their own
+ * directory, which is the first thing anything does with it, dies on it.
+ *
+ * Given away rather than hidden: whatever fsck ever puts here is the tenant's own data
+ * recovered, and the host cannot do this itself without mounting a tenant filesystem,
+ * which is the invariant the export path exists to keep.
+ *
+ * Never fatal. A volume that came from somewhere without one is still a volume, and
+ * failing the boot over a directory nobody has written to yet would be trading the
+ * papercut for an app that does not start. */
+static void give_away_lost_found(const struct tenant_data_mount *request) {
+  char path[PATH_MAX];
+  if (snprintf(path, sizeof(path), "%s/lost+found", request->target) >= (int)sizeof(path)) {
+    return;
+  }
+  if (chown(path, request->uid, request->gid) < 0 && errno != ENOENT) {
+    log_errno("could not give %s to uid %u", path, request->uid);
+  }
+}
+
 bool mounts_tenant_data(const struct tenant_data_mount *request) {
   if (!mounts_wait_for_device(request->device, DEVICE_WAIT_TIMEOUT_MS) ||
       !ensure_directory(request->target, 0755)) {
@@ -147,6 +170,7 @@ bool mounts_tenant_data(const struct tenant_data_mount *request) {
     log_errno("could not give %s to uid %u", request->target, request->uid);
     return false;
   }
+  give_away_lost_found(request);
   return true;
 }
 

--- a/apps/runtime/tests/test-mounts.c
+++ b/apps/runtime/tests/test-mounts.c
@@ -7,6 +7,7 @@
  * Argument 1 is a loop device holding a squashfs, argument 2 one holding an ext4
  * filesystem. tests/mounts.sh builds both. */
 
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sched.h>
@@ -183,6 +184,47 @@ static size_t count_mounts_at(const char *target) {
   return mounts;
 }
 
+/* Every entry of the directory read as the tenant, which is what an app does to its own
+ * data/ before it does anything else. mkfs.ext4's lost+found is the one thing in there
+ * they did not put there, and for a walk it is indistinguishable from their own. */
+static bool can_walk_as_tenant(const char *directory) {
+  pid_t child = fork();
+  if (child == 0) {
+    if (setgid(TENANT_GID) < 0 || setuid(TENANT_UID) < 0) {
+      _exit(1);
+    }
+    DIR *opened = opendir(directory);
+    if (opened == NULL) {
+      _exit(1);
+    }
+    /* Relative to the directory's own descriptor, so no entry name has to be pasted onto
+     * a path — which is also how a walk that does not race a rename would do it. */
+    int at = dirfd(opened);
+    for (struct dirent *entry = readdir(opened); entry != NULL; entry = readdir(opened)) {
+      if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+        continue;
+      }
+      struct stat details;
+      if (fstatat(at, entry->d_name, &details, 0) < 0) {
+        _exit(1);
+      }
+      if (!S_ISDIR(details.st_mode)) {
+        continue;
+      }
+      int below = openat(at, entry->d_name, O_RDONLY | O_DIRECTORY);
+      if (below < 0) {
+        _exit(1);
+      }
+      close(below);
+    }
+    closedir(opened);
+    _exit(0);
+  }
+  int status = 0;
+  waitpid(child, &status, 0);
+  return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
 static bool can_write_as_tenant(const char *directory) {
   pid_t child = fork();
   if (child == 0) {
@@ -254,6 +296,9 @@ int main(int argc, char **argv) {
   /* Its own directory and nothing above it: /run stands in for the tmpfs the guest
    * mounts at /app, which the tenant must not be able to write. */
   EXPECT(!can_write_as_tenant("/run"));
+  /* mkfs.ext4 leaves lost+found to root at 0700, so without this the first recursive
+   * walk an app makes of its own data/ ends in EACCES on a directory it never made. */
+  EXPECT(can_walk_as_tenant(DATA_MOUNT));
 
   /* A frozen filesystem cannot be asked whether it is frozen, and a write that proved
    * it would be a write that never returns. What answers instead is the pair of


### PR DESCRIPTION
`mkfs.ext4` makes `lost+found` on every volume and keeps it for root at 0700, so it was the one thing in the tenant's own `data/` they could not read. A recursive walk of that directory — the first thing anything does with it — died on a directory they never made:

```
EACCES: permission denied, scandir '/app/data/lost+found'
```

Found by deploying an app seeded with `nib run --data-folder` and having it list its own data. It is not specific to imports: every volume has one, seeded or not. `MKFS_ROOT_ENTRIES` already hides it from `nib apps files ls` and from exports, but that only cleans nibrun's own surfaces — the tenant's process still sees it.

Given away rather than hidden, in the guest rather than on the host: whatever `fsck` ever puts there is the tenant's own data recovered, and the host cannot chown it without mounting a tenant filesystem, which is the invariant the export path exists to keep. Never fatal — a volume without one is still a volume.

The new assertion fails against the runtime as it stands (`mounts: 47 checks, 1 failures`) and passes with the change; all three Docker suites are green.

**This changes `dist/init`, so it is a new guest-image version** — the image has to be rebuilt, published and adopted before a host boots it, and `infra/guest-image` hashes the runtime binary into its own version.
