### PR TITLE
feat(cli): a folder of files is something nib can serve on nibrun

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -88,7 +88,8 @@ the layout under `src/commands/` is the command tree.
   anywhere shared. The terminal question is a typed phrase, not a y/n, which is
   answered by the muscle that answers every other one — see `src/lib/delete.ts`.
 - **`nib serve` runs only inside a guest**, being the thing being hosted rather
-  than the thing that deploys it: it talks to no api, and refuses anywhere the
+  than the thing that deploys it: it takes nothing from the cli context — the
+  two guest variables are declared in the command — and refuses anywhere the
   guest set no `NIBRUN_HTTP_PORT` rather than picking a port nothing probes.
   `cli.main()` exits the moment a handler returns, so serving has to *be* the
   handler — that is what `untilStopped` is for.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -87,35 +87,11 @@ the layout under `src/commands/` is the command tree.
   it from a script — and that is why `--yes` lives on such a command rather than
   anywhere shared. The terminal question is a typed phrase, not a y/n, which is
   answered by the muscle that answers every other one — see `src/lib/delete.ts`.
-- **`nib serve` is the one command that is the thing being hosted** rather than the
-  thing that deploys it — the same nib serves a folder here and, deployed as an
-  app's binary, serves that app's volume. So it talks to no api and needs no
-  token; what it reads instead is what the host handed the process, through the
-  `runtime` group in `src/context.ts`. Which interface it binds follows from
-  whether anything assigned the port: nothing did means somebody's own machine
-  and the loopback, and anything did means a host reaching it across a network,
-  which on nibrun is `0.0.0.0` and no other address. `PORT` is read beside
-  `NIBRUN_HTTP_PORT` and is spelled here rather than imported, being the name
-  every host uses rather than one of ours — `RUNTIME_VALUES` is what a tenant
-  value may name, and `PORT` deliberately is not one. `cli.main()` exits the
-  moment a handler returns, so serving has to *be* the handler: `untilStopped` is
-  what keeps it there until a signal takes it down.
-- **The single-page fallback is asked for rather than assumed**, which is what
-  `serve`, sirv, Caddy and Netlify all settle on: answering every miss with the
-  shell makes a stale asset url a `200 text/html`, so the app reports a syntax
-  error instead of a missing file, and a docs site answers a bad link with its
-  homepage. Under the flag a real file is the only thing that beats the shell —
-  a directory's own `index.html` does not, because `serve`'s `--single` rewrites
-  to the root before it ever looks inside a directory, and matching it keeps the
-  rule to one sentence. A path that resolved outside the folder is never given
-  the shell either. Note that a traversal cannot reach `requestedPath` over HTTP
-  at all: the URL parser resolves `..` and `%2e%2e` alike before a pathname is
-  anything the handler can read, so that check is tested on its own rather than
-  through a request.
-- **A miss is answered with the folder's own `404.html`** where it has one, and
-  under the 404 it is — a browser, a crawler and a `curl -f` all read the status
-  rather than the body. The filename is spelled from the status code rather than
-  written out, which is how `serve` names it too (`${statusCode}.html`).
+- **`nib serve` runs only inside a guest**, being the thing being hosted rather
+  than the thing that deploys it: it talks to no api, and refuses anywhere the
+  guest set no `NIBRUN_HTTP_PORT` rather than picking a port nothing probes.
+  `cli.main()` exits the moment a handler returns, so serving has to *be* the
+  handler — that is what `untilStopped` is for.
 - Run it with `bun run --filter @repo/cli nib …`. A package script runs from the
   package directory, so relative paths resolve against `packages/cli` rather than
   the caller's shell — pass absolute ones until the CLI ships as a real `bin`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -87,6 +87,19 @@ the layout under `src/commands/` is the command tree.
   it from a script — and that is why `--yes` lives on such a command rather than
   anywhere shared. The terminal question is a typed phrase, not a y/n, which is
   answered by the muscle that answers every other one — see `src/lib/delete.ts`.
+- **`nib serve` is the one command that is the thing being hosted** rather than the
+  thing that deploys it — the same nib serves a folder here and, deployed as an
+  app's binary, serves that app's volume. So it talks to no api and needs no
+  token; what it reads instead is what the host handed the process, through the
+  `runtime` group in `src/context.ts`. Which interface it binds follows from
+  whether anything assigned the port: nothing did means somebody's own machine
+  and the loopback, and anything did means a host reaching it across a network,
+  which on nibrun is `0.0.0.0` and no other address. `PORT` is read beside
+  `NIBRUN_HTTP_PORT` and is spelled here rather than imported, being the name
+  every host uses rather than one of ours — `RUNTIME_VALUES` is what a tenant
+  value may name, and `PORT` deliberately is not one. `cli.main()` exits the
+  moment a handler returns, so serving has to *be* the handler: `untilStopped` is
+  what keeps it there until a signal takes it down.
 - Run it with `bun run --filter @repo/cli nib …`. A package script runs from the
   package directory, so relative paths resolve against `packages/cli` rather than
   the caller's shell — pass absolute ones until the CLI ships as a real `bin`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -100,6 +100,15 @@ the layout under `src/commands/` is the command tree.
   value may name, and `PORT` deliberately is not one. `cli.main()` exits the
   moment a handler returns, so serving has to *be* the handler: `untilStopped` is
   what keeps it there until a signal takes it down.
+- **The single-page fallback is asked for rather than assumed**, which is what
+  `serve`, sirv, Caddy and Netlify all settle on: answering every miss with the
+  shell makes a stale asset url a `200 text/html`, so the app reports a syntax
+  error instead of a missing file, and a docs site answers a bad link with its
+  homepage. A path that resolved outside the folder is never given the shell
+  either — the fallback is for paths that were asked for honestly. Note that a
+  traversal cannot reach `requestedPath` over HTTP at all: the URL parser
+  resolves `..` and `%2e%2e` alike before a pathname is anything the handler can
+  read, so that check is tested on its own rather than through a request.
 - Run it with `bun run --filter @repo/cli nib …`. A package script runs from the
   package directory, so relative paths resolve against `packages/cli` rather than
   the caller's shell — pass absolute ones until the CLI ships as a real `bin`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -104,11 +104,18 @@ the layout under `src/commands/` is the command tree.
   `serve`, sirv, Caddy and Netlify all settle on: answering every miss with the
   shell makes a stale asset url a `200 text/html`, so the app reports a syntax
   error instead of a missing file, and a docs site answers a bad link with its
-  homepage. A path that resolved outside the folder is never given the shell
-  either — the fallback is for paths that were asked for honestly. Note that a
-  traversal cannot reach `requestedPath` over HTTP at all: the URL parser
-  resolves `..` and `%2e%2e` alike before a pathname is anything the handler can
-  read, so that check is tested on its own rather than through a request.
+  homepage. Under the flag a real file is the only thing that beats the shell —
+  a directory's own `index.html` does not, because `serve`'s `--single` rewrites
+  to the root before it ever looks inside a directory, and matching it keeps the
+  rule to one sentence. A path that resolved outside the folder is never given
+  the shell either. Note that a traversal cannot reach `requestedPath` over HTTP
+  at all: the URL parser resolves `..` and `%2e%2e` alike before a pathname is
+  anything the handler can read, so that check is tested on its own rather than
+  through a request.
+- **A miss is answered with the folder's own `404.html`** where it has one, and
+  under the 404 it is — a browser, a crawler and a `curl -f` all read the status
+  rather than the body. The filename is spelled from the status code rather than
+  written out, which is how `serve` names it too (`${statusCode}.html`).
 - Run it with `bun run --filter @repo/cli nib …`. A package script runs from the
   package directory, so relative paths resolve against `packages/cli` rather than
   the caller's shell — pass absolute ones until the CLI ships as a real `bin`.

--- a/packages/cli/src/command-tree.gen.ts
+++ b/packages/cli/src/command-tree.gen.ts
@@ -18,6 +18,7 @@ import type { command as appsUpdateCmd } from './commands/apps/update.ts';
 import type { command as loginCmd } from './commands/login.ts';
 import type { command as rootCmd } from './commands/_root.ts';
 import type { command as runCommandCmd } from './commands/run/[command].ts';
