### PR TITLE
fix(ui): a table that is the whole view stands in its own panel, not in a card

### DIFF
--- a/apps/dashboard/src/components/apps/apps-list.tsx
+++ b/apps/dashboard/src/components/apps/apps-list.tsx
@@ -1,5 +1,5 @@
-import { Card } from '@repo/ui/components/card';
 import { Skeleton } from '@repo/ui/components/skeleton';
+import { TableContainer } from '@repo/ui/custom/table-container';
 import { AppsTable } from '#components/apps/apps-table.tsx';
 import { NoAppsEmpty } from '#components/apps/no-apps-empty.tsx';
 import { FailureEmpty } from '#components/failure-empty.tsx';
@@ -19,8 +19,8 @@ export function AppsList() {
   }
 
   return (
-    <Card className="overflow-hidden p-0">
+    <TableContainer>
       <AppsTable apps={apps.data} />
-    </Card>
+    </TableContainer>
   );
 }

--- a/apps/dashboard/src/components/apps/deployment-history.tsx
+++ b/apps/dashboard/src/components/apps/deployment-history.tsx
@@ -43,12 +43,16 @@ export function DeploymentHistory() {
     );
   }
 
+  // A card that happens to hold a table, rather than a table in a card: the title is the card's and
+  // the rows are one thing it shows. It keeps its own padding above and below, so the rows stop
+  // short of the edges and the rivets have face to sit on; only the sides are given over, so a row
+  // still runs the full width.
   return (
-    <Card className="overflow-hidden p-0">
-      <CardHeader className="px-4 pt-4">
+    <Card>
+      <CardHeader className="px-4">
         <CardTitle>Deployments</CardTitle>
       </CardHeader>
-      <CardContent className="px-0 pb-0">
+      <CardContent className="px-0">
         {newest.state === 'failed' && (
           <div className="px-4 pb-4">
             <FailedDeploymentNotice deployment={newest} />

--- a/apps/dashboard/src/components/files/directory-listing.tsx
+++ b/apps/dashboard/src/components/files/directory-listing.tsx
@@ -1,7 +1,7 @@
 import { DIRECTORY_ENTRY_LIMIT } from '@repo/protocol';
-import { Card } from '@repo/ui/components/card';
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle } from '@repo/ui/components/empty';
 import { Skeleton } from '@repo/ui/components/skeleton';
+import { TableContainer } from '@repo/ui/custom/table-container';
 import { FolderOpenIcon } from 'lucide-react';
 import { DeploymentLine } from '#components/apps/deployment-line.tsx';
 import { FailureEmpty } from '#components/failure-empty.tsx';
@@ -39,9 +39,9 @@ export function DirectoryListing() {
             </EmptyHeader>
           </Empty>
         ) : (
-          <Card className="overflow-hidden p-0">
+          <TableContainer>
             <DirectoryTable entries={view.listing.entries} />
-          </Card>
+          </TableContainer>
         ))}
       {view.listing?.truncated === true && (
         <p className="text-muted-foreground text-sm">

--- a/packages/ui/src/custom/table-container.tsx
+++ b/packages/ui/src/custom/table-container.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@repo/ui/lib/utils';
+import type { ComponentProps } from 'react';
+
+/**
+ * The panel a table stands in when the table is the whole of what is being shown.
+ *
+ * A `Card` was doing this and is the wrong thing for it: a card holds its content on a face, inset
+ * from the edges and riveted down at the corners, and a table handed that face whole leaves nothing
+ * to inset from and nothing to fasten — so every caller turned the padding off and the rivets came
+ * to rest on the header row and the last line.
+ *
+ * A table that is one section of something larger is not this. It belongs in the card that has the
+ * rest, where the panel around it is already drawn.
+ */
+export function TableContainer({ className, ...props }: ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="table-container-panel"
+      className={cn(
+        'overflow-hidden rounded-[min(var(--radius-4xl),24px)] border-2 border-border bg-card text-card-foreground shadow-sm',
+        className,
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
The rivets were landing on the header row and the last line of the files and apps tables. A card handed its face whole to a table has none left to fasten — the tell that the card was never the right container; both callers were already turning its padding off to get there.

`TableContainer` is the panel those two wanted. The deployments card keeps its `Card`: it has a title and the rows are one thing it shows, so it keeps its padding above and below and gives over only the sides.