### PR TITLE
fix(deploy-link): pocketbase looks for pb_public beside the binary, which is read-only

### DIFF
--- a/packages/deploy-link/src/presets.ts
+++ b/packages/deploy-link/src/presets.ts
@@ -7,10 +7,10 @@ export const DEPLOY_PRESETS = {
   pocketbase: {
     name: 'pocketbase',
     binary:
-      'https://github.com/pocketbase/pocketbase/releases/download/v0.40.2/pocketbase_0.40.2_linux_amd64.zip',
-    sha256: 'dd86b424a07f2bb5ac2b8ba8cdf013a37400a9cf56bd1f92e560981f7dd24244',
+      'https://github.com/pocketbase/pocketbase/releases/download/v0.40.3/pocketbase_0.40.3_linux_amd64.zip',
+    sha256: '8d81b6b79add0e219373e922ebe1dddbee7f57fcff602e3585e0d2c654b983ce',
     port: 8090,
-    arg: ['serve', '--http=0.0.0.0:8090', '--dir=./data/pb_data'],
+    arg: ['serve', '--http=0.0.0.0:8090', '--dir=./data/pb_data', '--publicDir=./data/pb_public'],
     minimal: true,
   },
   sharkord: {


### PR DESCRIPTION
PocketBase resolves `--publicDir` relative to `os.Args[0]`, which on nibrun is `/mnt/artifact/server` — the read-only artifact image, holding one file. A user who seeded `pb_public` through the initial archive got a 404 on every path. `--dir` already redirects `pb_data` for the same reason; `--publicDir` is the half nobody passed.

`pb_migrations` and `pb_hooks` default off `app.DataDir()`, so they already follow `--dir` onto the volume and need no flag of their own.

Also bumps to v0.40.3, the latest release.