### PR TITLE
fix(agent): an archive packed as a folder still seeds the folder's contents

### DIFF
--- a/apps/agent/src/lib/volumes/seed.ts
+++ b/apps/agent/src/lib/volumes/seed.ts
@@ -114,9 +114,25 @@ type Unpacked = {
   readonly bytes: number;
   readonly entries: number;
   readonly symlinks: ReadonlySet<string>;
+  readonly roots: Roots;
 };
 
-const EMPTY: Unpacked = { bytes: 0, entries: 0, symlinks: new Set() };
+/**
+ * What sits directly at the archive's root, which is what says whether the whole archive is a
+ * folder somebody packed rather than the contents of one.
+ */
+type Roots = {
+  readonly names: ReadonlySet<string>;
+  /** Those of them that are not directories, any one of which is a root somebody meant. */
+  readonly files: ReadonlySet<string>;
+};
+
+const EMPTY: Unpacked = {
+  bytes: 0,
+  entries: 0,
+  symlinks: new Set(),
+  roots: { names: new Set(), files: new Set() },
+};
 
 /**
  * The archive's path as the segments of it that mean anything, or nothing where it is one the
@@ -244,7 +260,77 @@ const advanced = ({
     entry.kind === 'symlink'
       ? new Set([...unpacked.symlinks, segments.join('/')])
       : unpacked.symlinks,
+  roots: rootsWith({ roots: unpacked.roots, entry, segments }),
 });
+
+/** An AppleDouble sidecar, which macOS writes beside the file whose metadata it carries. */
+const APPLE_DOUBLE_PREFIX = '._';
+const ARCHIVER_LITTER: ReadonlySet<string> = new Set(['.DS_Store', '__MACOSX']);
+
+/**
+ * Whether the archiver wrote this name rather than the owner, in which case it is not a root
+ * anybody meant.
+ *
+ * macOS is the one that decides this rule works at all: `tar czf data.tar.gz data/` there writes an
+ * AppleDouble `._data` beside the folder, and Finder's zip adds a `__MACOSX` tree — so the very
+ * archives the stripping exists to rescue are the ones a second name at the root would veto.
+ *
+ * Ignored for the decision and nothing else. They are still unpacked, and stripping is what leaves
+ * them behind: they sit at the tree's root, which is no longer where the filesystem is written from.
+ */
+function addedByAnArchiver(name: string): boolean {
+  return name.startsWith(APPLE_DOUBLE_PREFIX) || ARCHIVER_LITTER.has(name);
+}
+
+/**
+ * What this entry says about the archive's root. Anything below the root proves the name above it
+ * is a directory whether or not the archive bothered to write one, and anything at the root that is
+ * not a directory is a root somebody meant: no packing of a folder puts a file beside it.
+ */
+function rootsWith({
+  roots,
+  entry,
+  segments,
+}: {
+  roots: Roots;
+  entry: TarEntry;
+  segments: readonly string[];
+}): Roots {
+  const [name] = segments;
+  if (name === undefined || addedByAnArchiver(name)) {
+    return roots;
+  }
+  const directory = segments.length > 1 || entry.kind === 'directory';
+  return {
+    names: new Set([...roots.names, name]),
+    files: directory ? roots.files : new Set([...roots.files, name]),
+  };
+}
+
+/**
+ * Where the tree really begins.
+ *
+ * The archive's root is the root of `data/` — but the two commonest ways of making one put the
+ * folder in the archive rather than the contents of it. `tar czf data.tar.gz data/` writes every
+ * path under `data/`, and a desktop archiver does the same with whatever folder it was pointed at.
+ * Both land the files one directory below where the app goes looking, and what the owner gets is an
+ * app that started with an empty `data/` and nothing anywhere saying why.
+ *
+ * So a tree that is a single directory and nothing beside it is read as one of those. It is a
+ * guess, and a dataset that genuinely is one directory is the case it guesses wrong: an app whose
+ * `data/` holds only `uploads/` is seeded with what was inside it. Both readings fail the same way
+ * and only one of them is common, which is the whole of why it reads in this direction.
+ *
+ * A lone symlink is not stripped into, which is the reason this is decided from the walk rather
+ * than from the tree afterwards: what it points at is a directory to anything that asks the
+ * filesystem, and `mkfs.ext4 -d` would follow it back out of the tree it was given.
+ */
+function strippedRoot({ tree, roots }: { tree: string; roots: Roots }): string {
+  const [only] = roots.names;
+  return only !== undefined && roots.names.size === 1 && roots.files.size === 0
+    ? posix.join(tree, only)
+    : tree;
+}
 
 /**
  * One entry, refused or written.
@@ -303,9 +389,11 @@ function refusalFor(path: string): string {
 }
 
 /**
- * The archive's root becomes the root of `data/`, so nothing is stripped and no leading directory
- * is looked for. An export bundle nests its dataset under `data/` beside the binary, which is why
- * one does not round-trip through here — restoring from an export is its own thing.
+ * The archive unpacked, and the directory a filesystem should be written from — the tree itself,
+ * unless it turns out to hold a folder rather than the contents of one.
+ *
+ * An export bundle nests its dataset under `data/` beside the binary, which is why one does not
+ * round-trip through here — restoring from an export is its own thing.
  */
 export const unpackSeed = Effect.fn('unpackSeed')(function* ({
   archivePath,
@@ -341,8 +429,13 @@ export const unpackSeed = Effect.fn('unpackSeed')(function* ({
   );
 
   const unpacked = yield* Ref.get(progress);
-  yield* Effect.annotateCurrentSpan({ entries: unpacked.entries, bytes: unpacked.bytes });
-  return unpacked;
+  const root = strippedRoot({ tree: destination, roots: unpacked.roots });
+  yield* Effect.annotateCurrentSpan({
+    entries: unpacked.entries,
+    bytes: unpacked.bytes,
+    stripped: root !== destination,
+  });
+  return { bytes: unpacked.bytes, entries: unpacked.entries, root };
 });
 
 /**
@@ -397,9 +490,14 @@ export const formatFromSeed = Effect.fn('formatFromSeed')(function* ({
       // not also holding the copy it was written from.
       yield* fs.remove(archivePath, { force: true });
       yield* Effect.logInfo('volume seed unpacked').pipe(
-        Effect.annotateLogs({ volumeId, entries: unpacked.entries, bytes: unpacked.bytes }),
+        Effect.annotateLogs({
+          volumeId,
+          entries: unpacked.entries,
+          bytes: unpacked.bytes,
+          stripped: unpacked.root !== tree,
+        }),
       );
-      return yield* format({ devicePath, seedDir: Option.some(tree) });
+      return yield* format({ devicePath, seedDir: Option.some(unpacked.root) });
     }),
     fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),
   );

--- a/apps/agent/tests/lib/volumes/seed.test.ts
+++ b/apps/agent/tests/lib/volumes/seed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { lstat, mkdir, readdir, readFile, readlink, symlink, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { Effect, Either } from 'effect';
 import { type Owner, type SeedLimits, unpackSeed } from '#lib/volumes/seed.ts';
 import { platform, provided, temporaryDirectory } from '#tests/support/run.ts';
@@ -93,12 +93,16 @@ function unpacking({
     );
     return {
       refusal: refusalOf(result),
+      root: Either.isRight(result) ? relative(destination, result.right.root) : undefined,
       written: yield* Effect.promise(() => surveyed(destination)),
     };
   });
 }
 
 const NOTHING_REFUSED = 'nothing was refused';
+
+/** Where the unpack said the tree begins, as a name under it — empty where that is the tree. */
+const NOT_STRIPPED = '';
 
 /** The refusal as an operator reads it, which is the message rather than the tag. */
 function refusalOf(result: Either.Either<unknown, { message: string }>): string {
@@ -158,6 +162,109 @@ describe("the archive's root becomes the root of the tree", () => {
 
     // Masked to every mode bit when it was read back, so this is also "and nothing above them".
     expect(written.modes.helper).toBe(RUNNABLE_MODE);
+  });
+});
+
+/**
+ * The archive's root is the root of `data/`, and the two commonest ways of making one put the
+ * folder in the archive instead. What that costs an owner is an app that started with an empty
+ * `data/`, so a tree that is a single directory and nothing beside it is read as the folder.
+ */
+describe('an archive holding one folder is read as the folder somebody packed', () => {
+  test('the tree begins at the folder rather than above it', async () => {
+    const { refusal, root, written } = await run(
+      unpacking({
+        entries: [
+          { path: 'data/', type: TYPE_DIRECTORY },
+          { path: 'data/pb_data/data.db', body: 'rows' },
+        ],
+      }),
+    );
+
+    expect(refusal).toBe(NOTHING_REFUSED);
+    expect(root).toBe('data');
+    // Written where the archive put it: what moves is where the filesystem is written from.
+    expect(written.content['data/pb_data/data.db']).toBe('rows');
+  });
+
+  test('a folder the archive never declared is still the one it begins at', async () => {
+    const { root } = await run(
+      unpacking({ entries: [{ path: 'myapp/pb_data/data.db', body: 'rows' }] }),
+    );
+
+    expect(root).toBe('myapp');
+  });
+
+  test('a second name at the root is a root somebody meant', async () => {
+    const { root } = await run(
+      unpacking({
+        entries: [
+          { path: 'pb_data/', type: TYPE_DIRECTORY },
+          { path: 'pb_migrations/', type: TYPE_DIRECTORY },
+        ],
+      }),
+    );
+
+    expect(root).toBe(NOT_STRIPPED);
+  });
+
+  test('a file beside the folder is a root somebody meant', async () => {
+    const { root } = await run(
+      unpacking({
+        entries: [
+          { path: 'data/', type: TYPE_DIRECTORY },
+          { path: 'data/data.db', body: 'rows' },
+          { path: 'README', body: 'read me' },
+        ],
+      }),
+    );
+
+    expect(root).toBe(NOT_STRIPPED);
+  });
+
+  /**
+   * What decides whether this rule ever fires on a real archive: macOS writes `._data` beside the
+   * folder `tar` was pointed at, so without this the archives likeliest to need stripping are
+   * exactly the ones that would never get it.
+   */
+  test('names the archiver wrote are not roots somebody meant', async () => {
+    const { root } = await run(
+      unpacking({
+        entries: [
+          { path: '._data', body: 'apple double' },
+          { path: '.DS_Store', body: 'finder' },
+          { path: '__MACOSX/', type: TYPE_DIRECTORY },
+          { path: 'data/', type: TYPE_DIRECTORY },
+          { path: 'data/data.db', body: 'rows' },
+        ],
+      }),
+    );
+
+    expect(root).toBe('data');
+  });
+
+  test('a lone file is not a folder to begin at', async () => {
+    const { root } = await run(unpacking({ entries: [{ path: 'data.db', body: 'rows' }] }));
+
+    expect(root).toBe(NOT_STRIPPED);
+  });
+
+  /**
+   * The one a look at the tree afterwards would get wrong: what it points at is a directory to
+   * anything that asks the filesystem, and beginning there hands `mkfs.ext4 -d` a way back out.
+   */
+  test('a lone symlink is not a folder to begin at', async () => {
+    const { root } = await run(
+      unpacking({ entries: [{ path: 'latest', type: TYPE_SYMLINK, linkTarget: '.' }] }),
+    );
+
+    expect(root).toBe(NOT_STRIPPED);
+  });
+
+  test('an archive holding nothing begins where it always did', async () => {
+    const { root } = await run(unpacking({ entries: [] }));
+
+    expect(root).toBe(NOT_STRIPPED);
   });
 });
 
@@ -304,7 +411,7 @@ test('bytes that are not a gzipped tarball are refused rather than half unpacked
  * this is also the one test that proves the walk against a real tar's output end to end.
  */
 test('an archive a real tar wrote from the tree root unpacks whole', async () => {
-  const { refusal, written } = await run(
+  const { refusal, root, written } = await run(
     Effect.gen(function* () {
       const directory = yield* temporaryDirectory;
       const source = join(directory, 'source');
@@ -321,12 +428,41 @@ test('an archive a real tar wrote from the tree root unpacks whole', async () =>
       );
       return {
         refusal: refusalOf(result),
+        root: Either.isRight(result) ? relative(destination, result.right.root) : undefined,
         written: yield* Effect.promise(() => surveyed(destination)),
       };
     }),
   );
 
   expect(refusal).toBe(NOTHING_REFUSED);
+  expect(root).toBe(NOT_STRIPPED);
   expect(written.content['pb_data/data.db']).toBe('rows');
   expect(written.links.latest).toBe('pb_data/data.db');
+});
+
+/** And the mistake itself, as a real `tar` writes it: the folder it was named, not the inside. */
+test('an archive a real tar wrote from the folder above begins at the folder', async () => {
+  const { refusal, root } = await run(
+    Effect.gen(function* () {
+      const directory = yield* temporaryDirectory;
+      const source = join(directory, 'source');
+      yield* Effect.promise(async () => {
+        await mkdir(join(source, 'data', 'pb_data'), { recursive: true });
+        await writeFile(join(source, 'data', 'pb_data', 'data.db'), 'rows');
+      });
+      const archivePath = join(directory, 'archive.tar.gz');
+      yield* Effect.promise(() => Bun.$`tar czf ${archivePath} -C ${source} data`.quiet());
+      const destination = join(directory, 'tree');
+      const result = yield* Effect.either(
+        unpackSeed({ archivePath, destination, owner: OWNER, limits: ROOMY }),
+      );
+      return {
+        refusal: refusalOf(result),
+        root: Either.isRight(result) ? relative(destination, result.right.root) : undefined,
+      };
+    }),
+  );
+
+  expect(refusal).toBe(NOTHING_REFUSED);
+  expect(root).toBe('data');
 });


### PR DESCRIPTION
`tar czf data.tar.gz data/` and every desktop archiver pack the folder rather than its contents, which lands an app's files one directory below where it looks. The owner sees an app that started with an empty `data/` and nothing saying why.

A tree that is a single directory and nothing beside it is now read as one of those, and `mkfs.ext4 -d` is pointed at the directory. Names an archiver wrote on the owner's behalf don't count as being beside it — macOS puts an AppleDouble `._data` next to the folder `tar` was given, which would otherwise veto the rescue on exactly the archives needing it.

It is a guess, and it is wrong for a dataset that genuinely is one directory: an app whose `data/` holds only `uploads/` gets what was inside it. Both readings fail the same way, and only one of them is common.

Nothing about the upload contract changes — the archive's root is still the root of `data/`, and the CLI's own `--data-folder` output is unaffected (there's a test for that).