### PR TITLE
feat(dashboard): an app can be created holding the data its owner uploads

### DIFF
--- a/apps/dashboard/src/components/deploy/binary-drop-zone.tsx
+++ b/apps/dashboard/src/components/deploy/binary-drop-zone.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@repo/ui/components/button';
-import { useBinaryPicker } from '@repo/ui/hooks/use-binary-picker';
-import { FileTerminalIcon, UploadIcon, XIcon } from 'lucide-react';
+import { FileTerminalIcon } from 'lucide-react';
+import { FileDropZone } from '#components/deploy/file-drop-zone.tsx';
 
 export const BINARY_INPUT_ID = 'deploy-binary';
 
@@ -15,59 +14,19 @@ export function BinaryDropZone({
   keeping: boolean;
   onPick: (binary: File | undefined) => void;
 }) {
-  const picker = useBinaryPicker({ onPick });
-
   return (
-    <div
-      data-dragging={picker.dragging || undefined}
-      data-invalid={invalid || undefined}
-      className="relative flex w-full items-center gap-2 rounded-2xl border border-muted-foreground/30 border-dashed bg-input/50 px-3 py-4 text-sm transition-[color,background-color,box-shadow] duration-200 hover:bg-input has-[input:focus-visible]:border-ring has-[input:focus-visible]:ring-3 has-[input:focus-visible]:ring-ring/30 data-[dragging=true]:border-ring data-[invalid=true]:border-destructive/50 data-[dragging=true]:border-solid data-[dragging=true]:bg-primary/10"
-      {...picker.dropHandlers}
-    >
-      <input
-        ref={picker.inputRef}
-        id={BINARY_INPUT_ID}
-        type="file"
-        className="sr-only"
-        aria-invalid={invalid}
-        onChange={(event) => onPick(event.target.files?.[0])}
-      />
-      <label
-        htmlFor={BINARY_INPUT_ID}
-        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 font-normal"
-      >
-        {binary === undefined ? (
-          <>
-            <UploadIcon className="size-4 shrink-0 text-muted-foreground" />
-            <span>
-              {keeping
-                ? 'Drop a binary here to replace the one it runs.'
-                : 'Drop the binary here, or browse for it.'}
-            </span>
-          </>
-        ) : (
-          <>
-            <FileTerminalIcon className="size-4 shrink-0 text-muted-foreground" />
-            <span className="flex min-w-0 flex-col">
-              <span className="truncate font-mono" title={binary.name}>
-                {binary.name}
-              </span>
-              <span className="text-muted-foreground text-xs">Drop another to replace it.</span>
-            </span>
-          </>
-        )}
-      </label>
-      {binary !== undefined && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Clear the binary"
-          onClick={picker.clear}
-        >
-          <XIcon />
-        </Button>
-      )}
-    </div>
+    <FileDropZone
+      inputId={BINARY_INPUT_ID}
+      file={binary}
+      icon={FileTerminalIcon}
+      invitation={
+        keeping
+          ? 'Drop a binary here to replace the one it runs.'
+          : 'Drop the binary here, or browse for it.'
+      }
+      clearLabel="Clear the binary"
+      invalid={invalid}
+      onPick={onPick}
+    />
   );
 }

--- a/apps/dashboard/src/components/deploy/deploy-configuration.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-configuration.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from '@repo/ui/components/input';
 import { Textarea } from '@repo/ui/components/textarea';
 import { DeployEnvironmentField } from '#components/deploy/deploy-environment-field.tsx';
