### PR TITLE
feat(dashboard): show app URLs in the apps table

### DIFF
--- a/apps/dashboard/src/components/apps/app-overview-card.tsx
+++ b/apps/dashboard/src/components/apps/app-overview-card.tsx
@@ -1,7 +1,7 @@
 import { Badge } from '@repo/ui/components/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
-import { ExternalLinkIcon } from 'lucide-react';
 import { AppStatusBadge } from '#components/apps/app-status-badge.tsx';
+import { HostnameLink } from '#components/apps/hostname-link.tsx';
 import { HostnameStateBadge } from '#components/apps/hostname-state-badge.tsx';
 import { dayAndMinute } from '#lib/format-timestamp.ts';
 import type { AppSummary } from '#queries/apps.ts';
@@ -26,15 +26,7 @@ export function AppOverviewCard({ app }: { app: AppSummary }) {
           <ul className="flex flex-col gap-2">
             {app.hostnames.map((hostname) => (
               <li key={hostname.hostname} className="flex items-center justify-between gap-4">
-                <a
-                  href={`https://${hostname.hostname}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex min-w-0 items-center gap-1.5 font-mono hover:underline"
-                >
-                  <span className="truncate">{hostname.hostname}</span>
-                  <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
-                </a>
+                <HostnameLink hostname={hostname.hostname} />
                 <span className="flex shrink-0 items-center gap-2">
                   {hostname.kind === 'custom' ? <Badge variant="outline">Custom</Badge> : null}
                   {/* Only where it says something: a platform hostname is active from the moment

--- a/apps/dashboard/src/components/apps/apps-table.tsx
+++ b/apps/dashboard/src/components/apps/apps-table.tsx
@@ -1,3 +1,4 @@
+import { servingHostname } from '@repo/app-operations';
 import {
   Table,
   TableBody,
@@ -8,6 +9,7 @@ import {
 } from '@repo/ui/components/table';
 import { Link } from '@tanstack/react-router';
 import { AppStatusBadge } from '#components/apps/app-status-badge.tsx';
+import { HostnameLink } from '#components/apps/hostname-link.tsx';
 import { dayAndMinute } from '#lib/format-timestamp.ts';
 import type { AppSummary } from '#queries/apps.ts';
 import { Route as AppRoute } from '#routes/(dashboard)/apps/$appId/index.tsx';
@@ -18,6 +20,7 @@ export function AppsTable({ apps }: { apps: readonly AppSummary[] }) {
       <TableHeader>
         <TableRow>
           <TableHead>Slug</TableHead>
+          <TableHead>URL</TableHead>
           <TableHead>Status</TableHead>
           <TableHead>Last change</TableHead>
         </TableRow>
@@ -33,6 +36,9 @@ export function AppsTable({ apps }: { apps: readonly AppSummary[] }) {
               >
                 {app.slug}
               </Link>
+            </TableCell>
+            <TableCell>
+              <HostnameLink hostname={servingHostname(app.hostnames)} />
             </TableCell>
             <TableCell>
               <AppStatusBadge app={app} />

--- a/apps/dashboard/src/components/apps/domain-row.tsx
+++ b/apps/dashboard/src/components/apps/domain-row.tsx
@@ -1,8 +1,9 @@
 import { Badge } from '@repo/ui/components/badge';
 import { Button } from '@repo/ui/components/button';
 import { Spinner } from '@repo/ui/components/spinner';
-import { ExternalLinkIcon, Trash2Icon } from 'lucide-react';
+import { Trash2Icon } from 'lucide-react';
 import { DomainRecords } from '#components/apps/domain-records.tsx';
+import { HostnameLink } from '#components/apps/hostname-link.tsx';
 import { HostnameStateBadge } from '#components/apps/hostname-state-badge.tsx';
 import { useRemoveDomain } from '#lib/hooks/use-app-domains.ts';
 import { useAppId } from '#lib/hooks/use-app-id.ts';
@@ -19,15 +20,7 @@ export function DomainRow({ hostname }: { hostname: Hostname }) {
   return (
     <li className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-4">
-        <a
-          href={`https://${hostname.hostname}`}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex min-w-0 items-center gap-1.5 font-mono hover:underline"
-        >
-          <span className="truncate">{hostname.hostname}</span>
-          <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
-        </a>
+        <HostnameLink hostname={hostname.hostname} />
         <div className="flex shrink-0 items-center gap-2">
           {isPlatform ? <Badge variant="outline">Issued</Badge> : null}
           <HostnameStateBadge state={hostname.state} />

--- a/apps/dashboard/src/components/apps/hostname-link.tsx
+++ b/apps/dashboard/src/components/apps/hostname-link.tsx
@@ -1,0 +1,15 @@
+import { ExternalLinkIcon } from 'lucide-react';
+
+export function HostnameLink({ hostname }: { hostname: string }) {
+  return (
+    <a
+      href={`https://${hostname}`}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex min-w-0 items-center gap-1.5 font-mono hover:underline"
+    >
+      <span className="truncate">{hostname}</span>
+      <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
+    </a>
+  );
+}

--- a/packages/app-operations/src/index.ts
+++ b/packages/app-operations/src/index.ts
@@ -43,7 +43,7 @@ export { type UploadableArchive, uploadImport } from '#imports.ts';
 export { type FollowInput, followLogs } from '#logs.ts';
 export { APP_OPERATIONS, type AppOperation, operationRefusal } from '#operations.ts';
 export { type RedeployInput, redeploy } from '#redeploy.ts';
-export type { ConfigEdit, Deployed, DeployStep } from '#release.ts';
+export { type ConfigEdit, type Deployed, type DeployStep, servingHostname } from '#release.ts';
 export {
   APP_STATUS_LABELS,
   type AppStatus,


### PR DESCRIPTION
Add a URL column between Slug and Status that opens each app in a new tab.
