### PR TITLE
fix(dashboard): an update keeps the binary it runs without being given one

### DIFF
--- a/apps/dashboard/src/components/deploy/deploy-binary-field.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-binary-field.tsx
@@ -8,8 +8,11 @@ import {
 } from '#lib/hooks/use-deploy-form.ts';
 
 export function DeployBinaryField({ form }: { form: DeployFormState }) {
-  const { api, binaryListeners, replacing } = form;
-  const validate = replacing === undefined ? validateBinary : validateKeptBinary;
+  const { api, binaryListeners, locked } = form;
+  // Whether a binary is required is asked of the form at mount, and answered again only when the
+  // field changes — so it is read off the app this deploy targets rather than off the summary of
+  // it, which arrives later and would leave a field the owner can fill refusing to be left empty.
+  const validate = locked ? validateKeptBinary : validateBinary;
 
   return (
     <api.Field
@@ -25,7 +28,7 @@ export function DeployBinaryField({ form }: { form: DeployFormState }) {
             <BinarySourcePicker
               value={field.state.value}
               invalid={rejected}
-              keeping={replacing !== undefined}
+              keeping={locked}
               onChange={field.handleChange}
             />
             {rejected && <FieldError>{field.state.meta.errors[0]}</FieldError>}

--- a/apps/dashboard/src/components/deploy/deploy-form.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-form.tsx
@@ -53,7 +53,7 @@ export function DeployForm({
       {!stripped && <DeployConfiguration form={form} suggested={suggested} />}
 
       {replacing !== undefined && (
-        <p className="wrap-anywhere rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
+        <p className="wrap-anywhere rounded-2xl bg-warning/10 px-3 py-2 text-sm text-warning">
           This restarts <span className="font-medium font-mono">{replacing.slug}</span>
           {picked ? ' on the binary above' : ' on the binary it already runs'}. Its hostnames and
           everything on its volume stay as they are.


### PR DESCRIPTION
Update refused to deploy without a binary, though the api takes a release that keeps the one the app runs — and switching to the url card let it through, because leaving a card re-validates the field.

The field read whether a binary is required off the app summary, which the form fetches; on a page where that list is not already cached, the field mounts before it arrives, takes the new-app error, and keeps it. It now reads the question off the app the deploy targets, which is known at mount.

The restart notice is amber rather than red — nothing about it has gone wrong.