### PR TITLE
style: a component is a function declaration, and Biome says so

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,9 @@ Bun + TypeScript monorepo (`apps/*`, `packages/*`).
 - Biome caps cognitive complexity at 15 — extract a named function rather than silencing it
 - Only re-export from index files - Biome enforces that
 - Declare functions with `function`, never a `const` bound to an arrow. Applies
-  to test fixtures and one-line helpers too
+  to test fixtures and one-line helpers too. Biome's
+  `useReactFunctionComponentDefinition` holds the line for components, except in
+  `packages/ui/src/components`, which shadcn writes
 
 ## Validation
 

--- a/apps/agent/tests/lib/filesystem/protocol.test.ts
+++ b/apps/agent/tests/lib/filesystem/protocol.test.ts
@@ -40,7 +40,9 @@ import {
 
 const ROOT = Value.Parse(GuestPathSchema, '/');
 const APP = Value.Parse(AppIdSchema, 'app-pocketbase');
-const AT = (value: string): Timestamp => Value.Parse(TimestampSchema, value);
+function AT(value: string): Timestamp {
+  return Value.Parse(TimestampSchema, value);
+}
 const MODIFIED = AT('2026-01-15T10:24:00Z');
 const SOME_SIZE = 32_768;
 const UINT32_BYTES = 4;

--- a/biome.json
+++ b/biome.json
@@ -47,6 +47,10 @@
       },
       "nursery": {
         "useAwaitThenable": "error",
+        "useReactFunctionComponentDefinition": {
+          "level": "error",
+          "options": { "namedComponents": "functionDeclaration" }
+        },
         "noFloatingPromises": "error",
         "useSortedClasses": {
           "level": "error",
@@ -188,6 +192,9 @@
       "includes": ["packages/ui/src/components/*.tsx"],
       "linter": {
         "rules": {
+          "nursery": {
+            "useReactFunctionComponentDefinition": "off"
+          },
           "a11y": {
             "noLabelWithoutControl": "off",
             "useFocusableInteractive": "off",


### PR DESCRIPTION
`useReactFunctionComponentDefinition` (Biome 2.5.0, nursery) turns the AGENTS.md convention into a rule. `packages/ui/src/components` is exempt — shadcn writes those.

One pre-existing hit outside React: an agent test helper bound to a const arrow, which the same convention already covered.