### PR TITLE
docs: a folder of static assets is deployed as nib serve, with nothing to build

### DIFF
--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -44,6 +44,18 @@ root of `data/`. Up to 1 GiB, and only as the app is created.
 `.env` of the variables the app was deployed with. Unpack it, and `--data-folder ./data` gives a
 second app the same disk.
 
+## A folder of static assets
+
+Needs no binary of its own: `nib` is one, and `nib serve` serves whatever folder it is given on
+the port the guest hands it. The folder goes up as `data/`, the CLI's own Linux build as the binary:
+
+```sh
+nib run "https://github.com/ilbertt/nibrun/releases/latest/download/nib-linux-x64 serve /app/data" --name my-site --data-folder ./dist
+```
+
+`serve /app/data --single-page` answers every miss with the root `index.html`, for a SPA. The
+assets go up only as the app is created, so a rebuilt site is a new app.
+
 ## What the binary can count on
 
 Linux x86_64 (glibc). Working directory `/app`. The persistent volume is `/app/data`; everything

--- a/skills/deploy-to-nibrun/SKILL.md
+++ b/skills/deploy-to-nibrun/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-to-nibrun
-description: Deploy a compiled binary to nibrun and run it as an HTTPS service. Use when asked to deploy, ship, host or run a self-contained server binary (Bun, Go, Rust, Zig, C) on nibrun, when working in a repo that targets nibrun, or when deciding whether nibrun fits an app.
+description: Deploy a compiled binary to nibrun and run it as an HTTPS service. Use when asked to deploy, ship, host or run a self-contained server binary (Bun, Go, Rust, Zig, C) or a folder of static assets on nibrun, when working in a repo that targets nibrun, or when deciding whether nibrun fits an app.
 ---
 
 # Deploy to nibrun
@@ -59,6 +59,21 @@ Three things to read off the binary before deploying rather than after:
 - **What it needs from the environment**, off a `.env.example` or whatever it loads config from. It
   has to be there on the **first** deploy: a process that exits over a missing variable never
   starts serving, and the deploy fails with it.
+
+**A folder of static assets has no binary to build**: `nib` is one, and `nib serve` answers for
+whatever folder it is given, on the port the guest hands it. So the folder goes up as the app's
+`data/`, and the CLI's own Linux build as the binary that serves it:
+
+```sh
+nib run "https://github.com/ilbertt/nibrun/releases/latest/download/nib-linux-x64 serve /app/data" --name my-site --data-folder ./dist
+```
+
+A path naming a directory answers with its `index.html`, and a miss with the folder's own
+`404.html` where it has one; `serve /app/data --single-page` answers every miss with the root
+`index.html` instead, for a SPA whose routes exist only in the browser. No `--port`: `nib serve`
+binds whichever port the guest assigns. The assets ride in as data, which goes up only as the app
+is created — a rebuilt site is a new app, at a new URL, and a custom domain (`nib apps domains`)
+is what keeps an address across that.
 
 ## 3. Deploy
 


### PR DESCRIPTION
The skill and llms.txt now say that a folder of static assets needs no binary: \`nib\` is one, and \`nib serve /app/data\` over \`--data-folder\` is the deploy. The skill's description widens so it triggers on a static site, and both name the trap — data goes up only at creation, so a rebuilt site is a new app.