### PR TITLE
feat(www): the site header points agents at llms.txt

### DIFF
--- a/apps/www/src/components/site-header.tsx
+++ b/apps/www/src/components/site-header.tsx
@@ -21,9 +21,6 @@ export function SiteHeader() {
         <Button variant="ghost" size="sm" render={<Link to="/blog" />}>
           Blog
         </Button>
-        {/* A file in `public/` rather than a route, so an anchor: `Link` has nothing to resolve.
-            Gone below `sm`, where the row already spends every pixel it has — and whoever wants
-            this is pointing an agent at the site from a desktop, not reading it on a phone. */}
         <Button
           variant="ghost"
           size="sm"

--- a/apps/www/src/components/site-header.tsx
+++ b/apps/www/src/components/site-header.tsx
@@ -1,3 +1,4 @@
+import { LLMS_TXT_PATH } from '@repo/global-constants';
 import { Button } from '@repo/ui/components/button';
 import { Link } from '@tanstack/react-router';
 import { DashboardLink } from '#components/dashboard-link.tsx';
@@ -19,6 +20,17 @@ export function SiteHeader() {
         </Button>
         <Button variant="ghost" size="sm" render={<Link to="/blog" />}>
           Blog
+        </Button>
+        {/* A file in `public/` rather than a route, so an anchor: `Link` has nothing to resolve.
+            Gone below `sm`, where the row already spends every pixel it has — and whoever wants
+            this is pointing an agent at the site from a desktop, not reading it on a phone. */}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="hidden sm:inline-flex"
+          render={<a href={LLMS_TXT_PATH} />}
+        >
+          llms.txt
         </Button>
       </div>
       <div className="flex items-center justify-end gap-1">

--- a/apps/www/src/lib/page-head.ts
+++ b/apps/www/src/lib/page-head.ts
@@ -1,4 +1,4 @@
-import { PRODUCT_NAME, WWW_SITE } from '@repo/global-constants';
+import { LLMS_TXT_PATH, PRODUCT_NAME, WWW_SITE } from '@repo/global-constants';
 
 /**
  * The tags that differ per page, kept in one place because some of them cannot be repeated:
@@ -12,7 +12,7 @@ export function pageHead({
   description,
   publishedAt,
   image,
-  markdown = { path: '/llms.txt', title: `${PRODUCT_NAME} for agents` },
+  markdown = { path: LLMS_TXT_PATH, title: `${PRODUCT_NAME} for agents` },
 }: {
   path: string;
   title: string;

--- a/packages/global-constants/src/index.ts
+++ b/packages/global-constants/src/index.ts
@@ -9,6 +9,7 @@ export {
   GITHUB_REPO_SLUG,
   GITHUB_REPO_URL,
 } from '#github.ts';
+export { LLMS_TXT_PATH } from '#llms.ts';
 export { FREE_APPS_COUNT, PRICE_PER_APP_USD } from '#pricing.ts';
 export {
   BASE_DOMAIN,

--- a/packages/global-constants/src/llms.ts
+++ b/packages/global-constants/src/llms.ts
@@ -1,0 +1,2 @@
+/** The site's Markdown for agents, served from `apps/www/public`. */
+export const LLMS_TXT_PATH = '/llms.txt';


### PR DESCRIPTION
`llms.txt` was already advertised to machines — every page emits a `rel="alternate" type="text/markdown"` pointing at it. This adds the half a person can click, as a header nav item beside Pricing and Blog (shadcn/ui does the same; Stripe's docs put it in the footer, which this site doesn't have).

Hidden below `sm`: a third nav item overflowed the phone header and clipped the Deploy button.

`LLMS_TXT_PATH` moves into `@repo/global-constants` rather than being spelled twice, following `CLI_INSTALL_SCRIPT_URL`'s precedent for a www `public/` asset path.