### PR TITLE
ci(release): the cli version bump reaches the lockfile too

### DIFF
--- a/.github/workflows/prepare-cli-release.yml
+++ b/.github/workflows/prepare-cli-release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           branch: release/${{ steps.release.outputs.tag }}
           title: "chore(release): ${{ steps.release.outputs.tag }}"
-          paths: packages/cli/package.json packages/cli/CHANGELOG.md
+          paths: packages/cli/package.json packages/cli/CHANGELOG.md bun.lock
           token: ${{ secrets.OPEN_PR_TOKEN || github.token }}
           body: |
             Bumps `@repo/cli` to **${{ steps.release.outputs.version }}** and regenerates its changelog.

--- a/bun.lock
+++ b/bun.lock
@@ -146,7 +146,7 @@
     },
     "packages/cli": {
       "name": "@repo/cli",
-      "version": "2026.9.7-1",
+      "version": "2026.9.7-2",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
         "@parshjs/core": "^0.0.10",

--- a/packages/internal-scripts/src/shared/cli-release.ts
+++ b/packages/internal-scripts/src/shared/cli-release.ts
@@ -62,6 +62,10 @@ export async function hasUnreleasedChanges(): Promise<boolean> {
 export async function writeCliVersion(version: string) {
   const updated = { ...packageJson.cli, version };
   await Bun.write(cliPackageJsonPath, `${JSON.stringify(updated, null, 2)}\n`);
+  // The lockfile records every workspace package's version and `--frozen-lockfile` does not object
+  // when one drifts, so skipping this leaves it a release behind until an unrelated branch sweeps
+  // the line up.
+  await $`bun install`.cwd(repoRoot);
 }
 
 async function scoped(options: CliCliffOptions): Promise<Options> {


### PR DESCRIPTION
`bun.lock` records every workspace package's own `version`, so a release that only writes `packages/cli/package.json` leaves it a release behind — `--frozen-lockfile` does not object, so nothing catches it until an unrelated branch sweeps the line up. It had already drifted on main; that line is fixed here too.