### PR TITLE
fix(www): a deploy link is the worker's to answer, not a page to prerender

### DIFF
--- a/apps/www/src/lib/blog-markdown.ts
+++ b/apps/www/src/lib/blog-markdown.ts
@@ -3,10 +3,9 @@ import { findPost } from '#lib/blog.ts';
 const MARKDOWN_PATH = /^\/blog\/([a-z0-9-]+)\.md$/;
 
 /**
- * The one URL on this site the worker answers itself. Every page is prerendered to a static file
- * and served from the edge, but a `.md` prerendered alongside them would be handed back with
- * whatever content type the extension is guessed to mean — and being read as markdown rather
- * than downloaded is the entire point of the URL.
+ * Every page is prerendered to a static file and served from the edge, but a `.md` prerendered
+ * alongside them would be handed back with whatever content type the extension is guessed to
+ * mean — and being read as markdown rather than downloaded is the entire point of the URL.
  */
 export function markdownResponse(request: Request): Response | undefined {
   const slug = MARKDOWN_PATH.exec(new URL(request.url).pathname)?.[1];

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -1,4 +1,5 @@
 import { cloudflare } from '@cloudflare/vite-plugin';
+import { WWW_DEPLOY_PATH } from '@repo/global-constants';
 import tailwindcss from '@tailwindcss/vite';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react';
@@ -15,15 +16,25 @@ const config = defineConfig({
     tanstackStart({
       prerender: {
         enabled: true,
-        // The crawler follows every root-relative `<a href>` it renders, which includes each
-        // post's "View markdown" link. Prerendered, those would become static assets typed by
-        // extension rather than by us — so they are left to the worker, which serves them as
-        // `text/markdown`.
-        filter: (page) => !page.path.endsWith('.md'),
+        filter: (page) => !answeredByWorker(page.path),
       },
     }),
     viteReact(),
   ],
 });
+
+/**
+ * Whether `src/server.ts` answers this address itself, in which case the crawler has to leave it
+ * alone: it follows every root-relative `<a href>` it renders, and a page it writes is a static
+ * asset the edge hands back without ever waking the worker.
+ *
+ * A post's "View markdown" link would be typed by its extension rather than by us. A deploy link
+ * has no route behind it at all — the worker redirects it to the dashboard's deploy screen — so a
+ * page written for one is an empty shell, and the roller on the landing page renders exactly one
+ * of them for the crawler to find.
+ */
+function answeredByWorker(path: string): boolean {
+  return path.endsWith('.md') || path === WWW_DEPLOY_PATH || path.startsWith(`${WWW_DEPLOY_PATH}/`);
+}
 
 export default config;


### PR DESCRIPTION
`/deploy/pocketbase` served a blank page while every other preset redirected.

The prerender crawler follows every root-relative `<a href>` it renders, and the roller on the landing page renders one — the first preset. So the build wrote `dist/client/deploy/pocketbase/index.html`, a shell with no route behind it, and the edge handed that back without ever waking the worker that answers the address with the move to the dashboard.

The prerender filter already leaves `.md` to the worker for the same reason; it now leaves the deploy path too.