### PR TITLE
feat: an account at its app limit is told where to ask for more

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1127.0",
     "@ilbertt/better-auth-bun-sql": "^0.4.0",
     "@ilbertt/bun-sqlgen": "^0.6.2",
+    "@repo/global-constants": "workspace:*",
     "@repo/protocol": "workspace:*",
     "better-auth": "catalog:",
     "elysia": "^1.4.30"

--- a/apps/api/src/lib/app-quota.ts
+++ b/apps/api/src/lib/app-quota.ts
@@ -1,3 +1,7 @@
+import { HELLO_EMAIL } from '@repo/global-constants';
+import type { AppQuotaRefusal } from '@repo/protocol';
+import { ForbiddenError } from '#lib/errors.ts';
+
 /**
  * Names the limit rather than the shortfall: someone reading this is looking at a number they did
  * not choose and cannot see anywhere else, and "you have 3" answers that where "you have 0 left"
@@ -6,9 +10,26 @@
  * The number is the database's — `nibrun.app_quotas` carries the default and any grant over
  * it — so nothing here states one. A constant beside the view would be a second place to change
  * the free tier, which is a second place to forget.
+ *
+ * Carried in the body as well as read into the sentence, for the client that can open the email
+ * already written rather than name the address.
  */
-export function overAppQuota(allowed: number): string {
+export class AppQuotaError extends ForbiddenError {
+  readonly appsAllowed: number;
+
+  constructor(appsAllowed: number) {
+    super(overAppQuota(appsAllowed));
+    this.name = 'AppQuotaError';
+    this.appsAllowed = appsAllowed;
+  }
+
+  override body(): AppQuotaRefusal {
+    return { error: this.message, appsAllowed: this.appsAllowed };
+  }
+}
+
+function overAppQuota(allowed: number): string {
   return allowed === 0
     ? 'This account cannot create apps.'
-    : `This account can have ${allowed} app${allowed === 1 ? '' : 's'}. Delete one to make room for another.`;
+    : `This account can have ${allowed} app${allowed === 1 ? '' : 's'}. Delete one to make room for another, or send an email to ${HELLO_EMAIL} to ask for more.`;
 }

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -14,6 +14,11 @@ export class AppError extends Error {
     this.name = 'AppError';
     this.statusCode = statusCode;
   }
+
+  /** What the response says — the sentence alone, unless a refusal has more a client can act on. */
+  body(): { error: string } {
+    return { error: this.message };
+  }
 }
 
 export class BadRequestError extends AppError {
@@ -105,7 +110,7 @@ export function elysiaErrorHandler({
     if (error.statusCode >= StatusMap['Internal Server Error']) {
       errorLogger.error(code, error);
     }
-    return status(error.statusCode, { error: error.message });
+    return status(error.statusCode, error.body());
   }
   if (code === 'VALIDATION') {
     return status(StatusMap['Bad Request'], {

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -25,9 +25,9 @@ import {
   toAppConfig,
 } from '#lib/app-config.ts';
 import { type PublicAppHostname, platformHostname, toAppHostname } from '#lib/app-hostname.ts';
-import { overAppQuota } from '#lib/app-quota.ts';
+import { AppQuotaError } from '#lib/app-quota.ts';
 import { deriveAppSlug } from '#lib/app-slug.ts';
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from '#lib/errors.ts';
+import { BadRequestError, ConflictError, NotFoundError } from '#lib/errors.ts';
 import { isUniqueViolation } from '#lib/pg-errors.ts';
 import { sealEnvironment, type TenantSecretsKey } from '#lib/tenant-secrets.ts';
 import { toTimestamp } from '#lib/timestamp.ts';
@@ -186,7 +186,7 @@ export class AppsService extends Service {
           if (allowed === null) {
             throw new Error('The owner refused an app has no quota.');
           }
-          throw new ForbiddenError(overAppQuota(allowed));
+          throw new AppQuotaError(allowed);
         }
         return toPublicApp(created);
       } catch (error) {

--- a/apps/api/tests/lib/app-quota.test.ts
+++ b/apps/api/tests/lib/app-quota.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'bun:test';
+import { HELLO_EMAIL } from '@repo/global-constants';
+import { AppQuotaRefusalSchema, Value } from '@repo/protocol';
+import { StatusMap } from 'elysia';
+import { AppQuotaError } from '#lib/app-quota.ts';
+
+const ALLOWED = 3;
+const NONE = 0;
+
+test('the body is what a client is promised: the sentence and the number it names', () => {
+  const body = new AppQuotaError(ALLOWED).body();
+
+  expect(Value.Check(AppQuotaRefusalSchema, body)).toBe(true);
+  expect(body.appsAllowed).toBe(ALLOWED);
+});
+
+test('the sentence names the limit and the address to ask for more at', () => {
+  const refused = new AppQuotaError(ALLOWED);
+
+  expect(refused.statusCode).toBe(StatusMap.Forbidden);
+  expect(refused.message).toContain(`can have ${ALLOWED} apps`);
+  expect(refused.message).toContain(HELLO_EMAIL);
+});
+
+test('an account allowed none is told that, with no number to read as room', () => {
+  const refused = new AppQuotaError(NONE);
+
+  expect(refused.message).toBe('This account cannot create apps.');
+  expect(refused.body().appsAllowed).toBe(NONE);
+});

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -33,7 +33,8 @@ import type {
   SealedConfigPatch,
   StoredAppConfig,
 } from '#lib/app-config.ts';
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from '#lib/errors.ts';
+import { AppQuotaError } from '#lib/app-quota.ts';
+import { BadRequestError, ConflictError, NotFoundError } from '#lib/errors.ts';
 import { openSecret, sealedFromStore } from '#lib/tenant-secrets.ts';
 import type {
   AppHostnameRow,
@@ -1386,7 +1387,8 @@ describe('an owner at their limit is told so rather than retried', () => {
 
     const refused = createApp({ appsRepo });
 
-    await expect(refused).rejects.toBeInstanceOf(ForbiddenError);
+    await expect(refused).rejects.toBeInstanceOf(AppQuotaError);
+    await expect(refused).rejects.toMatchObject({ appsAllowed: 1 });
     await expect(refused).rejects.toThrow('can have 1 app');
     // One offer and no second: nothing about a full account changes on the next roll of the dice.
     expect(appsRepo.offeredSlugs).toHaveLength(2);

--- a/apps/dashboard/src/components/deploy/deploy-progress.tsx
+++ b/apps/dashboard/src/components/deploy/deploy-progress.tsx
@@ -3,6 +3,7 @@ import { Button } from '@repo/ui/components/button';
 import { Spinner } from '@repo/ui/components/spinner';
 import { CheckIcon, TriangleAlertIcon } from 'lucide-react';
 import { type ReactNode, useEffect, useRef } from 'react';
+import { OverAppQuota } from '#components/deploy/over-app-quota.tsx';
 import { UploadMeter } from '#components/deploy/upload-meter.tsx';
 import { useDeployRun } from '#lib/hooks/use-deploy-run.ts';
 import { type DeployPhase, isUploading } from '#lib/hooks/use-run-app.ts';
@@ -60,7 +61,9 @@ export function DeployProgress({ done, goToApp }: { done: ReactNode; goToApp: ()
       {run.reason !== undefined && (
         <p className="flex items-start gap-2 rounded-2xl bg-destructive/10 px-3 py-2 text-destructive text-sm">
           <TriangleAlertIcon className="mt-0.5 size-4 shrink-0" />
-          <span className="wrap-anywhere">{run.reason}</span>
+          <span className="wrap-anywhere">
+            {run.overQuota === undefined ? run.reason : <OverAppQuota refusal={run.overQuota} />}
+          </span>
         </p>
       )}
 

--- a/apps/dashboard/src/components/deploy/over-app-quota.tsx
+++ b/apps/dashboard/src/components/deploy/over-app-quota.tsx
@@ -1,0 +1,33 @@
+import { HELLO_EMAIL, helloMailto } from '@repo/global-constants';
+import type { AppQuotaRefusal } from '@repo/protocol';
+
+/**
+ * The api's refusal, said again with the way out as a link: the email arrives already addressed
+ * and already asking, so what is left is to send it.
+ */
+export function OverAppQuota({ refusal }: { refusal: AppQuotaRefusal }) {
+  // An account allowed none was told so by the api, and there is no number to ask for more against.
+  if (refusal.appsAllowed === 0) {
+    return refusal.error;
+  }
+  const allowed = apps(refusal.appsAllowed);
+  return (
+    <>
+      This account can have {allowed}. Delete one to make room for another, or{' '}
+      <a
+        href={helloMailto({
+          subject: `I need more than ${allowed}`,
+          body: `Hi,\n\nI need more than ${allowed}.\n\nThanks!`,
+        })}
+        className="font-medium underline underline-offset-4"
+      >
+        send an email to {HELLO_EMAIL}
+      </a>{' '}
+      to ask for more.
+    </>
+  );
+}
+
+function apps(count: number): string {
+  return `${count} app${count === 1 ? '' : 's'}`;
+}

--- a/apps/dashboard/src/lib/hooks/use-run-app.ts
+++ b/apps/dashboard/src/lib/hooks/use-run-app.ts
@@ -1,4 +1,10 @@
-import type { Deployed, DeployStep, UploadProgress } from '@repo/app-operations';
+import {
+  appQuotaRefusal,
+  type Deployed,
+  type DeployStep,
+  type UploadProgress,
+} from '@repo/app-operations';
+import type { AppQuotaRefusal } from '@repo/protocol';
 import { useState } from 'react';
 import {
   type BinaryDelivery,
@@ -46,6 +52,8 @@ export type DeployRun = {
   progress: UploadProgress | undefined;
   deployed: Deployed | undefined;
   reason: string | undefined;
+  /** The same failure as `reason`, where it was the account's limit and there is a number to ask against. */
+  overQuota: AppQuotaRefusal | undefined;
   start: (request: ReleaseRequest) => void;
   reset: () => void;
 };
@@ -70,6 +78,7 @@ export function useRunApp({
     progress,
     deployed: run.data,
     reason: run.error?.message,
+    overQuota: appQuotaRefusal(run.error),
     start: (request) => {
       setSteps([]);
       setProgress(undefined);

--- a/apps/www/src/components/pricing.tsx
+++ b/apps/www/src/components/pricing.tsx
@@ -1,4 +1,4 @@
-import { FREE_APPS_COUNT, HELLO_EMAIL, PRICE_PER_APP_USD } from '@repo/global-constants';
+import { FREE_APPS_COUNT, helloMailto, PRICE_PER_APP_USD } from '@repo/global-constants';
 import { DEFAULT_INSTANCE_RESOURCES, DEFAULT_VOLUME_SIZE_BYTES } from '@repo/protocol';
 import { Button } from '@repo/ui/components/button';
 import { CpuIcon, HardDriveIcon, MemoryStickIcon, MinusIcon, PlusIcon } from 'lucide-react';
@@ -17,11 +17,8 @@ const BIGGER_MACHINE_FACTOR = 2;
 
 const CONTACT_BODY = "Hi,\n\nI'd like to know more.\n\nThanks!";
 
-// Percent-encoded rather than form-encoded: a mail client reads `+` in these as a plus sign
-// rather than a space, so `URLSearchParams` would put one in every subject it wrote.
 function contactUrl(subject: string) {
-  const query = `subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(CONTACT_BODY)}`;
-  return `mailto:${HELLO_EMAIL}?${query}`;
+  return helloMailto({ subject, body: CONTACT_BODY });
 }
 
 const VOLUME_GIB = DEFAULT_VOLUME_SIZE_BYTES / BYTES_PER_GIB;

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "@aws-sdk/s3-request-presigner": "^3.1127.0",
         "@ilbertt/better-auth-bun-sql": "^0.4.0",
         "@ilbertt/bun-sqlgen": "^0.6.2",
+        "@repo/global-constants": "workspace:*",
         "@repo/protocol": "workspace:*",
         "better-auth": "catalog:",
         "elysia": "^1.4.30",

--- a/packages/api-client/src/unwrap.ts
+++ b/packages/api-client/src/unwrap.ts
@@ -5,6 +5,24 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * The api answered, and this is what it said — kept whole beside the sentence made of it, for the
+ * caller that shows a refusal as more than text.
+ *
+ * The status is said as well as the body, because the body alone reads as this program's own
+ * verdict: `Not Found` sounds like a binary that could not be opened rather than a route that
+ * does not exist.
+ */
+export class ApiRefusal extends ApiError {
+  readonly body: unknown;
+
+  constructor({ status, body }: { status: string; body: unknown }) {
+    super(`The api answered ${status}: ${bodyMessage(body)}`);
+    this.name = 'ApiRefusal';
+    this.body = body;
+  }
+}
+
 type Reply = { data: unknown; error: unknown };
 
 /**
@@ -14,7 +32,7 @@ type Reply = { data: unknown; error: unknown };
  */
 export function unwrap<R extends Reply>(reply: R): NonNullable<R['data']> {
   if (reply.error !== null) {
-    throw new ApiError(describeFailure(reply.error));
+    throw failureOf(reply.error);
   }
   return reply.data as NonNullable<R['data']>;
 }
@@ -22,23 +40,19 @@ export function unwrap<R extends Reply>(reply: R): NonNullable<R['data']> {
 /**
  * Eden wraps the body it was given in an `Error` whose message is that body stringified, which
  * for the api's `{ error }` shape reads as `[object Object]`.
- *
- * The status is said as well as the body, because the body alone reads as this program's own
- * verdict: `Not Found` sounds like a binary that could not be opened rather than a route that
- * does not exist.
  */
-export function describeFailure(failure: unknown): string {
+export function failureOf(failure: unknown): ApiError {
   if (typeof failure !== 'object' || failure === null || !('value' in failure)) {
-    return String(failure);
+    return new ApiError(String(failure));
   }
   const { value } = failure;
   // Eden reports a request it never managed to send as a 503 of its own, so a thrown value is
   // this end failing to reach the api rather than the api answering.
   if (value instanceof Error) {
-    return value.message;
+    return new ApiError(value.message);
   }
   const status = 'status' in failure ? String(failure.status) : 'no status';
-  return `The api answered ${status}: ${bodyMessage(value)}`;
+  return new ApiRefusal({ status, body: value });
 }
 
 function bodyMessage(value: unknown): string {

--- a/packages/api-client/tests/unwrap.test.ts
+++ b/packages/api-client/tests/unwrap.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { ApiError, describeFailure, unwrap } from '#unwrap.ts';
+import { ApiError, ApiRefusal, failureOf, unwrap } from '#unwrap.ts';
 
 test('a reply that carries no failure is the data it carries', () => {
   expect(unwrap({ data: { apps: [] }, error: null })).toEqual({ apps: [] });
@@ -20,13 +20,23 @@ test('a refusal is reported as the api answering, not as this program deciding',
     value: { error: 'Not Found' },
   });
 
-  expect(describeFailure(failure)).toBe('The api answered 404: Not Found');
+  expect(failureOf(failure).message).toBe('The api answered 404: Not Found');
+});
+
+test('a refusal keeps the body the api answered with, whole', () => {
+  const body = { error: 'This account can have 3 apps.', appsAllowed: 3 };
+  const failure = Object.assign(new Error('[object Object]'), { status: 403, value: body });
+
+  const refusal = failureOf(failure);
+
+  expect(refusal).toBeInstanceOf(ApiRefusal);
+  expect((refusal as ApiRefusal).body).toEqual(body);
 });
 
 test('a body that names no error is still worth repeating', () => {
   const failure = Object.assign(new Error('nope'), { status: 500, value: 'nope' });
 
-  expect(describeFailure(failure)).toBe('The api answered 500: nope');
+  expect(failureOf(failure).message).toBe('The api answered 500: nope');
 });
 
 // Eden reports a request it never sent as a 503 of its own, and saying the api answered it would
@@ -37,5 +47,8 @@ test('an api that could not be reached is not one that answered', () => {
     value: new TypeError('Unable to connect'),
   });
 
-  expect(describeFailure(failure)).toBe('Unable to connect');
+  const failed = failureOf(failure);
+
+  expect(failed.message).toBe('Unable to connect');
+  expect(failed).not.toBeInstanceOf(ApiRefusal);
 });

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -42,6 +42,7 @@ export { guestPath, readDirectory } from '#filesystem.ts';
 export { type UploadableArchive, uploadImport } from '#imports.ts';
 export { type FollowInput, followLogs } from '#logs.ts';
 export { APP_OPERATIONS, type AppOperation, operationRefusal } from '#operations.ts';
+export { appQuotaRefusal } from '#quota.ts';
 export { type RedeployInput, redeploy } from '#redeploy.ts';
 export type { ConfigEdit, Deployed, DeployStep } from '#release.ts';
 export {

--- a/packages/app-operations/src/quota.ts
+++ b/packages/app-operations/src/quota.ts
@@ -1,0 +1,13 @@
+import { ApiRefusal } from '@repo/api-client/unwrap';
+import { type AppQuotaRefusal, AppQuotaRefusalSchema, Value } from '@repo/protocol';
+
+/**
+ * The refusal a failed deploy was, when it was the account's limit rather than anything about the
+ * binary — the one failure whose way out is asking somebody, so a caller may want to show more
+ * than the sentence. `undefined` for every other failure, which the sentence already covers.
+ */
+export function appQuotaRefusal(failure: unknown): AppQuotaRefusal | undefined {
+  return failure instanceof ApiRefusal && Value.Check(AppQuotaRefusalSchema, failure.body)
+    ? failure.body
+    : undefined;
+}

--- a/packages/app-operations/tests/quota.test.ts
+++ b/packages/app-operations/tests/quota.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { ApiError, ApiRefusal } from '@repo/api-client/unwrap';
+import { appQuotaRefusal } from '#quota.ts';
+
+const OVER_QUOTA = { error: 'This account can have 3 apps.', appsAllowed: 3 };
+
+test('a refusal naming the number is the account at its limit', () => {
+  const failure = new ApiRefusal({ status: '403', body: OVER_QUOTA });
+
+  expect(appQuotaRefusal(failure)).toEqual(OVER_QUOTA);
+});
+
+test('a refusal with only a sentence is not', () => {
+  const failure = new ApiRefusal({ status: '403', body: { error: 'Forbidden' } });
+
+  expect(appQuotaRefusal(failure)).toBeUndefined();
+});
+
+test('a failure the api never answered is not', () => {
+  expect(appQuotaRefusal(new ApiError('Unable to connect'))).toBeUndefined();
+  expect(appQuotaRefusal(new Error('boom'))).toBeUndefined();
+});

--- a/packages/global-constants/src/index.ts
+++ b/packages/global-constants/src/index.ts
@@ -15,6 +15,7 @@ export {
   BASE_DOMAIN,
   DASHBOARD_SITE,
   HELLO_EMAIL,
+  helloMailto,
   PRODUCT_NAME,
   type Site,
   WWW_SITE,

--- a/packages/global-constants/src/sites.ts
+++ b/packages/global-constants/src/sites.ts
@@ -39,3 +39,9 @@ export const DASHBOARD_SITE = site({
 });
 
 export const HELLO_EMAIL = `hello@${BASE_DOMAIN}`;
+
+// Percent-encoded rather than form-encoded: a mail client reads `+` in these as a plus sign
+// rather than a space, so `URLSearchParams` would put one in every subject it wrote.
+export function helloMailto({ subject, body }: { subject: string; body: string }): string {
+  return `mailto:${HELLO_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}

--- a/packages/protocol/src/domain/app.ts
+++ b/packages/protocol/src/domain/app.ts
@@ -305,3 +305,15 @@ export const AppSchema = Type.Object({
 });
 
 export type App = typeof AppSchema.static;
+
+/**
+ * What an app past the account's limit is refused with. The number rides beside the sentence
+ * because it is the database's — a grant over the default is only visible here — and a client
+ * that can offer more than text asks for more against it.
+ */
+export const AppQuotaRefusalSchema = Type.Object({
+  error: Type.String(),
+  appsAllowed: Type.Integer({ minimum: 0 }),
+});
+
+export type AppQuotaRefusal = typeof AppQuotaRefusalSchema.static;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -80,6 +80,8 @@ export {
   AppHostnameSchema,
   type AppHostnameState,
   AppHostnameStateSchema,
+  type AppQuotaRefusal,
+  AppQuotaRefusalSchema,
   AppSchema,
   type AppState,
   AppStateSchema,


### PR DESCRIPTION
Hitting the free-apps limit used to end in a bare 403 with nowhere to go. The refusal now carries `appsAllowed` beside the sentence, and the sentence names hello@nibrun.com — so the CLI prints the way out as-is, and the dashboard renders it as a `mailto:` link with the subject and body already written (`I need more than 3 apps`, using the account's actual limit).