### PR TITLE
fix(dashboard): a terminal's sign-in is not failed by the code it has already redeemed

### DIFF
--- a/apps/dashboard/src/components/device/device-approval.tsx
+++ b/apps/dashboard/src/components/device/device-approval.tsx
@@ -10,22 +10,6 @@ export function DeviceApproval({ userCode }: { userCode: string }) {
   const code = useDeviceCode(userCode);
   const decide = useDeviceDecision(userCode);
 
-  if (code.status === 'checking') {
-    return (
-      <DeviceCard failed={false} title="Sign in a terminal" description="Checking that code…">
-        {null}
-      </DeviceCard>
-    );
-  }
-
-  if (code.status === 'refused') {
-    return (
-      <DeviceCard failed title="Sign in failed" description={code.reason}>
-        {null}
-      </DeviceCard>
-    );
-  }
-
   if (decide.isSuccess) {
     return decide.variables === 'approve' ? (
       <DeviceCard failed={false} title="Signed in" description="You can close this page.">
@@ -37,6 +21,22 @@ export function DeviceApproval({ userCode }: { userCode: string }) {
         title="Sign in refused"
         description="Nothing was signed in. You can close this page."
       >
+        {null}
+      </DeviceCard>
+    );
+  }
+
+  if (code.status === 'checking') {
+    return (
+      <DeviceCard failed={false} title="Sign in a terminal" description="Checking that code…">
+        {null}
+      </DeviceCard>
+    );
+  }
+
+  if (code.status === 'refused') {
+    return (
+      <DeviceCard failed title="Sign in failed" description={code.reason}>
         {null}
       </DeviceCard>
     );

--- a/apps/dashboard/src/lib/hooks/use-device-decision.ts
+++ b/apps/dashboard/src/lib/hooks/use-device-decision.ts
@@ -1,19 +1,12 @@
-import { type UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query';
+import { type UseMutationResult, useMutation } from '@tanstack/react-query';
 import { authClient } from '#lib/auth.ts';
-import { DEVICE_CODE_QUERY_KEY } from '#queries/device.ts';
 
 export type DeviceDecision = 'approve' | 'deny';
 
-/**
- * Both answers are the same request with a different verb, and both end the code's life — so the
- * cached status is dropped either way rather than left saying `pending` next to a decision the
- * owner has already made.
- */
+/** Both answers are the same request with a different verb. */
 export function useDeviceDecision(
   userCode: string,
 ): UseMutationResult<void, Error, DeviceDecision> {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: async (decision: DeviceDecision) => {
       const { error } = await authClient.device[decision]({ userCode });
@@ -21,6 +14,5 @@ export function useDeviceDecision(
         throw new Error(error.error_description ?? 'That decision could not be recorded.');
       }
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: [DEVICE_CODE_QUERY_KEY, userCode] }),
   });
 }

--- a/apps/dashboard/src/queries/device.ts
+++ b/apps/dashboard/src/queries/device.ts
@@ -1,16 +1,18 @@
 import { queryOptions } from '@tanstack/react-query';
 import { authClient } from '#lib/auth.ts';
 
-export const DEVICE_CODE_QUERY_KEY = 'device-code';
-
 /**
  * Reading a pending code is also what claims it: the endpoint stamps the signed-in owner onto the
  * record, and approving one nobody has claimed is refused. So this runs before the buttons are
  * shown rather than being a lookup they could skip.
+ *
+ * Read once: the terminal redeems the code the moment it is answered and the record goes with it,
+ * so a re-read past that point reports an invalid code, not the decision. What the page shows
+ * after the claim comes from the owner's own click.
  */
 export function deviceCodeQueryOptions(userCode: string) {
   return queryOptions({
-    queryKey: [DEVICE_CODE_QUERY_KEY, userCode],
+    queryKey: ['device-code', userCode],
     queryFn: async () => {
       const { data, error } = await authClient.device({ query: { user_code: userCode } });
       if (error) {
@@ -18,6 +20,7 @@ export function deviceCodeQueryOptions(userCode: string) {
       }
       return data;
     },
+    staleTime: Number.POSITIVE_INFINITY,
     retry: false,
   });
 }


### PR DESCRIPTION
Approving a terminal showed "Sign in failed — Invalid user code" once the browser regained focus, even though the CLI had signed in. The terminal redeems the code the moment it is answered and better-auth deletes the record with it, so a re-read past that point is a 400 — and the page let that re-read outrank the decision the owner had just made.

The decision is now the page's final state, and the code is read once: no invalidation after answering, and no refetch on focus.