+import { DeployInitialDataField } from '#components/deploy/deploy-initial-data-field.tsx';
 import { DeployNameField } from '#components/deploy/deploy-name-field.tsx';
 import {
   type EnvironmentVariable,
@@ -28,6 +29,7 @@ import { type DeployFormState, tenantArguments, validatePort } from '#lib/hooks/
 
 const ARGUMENTS = 'Arguments';
 const ADDITIONAL_PORTS = 'Additional ports';
+const INITIAL_DATA = 'Initial data';
 const ENVIRONMENT = 'environment';
 
 const AWAITING = 'Fill these in.';
@@ -187,6 +189,34 @@ export function DeployConfiguration({
           </AccordionContent>
         </AccordionItem>
       </Accordion>
+
+      {/* An app's data is created once, along with the app itself — the api refuses an import
+          against a volume a host has already reported — so there is nothing here to ask an app
+          that is already running. */}
+      {!locked && (
+        <Accordion>
+          <AccordionItem>
+            <AccordionTrigger>
+              <span className="flex items-baseline gap-2">
+                {INITIAL_DATA}
+                <api.Subscribe selector={(state) => state.values.initialData?.name}>
+                  {(name) => <CollapsedName name={name} />}
+                </api.Subscribe>
+              </span>
+              {/* Shut, a refused archive would disable the button with nothing on screen saying
+                  why, so the section that holds it says so itself. */}
+              <api.Subscribe
+                selector={(state) => (state.fieldMeta.initialData?.errors.length ?? 0) > 0}
+              >
+                {(refused) => refused && <NeedsALook />}
+              </api.Subscribe>
+            </AccordionTrigger>
+            <AccordionContent keepMounted>
+              <DeployInitialDataField api={api} />
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
     </>
   );
 }
@@ -219,9 +249,14 @@ function environmentMark({
   return refused ? 'refused' : undefined;
 }
 
+/** What a shut section says where the field inside it has refused what it was given. */
+function NeedsALook() {
+  return <span className="font-normal text-destructive">needs a look</span>;
+}
+
 function EnvironmentMark({ mark }: { mark: EnvironmentMarkKind }) {
   if (mark === 'refused') {
-    return <span className="font-normal text-destructive">needs a look</span>;
+    return <NeedsALook />;
   }
   if (mark === 'awaiting') {
     return (
@@ -239,6 +274,15 @@ function CollapsedState({ on }: { on: boolean }) {
   return (
     <span className="font-normal text-muted-foreground text-xs group-aria-expanded/accordion-trigger:hidden">
       {on ? 'one' : 'none'}
+    </span>
+  );
+}
+
+/** The same, where what the section holds is one file rather than a number of anything. */
+function CollapsedName({ name }: { name: string | undefined }) {
+  return (
+    <span className="max-w-40 truncate font-mono font-normal text-muted-foreground text-xs group-aria-expanded/accordion-trigger:hidden">
+      {name ?? 'none'}
     </span>
   );
 }

--- a/apps/dashboard/src/components/deploy/deploy-initial-data-field.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-initial-data-field.tsx
@@ -28,14 +28,9 @@ export function DeployInitialDataField({ api }: { api: DeployFormApi }) {
               onPick={field.handleChange}
             />
             <FieldDescription>
-              What the app finds in <code className="font-mono">data/</code> the first time it runs.
-              nibrun unpacks the archive before the app starts, so what is inside it becomes the
-              root of <code className="font-mono">data/</code> — the folder you packed is not a
-              directory inside it.
-            </FieldDescription>
-            <FieldDescription>
-              One <code className="font-mono">.tar.gz</code>, up to{' '}
-              {formatBytes(MAX_IMPORT_SIZE_BYTES)}.
+              Unpacked into <code className="font-mono">data/</code> before the app starts. One{' '}
+              <code className="font-mono">.tar.gz</code>, up to {formatBytes(MAX_IMPORT_SIZE_BYTES)}
+              .
             </FieldDescription>
             {issue !== undefined && <FieldError>{issue}</FieldError>}
           </Field>

--- a/apps/dashboard/src/components/deploy/deploy-initial-data-field.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-initial-data-field.tsx
@@ -1,0 +1,46 @@
+import { MAX_IMPORT_SIZE_BYTES } from '@repo/app-operations';
+import { Field, FieldDescription, FieldError } from '@repo/ui/components/field';
+import { FileArchiveIcon } from 'lucide-react';
+import { FileDropZone } from '#components/deploy/file-drop-zone.tsx';
+import { formatBytes } from '#lib/format-bytes.ts';
+import { type DeployFormApi, validateInitialData } from '#lib/hooks/use-deploy-form.ts';
+
+const INITIAL_DATA_INPUT_ID = 'deploy-initial-data';
+
+/**
+ * The archive the app's volume is created holding, refused here before it is sent: the api reads
+ * the object rather than the request, so anything but a `.tar.gz` is a gibibyte spent to be told no.
+ */
+export function DeployInitialDataField({ api }: { api: DeployFormApi }) {
+  return (
+    <api.Field name="initialData" validators={{ onChangeAsync: validateInitialData }}>
+      {(field) => {
+        const [issue] = field.state.meta.errors;
+        return (
+          <Field data-invalid={issue !== undefined || undefined}>
+            <FileDropZone
+              inputId={INITIAL_DATA_INPUT_ID}
+              file={field.state.value}
+              icon={FileArchiveIcon}
+              invitation="Drop a .tar.gz here, or browse for it."
+              clearLabel="Clear the archive"
+              invalid={issue !== undefined}
+              onPick={field.handleChange}
+            />
+            <FieldDescription>
+              What the app finds in <code className="font-mono">data/</code> the first time it runs.
+              nibrun unpacks the archive before the app starts, so what is inside it becomes the
+              root of <code className="font-mono">data/</code> — the folder you packed is not a
+              directory inside it.
+            </FieldDescription>
+            <FieldDescription>
+              One <code className="font-mono">.tar.gz</code>, up to{' '}
+              {formatBytes(MAX_IMPORT_SIZE_BYTES)}.
+            </FieldDescription>
+            {issue !== undefined && <FieldError>{issue}</FieldError>}
+          </Field>
+        );
+      }}
+    </api.Field>
+  );
+}

--- a/apps/dashboard/src/components/deploy/deploy-progress.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-progress.tsx
@@ -5,7 +5,7 @@ import { CheckIcon, TriangleAlertIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { UploadMeter } from '#components/deploy/upload-meter.tsx';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
-import type { DeployPhase } from '#lib/hooks/use-run-app.ts';
+import { type DeployPhase, isUploading } from '#lib/hooks/use-run-app.ts';
 
 // `done` is the caller's: a dialog closes itself where a page of its own has somewhere to go,
 // and this view has no way to know which of those it is inside.
@@ -28,7 +28,7 @@ export function DeployProgress({ done }: { done: ReactNode }) {
               <Spinner className="shrink-0" />
               <span>{waiting}</span>
             </div>
-            {run.progress !== undefined && run.phase === 'uploading' && (
+            {run.progress !== undefined && isUploading(run.phase) && (
               <UploadMeter progress={run.progress} />
             )}
           </li>
@@ -73,6 +73,9 @@ export function DeployProgress({ done }: { done: ReactNode }) {
 function waitingOn(phase: DeployPhase): string | undefined {
   if (phase === 'uploading') {
     return 'uploading the binary';
+  }
+  if (phase === 'uploading-data') {
+    return 'uploading the data the app starts with';
   }
   // No meter under this one: the bytes are moving between the url and nibrun, and this end is
   // only waiting to be told how it went.

--- a/apps/dashboard/src/components/deploy/file-drop-zone.tsx
+++ b/apps/dashboard/src/components/deploy/file-drop-zone.tsx
@@ -1,0 +1,80 @@
+import { Button } from '@repo/ui/components/button';
+import { useBinaryPicker } from '@repo/ui/hooks/use-binary-picker';
+import { type LucideIcon, UploadIcon, XIcon } from 'lucide-react';
+
+const REPLACE = 'Drop another to replace it.';
+
+/**
+ * One row of the deploy form that takes a file off this machine. Shared between them so that the
+ * binary and the archive read as two answers to the same kind of question rather than as two
+ * different controls that happen to sit on the same form.
+ */
+export function FileDropZone({
+  inputId,
+  file,
+  icon: PickedIcon,
+  invitation,
+  clearLabel,
+  invalid,
+  onPick,
+}: {
+  inputId: string;
+  file: File | undefined;
+  icon: LucideIcon;
+  invitation: string;
+  clearLabel: string;
+  invalid: boolean;
+  onPick: (file: File | undefined) => void;
+}) {
+  const picker = useBinaryPicker({ onPick });
+
+  return (
+    <div
+      data-dragging={picker.dragging || undefined}
+      data-invalid={invalid || undefined}
+      className="relative flex w-full items-center gap-2 rounded-2xl border border-muted-foreground/30 border-dashed bg-input/50 px-3 py-4 text-sm transition-[color,background-color,box-shadow] duration-200 hover:bg-input has-[input:focus-visible]:border-ring has-[input:focus-visible]:ring-3 has-[input:focus-visible]:ring-ring/30 data-[dragging=true]:border-ring data-[invalid=true]:border-destructive/50 data-[dragging=true]:border-solid data-[dragging=true]:bg-primary/10"
+      {...picker.dropHandlers}
+    >
+      <input
+        ref={picker.inputRef}
+        id={inputId}
+        type="file"
+        className="sr-only"
+        aria-invalid={invalid}
+        onChange={(event) => onPick(event.target.files?.[0])}
+      />
+      <label
+        htmlFor={inputId}
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 font-normal"
+      >
+        {file === undefined ? (
+          <>
+            <UploadIcon className="size-4 shrink-0 text-muted-foreground" />
+            <span>{invitation}</span>
+          </>
+        ) : (
+          <>
+            <PickedIcon className="size-4 shrink-0 text-muted-foreground" />
+            <span className="flex min-w-0 flex-col">
+              <span className="truncate font-mono" title={file.name}>
+                {file.name}
+              </span>
+              <span className="text-muted-foreground text-xs">{REPLACE}</span>
+            </span>
+          </>
+        )}
+      </label>
+      {file !== undefined && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={clearLabel}
+          onClick={picker.clear}
+        >
+          <XIcon />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/lib/hooks/use-deploy-form.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy-form.ts
@@ -3,6 +3,8 @@ import {
   type FetchableBinary,
   InvalidEnvironmentError,
   parseEnvironmentPatch,
+  refusedArchive,
+  type UploadableArchive,
 } from '@repo/app-operations';
 import { type DeploySuggestion, namedByUrl, refusedChecksum, refusedUrl } from '@repo/deploy-link';
 import { DEFAULT_HTTP_PORT, FilenameSchema, Sha256DigestSchema, Value } from '@repo/protocol';
@@ -35,6 +37,7 @@ export type DeployFormValues = {
   extraPublicPort: boolean | undefined;
   args: string | undefined;
   environment: EnvironmentVariable[] | undefined;
+  initialData: File | undefined;
 };
 
 export type DeployFormApi = ReactFormExtendedApi<
@@ -73,6 +76,7 @@ const UNTOUCHED: DeployFormValues = {
   extraPublicPort: undefined,
   args: undefined,
   environment: undefined,
+  initialData: undefined,
 };
 
 export function validateBinary({ value }: { value: BinarySource | undefined }): string | undefined {
@@ -100,6 +104,20 @@ function validateBinarySource(source: BinarySource): string | undefined {
   return file !== undefined && !Value.Check(FilenameSchema, file.name)
     ? 'That file cannot be named inside an export. Rename it and pick it again.'
     : undefined;
+}
+
+/**
+ * Whether the archive is one an app could be created from, read from the front of the file.
+ *
+ * The api is the authority, but it only reads the object once the whole of it has arrived — so the
+ * one thing this end can do for an owner who picked the wrong file is say so before the gibibyte.
+ */
+export async function validateInitialData({
+  value,
+}: {
+  value: File | undefined;
+}): Promise<string | undefined> {
+  return value === undefined ? undefined : await refusedArchive({ name: value.name, body: value });
 }
 
 export function validatePort({ value }: { value: string | undefined }): string | undefined {
@@ -265,7 +283,26 @@ function asReleaseRequest({
         binary,
         app: replacing?.slug,
         name: replacing === undefined ? value.name.trim() || undefined : undefined,
+        initialData: initialDataFrom({ file: value.initialData, replacing }),
       };
+}
+
+/**
+ * The archive as the deploy sends it. Nothing at all for an app that already exists: its data was
+ * created with it, and the form does not offer this there — but the values outlive the field, and
+ * a release is made of what they hold rather than of what was on screen.
+ */
+function initialDataFrom({
+  file,
+  replacing,
+}: {
+  file: File | undefined;
+  replacing: AppSummary | undefined;
+}): UploadableArchive | undefined {
+  if (file === undefined || replacing !== undefined) {
+    return undefined;
+  }
+  return Value.Check(FilenameSchema, file.name) ? { name: file.name, body: file } : undefined;
 }
 
 /**

--- a/apps/dashboard/src/lib/hooks/use-deploy.ts
+++ b/apps/dashboard/src/lib/hooks/use-deploy.ts
@@ -6,6 +6,7 @@ import {
   deploy,
   describeUnservedDeployment,
   redeploy,
+  type UploadableArchive,
   type UploadProgress,
 } from '@repo/app-operations';
 import type { TenantArguments, TenantEnvironmentPatch } from '@repo/protocol';
@@ -23,6 +24,7 @@ export type DeployRequest = Configured & {
   binary: DeployableBinary;
   app: string | undefined;
   name: string | undefined;
+  initialData: UploadableArchive | undefined;
 };
 
 /** The same release without a binary to upload, which only an app already running one can ask for. */
@@ -32,6 +34,11 @@ export type ReleaseRequest = DeployRequest | RedeployRequest;
 
 export function carriesBinary(request: ReleaseRequest): request is DeployRequest {
   return 'binary' in request;
+}
+
+/** Whether an archive follows the binary, which is a second upload and leaves no step of its own. */
+export function carriesInitialData(request: ReleaseRequest): boolean {
+  return carriesBinary(request) && request.initialData !== undefined;
 }
 
 export type BinaryDelivery = 'upload' | 'fetch' | 'none';

--- a/apps/dashboard/src/lib/hooks/use-run-app.ts
+++ b/apps/dashboard/src/lib/hooks/use-run-app.ts
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import {
   type BinaryDelivery,
   binaryDelivery,
+  carriesInitialData,
   type ReleaseRequest,
   useDeploy,
 } from '#lib/hooks/use-deploy.ts';
@@ -10,6 +11,7 @@ import {
 export type DeployPhase =
   | 'idle'
   | 'uploading'
+  | 'uploading-data'
   | 'fetching'
   | 'releasing'
   | 'settling'
@@ -20,6 +22,23 @@ export type DeployPhase =
 export function isReleasing(phase: DeployPhase): boolean {
   return phase === 'releasing' || phase === 'settling';
 }
+
+/** The phases whose bytes are leaving this end, which are the ones there is a meter for. */
+export function isUploading(phase: DeployPhase): boolean {
+  return phase === 'uploading' || phase === 'uploading-data';
+}
+
+/**
+ * What the run was asked to send, because the steps cannot say it: a release that reuses the stored
+ * binary reports the same artifact as one that just uploaded it, one the api fetched reports it
+ * without this end having sent a byte, and an archive is reported as nothing at all.
+ */
+type Sending = {
+  binary: BinaryDelivery;
+  initialData: boolean;
+};
+
+const SENDING_NOTHING: Sending = { binary: 'none', initialData: false };
 
 export type DeployRun = {
   phase: DeployPhase;
@@ -38,10 +57,7 @@ export function useRunApp({
 }): DeployRun {
   const [steps, setSteps] = useState<readonly DeployStep[]>([]);
   const [progress, setProgress] = useState<UploadProgress | undefined>(undefined);
-  // What the run was asked for, because the steps cannot say it: a release that reuses the stored
-  // binary reports the same artifact as one that just uploaded it, and one the api fetched reports
-  // it without this end having sent a byte.
-  const [delivery, setDelivery] = useState<BinaryDelivery>('none');
+  const [sending, setSending] = useState<Sending>(SENDING_NOTHING);
   const run = useDeploy({
     onStep: (step) => setSteps((seen) => [...seen, step]),
     onProgress: setProgress,
@@ -49,7 +65,7 @@ export function useRunApp({
   });
 
   return {
-    phase: phaseOf({ status: run.status, steps, delivery }),
+    phase: phaseOf({ status: run.status, steps, sending }),
     steps,
     progress,
     deployed: run.data,
@@ -57,7 +73,7 @@ export function useRunApp({
     start: (request) => {
       setSteps([]);
       setProgress(undefined);
-      setDelivery(binaryDelivery(request));
+      setSending({ binary: binaryDelivery(request), initialData: carriesInitialData(request) });
       run.mutate(request);
     },
     reset: () => {
@@ -71,11 +87,11 @@ export function useRunApp({
 function phaseOf({
   status,
   steps,
-  delivery,
+  sending,
 }: {
   status: 'idle' | 'pending' | 'success' | 'error';
   steps: readonly DeployStep[];
-  delivery: BinaryDelivery;
+  sending: Sending;
 }): DeployPhase {
   if (status === 'success') {
     return 'done';
@@ -89,8 +105,13 @@ function phaseOf({
   if (steps.some((step) => step.kind === 'deployment')) {
     return 'settling';
   }
-  if (delivery === 'none') {
+  // The archive is sent after the binary, so the artifact is the only thing that says which of the
+  // two the meter is on.
+  if (sending.initialData && steps.some((step) => step.kind === 'artifact')) {
+    return 'uploading-data';
+  }
+  if (sending.binary === 'none') {
     return 'releasing';
   }
-  return delivery === 'upload' ? 'uploading' : 'fetching';
+  return sending.binary === 'upload' ? 'uploading' : 'fetching';
 }

--- a/apps/dashboard/tests/components/deploy/deploy-configuration.test.tsx
+++ b/apps/dashboard/tests/components/deploy/deploy-configuration.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import { useForm } from '@tanstack/react-form';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type {
+  DeployFormApi,
+  DeployFormState,
+  DeployFormValues,
+} from '#lib/hooks/use-deploy-form.ts';
+import type { AppSummary } from '#queries/apps.ts';
+
+const INITIAL_DATA = 'Initial data';
+const PORT = '8080';
+
+/**
+ * The api client is built against the origin it is same-origin with as it is imported, and the form
+ * reaches it through the hooks it shares with the rest of the deploy. So the origin is there before
+ * the component is, which is what the dynamic import below is for.
+ */
+Object.defineProperty(globalThis, 'window', {
+  value: { location: { origin: 'https://app.nibrun.com' } },
+});
+
+const { DeployConfiguration } = await import('#components/deploy/deploy-configuration.tsx');
+
+const UNTOUCHED: DeployFormValues = {
+  binary: undefined,
+  name: '',
+  port: undefined,
+  extraPublicPort: undefined,
+  args: undefined,
+  environment: undefined,
+  initialData: undefined,
+};
+
+// Cast because what this file is about is which fields the form offers, not what an app row holds.
+const RUNNING = { config: { args: [], environment: [] } } as unknown as AppSummary;
+
+/** The form as this file needs it: a real api, and around it what the hook would have read. */
+function Configuration({ replacing }: { replacing: AppSummary | undefined }) {
+  const api: DeployFormApi = useForm({ defaultValues: UNTOUCHED });
+  const form: DeployFormState = {
+    api,
+    binaryListeners: {},
+    locked: replacing !== undefined,
+    replacing,
+    targetResolved: true,
+    defaultPort: PORT,
+    defaultExtraPublicPort: false,
+    defaultArgs: '',
+  };
+
+  return <DeployConfiguration form={form} suggested={undefined} />;
+}
+
+describe('what a deploy is beyond the binary itself', () => {
+  test('an app being created is offered the data its filesystem starts as', () => {
+    const markup = renderToStaticMarkup(<Configuration replacing={undefined} />);
+
+    expect(markup).toContain(INITIAL_DATA);
+    expect(markup).toContain('.tar.gz');
+  });
+
+  /**
+   * An app's data is created once, along with the app: the api refuses an import against a volume a
+   * host has already reported ready, so a release onto an app that exists has nowhere to put one —
+   * and a field only ever answered with a 409 is worse than no field.
+   */
+  test('an app that already has one is not asked for it again', () => {
+    const markup = renderToStaticMarkup(<Configuration replacing={RUNNING} />);
+
+    expect(markup).not.toContain(INITIAL_DATA);
+    expect(markup).toContain('Environment variables');
+  });
+});

--- a/packages/app-operations/src/archive.ts
+++ b/packages/app-operations/src/archive.ts
@@ -42,28 +42,44 @@ export type OfferedArchive = {
 };
 
 /**
- * Why this file cannot be the data an app is created holding, or nothing where it can be.
+ * Why these bytes cannot be the data an app is created holding, or nothing where they can be.
  *
  * The api is the authority and reads the object it was sent for itself — but it can only do that
- * once the upload has finished, so a `.zip` picked here would cost a gibibyte before anybody said a
- * word about it. Answered from the front of the file, which is where the answer is.
+ * once the upload has finished, so a `.zip` would cost a gibibyte before anybody said a word about
+ * it. Answered from the front of the file, which is where the answer is.
+ *
+ * Held apart from the name because only one of the two is ever a caller's own doing: `uploadImport`
+ * asks this of everything it sends, where a name is checked by whoever took one from a person.
  */
-export async function refusedArchive({ name, body }: OfferedArchive): Promise<string | undefined> {
+export async function refusedArchiveBody({
+  name,
+  body,
+}: OfferedArchive): Promise<string | undefined> {
   if (body.size === 0) {
     return `There is nothing in ${name} to give the app as its data.`;
   }
   if (body.size > MAX_IMPORT_SIZE_BYTES) {
     return `An app is created with at most ${MAX_IMPORT_GIBIBYTES} GiB of data, and ${name} is more than that.`;
   }
-  // The name travels with the archive and is what the api records the upload as, so one it would
-  // refuse costs a line here rather than the upload that preceded the refusal.
-  if (!Value.Check(FilenameSchema, name)) {
-    return `${name} is not a name nibrun takes: it must start with a letter or digit and hold only letters, digits, dots, dashes or underscores.`;
-  }
   const opening = await heldFrom({ stream: body.stream(), count: OPENING_BYTES });
   return (await isGzippedTarball(opening))
     ? undefined
     : `${name} is not a .tar.gz. An app's data is created from one archive, whose root becomes the root of data/.`;
+}
+
+/**
+ * The same, of a file somebody picked — which is the one case where the name is theirs too.
+ *
+ * The name travels with the archive and is what the api records the upload as, so one it would
+ * refuse costs a line here rather than the upload that preceded the refusal. Nothing asks this of
+ * a name the caller generated: `UploadableArchive` takes a `Filename`, so one that got that far
+ * was already held to it.
+ */
+export async function refusedArchive({ name, body }: OfferedArchive): Promise<string | undefined> {
+  if (!Value.Check(FilenameSchema, name)) {
+    return `${name} is not a name nibrun takes: it must start with a letter or digit and hold only letters, digits, dots, dashes or underscores.`;
+  }
+  return await refusedArchiveBody({ name, body });
 }
 
 async function isGzippedTarball(opening: Uint8Array): Promise<boolean> {

--- a/packages/app-operations/src/archive.ts
+++ b/packages/app-operations/src/archive.ts
@@ -54,11 +54,13 @@ export type OfferedArchive = {
 export async function refusedArchiveBody({
   name,
   body,
-}: OfferedArchive): Promise<string | undefined> {
+  // Named by the caller so a bound can be reached without staging a gibibyte to reach it.
+  limitBytes = MAX_IMPORT_SIZE_BYTES,
+}: OfferedArchive & { limitBytes?: number }): Promise<string | undefined> {
   if (body.size === 0) {
     return `There is nothing in ${name} to give the app as its data.`;
   }
-  if (body.size > MAX_IMPORT_SIZE_BYTES) {
+  if (body.size > limitBytes) {
     return `An app is created with at most ${MAX_IMPORT_GIBIBYTES} GiB of data, and ${name} is more than that.`;
   }
   const opening = await heldFrom({ stream: body.stream(), count: OPENING_BYTES });

--- a/packages/app-operations/src/archive.ts
+++ b/packages/app-operations/src/archive.ts
@@ -1,0 +1,140 @@
+import { FilenameSchema, Value } from '@repo/protocol';
+
+const BYTES_PER_GIBIBYTE = 1_073_741_824;
+const MAX_IMPORT_GIBIBYTES = 1;
+
+/**
+ * Kept in step by hand with `MAX_IMPORT_SIZE_BYTES` in `apps/api/src/services/imports.service.ts`:
+ * the api signs the upload for the length it was told and is the end that holds an owner to this,
+ * and this is only what the end sending the bytes refuses before it sends them.
+ */
+export const MAX_IMPORT_SIZE_BYTES = MAX_IMPORT_GIBIBYTES * BYTES_PER_GIBIBYTE;
+
+const GZIP = 'gzip';
+
+/** What a gzip opens with, whatever it turns out to be wrapped around. */
+const GZIP_MAGIC = '\u001f\u008b';
+
+/**
+ * What every tar carries, in the one form both of its dialects share: posix follows it with a NUL
+ * and gnu with a space, so five characters is what they agree on.
+ */
+const TAR_MAGIC = 'ustar';
+const TAR_MAGIC_AT = 257;
+
+/** Through the magic, which is the last of what says a stream of bytes is a tar at all. */
+const TAR_IDENTITY_BYTES = TAR_MAGIC_AT + TAR_MAGIC.length;
+
+/**
+ * How much of the file is read to answer this.
+ *
+ * A tar says what it is 262 bytes into its first header and gzip only ever shrinks, so this reaches
+ * that for anything but a pathologically incompressible one. Fixed whatever was picked, which is
+ * what keeps a decompression bomb out of it: nothing here reads past this many bytes of input, so
+ * what the file claims to expand to never costs this end anything.
+ */
+const OPENING_BYTES = 4096;
+
+/** A file offered as an app's starting data, before anything has agreed that it is one. */
+export type OfferedArchive = {
+  name: string;
+  body: Blob;
+};
+
+/**
+ * Why this file cannot be the data an app is created holding, or nothing where it can be.
+ *
+ * The api is the authority and reads the object it was sent for itself — but it can only do that
+ * once the upload has finished, so a `.zip` picked here would cost a gibibyte before anybody said a
+ * word about it. Answered from the front of the file, which is where the answer is.
+ */
+export async function refusedArchive({ name, body }: OfferedArchive): Promise<string | undefined> {
+  if (body.size === 0) {
+    return `There is nothing in ${name} to give the app as its data.`;
+  }
+  if (body.size > MAX_IMPORT_SIZE_BYTES) {
+    return `An app is created with at most ${MAX_IMPORT_GIBIBYTES} GiB of data, and ${name} is more than that.`;
+  }
+  // The name travels with the archive and is what the api records the upload as, so one it would
+  // refuse costs a line here rather than the upload that preceded the refusal.
+  if (!Value.Check(FilenameSchema, name)) {
+    return `${name} is not a name nibrun takes: it must start with a letter or digit and hold only letters, digits, dots, dashes or underscores.`;
+  }
+  const opening = await heldFrom({ stream: body.stream(), count: OPENING_BYTES });
+  return (await isGzippedTarball(opening))
+    ? undefined
+    : `${name} is not a .tar.gz. An app's data is created from one archive, whose root becomes the root of data/.`;
+}
+
+async function isGzippedTarball(opening: Uint8Array): Promise<boolean> {
+  if (!reads({ bytes: opening, at: 0, magic: GZIP_MAGIC })) {
+    return false;
+  }
+  const header = await heldFrom({
+    stream: inflating(opening),
+    count: TAR_IDENTITY_BYTES,
+  });
+  return (
+    header.length === TAR_IDENTITY_BYTES &&
+    reads({ bytes: header, at: TAR_MAGIC_AT, magic: TAR_MAGIC })
+  );
+}
+
+/**
+ * The opening as what it holds, as far as it goes.
+ *
+ * These bytes are a prefix of a stream, so the inflate ends by running out rather than by finishing,
+ * which is the ordinary case here and not a failure. What came out before it stopped is still the
+ * front of the archive, and the front is the whole question.
+ *
+ * Copied into a buffer of its own because a decompression stream takes bytes that are not backed by
+ * shared memory, which somebody else's may be.
+ */
+function inflating(opening: Uint8Array): ReadableStream<Uint8Array> {
+  const compressed = new ReadableStream<Uint8Array<ArrayBuffer>>({
+    start(controller) {
+      controller.enqueue(new Uint8Array(opening));
+      controller.close();
+    },
+  });
+  return compressed.pipeThrough(new DecompressionStream(GZIP));
+}
+
+/**
+ * The front of a stream, and no more of it than that: the reader is cancelled the moment it holds
+ * enough, so the rest of a file this size is never pulled through.
+ */
+async function heldFrom({
+  stream,
+  count,
+}: {
+  stream: ReadableStream<Uint8Array>;
+  count: number;
+}): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const held = new Uint8Array(count);
+  let filled = 0;
+
+  try {
+    while (filled < count) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      const wanted = value.subarray(0, count - filled);
+      held.set(wanted, filled);
+      filled += wanted.length;
+    }
+  } catch {
+    // The source stopped mid-stream, and what came out before it did is still an answer.
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  return held.subarray(0, filled);
+}
+
+/** A fixed run of bytes read as the latin1 text it would be, which is how a magic is written. */
+function reads({ bytes, at, magic }: { bytes: Uint8Array; at: number; magic: string }): boolean {
+  return String.fromCharCode(...bytes.subarray(at, at + magic.length)) === magic;
+}

--- a/packages/app-operations/src/imports.ts
+++ b/packages/app-operations/src/imports.ts
@@ -1,6 +1,7 @@
 import type { PublicApiClient } from '@repo/api-client/public';
-import { unwrap } from '@repo/api-client/unwrap';
+import { ApiError, unwrap } from '@repo/api-client/unwrap';
 import type { Filename, ImportId } from '@repo/protocol';
+import { refusedArchiveBody } from '#archive.ts';
 import { mebibytes, putObject, type UploadTransport, type UploadWait } from '#upload.ts';
 
 /**
@@ -25,6 +26,10 @@ export type UploadableArchive = {
  * It is told either way. Only this end watched the upload happen, so an import whose bytes never
  * arrived is one nothing else can ever find out about — and the row and the object it names would
  * both sit there until they were swept.
+ *
+ * What is being sent is read before any of that. The api refuses the same bytes for the same
+ * reasons, but only once they have all arrived — so asking here is the difference between a
+ * sentence and a gibibyte, and every caller gets the same one rather than remembering to ask.
  */
 export async function uploadImport({
   api,
@@ -39,6 +44,10 @@ export async function uploadImport({
   whileUploading: UploadWait;
   upload: UploadTransport;
 }): Promise<ImportId> {
+  const refusal = await refusedArchiveBody(archive);
+  if (refusal) {
+    throw new ApiError(refusal);
+  }
   const { importId, url } = unwrap(
     await api.api.apps({ appId }).imports.post({
       filename: archive.name,

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -16,6 +16,7 @@ export {
   newestDeployment,
   pinnedArtifact,
 } from '#apps.ts';
+export { MAX_IMPORT_SIZE_BYTES, type OfferedArchive, refusedArchive } from '#archive.ts';
 export { deleteApp } from '#delete.ts';
 export {
   awaitDeploymentSettled,

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -16,7 +16,12 @@ export {
   newestDeployment,
   pinnedArtifact,
 } from '#apps.ts';
-export { MAX_IMPORT_SIZE_BYTES, type OfferedArchive, refusedArchive } from '#archive.ts';
+export {
+  MAX_IMPORT_SIZE_BYTES,
+  type OfferedArchive,
+  refusedArchive,
+  refusedArchiveBody,
+} from '#archive.ts';
 export { deleteApp } from '#delete.ts';
 export {
   awaitDeploymentSettled,

--- a/packages/app-operations/tests/archive.test.ts
+++ b/packages/app-operations/tests/archive.test.ts
@@ -1,19 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import { MAX_IMPORT_SIZE_BYTES, refusedArchive } from '#archive.ts';
+import { gzippedTarball } from '#tests/support/archives.ts';
 
-const BLOCK_BYTES = 512;
-const TAR_MAGIC_AT = 257;
 const NAME = 'data.tar.gz';
 
 const encoder = new TextEncoder();
-
-/** A tar's first header, which is the only part of one that says a stream of bytes is a tar. */
-function tarball(): Uint8Array<ArrayBuffer> {
-  const block = new Uint8Array(BLOCK_BYTES);
-  block.set(encoder.encode('data.db'));
-  block.set(encoder.encode('ustar'), TAR_MAGIC_AT);
-  return block;
-}
 
 function offered({ name = NAME, bytes }: { name?: string; bytes: Uint8Array }) {
   return { name, body: new Blob([new Uint8Array(bytes)]) };
@@ -24,13 +15,13 @@ function offered({ name = NAME, bytes }: { name?: string; bytes: Uint8Array }) {
  * to be refused for being a gibibyte is the one thing this check exists to spare anybody.
  */
 function claiming(sizeBytes: number) {
-  const { body } = offered({ bytes: Bun.gzipSync(tarball()) });
+  const { body } = offered({ bytes: gzippedTarball() });
   return { name: NAME, body: { size: sizeBytes, stream: body.stream.bind(body) } as Blob };
 }
 
 describe('an archive an app can be created from', () => {
   test('a gzipped tarball is what one is', async () => {
-    expect(await refusedArchive(offered({ bytes: Bun.gzipSync(tarball()) }))).toBeUndefined();
+    expect(await refusedArchive(offered({ bytes: gzippedTarball() }))).toBeUndefined();
   });
 
   test('a zip is named as the shape it is not, rather than as what was found', async () => {
@@ -63,7 +54,7 @@ describe('an archive an app can be created from', () => {
   });
 
   test('a name the api would refuse costs a line rather than the upload before it', async () => {
-    const named = { ...offered({ bytes: Bun.gzipSync(tarball()) }), name: 'my data.tar.gz' };
+    const named = { ...offered({ bytes: gzippedTarball() }), name: 'my data.tar.gz' };
 
     expect(await refusedArchive(named)).toContain('is not a name nibrun takes');
   });

--- a/packages/app-operations/tests/archive.test.ts
+++ b/packages/app-operations/tests/archive.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { MAX_IMPORT_SIZE_BYTES, refusedArchive } from '#archive.ts';
+
+const BLOCK_BYTES = 512;
+const TAR_MAGIC_AT = 257;
+const NAME = 'data.tar.gz';
+
+const encoder = new TextEncoder();
+
+/** A tar's first header, which is the only part of one that says a stream of bytes is a tar. */
+function tarball(): Uint8Array<ArrayBuffer> {
+  const block = new Uint8Array(BLOCK_BYTES);
+  block.set(encoder.encode('data.db'));
+  block.set(encoder.encode('ustar'), TAR_MAGIC_AT);
+  return block;
+}
+
+function offered({ name = NAME, bytes }: { name?: string; bytes: Uint8Array }) {
+  return { name, body: new Blob([new Uint8Array(bytes)]) };
+}
+
+/**
+ * An archive that says it is a given size while holding only its opening: a gibibyte held in memory
+ * to be refused for being a gibibyte is the one thing this check exists to spare anybody.
+ */
+function claiming(sizeBytes: number) {
+  const { body } = offered({ bytes: Bun.gzipSync(tarball()) });
+  return { name: NAME, body: { size: sizeBytes, stream: body.stream.bind(body) } as Blob };
+}
+
+describe('an archive an app can be created from', () => {
+  test('a gzipped tarball is what one is', async () => {
+    expect(await refusedArchive(offered({ bytes: Bun.gzipSync(tarball()) }))).toBeUndefined();
+  });
+
+  test('a zip is named as the shape it is not, rather than as what was found', async () => {
+    const zip = encoder.encode('PK and the rest of an ordinary zip');
+
+    expect(await refusedArchive(offered({ bytes: zip }))).toContain('is not a .tar.gz');
+  });
+
+  // `gzip data.db` opens exactly as `tar czf` does, and only the bytes inside tell them apart.
+  test('a gzip wrapped around anything else is refused for what it holds', async () => {
+    const gzipped = Bun.gzipSync(encoder.encode('SQLite format 3'));
+
+    expect(await refusedArchive(offered({ bytes: gzipped }))).toContain('is not a .tar.gz');
+  });
+
+  test('nothing at all is refused as nothing to give the app', async () => {
+    expect(await refusedArchive(offered({ bytes: new Uint8Array() }))).toBe(
+      'There is nothing in data.tar.gz to give the app as its data.',
+    );
+  });
+
+  test('more than the api would sign for is refused before a byte of it is read', async () => {
+    expect(await refusedArchive(claiming(MAX_IMPORT_SIZE_BYTES + 1))).toContain(
+      'at most 1 GiB of data',
+    );
+  });
+
+  test('the size the api signs for is not itself too much', async () => {
+    expect(await refusedArchive(claiming(MAX_IMPORT_SIZE_BYTES))).toBeUndefined();
+  });
+
+  test('a name the api would refuse costs a line rather than the upload before it', async () => {
+    const named = { ...offered({ bytes: Bun.gzipSync(tarball()) }), name: 'my data.tar.gz' };
+
+    expect(await refusedArchive(named)).toContain('is not a name nibrun takes');
+  });
+});

--- a/packages/app-operations/tests/deploy.test.ts
+++ b/packages/app-operations/tests/deploy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import type { PublicApiClient } from '@repo/api-client/public';
 import type { Filename } from '@repo/protocol';
+import { MAX_IMPORT_SIZE_BYTES } from '#archive.ts';
 import { deploy, describeUnservedDeployment } from '#deploy.ts';
 import type { DeployStep } from '#release.ts';
 import { answering } from '#tests/support/api.ts';
@@ -12,6 +13,7 @@ import {
   PLATFORM,
   SLUG,
 } from '#tests/support/app.ts';
+import { gzippedTarball } from '#tests/support/archives.ts';
 import type { UploadProgress } from '#upload.ts';
 
 const PUT_URL = 'https://store.example/artifact-1?signature=x';
@@ -19,7 +21,6 @@ const IMPORT_PUT_URL = 'https://store.example/import-1?signature=x';
 const IMPORT_ID = 'import-1';
 const PORT = 8080;
 const SIZE_BYTES = 1_048_576;
-const ARCHIVE_BYTES = 4_096;
 const PART_BYTES = 262_144;
 const REFUSED = 403;
 
@@ -113,9 +114,13 @@ function binary() {
   return { name: 'my-server' as Filename, body: new Blob([new Uint8Array(SIZE_BYTES)]) };
 }
 
+/** A real one, because a send now reads the front of what it is given before it sends it. */
 function archive() {
-  return { name: 'data.tar.gz' as Filename, body: new Blob([new Uint8Array(ARCHIVE_BYTES)]) };
+  return { name: 'data.tar.gz' as Filename, body: new Blob([gzippedTarball()]) };
 }
+
+/** Enough that nothing refuses it for being empty, and nothing like an archive. */
+const NOT_AN_ARCHIVE_BYTES = 64;
 
 const REAL_FETCH = globalThis.fetch;
 
@@ -339,7 +344,7 @@ describe("an archive the app's data is created from", () => {
     ]);
     expect(sent[4]).toEqual({
       what: 'import',
-      body: { filename: 'data.tar.gz', sizeBytes: ARCHIVE_BYTES },
+      body: { filename: 'data.tar.gz', sizeBytes: archive().body.size },
     });
     expect(sent[5]).toEqual({ what: 'put', body: IMPORT_PUT_URL });
     expect(sent[6]).toEqual({ what: 'import patch', body: { upload: 'complete' } });
@@ -364,6 +369,51 @@ describe("an archive the app's data is created from", () => {
 
     await expect(attempt).rejects.toThrow('the length is not what was signed');
     expect(sent.at(-1)).toEqual({ what: 'import patch', body: { upload: 'failed' } });
+  });
+
+  /**
+   * The api refuses the same bytes for the same reasons, but only once every one of them has
+   * arrived — so what this spares a caller is the upload, and every caller gets it rather than
+   * each remembering to ask. The CLI packs its own archive and never asked.
+   */
+  test('more data than the api would sign for is refused before anything is created', async () => {
+    const sent: Sent[] = [];
+    storeAnswering({ sent });
+    const oversized = archive();
+
+    const attempt = deploy({
+      api: apiHolding({ apps: [], sent }),
+      binary: binary(),
+      args: [],
+      initialData: {
+        ...oversized,
+        body: {
+          size: MAX_IMPORT_SIZE_BYTES + 1,
+          stream: oversized.body.stream.bind(oversized.body),
+        } as Blob,
+      },
+    });
+
+    await expect(attempt).rejects.toThrow('at most 1 GiB of data');
+    expect(sent.some((one) => one.what === 'import')).toBe(false);
+  });
+
+  test('and bytes that are not an archive at all, before the store is asked for a url', async () => {
+    const sent: Sent[] = [];
+    storeAnswering({ sent });
+
+    const attempt = deploy({
+      api: apiHolding({ apps: [], sent }),
+      binary: binary(),
+      args: [],
+      initialData: {
+        name: 'data.tar.gz' as Filename,
+        body: new Blob([new Uint8Array(NOT_AN_ARCHIVE_BYTES)]),
+      },
+    });
+
+    await expect(attempt).rejects.toThrow('is not a .tar.gz');
+    expect(sent.some((one) => one.what === 'import')).toBe(false);
   });
 
   test('a deployment nobody gave one to names none', async () => {

--- a/packages/app-operations/tests/support/archives.ts
+++ b/packages/app-operations/tests/support/archives.ts
@@ -1,0 +1,17 @@
+const BLOCK_BYTES = 512;
+const TAR_MAGIC_AT = 257;
+
+const encoder = new TextEncoder();
+
+/** A tar's first header, which is the only part of one that says a stream of bytes is a tar. */
+export function tarball(): Uint8Array<ArrayBuffer> {
+  const block = new Uint8Array(BLOCK_BYTES);
+  block.set(encoder.encode('data.db'));
+  block.set(encoder.encode('ustar'), TAR_MAGIC_AT);
+  return block;
+}
+
+/** What an owner actually offers as an app's starting data, and the only thing a send accepts. */
+export function gzippedTarball(): Uint8Array<ArrayBuffer> {
+  return Bun.gzipSync(tarball());
+}

--- a/packages/cli/src/lib/data-folder.ts
+++ b/packages/cli/src/lib/data-folder.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readdir, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
-import type { UploadableArchive } from '@repo/app-operations';
+import { refusedArchiveBody, type UploadableArchive } from '@repo/app-operations';
 import { type Filename, FilenameSchema, Value } from '@repo/protocol';
 import { UsageError } from '#lib/errors.ts';
 import type { Ui } from '#lib/ui.ts';
@@ -73,9 +73,11 @@ export type PackedFolder = {
 export async function packDataFolder({
   folder,
   ui,
+  limitBytes,
 }: {
   folder: string;
   ui: Ui;
+  limitBytes?: number;
 }): Promise<PackedFolder> {
   const staging = await mkdtemp(join(tmpdir(), STAGING_PREFIX));
   const name = archiveName(folder);
@@ -90,12 +92,20 @@ export async function packDataFolder({
       message: `packing ${folder}`,
       task: () => pack({ folder, into: path }),
     });
+    const archive = { name, body: Bun.file(path) };
+    // `uploadImport` asks this too, but only once an app has been created and a binary uploaded
+    // against it — so asking here is the difference between a sentence and an app the owner has to
+    // go and delete. What it packed to is knowable no earlier than this: compression is what
+    // decides it, so no reading of the folder could have said.
+    const refusal = await refusedArchiveBody({ ...archive, ...(limitBytes && { limitBytes }) });
+    if (refusal) {
+      throw new UsageError(refusal);
+    }
+    return { archive, discard };
   } catch (failure) {
     await discard();
     throw failure;
   }
-
-  return { archive: { name, body: Bun.file(path) }, discard };
 }
 
 /**

--- a/packages/cli/tests/lib/data-folder.test.ts
+++ b/packages/cli/tests/lib/data-folder.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from 'bun:test';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { dataFolderFor, packDataFolder } from '#lib/data-folder.ts';
@@ -92,3 +92,30 @@ test('the archive is a file on disk, and is gone once it has been sent', async (
   // Asked again rather than of the same handle: a `BunFile` answers from the stat it already took.
   expect(await Bun.file(written).exists()).toBe(false);
 });
+
+/**
+ * `uploadImport` refuses the same archive, but only once an app has been created and a binary
+ * uploaded against it — so a folder that packs past the cap has to be answered here, before any of
+ * that. What it packs to is knowable no earlier: compression is what decides it.
+ */
+test('a folder that packs past the cap is refused before an app is created', async () => {
+  const folder = await folderHolding({ 'notes.txt': 'hello' });
+  const packing = packDataFolder({ folder, ui: uiRecording(), limitBytes: 1 });
+
+  await expect(packing).rejects.toThrow('at most');
+});
+
+test('and the archive it packed does not stay on the machine', async () => {
+  const folder = await folderHolding({ 'notes.txt': 'hello' });
+  const staging = await stagingDirectories();
+
+  await packDataFolder({ folder, ui: uiRecording(), limitBytes: 1 }).catch(() => undefined);
+
+  expect(await stagingDirectories()).toEqual(staging);
+});
+
+/** The temporary directories `packDataFolder` makes, so a leaked one is visible as a new name. */
+async function stagingDirectories(): Promise<string[]> {
+  const entries = await readdir(tmpdir());
+  return entries.filter((entry) => entry.startsWith('nib-data-')).sort();
+}


### PR DESCRIPTION
The deploy form's last accordion takes a `.tar.gz` and passes it as the deployment's `initialDataFrom`. It is offered only where an app is being created — its data is created with it, and the api answers an import against an existing volume with a 409.

The archive is checked in the browser before anything is uploaded: gzip magic, then a bounded inflate looking for the ustar magic, plus the 1 GiB cap and an empty file. That check lives in `@repo/app-operations` beside `uploadImport`, not in the dashboard and not shared with the api. The api's `lib/archive/gzipped-tarball.ts` stays where it is and remains the authority — it is api-internal, it sits on top of that package's tar/stream machinery, and bundling api code into the browser to save one magic constant is the wrong trade. Putting it in `app-operations` instead means the precondition travels with the function it guards, so a second caller of `uploadImport` gets the same refusal in the same words rather than a third opinion. The size cap is duplicated deliberately and says so, the way `FREE_APPS_COUNT` does against its migration.