### PR TITLE
fix(www): the drop target names what to drop

### DIFF
--- a/apps/dashboard/src/components/deploy/minimal-binary-field.tsx
+++ b/apps/dashboard/src/components/deploy/minimal-binary-field.tsx
@@ -72,7 +72,7 @@ function FetchedBinary({ url }: { url: string }) {
 // Whoever followed the link compiled one binary for one app, and the link knows which.
 function invitation(appName: string | undefined): ReactNode {
   if (appName === undefined) {
-    return 'Drop it here';
+    return 'Drop your binary here';
   }
   return (
     <>

--- a/apps/www/src/components/binary-drop.tsx
+++ b/apps/www/src/components/binary-drop.tsx
@@ -11,7 +11,7 @@ export function BinaryDrop() {
       <BinaryDropTarget
         inputId={BINARY_INPUT_ID}
         binary={handoff.binary}
-        title="Drop it here"
+        title="Drop your binary here"
         caption={sending(handoff)}
         busy={handoff.sending}
         invalid={handoff.failure !== undefined}


### PR DESCRIPTION
On the landing page "Drop it here" has no antecedent — nothing above it says what "it" is. It now says "Drop your binary here".

The deploy link stripped to its binary renders the same target, so it says the same thing.