### PR TITLE
fix(ui): the deploy button keeps its corner when there are no apps

### DIFF
--- a/apps/dashboard/src/components/apps/no-apps-empty.tsx
+++ b/apps/dashboard/src/components/apps/no-apps-empty.tsx
@@ -12,8 +12,6 @@ import { CopyableLine } from '@repo/ui/custom/copyable-line';
 import { DeployPresetRoller } from '@repo/ui/custom/deploy-preset-roller';
 import { Link } from '@tanstack/react-router';
 import { BoxIcon } from 'lucide-react';
-import { DeployDialog } from '#components/deploy/deploy-dialog.tsx';
-import { ENABLED } from '#lib/app-actions.ts';
 import { Route as DeployRoute } from '#routes/deploy.tsx';
 
 export function NoAppsEmpty() {
@@ -26,8 +24,6 @@ export function NoAppsEmpty() {
         <EmptyTitle>You have no apps</EmptyTitle>
       </EmptyHeader>
       <EmptyContent>
-        <DeployDialog appId={undefined} availability={ENABLED} />
-        <p className="text-muted-foreground">Or</p>
         <DeployPresetRoller
           presets={DEPLOY_PRESET_SLUGS}
           linkToPreset={(preset) => <Link to={DeployRoute.to} search={DEPLOY_PRESETS[preset]} />}

--- a/apps/dashboard/src/routes/(dashboard)/apps/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/apps/index.tsx
@@ -2,20 +2,15 @@ import { createFileRoute } from '@tanstack/react-router';
 import { AppsList } from '#components/apps/apps-list.tsx';
 import { DeployDialog } from '#components/deploy/deploy-dialog.tsx';
 import { ENABLED } from '#lib/app-actions.ts';
-import { useApps } from '#lib/hooks/use-apps.ts';
 
 export const Route = createFileRoute('/(dashboard)/apps/')({ component: RouteComponent });
 
 function RouteComponent() {
-  const apps = useApps();
-  const noApps = apps.data?.length === 0;
-
   return (
     <div className="@container/main flex flex-col gap-4 p-4 md:gap-6 md:p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="font-medium text-base">Apps</h1>
-        {/* The empty state puts its own Deploy button in the middle of the page. */}
-        {noApps ? null : <DeployDialog appId={undefined} availability={ENABLED} />}
+        <DeployDialog appId={undefined} availability={ENABLED} />
       </div>
       <AppsList />
     </div>


### PR DESCRIPTION
The empty apps placeholder is the presets roller and the agent prompt, so the Deploy button it used to carry in the middle of the page goes back to the header — where it now stands whether or not there is a list under it.