+import type { command as serveDirectoryCmd } from './commands/serve/[directory].ts';
 import type { command as upgradeCmd } from './commands/upgrade.ts';
 
 declare module '@parshjs/core' {
@@ -112,6 +113,10 @@ declare module '@parshjs/core' {
       rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
     'run [command]': {
+      parents: {};
+      rootOptions: InferForwardedOptions<typeof rootCmd.options>;
+    };
+    'serve [directory]': {
       parents: {};
       rootOptions: InferForwardedOptions<typeof rootCmd.options>;
     };
@@ -246,6 +251,17 @@ export const commandTree: RuntimeNode = {
       paramChild: {
         segment: { kind: 'param', name: 'command' },
         command: { path: 'run [command]', load: () => import('./commands/run/[command].ts').then((m) => m.command) },
+        literalChildren: {},
+        paramChild: null,
+      },
+    },
+    'serve': {
+      segment: { kind: 'literal', value: 'serve' },
+      command: null,
+      literalChildren: {},
+      paramChild: {
+        segment: { kind: 'param', name: 'directory' },
+        command: { path: 'serve [directory]', load: () => import('./commands/serve/[directory].ts').then((m) => m.command) },
         literalChildren: {},
         paramChild: null,
       },

--- a/packages/cli/src/commands/serve/[directory].ts
+++ b/packages/cli/src/commands/serve/[directory].ts
@@ -1,10 +1,8 @@
 import { defineCommand } from '@parshjs/core';
 import { z } from 'zod';
-import { SHARED_OPTIONS } from '#config.ts';
 import { createOutput } from '#lib/output.ts';
 import {
-  addressFor,
-  DEFAULT_PORT,
+  guestAddress,
   SERVING_OUTPUT,
   serveDirectory,
   servedRoot,
@@ -12,26 +10,21 @@ import {
 } from '#lib/serve.ts';
 
 /**
- * The one command that is the thing being hosted rather than the thing that hosts it: a nib
- * deployed as an app's binary serves its volume, and the same nib serves a folder here. So it
- * talks to no api and needs no token — what it reads instead is what the host handed the process.
+ * The one command that is the thing being hosted rather than the thing that hosts it, and so the
+ * one that talks to no api and needs no token: what it reads instead is what the guest handed the
+ * process. Off a guest there is nothing to read and nothing it could serve, so it says so.
  */
 export const command = defineCommand('serve [directory]', {
+  // Nothing an owner types at their own terminal, so it is not offered among the things they
+  // might: it is the argument a deployed binary is given. Still readable where somebody goes
+  // looking, as `nib serve anything --help` — the help does not read the positional.
+  hidden: true,
   description:
-    'Serve a folder of files over HTTP. On this machine that is http://127.0.0.1:3000; on nibrun it binds the port and the interface the guest hands it, so `nib run "./nib serve data"` deploys the app volume as a static site. A path naming a directory is answered with the index.html in it, and a path naming nothing with the folder’s own 404.html where it has one.',
+    'Serve a folder of static assets from inside a nibrun app, which is what a folder of them is deployed as: `nib run "./nib serve data"` serves the app volume, on the port and the address the guest hands it. It runs nowhere else — nothing outside a guest assigns the port nibrun probes, and it says so rather than picking one. A path naming a directory is answered with the index.html in it, and a path naming nothing with the folder’s own 404.html where it has one.',
   params: {
     directory: { schema: z.string().min(1) },
   },
   options: {
-    [SHARED_OPTIONS.port.name]: {
-      ...SHARED_OPTIONS.port.option,
-      description: `Port to listen on. Defaults to the one the host assigned, and to ${DEFAULT_PORT} where nothing did.`,
-    },
-    host: {
-      schema: z.string().optional(),
-      description:
-        'Interface to listen on. Defaults to 127.0.0.1, and to 0.0.0.0 wherever a host assigned the port — which is the only address nibrun reaches an app on.',
-    },
     'single-page': {
       schema: z.boolean().optional(),
       description:
@@ -40,13 +33,15 @@ export const command = defineCommand('serve [directory]', {
   },
   handler: async ({ params, options, context, print, rootOptions }) => {
     const { emit } = createOutput({ output: SERVING_OUTPUT, print, json: rootOptions.json });
-    const { 'single-page': singlePage = false, ...listening } = options;
+    const singlePage = options['single-page'] ?? false;
 
+    // Before the folder is read, because a nib that is not in a guest has nowhere to serve one
+    // whether or not the path is good, and that is the more useful of the two things to be told.
+    const { hostname, port, url } = guestAddress(context.runtime);
     const directory = await servedRoot(params.directory);
-    const address = addressFor({ options: listening, environment: context.runtime });
-    const server = serveDirectory({ root: directory, ...address, singlePage });
+    const server = serveDirectory({ root: directory, hostname, port, singlePage });
 
-    emit({ directory, ...address, singlePage });
+    emit({ directory, url, port, singlePage });
     await untilStopped(server);
   },
 });

--- a/packages/cli/src/commands/serve/[directory].ts
+++ b/packages/cli/src/commands/serve/[directory].ts
@@ -1,0 +1,46 @@
+import { defineCommand } from '@parshjs/core';
+import { z } from 'zod';
+import { SHARED_OPTIONS } from '#config.ts';
+import { createOutput } from '#lib/output.ts';
+import {
+  addressFor,
+  DEFAULT_PORT,
+  SERVING_OUTPUT,
+  serveDirectory,
+  servedRoot,
+  untilStopped,
+} from '#lib/serve.ts';
+
+/**
+ * The one command that is the thing being hosted rather than the thing that hosts it: a nib
+ * deployed as an app's binary serves its volume, and the same nib serves a folder here. So it
+ * talks to no api and needs no token — what it reads instead is what the host handed the process.
+ */
+export const command = defineCommand('serve [directory]', {
+  description:
+    'Serve a folder of files over HTTP. On this machine that is http://127.0.0.1:3000; on nibrun it binds the port and the interface the guest hands it, so `nib run "./nib serve data"` deploys the app volume as a static site. A path naming a directory is answered with the index.html in it.',
+  params: {
+    directory: { schema: z.string().min(1) },
+  },
+  options: {
+    [SHARED_OPTIONS.port.name]: {
+      ...SHARED_OPTIONS.port.option,
+      description: `Port to listen on. Defaults to the one the host assigned, and to ${DEFAULT_PORT} where nothing did.`,
+    },
+    host: {
+      schema: z.string().optional(),
+      description:
+        'Interface to listen on. Defaults to 127.0.0.1, and to 0.0.0.0 wherever a host assigned the port — which is the only address nibrun reaches an app on.',
+    },
+  },
+  handler: async ({ params, options, context, print, rootOptions }) => {
+    const { emit } = createOutput({ output: SERVING_OUTPUT, print, json: rootOptions.json });
+
+    const directory = await servedRoot(params.directory);
+    const address = addressFor({ options, environment: context.runtime });
+    const server = serveDirectory({ root: directory, ...address });
+
+    emit({ directory, ...address });
+    await untilStopped(server);
+  },
+});

--- a/packages/cli/src/commands/serve/[directory].ts
+++ b/packages/cli/src/commands/serve/[directory].ts
@@ -13,7 +13,7 @@ import {
 } from '#lib/serve.ts';
 
 /** Getters, so the environment is not read until a handler asks. */
-const GUEST: GuestEnvironment = createEnvContext({
+const GUEST_ENV: GuestEnvironment = createEnvContext({
   vars: {
     httpPort: {
       name: RUNTIME_VALUES.HTTP_PORT.name,
@@ -46,7 +46,7 @@ export const command = defineCommand('serve [directory]', {
   },
   handler: async ({ params, options, print, rootOptions }) => {
     // First, so that a nib outside a guest says so rather than reading a folder it cannot serve.
-    const { hostname, port, url } = guestAddress(GUEST);
+    const { hostname, port, url } = guestAddress(GUEST_ENV);
     const { emit } = createOutput({ output: SERVING_OUTPUT, print, json: rootOptions.json });
     const singlePage = options['single-page'] ?? false;
 

--- a/packages/cli/src/commands/serve/[directory].ts
+++ b/packages/cli/src/commands/serve/[directory].ts
@@ -11,6 +11,10 @@ import {
   untilStopped,
 } from '#lib/serve.ts';
 
+// parsh spells a flag exactly as its key, and this one is read back out of the options it was
+// declared in — so the two halves are one name rather than two spellings of it.
+const SINGLE_PAGE_FLAG = 'single-page';
+
 /**
  * The one command that is the thing being hosted rather than the thing that hosts it: a nib
  * deployed as an app's binary serves its volume, and the same nib serves a folder here. So it
@@ -32,15 +36,21 @@ export const command = defineCommand('serve [directory]', {
       description:
         'Interface to listen on. Defaults to 127.0.0.1, and to 0.0.0.0 wherever a host assigned the port — which is the only address nibrun reaches an app on.',
     },
+    [SINGLE_PAGE_FLAG]: {
+      schema: z.boolean().optional(),
+      description:
+        'Answer a path with no file of its own with the index.html at the root, for an app whose routes exist only in the browser. Off by default: it makes every miss a 200, so a stale asset url answers with the page rather than saying it is gone.',
+    },
   },
   handler: async ({ params, options, context, print, rootOptions }) => {
     const { emit } = createOutput({ output: SERVING_OUTPUT, print, json: rootOptions.json });
+    const { [SINGLE_PAGE_FLAG]: singlePage = false, ...listening } = options;
 
     const directory = await servedRoot(params.directory);
-    const address = addressFor({ options, environment: context.runtime });
-    const server = serveDirectory({ root: directory, ...address });
+    const address = addressFor({ options: listening, environment: context.runtime });
+    const server = serveDirectory({ root: directory, ...address, singlePage });
 
-    emit({ directory, ...address });
+    emit({ directory, ...address, singlePage });
     await untilStopped(server);
   },
 });

--- a/packages/cli/src/commands/serve/[directory].ts
+++ b/packages/cli/src/commands/serve/[directory].ts
@@ -11,10 +11,6 @@ import {
   untilStopped,
 } from '#lib/serve.ts';
 
-// parsh spells a flag exactly as its key, and this one is read back out of the options it was
-// declared in — so the two halves are one name rather than two spellings of it.
-const SINGLE_PAGE_FLAG = 'single-page';
-
 /**
  * The one command that is the thing being hosted rather than the thing that hosts it: a nib
  * deployed as an app's binary serves its volume, and the same nib serves a folder here. So it
@@ -22,7 +18,7 @@ const SINGLE_PAGE_FLAG = 'single-page';
  */
 export const command = defineCommand('serve [directory]', {
   description:
-    'Serve a folder of files over HTTP. On this machine that is http://127.0.0.1:3000; on nibrun it binds the port and the interface the guest hands it, so `nib run "./nib serve data"` deploys the app volume as a static site. A path naming a directory is answered with the index.html in it.',
+    'Serve a folder of files over HTTP. On this machine that is http://127.0.0.1:3000; on nibrun it binds the port and the interface the guest hands it, so `nib run "./nib serve data"` deploys the app volume as a static site. A path naming a directory is answered with the index.html in it, and a path naming nothing with the folder’s own 404.html where it has one.',
   params: {
     directory: { schema: z.string().min(1) },
   },
@@ -36,15 +32,15 @@ export const command = defineCommand('serve [directory]', {
       description:
         'Interface to listen on. Defaults to 127.0.0.1, and to 0.0.0.0 wherever a host assigned the port — which is the only address nibrun reaches an app on.',
     },
-    [SINGLE_PAGE_FLAG]: {
+    'single-page': {
       schema: z.boolean().optional(),
       description:
-        'Answer a path with no file of its own with the index.html at the root, for an app whose routes exist only in the browser. Off by default: it makes every miss a 200, so a stale asset url answers with the page rather than saying it is gone.',
+        'Answer everything no file of its own answers with the index.html at the root, for an app whose routes exist only in the browser. Off by default: it makes every miss a 200, so a stale asset url answers with the page rather than saying it is gone.',
     },
   },
   handler: async ({ params, options, context, print, rootOptions }) => {
     const { emit } = createOutput({ output: SERVING_OUTPUT, print, json: rootOptions.json });
-    const { [SINGLE_PAGE_FLAG]: singlePage = false, ...listening } = options;
+    const { 'single-page': singlePage = false, ...listening } = options;
 
     const directory = await servedRoot(params.directory);
     const address = addressFor({ options: listening, environment: context.runtime });

--- a/packages/cli/src/commands/serve/[directory].ts
+++ b/packages/cli/src/commands/serve/[directory].ts
@@ -1,7 +1,10 @@
 import { defineCommand } from '@parshjs/core';
+import { createEnvContext } from '@parshjs/env';
+import { RUNTIME_VALUES } from '@repo/protocol';
 import { z } from 'zod';
 import { createOutput } from '#lib/output.ts';
 import {
+  type GuestEnvironment,
   guestAddress,
   SERVING_OUTPUT,
   serveDirectory,
@@ -10,8 +13,28 @@ import {
 } from '#lib/serve.ts';
 
 /**
+ * What the guest tells this app about itself, declared where the one command that reads it is
+ * rather than in the context every command is handed. Its properties are getters, so nothing is
+ * read from the environment until `guestAddress` asks.
+ */
+const GUEST: GuestEnvironment = createEnvContext({
+  vars: {
+    httpPort: {
+      name: RUNTIME_VALUES.HTTP_PORT.name,
+      schema: z.number().int().positive().nullable(),
+      default: null,
+    },
+    hostname: {
+      name: RUNTIME_VALUES.HOSTNAME.name,
+      schema: z.string().min(1).nullable(),
+      default: null,
+    },
+  },
+});
+
+/**
  * The one command that is the thing being hosted rather than the thing that hosts it, and so the
- * one that talks to no api and needs no token: what it reads instead is what the guest handed the
+ * one that takes nothing from the cli context: what it reads instead is what the guest handed the
  * process. Off a guest there is nothing to read and nothing it could serve, so it says so.
  */
 export const command = defineCommand('serve [directory]', {
@@ -31,13 +54,18 @@ export const command = defineCommand('serve [directory]', {
         'Answer everything no file of its own answers with the index.html at the root, for an app whose routes exist only in the browser. Off by default: it makes every miss a 200, so a stale asset url answers with the page rather than saying it is gone.',
     },
   },
-  handler: async ({ params, options, context, print, rootOptions }) => {
+  // Where `requireSignedIn` sits on the commands that talk to the api: the one thing that has to
+  // hold before anything else is tried, so that a nib outside a guest says so before it goes
+  // reading a folder it has nowhere to serve. Asked again below for the answer rather than the
+  // refusal — the environment is read once and cached, so the second ask costs nothing.
+  beforeHandler: () => {
+    guestAddress(GUEST);
+  },
+  handler: async ({ params, options, print, rootOptions }) => {
     const { emit } = createOutput({ output: SERVING_OUTPUT, print, json: rootOptions.json });
     const singlePage = options['single-page'] ?? false;
+    const { hostname, port, url } = guestAddress(GUEST);
 
-    // Before the folder is read, because a nib that is not in a guest has nowhere to serve one
-    // whether or not the path is good, and that is the more useful of the two things to be told.
-    const { hostname, port, url } = guestAddress(context.runtime);
     const directory = await servedRoot(params.directory);
     const server = serveDirectory({ root: directory, hostname, port, singlePage });
 

--- a/packages/cli/src/commands/serve/[directory].ts
+++ b/packages/cli/src/commands/serve/[directory].ts
@@ -12,11 +12,7 @@ import {
   untilStopped,
 } from '#lib/serve.ts';
 
-/**
- * What the guest tells this app about itself, declared where the one command that reads it is
- * rather than in the context every command is handed. Its properties are getters, so nothing is
- * read from the environment until `guestAddress` asks.
- */
+/** Getters, so the environment is not read until a handler asks. */
 const GUEST: GuestEnvironment = createEnvContext({
   vars: {
     httpPort: {
@@ -32,15 +28,9 @@ const GUEST: GuestEnvironment = createEnvContext({
   },
 });
 
-/**
- * The one command that is the thing being hosted rather than the thing that hosts it, and so the
- * one that takes nothing from the cli context: what it reads instead is what the guest handed the
- * process. Off a guest there is nothing to read and nothing it could serve, so it says so.
- */
 export const command = defineCommand('serve [directory]', {
-  // Nothing an owner types at their own terminal, so it is not offered among the things they
-  // might: it is the argument a deployed binary is given. Still readable where somebody goes
-  // looking, as `nib serve anything --help` — the help does not read the positional.
+  // Not one of the things an owner picks between, being the argument a deployed binary is given.
+  // Still readable, as `nib serve anything --help` — the help does not read the positional.
   hidden: true,
   description:
     'Serve a folder of static assets from inside a nibrun app, which is what a folder of them is deployed as: `nib run "./nib serve data"` serves the app volume, on the port and the address the guest hands it. It runs nowhere else — nothing outside a guest assigns the port nibrun probes, and it says so rather than picking one. A path naming a directory is answered with the index.html in it, and a path naming nothing with the folder’s own 404.html where it has one.',
@@ -54,17 +44,11 @@ export const command = defineCommand('serve [directory]', {
         'Answer everything no file of its own answers with the index.html at the root, for an app whose routes exist only in the browser. Off by default: it makes every miss a 200, so a stale asset url answers with the page rather than saying it is gone.',
     },
   },
-  // Where `requireSignedIn` sits on the commands that talk to the api: the one thing that has to
-  // hold before anything else is tried, so that a nib outside a guest says so before it goes
-  // reading a folder it has nowhere to serve. Asked again below for the answer rather than the
-  // refusal — the environment is read once and cached, so the second ask costs nothing.
-  beforeHandler: () => {
-    guestAddress(GUEST);
-  },
   handler: async ({ params, options, print, rootOptions }) => {
+    // First, so that a nib outside a guest says so rather than reading a folder it cannot serve.
+    const { hostname, port, url } = guestAddress(GUEST);
     const { emit } = createOutput({ output: SERVING_OUTPUT, print, json: rootOptions.json });
     const singlePage = options['single-page'] ?? false;
-    const { hostname, port, url } = guestAddress(GUEST);
 
     const directory = await servedRoot(params.directory);
     const server = serveDirectory({ root: directory, hostname, port, singlePage });

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -6,15 +6,9 @@ import { z } from 'zod';
 import { DEFAULT_API_URL, PROGRAM_NAME } from '#config.ts';
 import { createApi } from '#lib/api.ts';
 import { CredentialsSchema } from '#lib/credentials.ts';
-import type { HostEnvironment } from '#lib/serve.ts';
+import type { GuestEnvironment } from '#lib/serve.ts';
 
 const CREDENTIALS_FILENAME = 'credentials.json';
-
-/**
- * Not a nibrun name: it is what every other host sets, and nibrun sets it beside
- * `NIBRUN_HTTP_PORT` so that a binary written for one of them needs no porting to run here.
- */
-const PORT_VARIABLE = 'PORT';
 
 const AssignedPortSchema = z.number().int().positive().nullable();
 
@@ -29,19 +23,17 @@ export async function createCliContext() {
   const apiUrl = env.NIBRUN_API_URL;
 
   /**
-   * What the host running this nib says about itself, for `nib serve` — the one command that is
-   * the thing being hosted. `null` rather than a default wherever nothing set it, because
-   * "nobody told us" is what says this is somebody's own machine, and a default would answer
-   * that question instead of leaving it to be asked.
+   * What the guest tells an app about itself, for `nib serve` — the one command that is the thing
+   * being hosted. `null` rather than a default wherever nothing set it: a default would be this
+   * end answering the one question serve exists to ask, which is whether it is on nibrun at all.
    */
-  const runtime: HostEnvironment = createEnvContext({
+  const runtime: GuestEnvironment = createEnvContext({
     vars: {
       httpPort: {
         name: RUNTIME_VALUES.HTTP_PORT.name,
         schema: AssignedPortSchema,
         default: null,
       },
-      port: { name: PORT_VARIABLE, schema: AssignedPortSchema, default: null },
       hostname: {
         name: RUNTIME_VALUES.HOSTNAME.name,
         schema: z.string().min(1).nullable(),

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -1,16 +1,12 @@
 import { join } from 'node:path';
 import { createEnvContext } from '@parshjs/env';
 import { createFilesContext, osHomeConfigDir } from '@parshjs/files';
-import { RUNTIME_VALUES } from '@repo/protocol';
 import { z } from 'zod';
 import { DEFAULT_API_URL, PROGRAM_NAME } from '#config.ts';
 import { createApi } from '#lib/api.ts';
 import { CredentialsSchema } from '#lib/credentials.ts';
-import type { GuestEnvironment } from '#lib/serve.ts';
 
 const CREDENTIALS_FILENAME = 'credentials.json';
-
-const AssignedPortSchema = z.number().int().positive().nullable();
 
 /**
  * What every handler is given. A factory rather than an object, because parsh runs one only once
@@ -22,26 +18,6 @@ export async function createCliContext() {
   });
   const apiUrl = env.NIBRUN_API_URL;
 
-  /**
-   * What the guest tells an app about itself, for `nib serve` — the one command that is the thing
-   * being hosted. `null` rather than a default wherever nothing set it: a default would be this
-   * end answering the one question serve exists to ask, which is whether it is on nibrun at all.
-   */
-  const runtime: GuestEnvironment = createEnvContext({
-    vars: {
-      httpPort: {
-        name: RUNTIME_VALUES.HTTP_PORT.name,
-        schema: AssignedPortSchema,
-        default: null,
-      },
-      hostname: {
-        name: RUNTIME_VALUES.HOSTNAME.name,
-        schema: z.string().min(1).nullable(),
-        default: null,
-      },
-    },
-  });
-
   const files = createFilesContext({
     basePath: join(osHomeConfigDir(), PROGRAM_NAME),
     files: {
@@ -52,5 +28,5 @@ export async function createCliContext() {
   const credentials = await files.credentials.maybeRead();
   const api = createApi({ baseUrl: apiUrl, credentials });
 
-  return { apiUrl, files, api, runtime };
+  return { apiUrl, files, api };
 }

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -1,12 +1,22 @@
 import { join } from 'node:path';
 import { createEnvContext } from '@parshjs/env';
 import { createFilesContext, osHomeConfigDir } from '@parshjs/files';
+import { RUNTIME_VALUES } from '@repo/protocol';
 import { z } from 'zod';
 import { DEFAULT_API_URL, PROGRAM_NAME } from '#config.ts';
 import { createApi } from '#lib/api.ts';
 import { CredentialsSchema } from '#lib/credentials.ts';
+import type { HostEnvironment } from '#lib/serve.ts';
 
 const CREDENTIALS_FILENAME = 'credentials.json';
+
+/**
+ * Not a nibrun name: it is what every other host sets, and nibrun sets it beside
+ * `NIBRUN_HTTP_PORT` so that a binary written for one of them needs no porting to run here.
+ */
+const PORT_VARIABLE = 'PORT';
+
+const AssignedPortSchema = z.number().int().positive().nullable();
 
 /**
  * What every handler is given. A factory rather than an object, because parsh runs one only once
@@ -18,6 +28,28 @@ export async function createCliContext() {
   });
   const apiUrl = env.NIBRUN_API_URL;
 
+  /**
+   * What the host running this nib says about itself, for `nib serve` — the one command that is
+   * the thing being hosted. `null` rather than a default wherever nothing set it, because
+   * "nobody told us" is what says this is somebody's own machine, and a default would answer
+   * that question instead of leaving it to be asked.
+   */
+  const runtime: HostEnvironment = createEnvContext({
+    vars: {
+      httpPort: {
+        name: RUNTIME_VALUES.HTTP_PORT.name,
+        schema: AssignedPortSchema,
+        default: null,
+      },
+      port: { name: PORT_VARIABLE, schema: AssignedPortSchema, default: null },
+      hostname: {
+        name: RUNTIME_VALUES.HOSTNAME.name,
+        schema: z.string().min(1).nullable(),
+        default: null,
+      },
+    },
+  });
+
   const files = createFilesContext({
     basePath: join(osHomeConfigDir(), PROGRAM_NAME),
     files: {
@@ -28,5 +60,5 @@ export async function createCliContext() {
   const credentials = await files.credentials.maybeRead();
   const api = createApi({ baseUrl: apiUrl, credentials });
 
-  return { apiUrl, files, api };
+  return { apiUrl, files, api, runtime };
 }

--- a/packages/cli/src/lib/serve.ts
+++ b/packages/cli/src/lib/serve.ts
@@ -10,35 +10,18 @@ import { defineOutput } from '#lib/output.ts';
 const INDEX_FILE = 'index.html';
 const NOT_FOUND = 404;
 const NOT_FOUND_BODY = 'Not found';
-
-/**
- * The page a folder answers its own misses with, named after the status it is answering — which is
- * the convention `serve` and every static host reads, and the reason it is spelled from the code
- * rather than written out.
- */
 const NOT_FOUND_PAGE = `${NOT_FOUND}.html`;
-
-/** The one address nibrun reaches an app on, and so the only one worth binding. */
 const EVERY_INTERFACE = '0.0.0.0';
-
-/** A terminal's own way of ending a run, and the one a host sends before it replaces the app. */
 const STOP_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
 
-/**
- * What the guest tells an app about itself. Both are set on every instance, so `null` here is not
- * a guest that left something out — it is a nib running somewhere that is not a guest at all.
- */
+/** `null` for anything the guest did not set, which is every one of them off a guest. */
 export type GuestEnvironment = {
-  /** The port nibrun assigns and probes, which the app must be the one listening on. */
   httpPort: number | null;
-  /** The name the app is reached by, which is not the interface it is bound to. */
   hostname: string | null;
 };
 
-/** What `Bun.serve` hands back for a server that never upgrades a connection. */
 export type FileServer = Server<undefined>;
 
-/** Where the server listens, and where whoever deployed it should look. */
 export type Address = {
   hostname: string;
   port: number;
@@ -46,13 +29,9 @@ export type Address = {
 };
 
 /**
- * Where to listen, and the address the app answers at — which is not the one bound: nibrun's edge
- * terminates TLS in front of a guest listening on plain HTTP, so the port this process knows about
- * is no part of any URL anybody can type.
- *
- * Refused rather than defaulted where the guest said nothing, because there is no answer to default
- * to. A port nobody assigned is a port nothing probes, and a folder served on one is a folder
- * nothing ever reaches.
+ * The address bound is not the one the app answers at: nibrun's edge terminates TLS in front of a
+ * guest listening on plain HTTP, so the port this process knows about is no part of any URL
+ * anybody can type.
  */
 export function guestAddress(environment: GuestEnvironment): Address {
   const { httpPort, hostname } = environment;
@@ -72,10 +51,6 @@ function offNibrun(variable: string): UsageError {
   );
 }
 
-/**
- * The folder as an absolute path, or a refusal naming what was typed. Asked before the port is
- * bound, so a folder nobody can read costs one line rather than a server answering nothing.
- */
 export async function servedRoot(directory: string): Promise<string> {
   const root = resolve(directory);
   const stats = await stat(root).catch(() => undefined);
@@ -90,11 +65,8 @@ export async function servedRoot(directory: string): Promise<string> {
 }
 
 /**
- * Where a request lands under the root, or nothing where it lands outside it.
- *
- * A pathname is whatever a client sent — `../`, an escape spelled `%2e%2e`, a NUL — so what is
- * asked is whether the resolved path is still inside the folder, rather than whether the text it
- * arrived as looked like an escape.
+ * Containment is decided on the resolved path rather than on the text it arrived as, so no list of
+ * spellings has to stay ahead of what a client can send.
  */
 export function requestedPath({
   root,
@@ -115,20 +87,15 @@ export function requestedPath({
 function decodedPathname(pathname: string): string | null {
   try {
     const decoded = decodeURIComponent(pathname);
-    // A NUL truncates the path every syscall below this reads, so the file opened would not be the
-    // one the containment check was made against.
+    // A NUL truncates the path every syscall below reads, so the file opened would not be the one
+    // the containment check was made against.
     return decoded.includes('\0') ? null : decoded;
   } catch {
-    // Percent-encoding no file could have been meant by.
     return null;
   }
 }
 
-/**
- * Serve `root` and nothing else. Content types are the files' own — Bun reads one from the
- * extension, which is the whole of what a static server has to say about a body it hands over
- * untouched.
- */
+/** Content types are the files' own, Bun reading one from the extension. */
 export function serveDirectory({
   root,
   hostname,
@@ -150,13 +117,6 @@ export function serveDirectory({
   });
 }
 
-/**
- * The folder's own `404.html` where it has one, and a bare line where it does not.
- *
- * Answered as the 404 it is rather than as a 200: a browser, a crawler and a `curl -f` all read
- * the status rather than the page, and a "not found" served under a 200 is the one answer none of
- * them can act on.
- */
 async function missing(root: string): Promise<Response> {
   const page = await existingFile(join(root, NOT_FOUND_PAGE));
   return page === null
@@ -174,8 +134,7 @@ async function fileAt({
   singlePage: boolean;
 }): Promise<Bun.BunFile | null> {
   const target = requestedPath({ root, pathname });
-  // A path that resolved outside the folder is not a route of anybody's app, so it is answered as
-  // what it is rather than handed the page: the shell is for paths that were asked for honestly.
+  // Outside the folder is not a route of anybody's app, so it is not given the shell either.
   if (target === null) {
     return null;
   }
@@ -184,16 +143,11 @@ async function fileAt({
   if (await asked.exists()) {
     return asked;
   }
-  // Everything a real file did not answer is the app's own routing to do, directory indexes
-  // included: `serve`'s `--single` rewrites every path to the root index.html *before* it looks
-  // for one in the directory that was asked for, so a route that happens to name a real folder is
-  // still a route rather than somewhere to go looking.
+  // A directory's own index is skipped rather than missed: `serve`'s `--single` rewrites to the
+  // root before it looks inside a directory, so a route naming a real folder is still a route.
   if (singlePage) {
     return await existingFile(join(root, INDEX_FILE));
   }
-
-  // A directory is not a file Bun reads, so falling through to its index is also what answers `/`
-  // and every path a browser arrives at with a trailing slash.
   return await existingFile(join(target, INDEX_FILE));
 }
 
@@ -202,11 +156,7 @@ async function existingFile(path: string): Promise<Bun.BunFile | null> {
   return (await file.exists()) ? file : null;
 }
 
-/**
- * `cli.main()` exits the moment a handler returns, so serving has to be the handler rather than
- * something it leaves behind. Settles once the server has been asked to stop and has finished
- * answering whatever it was in the middle of.
- */
+/** `cli.main()` exits the moment a handler returns, so serving has to be one that has not. */
 export function untilStopped(server: FileServer): Promise<void> {
   return new Promise((settle) => {
     for (const signal of STOP_SIGNALS) {
@@ -222,11 +172,6 @@ const ServingSchema = z.object({
   singlePage: z.boolean(),
 });
 
-/**
- * The port as well as the URL, those being two different answers here and the port the one an app
- * that came up serving nothing turns out to have got wrong. Whether the shell is answering for
- * everything is said out loud for the same reason: it is what a 404 that came back 200 was.
- */
 export const SERVING_OUTPUT = defineOutput({
   schema: ServingSchema,
   render: ({ value, out }) =>

--- a/packages/cli/src/lib/serve.ts
+++ b/packages/cli/src/lib/serve.ts
@@ -13,6 +13,13 @@ const NOT_FOUND = 404;
 const NOT_FOUND_BODY = 'Not found';
 
 /**
+ * The page a folder answers its own misses with, named after the status it is answering — which is
+ * the convention `serve` and every static host reads, and the reason it is spelled from the code
+ * rather than written out.
+ */
+const NOT_FOUND_PAGE = `${NOT_FOUND}.html`;
+
+/**
  * Every interface, which is what a host reaches an app on, against the loopback a folder on
  * somebody's own machine is served on. Handing a local folder to the whole network is not
  * something to arrive at by accident, so which of the two is bound follows from whether anything
@@ -165,11 +172,23 @@ export function serveDirectory({
     port,
     fetch: async (request) => {
       const file = await fileAt({ root, pathname: new URL(request.url).pathname, singlePage });
-      return file === null
-        ? new Response(NOT_FOUND_BODY, { status: NOT_FOUND })
-        : new Response(file);
+      return file === null ? await missing(root) : new Response(file);
     },
   });
+}
+
+/**
+ * The folder's own `404.html` where it has one, and a bare line where it does not.
+ *
+ * Answered as the 404 it is rather than as a 200: a browser, a crawler and a `curl -f` all read
+ * the status rather than the page, and a "not found" served under a 200 is the one answer none of
+ * them can act on.
+ */
+async function missing(root: string): Promise<Response> {
+  const page = await existingFile(join(root, NOT_FOUND_PAGE));
+  return page === null
+    ? new Response(NOT_FOUND_BODY, { status: NOT_FOUND })
+    : new Response(page, { status: NOT_FOUND });
 }
 
 async function fileAt({
@@ -192,14 +211,17 @@ async function fileAt({
   if (await asked.exists()) {
     return asked;
   }
-  // A directory is not a file Bun reads, so falling through to its index is also what answers `/`
-  // and every path a browser arrives at with a trailing slash.
-  const index = Bun.file(join(target, INDEX_FILE));
-  if (await index.exists()) {
-    return index;
+  // Everything a real file did not answer is the app's own routing to do, directory indexes
+  // included: `serve`'s `--single` rewrites every path to the root index.html *before* it looks
+  // for one in the directory that was asked for, so a route that happens to name a real folder is
+  // still a route rather than somewhere to go looking.
+  if (singlePage) {
+    return await existingFile(join(root, INDEX_FILE));
   }
 
-  return singlePage ? await existingFile(join(root, INDEX_FILE)) : null;
+  // A directory is not a file Bun reads, so falling through to its index is also what answers `/`
+  // and every path a browser arrives at with a trailing slash.
+  return await existingFile(join(target, INDEX_FILE));
 }
 
 async function existingFile(path: string): Promise<Bun.BunFile | null> {

--- a/packages/cli/src/lib/serve.ts
+++ b/packages/cli/src/lib/serve.ts
@@ -153,16 +153,18 @@ export function serveDirectory({
   root,
   hostname,
   port,
+  singlePage,
 }: {
   root: string;
   hostname: string;
   port: number;
+  singlePage: boolean;
 }): FileServer {
   return Bun.serve({
     hostname,
     port,
     fetch: async (request) => {
-      const file = await fileAt({ root, pathname: new URL(request.url).pathname });
+      const file = await fileAt({ root, pathname: new URL(request.url).pathname, singlePage });
       return file === null
         ? new Response(NOT_FOUND_BODY, { status: NOT_FOUND })
         : new Response(file);
@@ -173,11 +175,15 @@ export function serveDirectory({
 async function fileAt({
   root,
   pathname,
+  singlePage,
 }: {
   root: string;
   pathname: string;
+  singlePage: boolean;
 }): Promise<Bun.BunFile | null> {
   const target = requestedPath({ root, pathname });
+  // A path that resolved outside the folder is not a route of anybody's app, so it is answered as
+  // what it is rather than handed the page: the shell is for paths that were asked for honestly.
   if (target === null) {
     return null;
   }
@@ -189,7 +195,16 @@ async function fileAt({
   // A directory is not a file Bun reads, so falling through to its index is also what answers `/`
   // and every path a browser arrives at with a trailing slash.
   const index = Bun.file(join(target, INDEX_FILE));
-  return (await index.exists()) ? index : null;
+  if (await index.exists()) {
+    return index;
+  }
+
+  return singlePage ? await existingFile(join(root, INDEX_FILE)) : null;
+}
+
+async function existingFile(path: string): Promise<Bun.BunFile | null> {
+  const file = Bun.file(path);
+  return (await file.exists()) ? file : null;
 }
 
 /**
@@ -210,13 +225,19 @@ const ServingSchema = z.object({
   url: z.string(),
   hostname: z.string(),
   port: z.number(),
+  singlePage: z.boolean(),
 });
 
 /**
  * The address bound as well as the URL to visit, because on a host those are two different
- * answers and a folder nobody can reach is usually the first of them.
+ * answers and a folder nobody can reach is usually the first of them. Whether the shell is
+ * answering for everything is said out loud for the same reason: it is what a 404 that came back
+ * 200 turns out to have been.
  */
 export const SERVING_OUTPUT = defineOutput({
   schema: ServingSchema,
-  render: ({ value, out }) => out.success(`${value.url} — serving ${value.directory}`),
+  render: ({ value, out }) =>
+    out.success(
+      `${value.url} — serving ${value.directory}${value.singlePage ? ' as a single-page app' : ''}`,
+    ),
 });

--- a/packages/cli/src/lib/serve.ts
+++ b/packages/cli/src/lib/serve.ts
@@ -1,12 +1,11 @@
 import { stat } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
+import { RUNTIME_VALUES } from '@repo/protocol';
 import type { Server } from 'bun';
 import { z } from 'zod';
+import { PROGRAM_NAME } from '#config.ts';
 import { UsageError } from '#lib/errors.ts';
 import { defineOutput } from '#lib/output.ts';
-
-/** What a folder is served on when nothing is hosting this nib. */
-export const DEFAULT_PORT = 3000;
 
 const INDEX_FILE = 'index.html';
 const NOT_FOUND = 404;
@@ -19,38 +18,27 @@ const NOT_FOUND_BODY = 'Not found';
  */
 const NOT_FOUND_PAGE = `${NOT_FOUND}.html`;
 
-/**
- * Every interface, which is what a host reaches an app on, against the loopback a folder on
- * somebody's own machine is served on. Handing a local folder to the whole network is not
- * something to arrive at by accident, so which of the two is bound follows from whether anything
- * assigned the port — see `addressFor`.
- */
+/** The one address nibrun reaches an app on, and so the only one worth binding. */
 const EVERY_INTERFACE = '0.0.0.0';
-const LOOPBACK = '127.0.0.1';
-
-/** The name a browser reaches `EVERY_INTERFACE` by, that address not being one it can dial. */
-const LOCALHOST = 'localhost';
 
 /** A terminal's own way of ending a run, and the one a host sends before it replaces the app. */
 const STOP_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
 
 /**
- * What the host running this nib said about itself, `null` for each thing it said nothing about.
- * Nothing at all is what says this is somebody's own machine rather than nibrun.
+ * What the guest tells an app about itself. Both are set on every instance, so `null` here is not
+ * a guest that left something out — it is a nib running somewhere that is not a guest at all.
  */
-export type HostEnvironment = {
+export type GuestEnvironment = {
   /** The port nibrun assigns and probes, which the app must be the one listening on. */
   httpPort: number | null;
-  /** That same number under the name every other host uses, read for the hosts that set only it. */
-  port: number | null;
-  /** The name the app is actually reached by, which is not the interface it is bound to. */
+  /** The name the app is reached by, which is not the interface it is bound to. */
   hostname: string | null;
 };
 
 /** What `Bun.serve` hands back for a server that never upgrades a connection. */
 export type FileServer = Server<undefined>;
 
-/** Where the server listens, and where whoever asked for it should look. */
+/** Where the server listens, and where whoever deployed it should look. */
 export type Address = {
   hostname: string;
   port: number;
@@ -58,45 +46,30 @@ export type Address = {
 };
 
 /**
- * The address to serve on, from what was typed and what the host said — in that order, because a
- * flag is the only one of the two anybody chose.
+ * Where to listen, and the address the app answers at — which is not the one bound: nibrun's edge
+ * terminates TLS in front of a guest listening on plain HTTP, so the port this process knows about
+ * is no part of any URL anybody can type.
  *
- * A host that assigned the port is a host reaching the app across a network, so it is also what
- * decides the interface: nibrun's guest is only answered on `0.0.0.0`, and everywhere nothing was
- * assigned is a folder being served to the person sitting in front of it.
+ * Refused rather than defaulted where the guest said nothing, because there is no answer to default
+ * to. A port nobody assigned is a port nothing probes, and a folder served on one is a folder
+ * nothing ever reaches.
  */
-export function addressFor({
-  options,
-  environment,
-}: {
-  options: { port?: number | undefined; host?: string | undefined };
-  environment: HostEnvironment;
-}): Address {
-  const assigned = environment.httpPort ?? environment.port;
-  const hostname = options.host ?? (assigned === null ? LOOPBACK : EVERY_INTERFACE);
-  const port = options.port ?? assigned ?? DEFAULT_PORT;
+export function guestAddress(environment: GuestEnvironment): Address {
+  const { httpPort, hostname } = environment;
 
-  return { hostname, port, url: reachedAt({ hostname, port, announced: environment.hostname }) };
+  if (httpPort === null) {
+    throw offNibrun(RUNTIME_VALUES.HTTP_PORT.name);
+  }
+  if (hostname === null) {
+    throw offNibrun(RUNTIME_VALUES.HOSTNAME.name);
+  }
+  return { hostname: EVERY_INTERFACE, port: httpPort, url: `https://${hostname}` };
 }
 
-/**
- * A host that named the app named the address it is reached at, and it is not the one bound here:
- * nibrun's edge terminates TLS in front of a guest listening on plain HTTP, so the port this
- * process knows about is not part of any URL anybody can type.
- */
-function reachedAt({
-  hostname,
-  port,
-  announced,
-}: {
-  hostname: string;
-  port: number;
-  announced: string | null;
-}): string {
-  if (announced !== null) {
-    return `https://${announced}`;
-  }
-  return `http://${hostname === EVERY_INTERFACE ? LOCALHOST : hostname}:${port}`;
+function offNibrun(variable: string): UsageError {
+  return new UsageError(
+    `${PROGRAM_NAME} serve is the binary a folder of assets is deployed as, and it serves on what the guest tells it. Nothing set ${variable} here, so this is not one. Deploy the folder instead: ${PROGRAM_NAME} run "./${PROGRAM_NAME} serve data"`,
+  );
 }
 
 /**
@@ -245,16 +218,14 @@ export function untilStopped(server: FileServer): Promise<void> {
 const ServingSchema = z.object({
   directory: z.string(),
   url: z.string(),
-  hostname: z.string(),
   port: z.number(),
   singlePage: z.boolean(),
 });
 
 /**
- * The address bound as well as the URL to visit, because on a host those are two different
- * answers and a folder nobody can reach is usually the first of them. Whether the shell is
- * answering for everything is said out loud for the same reason: it is what a 404 that came back
- * 200 turns out to have been.
+ * The port as well as the URL, those being two different answers here and the port the one an app
+ * that came up serving nothing turns out to have got wrong. Whether the shell is answering for
+ * everything is said out loud for the same reason: it is what a 404 that came back 200 was.
  */
 export const SERVING_OUTPUT = defineOutput({
   schema: ServingSchema,

--- a/packages/cli/src/lib/serve.ts
+++ b/packages/cli/src/lib/serve.ts
@@ -1,0 +1,222 @@
+import { stat } from 'node:fs/promises';
+import { join, resolve, sep } from 'node:path';
+import type { Server } from 'bun';
+import { z } from 'zod';
+import { UsageError } from '#lib/errors.ts';
+import { defineOutput } from '#lib/output.ts';
+
+/** What a folder is served on when nothing is hosting this nib. */
+export const DEFAULT_PORT = 3000;
+
+const INDEX_FILE = 'index.html';
+const NOT_FOUND = 404;
+const NOT_FOUND_BODY = 'Not found';
+
+/**
+ * Every interface, which is what a host reaches an app on, against the loopback a folder on
+ * somebody's own machine is served on. Handing a local folder to the whole network is not
+ * something to arrive at by accident, so which of the two is bound follows from whether anything
+ * assigned the port — see `addressFor`.
+ */
+const EVERY_INTERFACE = '0.0.0.0';
+const LOOPBACK = '127.0.0.1';
+
+/** The name a browser reaches `EVERY_INTERFACE` by, that address not being one it can dial. */
+const LOCALHOST = 'localhost';
+
+/** A terminal's own way of ending a run, and the one a host sends before it replaces the app. */
+const STOP_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
+
+/**
+ * What the host running this nib said about itself, `null` for each thing it said nothing about.
+ * Nothing at all is what says this is somebody's own machine rather than nibrun.
+ */
+export type HostEnvironment = {
+  /** The port nibrun assigns and probes, which the app must be the one listening on. */
+  httpPort: number | null;
+  /** That same number under the name every other host uses, read for the hosts that set only it. */
+  port: number | null;
+  /** The name the app is actually reached by, which is not the interface it is bound to. */
+  hostname: string | null;
+};
+
+/** What `Bun.serve` hands back for a server that never upgrades a connection. */
+export type FileServer = Server<undefined>;
+
+/** Where the server listens, and where whoever asked for it should look. */
+export type Address = {
+  hostname: string;
+  port: number;
+  url: string;
+};
+
+/**
+ * The address to serve on, from what was typed and what the host said — in that order, because a
+ * flag is the only one of the two anybody chose.
+ *
+ * A host that assigned the port is a host reaching the app across a network, so it is also what
+ * decides the interface: nibrun's guest is only answered on `0.0.0.0`, and everywhere nothing was
+ * assigned is a folder being served to the person sitting in front of it.
+ */
+export function addressFor({
+  options,
+  environment,
+}: {
+  options: { port?: number | undefined; host?: string | undefined };
+  environment: HostEnvironment;
+}): Address {
+  const assigned = environment.httpPort ?? environment.port;
+  const hostname = options.host ?? (assigned === null ? LOOPBACK : EVERY_INTERFACE);
+  const port = options.port ?? assigned ?? DEFAULT_PORT;
+
+  return { hostname, port, url: reachedAt({ hostname, port, announced: environment.hostname }) };
+}
+
+/**
+ * A host that named the app named the address it is reached at, and it is not the one bound here:
+ * nibrun's edge terminates TLS in front of a guest listening on plain HTTP, so the port this
+ * process knows about is not part of any URL anybody can type.
+ */
+function reachedAt({
+  hostname,
+  port,
+  announced,
+}: {
+  hostname: string;
+  port: number;
+  announced: string | null;
+}): string {
+  if (announced !== null) {
+    return `https://${announced}`;
+  }
+  return `http://${hostname === EVERY_INTERFACE ? LOCALHOST : hostname}:${port}`;
+}
+
+/**
+ * The folder as an absolute path, or a refusal naming what was typed. Asked before the port is
+ * bound, so a folder nobody can read costs one line rather than a server answering nothing.
+ */
+export async function servedRoot(directory: string): Promise<string> {
+  const root = resolve(directory);
+  const stats = await stat(root).catch(() => undefined);
+
+  if (stats === undefined) {
+    throw new UsageError(`No such folder: ${directory}`);
+  }
+  if (!stats.isDirectory()) {
+    throw new UsageError(`${directory} is a file, and what is served is a folder of them.`);
+  }
+  return root;
+}
+
+/**
+ * Where a request lands under the root, or nothing where it lands outside it.
+ *
+ * A pathname is whatever a client sent — `../`, an escape spelled `%2e%2e`, a NUL — so what is
+ * asked is whether the resolved path is still inside the folder, rather than whether the text it
+ * arrived as looked like an escape.
+ */
+export function requestedPath({
+  root,
+  pathname,
+}: {
+  root: string;
+  pathname: string;
+}): string | null {
+  const decoded = decodedPathname(pathname);
+  if (decoded === null) {
+    return null;
+  }
+
+  const target = resolve(root, `.${decoded}`);
+  return target === root || target.startsWith(`${root}${sep}`) ? target : null;
+}
+
+function decodedPathname(pathname: string): string | null {
+  try {
+    const decoded = decodeURIComponent(pathname);
+    // A NUL truncates the path every syscall below this reads, so the file opened would not be the
+    // one the containment check was made against.
+    return decoded.includes('\0') ? null : decoded;
+  } catch {
+    // Percent-encoding no file could have been meant by.
+    return null;
+  }
+}
+
+/**
+ * Serve `root` and nothing else. Content types are the files' own — Bun reads one from the
+ * extension, which is the whole of what a static server has to say about a body it hands over
+ * untouched.
+ */
+export function serveDirectory({
+  root,
+  hostname,
+  port,
+}: {
+  root: string;
+  hostname: string;
+  port: number;
+}): FileServer {
+  return Bun.serve({
+    hostname,
+    port,
+    fetch: async (request) => {
+      const file = await fileAt({ root, pathname: new URL(request.url).pathname });
+      return file === null
+        ? new Response(NOT_FOUND_BODY, { status: NOT_FOUND })
+        : new Response(file);
+    },
+  });
+}
+
+async function fileAt({
+  root,
+  pathname,
+}: {
+  root: string;
+  pathname: string;
+}): Promise<Bun.BunFile | null> {
+  const target = requestedPath({ root, pathname });
+  if (target === null) {
+    return null;
+  }
+
+  const asked = Bun.file(target);
+  if (await asked.exists()) {
+    return asked;
+  }
+  // A directory is not a file Bun reads, so falling through to its index is also what answers `/`
+  // and every path a browser arrives at with a trailing slash.
+  const index = Bun.file(join(target, INDEX_FILE));
+  return (await index.exists()) ? index : null;
+}
+
+/**
+ * `cli.main()` exits the moment a handler returns, so serving has to be the handler rather than
+ * something it leaves behind. Settles once the server has been asked to stop and has finished
+ * answering whatever it was in the middle of.
+ */
+export function untilStopped(server: FileServer): Promise<void> {
+  return new Promise((settle) => {
+    for (const signal of STOP_SIGNALS) {
+      process.once(signal, () => settle(server.stop()));
+    }
+  });
+}
+
+const ServingSchema = z.object({
+  directory: z.string(),
+  url: z.string(),
+  hostname: z.string(),
+  port: z.number(),
+});
+
+/**
+ * The address bound as well as the URL to visit, because on a host those are two different
+ * answers and a folder nobody can reach is usually the first of them.
+ */
+export const SERVING_OUTPUT = defineOutput({
+  schema: ServingSchema,
+  render: ({ value, out }) => out.success(`${value.url} — serving ${value.directory}`),
+});

--- a/packages/cli/tests/lib/serve.test.ts
+++ b/packages/cli/tests/lib/serve.test.ts
@@ -129,7 +129,13 @@ describe('a request reaches a path under the folder or it reaches nothing', () =
 const OUTSIDE_FILE = 'secret.txt';
 
 /** A site with a page at the root, one in a directory, and an asset beside them. */
-async function siteServedWith({ singlePage }: { singlePage: boolean }): Promise<FileServer> {
+async function siteServedWith({
+  singlePage,
+  notFoundPage = false,
+}: {
+  singlePage: boolean;
+  notFoundPage?: boolean;
+}): Promise<FileServer> {
   const scratch = await scratchDir();
   const root = join(scratch, 'site');
 
@@ -138,6 +144,9 @@ async function siteServedWith({ singlePage }: { singlePage: boolean }): Promise<
   await writeFile(join(root, 'index.html'), '<h1>home</h1>');
   await writeFile(join(root, 'app.css'), 'body{}');
   await writeFile(join(root, 'docs', 'index.html'), '<h1>docs</h1>');
+  if (notFoundPage) {
+    await writeFile(join(root, '404.html'), '<h1>nothing here</h1>');
+  }
 
   return serveDirectory({ root, hostname: '127.0.0.1', port: ANY_FREE_PORT, singlePage });
 }
@@ -211,7 +220,15 @@ describe('a single-page app is routed in the browser, so the shell answers for i
 
   test('a file that is there still wins, so assets are not shadowed by the shell', async () => {
     expect(await (await fetch(`${origin}/app.css`)).text()).toBe('body{}');
-    expect(await (await fetch(`${origin}/docs`)).text()).toBe('<h1>docs</h1>');
+    expect(await (await fetch(`${origin}/docs/index.html`)).text()).toBe('<h1>docs</h1>');
+  });
+
+  // What `serve`'s `--single` does, and the one place it differs from serving the folder plainly:
+  // the rewrite to the root index.html is applied before a directory is ever looked inside, so a
+  // real folder with a real index.html in it is answered by the shell all the same.
+  test('a directory with an index of its own is a route like any other', async () => {
+    expect(await (await fetch(`${origin}/docs`)).text()).toBe('<h1>home</h1>');
+    expect(await (await fetch(`${origin}/docs/`)).text()).toBe('<h1>home</h1>');
   });
 
   // The cost of asking for this, pinned down rather than left to be discovered: a stale bundle url
@@ -241,5 +258,36 @@ describe('a single-page app is routed in the browser, so the shell answers for i
 
     expect((await fetch(`${bare.url.origin}/anywhere`)).status).toBe(NOT_FOUND);
     await bare.stop(true);
+  });
+});
+
+describe("a folder's own 404.html is what its misses are answered with", () => {
+  let server: FileServer;
+  let origin: string;
+
+  beforeAll(async () => {
+    server = await siteServedWith({ singlePage: false, notFoundPage: true });
+    origin = server.url.origin;
+  });
+
+  afterAll(() => server.stop(true));
+
+  // The status, not just the page: a browser, a crawler and a `curl -f` all read that rather than
+  // the body, and `serve` writes the code it was answering rather than a 200 for the same reason.
+  test('the page is served, and it is served as the 404 it is', async () => {
+    const response = await fetch(`${origin}/missing.html`);
+
+    expect(response.status).toBe(NOT_FOUND);
+    expect(await response.text()).toBe('<h1>nothing here</h1>');
+    expect(response.headers.get('content-type')).toContain('text/html');
+  });
+
+  test('a route with no page behind it reaches it too', async () => {
+    expect(await (await fetch(`${origin}/projects/nibrun`)).text()).toBe('<h1>nothing here</h1>');
+  });
+
+  test('what the folder does have is still answered with itself', async () => {
+    expect(await (await fetch(`${origin}/`)).text()).toBe('<h1>home</h1>');
+    expect(await (await fetch(`${origin}/app.css`)).text()).toBe('body{}');
   });
 });

--- a/packages/cli/tests/lib/serve.test.ts
+++ b/packages/cli/tests/lib/serve.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { UsageError } from '#lib/errors.ts';
+import {
+  addressFor,
+  DEFAULT_PORT,
+  type FileServer,
+  type HostEnvironment,
+  requestedPath,
+  serveDirectory,
+  servedRoot,
+} from '#lib/serve.ts';
+
+const ASSIGNED_PORT = 8080;
+const CHOSEN_PORT = 4321;
+const ANY_FREE_PORT = 0;
+const NOT_FOUND = 404;
+
+const ALONE: HostEnvironment = { httpPort: null, port: null, hostname: null };
+
+const dirs: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function scratchDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'nib-serve-'));
+  dirs.push(dir);
+  return dir;
+}
+
+function hosted(overrides: Partial<HostEnvironment> = {}): HostEnvironment {
+  return { httpPort: ASSIGNED_PORT, port: ASSIGNED_PORT, hostname: null, ...overrides };
+}
+
+describe('where a folder is served follows from whether anything is hosting this nib', () => {
+  test('nothing assigned means the machine it was typed on, and nowhere else', () => {
+    expect(addressFor({ options: {}, environment: ALONE })).toEqual({
+      hostname: '127.0.0.1',
+      port: DEFAULT_PORT,
+      url: `http://127.0.0.1:${DEFAULT_PORT}`,
+    });
+  });
+
+  test('a host that assigned the port is answered on every interface, which is what it reaches', () => {
+    expect(addressFor({ options: {}, environment: hosted() })).toMatchObject({
+      hostname: '0.0.0.0',
+      port: ASSIGNED_PORT,
+    });
+  });
+
+  test('a host that sets only PORT is a host all the same', () => {
+    expect(
+      addressFor({ options: {}, environment: { ...ALONE, port: ASSIGNED_PORT } }),
+    ).toMatchObject({ hostname: '0.0.0.0', port: ASSIGNED_PORT });
+  });
+
+  // The two carry one number on nibrun, so which is read only shows up where they disagree.
+  test('the port nibrun assigns is the one it probes, so it wins over the alias beside it', () => {
+    expect(addressFor({ options: {}, environment: hosted({ port: CHOSEN_PORT }) }).port).toBe(
+      ASSIGNED_PORT,
+    );
+  });
+
+  test('a flag is the only one of the three anybody chose, so it wins over both', () => {
+    expect(addressFor({ options: { port: CHOSEN_PORT }, environment: hosted() })).toMatchObject({
+      hostname: '0.0.0.0',
+      port: CHOSEN_PORT,
+    });
+    expect(addressFor({ options: { host: '::1' }, environment: hosted() }).hostname).toBe('::1');
+  });
+
+  test('a host that named the app answers with that name rather than the bound address', () => {
+    expect(
+      addressFor({ options: {}, environment: hosted({ hostname: 'my-app.nibrun.app' }) }).url,
+    ).toBe('https://my-app.nibrun.app');
+  });
+});
+
+describe('a folder is what is served, and it is checked before a port is bound', () => {
+  test('one nobody can read is refused in the words `nib` refuses anything else in', async () => {
+    const nowhere = join(tmpdir(), 'nib-serve-nothing-here');
+
+    await expect(servedRoot(nowhere)).rejects.toThrow(UsageError);
+    await expect(servedRoot(nowhere)).rejects.toThrow('No such folder');
+  });
+
+  test('a file is not a folder of them', async () => {
+    const file = join(await scratchDir(), 'index.html');
+    await writeFile(file, 'hi');
+
+    await expect(servedRoot(file)).rejects.toThrow('is a file');
+  });
+});
+
+describe('a request reaches a path under the folder or it reaches nothing', () => {
+  const root = '/srv/site';
+
+  test('a path inside it resolves to the file it names', () => {
+    expect(requestedPath({ root, pathname: '/assets/app.css' })).toBe('/srv/site/assets/app.css');
+  });
+
+  test('the root itself is where a bare slash lands', () => {
+    expect(requestedPath({ root, pathname: '/' })).toBe(root);
+  });
+
+  test('an escape is refused however it is spelled', () => {
+    expect(requestedPath({ root, pathname: '/../etc/passwd' })).toBeNull();
+    expect(requestedPath({ root, pathname: '/%2e%2e/%2e%2e/etc/passwd' })).toBeNull();
+    expect(requestedPath({ root, pathname: '/a/../../etc/passwd' })).toBeNull();
+  });
+
+  // A prefix is not a parent: the folder beside the one being served is still outside it.
+  test('a sibling whose name starts with the folder is outside it', () => {
+    expect(requestedPath({ root, pathname: '/../site-backup/db' })).toBeNull();
+  });
+
+  test('a pathname no file could be meant by is refused rather than guessed at', () => {
+    expect(requestedPath({ root, pathname: '/a%00.html' })).toBeNull();
+    expect(requestedPath({ root, pathname: '/%zz' })).toBeNull();
+  });
+});
+
+describe('what the server answers with', () => {
+  let server: FileServer;
+  let origin: string;
+
+  beforeAll(async () => {
+    const root = await scratchDir();
+    await writeFile(join(root, 'index.html'), '<h1>home</h1>');
+    await writeFile(join(root, 'app.css'), 'body{}');
+    await mkdir(join(root, 'docs'));
+    await writeFile(join(root, 'docs', 'index.html'), '<h1>docs</h1>');
+
+    server = serveDirectory({ root, hostname: '127.0.0.1', port: ANY_FREE_PORT });
+    origin = server.url.origin;
+  });
+
+  afterAll(() => server.stop(true));
+
+  test('a file is handed over under the type its extension gives it', async () => {
+    const response = await fetch(`${origin}/app.css`);
+
+    expect(await response.text()).toBe('body{}');
+    expect(response.headers.get('content-type')).toContain('text/css');
+  });
+
+  test('a directory is answered with the index.html in it', async () => {
+    expect(await (await fetch(`${origin}/`)).text()).toBe('<h1>home</h1>');
+    expect(await (await fetch(`${origin}/docs`)).text()).toBe('<h1>docs</h1>');
+    expect(await (await fetch(`${origin}/docs/`)).text()).toBe('<h1>docs</h1>');
+  });
+
+  test('a path that is not there is a 404 rather than a stack trace', async () => {
+    expect((await fetch(`${origin}/missing.html`)).status).toBe(NOT_FOUND);
+  });
+
+  // Encoded, because a client that normalises `../` away never gets to ask this — and one that
+  // does not normalise it is exactly the client this is defended against.
+  test('a path out of the folder is answered the same way as one that is simply not there', async () => {
+    expect((await fetch(`${origin}/%2e%2e/%2e%2e/etc/passwd`)).status).toBe(NOT_FOUND);
+  });
+});

--- a/packages/cli/tests/lib/serve.test.ts
+++ b/packages/cli/tests/lib/serve.test.ts
@@ -4,22 +4,20 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { UsageError } from '#lib/errors.ts';
 import {
-  addressFor,
-  DEFAULT_PORT,
   type FileServer,
-  type HostEnvironment,
+  type GuestEnvironment,
+  guestAddress,
   requestedPath,
   serveDirectory,
   servedRoot,
 } from '#lib/serve.ts';
 
 const ASSIGNED_PORT = 8080;
-const CHOSEN_PORT = 4321;
 const ANY_FREE_PORT = 0;
 const OK = 200;
 const NOT_FOUND = 404;
 
-const ALONE: HostEnvironment = { httpPort: null, port: null, hostname: null };
+const IN_A_GUEST: GuestEnvironment = { httpPort: ASSIGNED_PORT, hostname: 'my-app.nibrun.app' };
 
 const dirs: string[] = [];
 
@@ -33,51 +31,24 @@ async function scratchDir(): Promise<string> {
   return dir;
 }
 
-function hosted(overrides: Partial<HostEnvironment> = {}): HostEnvironment {
-  return { httpPort: ASSIGNED_PORT, port: ASSIGNED_PORT, hostname: null, ...overrides };
-}
-
-describe('where a folder is served follows from whether anything is hosting this nib', () => {
-  test('nothing assigned means the machine it was typed on, and nowhere else', () => {
-    expect(addressFor({ options: {}, environment: ALONE })).toEqual({
-      hostname: '127.0.0.1',
-      port: DEFAULT_PORT,
-      url: `http://127.0.0.1:${DEFAULT_PORT}`,
-    });
-  });
-
-  test('a host that assigned the port is answered on every interface, which is what it reaches', () => {
-    expect(addressFor({ options: {}, environment: hosted() })).toMatchObject({
+describe('a folder is served on what the guest assigned, or it is not served at all', () => {
+  // Every interface, because that is the only address nibrun reaches a guest on; and the app's own
+  // name, because the port bound here is behind the edge and is in no URL anybody can type.
+  test('the port it was given, on every interface, under the name it is reached by', () => {
+    expect(guestAddress(IN_A_GUEST)).toEqual({
       hostname: '0.0.0.0',
       port: ASSIGNED_PORT,
+      url: 'https://my-app.nibrun.app',
     });
   });
 
-  test('a host that sets only PORT is a host all the same', () => {
-    expect(
-      addressFor({ options: {}, environment: { ...ALONE, port: ASSIGNED_PORT } }),
-    ).toMatchObject({ hostname: '0.0.0.0', port: ASSIGNED_PORT });
+  test('no port from the guest is no guest, and it says which name was missing', () => {
+    expect(() => guestAddress({ ...IN_A_GUEST, httpPort: null })).toThrow(UsageError);
+    expect(() => guestAddress({ ...IN_A_GUEST, httpPort: null })).toThrow('NIBRUN_HTTP_PORT');
   });
 
-  // The two carry one number on nibrun, so which is read only shows up where they disagree.
-  test('the port nibrun assigns is the one it probes, so it wins over the alias beside it', () => {
-    expect(addressFor({ options: {}, environment: hosted({ port: CHOSEN_PORT }) }).port).toBe(
-      ASSIGNED_PORT,
-    );
-  });
-
-  test('a flag is the only one of the three anybody chose, so it wins over both', () => {
-    expect(addressFor({ options: { port: CHOSEN_PORT }, environment: hosted() })).toMatchObject({
-      hostname: '0.0.0.0',
-      port: CHOSEN_PORT,
-    });
-    expect(addressFor({ options: { host: '::1' }, environment: hosted() }).hostname).toBe('::1');
-  });
-
-  test('a host that named the app answers with that name rather than the bound address', () => {
-    expect(
-      addressFor({ options: {}, environment: hosted({ hostname: 'my-app.nibrun.app' }) }).url,
-    ).toBe('https://my-app.nibrun.app');
+  test('nor is a guest that never said what the app is called', () => {
+    expect(() => guestAddress({ ...IN_A_GUEST, hostname: null })).toThrow('NIBRUN_HOSTNAME');
   });
 });
 

--- a/packages/cli/tests/lib/serve.test.ts
+++ b/packages/cli/tests/lib/serve.test.ts
@@ -32,8 +32,6 @@ async function scratchDir(): Promise<string> {
 }
 
 describe('a folder is served on what the guest assigned, or it is not served at all', () => {
-  // Every interface, because that is the only address nibrun reaches a guest on; and the app's own
-  // name, because the port bound here is behind the edge and is in no URL anybody can type.
   test('the port it was given, on every interface, under the name it is reached by', () => {
     expect(guestAddress(IN_A_GUEST)).toEqual({
       hostname: '0.0.0.0',
@@ -85,7 +83,6 @@ describe('a request reaches a path under the folder or it reaches nothing', () =
     expect(requestedPath({ root, pathname: '/a/../../etc/passwd' })).toBeNull();
   });
 
-  // A prefix is not a parent: the folder beside the one being served is still outside it.
   test('a sibling whose name starts with the folder is outside it', () => {
     expect(requestedPath({ root, pathname: '/../site-backup/db' })).toBeNull();
   });
@@ -96,10 +93,8 @@ describe('a request reaches a path under the folder or it reaches nothing', () =
   });
 });
 
-/** A file sitting beside the served folder, which no spelling of a path should ever reach. */
 const OUTSIDE_FILE = 'secret.txt';
 
-/** A site with a page at the root, one in a directory, and an asset beside them. */
 async function siteServedWith({
   singlePage,
   notFoundPage = false,
@@ -150,16 +145,12 @@ describe('what the server answers with', () => {
     expect((await fetch(`${origin}/missing.html`)).status).toBe(NOT_FOUND);
   });
 
-  // The default, and the whole reason the fallback below is asked for rather than assumed: a link
-  // nobody wrote a page for is a link that is wrong, and saying so is the only way anybody finds out.
   test('a route with no file behind it is a 404 too, until somebody asks for otherwise', async () => {
     expect((await fetch(`${origin}/projects/nibrun`)).status).toBe(NOT_FOUND);
   });
 
-  // No spelling of an escape reaches `requestedPath` over HTTP: the URL parser resolves `..` —
-  // and `%2e%2e`, which it reads as that same segment — before a pathname is anything this can
-  // look at. So what is pinned here is the end of it, that nothing beside the folder is ever
-  // handed over. The check itself is exercised directly, above.
+  // The URL parser resolves `..`, and `%2e%2e` as that same segment, before the handler sees a
+  // pathname — so no escape reaches `requestedPath` here. That check is exercised directly above.
   test('a file next door is never handed over, however the path is spelled', async () => {
     for (const spelling of [
       `/../${OUTSIDE_FILE}`,
@@ -194,16 +185,13 @@ describe('a single-page app is routed in the browser, so the shell answers for i
     expect(await (await fetch(`${origin}/docs/index.html`)).text()).toBe('<h1>docs</h1>');
   });
 
-  // What `serve`'s `--single` does, and the one place it differs from serving the folder plainly:
-  // the rewrite to the root index.html is applied before a directory is ever looked inside, so a
-  // real folder with a real index.html in it is answered by the shell all the same.
+  // `serve`'s `--single` rewrites to the root before it looks inside a directory, so a real
+  // folder with a real index.html in it is answered by the shell all the same.
   test('a directory with an index of its own is a route like any other', async () => {
     expect(await (await fetch(`${origin}/docs`)).text()).toBe('<h1>home</h1>');
     expect(await (await fetch(`${origin}/docs/`)).text()).toBe('<h1>home</h1>');
   });
 
-  // The cost of asking for this, pinned down rather than left to be discovered: a stale bundle url
-  // answers with the page, and the app reports a syntax error rather than a missing file.
   test('an asset that is gone answers with the page as well, which is what the flag buys', async () => {
     const response = await fetch(`${origin}/assets/app-a1b2c3.js`);
 
@@ -243,8 +231,6 @@ describe("a folder's own 404.html is what its misses are answered with", () => {
 
   afterAll(() => server.stop(true));
 
-  // The status, not just the page: a browser, a crawler and a `curl -f` all read that rather than
-  // the body, and `serve` writes the code it was answering rather than a 200 for the same reason.
   test('the page is served, and it is served as the 404 it is', async () => {
     const response = await fetch(`${origin}/missing.html`);
 

--- a/packages/cli/tests/lib/serve.test.ts
+++ b/packages/cli/tests/lib/serve.test.ts
@@ -16,6 +16,7 @@ import {
 const ASSIGNED_PORT = 8080;
 const CHOSEN_PORT = 4321;
 const ANY_FREE_PORT = 0;
+const OK = 200;
 const NOT_FOUND = 404;
 
 const ALONE: HostEnvironment = { httpPort: null, port: null, hostname: null };
@@ -124,18 +125,29 @@ describe('a request reaches a path under the folder or it reaches nothing', () =
   });
 });
 
+/** A file sitting beside the served folder, which no spelling of a path should ever reach. */
+const OUTSIDE_FILE = 'secret.txt';
+
+/** A site with a page at the root, one in a directory, and an asset beside them. */
+async function siteServedWith({ singlePage }: { singlePage: boolean }): Promise<FileServer> {
+  const scratch = await scratchDir();
+  const root = join(scratch, 'site');
+
+  await mkdir(join(root, 'docs'), { recursive: true });
+  await writeFile(join(scratch, OUTSIDE_FILE), 'not yours');
+  await writeFile(join(root, 'index.html'), '<h1>home</h1>');
+  await writeFile(join(root, 'app.css'), 'body{}');
+  await writeFile(join(root, 'docs', 'index.html'), '<h1>docs</h1>');
+
+  return serveDirectory({ root, hostname: '127.0.0.1', port: ANY_FREE_PORT, singlePage });
+}
+
 describe('what the server answers with', () => {
   let server: FileServer;
   let origin: string;
 
   beforeAll(async () => {
-    const root = await scratchDir();
-    await writeFile(join(root, 'index.html'), '<h1>home</h1>');
-    await writeFile(join(root, 'app.css'), 'body{}');
-    await mkdir(join(root, 'docs'));
-    await writeFile(join(root, 'docs', 'index.html'), '<h1>docs</h1>');
-
-    server = serveDirectory({ root, hostname: '127.0.0.1', port: ANY_FREE_PORT });
+    server = await siteServedWith({ singlePage: false });
     origin = server.url.origin;
   });
 
@@ -158,9 +170,76 @@ describe('what the server answers with', () => {
     expect((await fetch(`${origin}/missing.html`)).status).toBe(NOT_FOUND);
   });
 
-  // Encoded, because a client that normalises `../` away never gets to ask this — and one that
-  // does not normalise it is exactly the client this is defended against.
-  test('a path out of the folder is answered the same way as one that is simply not there', async () => {
-    expect((await fetch(`${origin}/%2e%2e/%2e%2e/etc/passwd`)).status).toBe(NOT_FOUND);
+  // The default, and the whole reason the fallback below is asked for rather than assumed: a link
+  // nobody wrote a page for is a link that is wrong, and saying so is the only way anybody finds out.
+  test('a route with no file behind it is a 404 too, until somebody asks for otherwise', async () => {
+    expect((await fetch(`${origin}/projects/nibrun`)).status).toBe(NOT_FOUND);
+  });
+
+  // No spelling of an escape reaches `requestedPath` over HTTP: the URL parser resolves `..` —
+  // and `%2e%2e`, which it reads as that same segment — before a pathname is anything this can
+  // look at. So what is pinned here is the end of it, that nothing beside the folder is ever
+  // handed over. The check itself is exercised directly, above.
+  test('a file next door is never handed over, however the path is spelled', async () => {
+    for (const spelling of [
+      `/../${OUTSIDE_FILE}`,
+      `/%2e%2e/${OUTSIDE_FILE}`,
+      `/docs/../../${OUTSIDE_FILE}`,
+    ]) {
+      expect((await fetch(`${origin}${spelling}`)).status).toBe(NOT_FOUND);
+    }
+  });
+});
+
+describe('a single-page app is routed in the browser, so the shell answers for its routes', () => {
+  let server: FileServer;
+  let origin: string;
+
+  beforeAll(async () => {
+    server = await siteServedWith({ singlePage: true });
+    origin = server.url.origin;
+  });
+
+  afterAll(() => server.stop(true));
+
+  test('a route with no file behind it is the page, and a page is a 200', async () => {
+    const response = await fetch(`${origin}/projects/nibrun`);
+
+    expect(response.status).toBe(OK);
+    expect(await response.text()).toBe('<h1>home</h1>');
+  });
+
+  test('a file that is there still wins, so assets are not shadowed by the shell', async () => {
+    expect(await (await fetch(`${origin}/app.css`)).text()).toBe('body{}');
+    expect(await (await fetch(`${origin}/docs`)).text()).toBe('<h1>docs</h1>');
+  });
+
+  // The cost of asking for this, pinned down rather than left to be discovered: a stale bundle url
+  // answers with the page, and the app reports a syntax error rather than a missing file.
+  test('an asset that is gone answers with the page as well, which is what the flag buys', async () => {
+    const response = await fetch(`${origin}/assets/app-a1b2c3.js`);
+
+    expect(response.status).toBe(OK);
+    expect(await response.text()).toBe('<h1>home</h1>');
+  });
+
+  test('a path reaching out of the folder gets the shell rather than what is out there', async () => {
+    const response = await fetch(`${origin}/%2e%2e/${OUTSIDE_FILE}`);
+
+    expect(await response.text()).toBe('<h1>home</h1>');
+  });
+
+  test('a folder with no index.html to fall back on has nothing to answer with', async () => {
+    const root = await scratchDir();
+    await writeFile(join(root, 'app.css'), 'body{}');
+    const bare = serveDirectory({
+      root,
+      hostname: '127.0.0.1',
+      port: ANY_FREE_PORT,
+      singlePage: true,
+    });
+
+    expect((await fetch(`${bare.url.origin}/anywhere`)).status).toBe(NOT_FOUND);
+    await bare.stop(true);
   });
 });


### PR DESCRIPTION
`nib serve <directory>` is what a folder of static assets is deployed as: `nib run "./nib serve data"` serves the app volume.

It runs only inside a guest. The port and the address come from `NIBRUN_HTTP_PORT` and `NIBRUN_HOSTNAME`, and a nib where the guest set neither refuses rather than picking a port nothing probes — so there are no `--port`/`--host` flags and no local mode to keep working. Hidden from the help listing, being the argument a deployed binary is given rather than something anybody types.

A path naming a directory is answered with the `index.html` in it, and a miss with the folder's own `404.html` where it has one — under the 404 it is, as `serve` does.

`--single-page` answers everything no file answers with the root `index.html`, matching `serve`'s `--single`: a real file is the only thing that beats the shell, a directory's own index included, because the rewrite lands before a directory is ever looked inside. Off by default — answering every miss with the shell makes a stale asset url a `200 text/html`, so the app reports a syntax error rather than a missing file.