### PR TITLE
feat(api): a profile says how long its apps live, and a stranger's live for an hour

### DIFF
--- a/apps/api/src/db/migrations/0046_better_auth_anonymous.sql
+++ b/apps/api/src/db/migrations/0046_better_auth_anonymous.sql
@@ -1,0 +1,11 @@
+-- Used by better-auth's anonymous plugin: a user signed in with no identity, and the row it
+-- deletes once that user signs in with one.
+--
+-- Emitted by the adapter's `createSchema`, as 0003, 0014 and 0034 ask for. The generated
+-- schema is whole tables, so what is carried is the one column that appears in `auth."user"`
+-- between a run without the plugin and a run with it, spelled as the CLI spelled it. From
+-- `apps/api` with its environment set, at the version of better-auth installed:
+--
+--   bunx --bun auth@1.7.3 generate --config src/lib/auth/better-auth.ts --output <file> -y
+
+ALTER TABLE "auth"."user" ADD COLUMN "isAnonymous" boolean;

--- a/apps/api/src/db/migrations/0047_a_profile_says_how_long_its_apps_live.sql
+++ b/apps/api/src/db/migrations/0047_a_profile_says_how_long_its_apps_live.sql
@@ -1,0 +1,50 @@
+-- An owner's apps can be given a lifetime, after which they are deleted rather than kept.
+--
+-- On the profile, beside the quota, because it is the same kind of thing: a number nibrun holds
+-- about a person, decided by how they arrived. Null is the ordinary case — an app lives until its
+-- owner deletes it — and an app is read against its owner's profile rather than stamped with a
+-- deadline of its own, so an app that changes hands takes on the lifetime of the profile it
+-- lands in with nothing to clear.
+--
+-- Seconds in an integer rather than an interval, as `idle_timeout_ms` is milliseconds in one:
+-- the generated row types map no interval, and a column typed `unknown` is one nothing can read.
+
+ALTER TABLE nibrun.profiles
+  ADD COLUMN app_lifetime_seconds integer,
+  ADD CONSTRAINT profiles_app_lifetime_seconds_check CHECK (app_lifetime_seconds > 0);
+
+COMMENT ON COLUMN nibrun.profiles.app_lifetime_seconds IS 'How long an app of this owner''s is kept before it is deleted; null keeps it until the owner does.';
+
+-- When each app whose owner gives it a lifetime is due to go. A view beside the app rather than
+-- a column on `live_apps`, because that view is read `FOR UPDATE` and a join inside it would be
+-- locked along with the app — or refused outright, on the nullable side of an outer join.
+--
+-- Read by the same two things that read `app_usage`: the owner, who is shown it, and — through
+-- `expirable_apps` below — the sweep that acts on it.
+CREATE VIEW nibrun.app_deadlines AS
+  SELECT a.id AS app_id,
+         a.created_at + make_interval(secs => p.app_lifetime_seconds) AS expires_at
+  FROM nibrun.apps a
+  JOIN nibrun.profiles p ON p.owner_id = a.owner_id
+  WHERE p.app_lifetime_seconds IS NOT NULL;
+
+COMMENT ON COLUMN nibrun.app_deadlines.app_id IS '@notNull';
+COMMENT ON COLUMN nibrun.app_deadlines.expires_at IS 'When this app is due to be deleted. @notNull';
+
+-- An app whose time is up and that nobody has started deleting. The owner is carried because
+-- deleting an app is done as its owner, and this is the one deletion no owner asks for.
+--
+-- Read off `app_deadlines` rather than restating its arithmetic, so what an owner is shown and
+-- what is deleted cannot disagree about the same app.
+--
+-- A relation rather than a state written down, so an app leaves by having been moved on, and
+-- a pass that fails part way is retried by the next one finding the same app still listed.
+CREATE VIEW nibrun.expirable_apps AS
+  SELECT a.id AS app_id, a.owner_id
+  FROM nibrun.live_apps a
+  JOIN nibrun.app_deadlines d ON d.app_id = a.id
+  WHERE a.state <> 'deleting'
+    AND d.expires_at <= now();
+
+COMMENT ON COLUMN nibrun.expirable_apps.app_id IS '@notNull';
+COMMENT ON COLUMN nibrun.expirable_apps.owner_id IS '@notNull';

--- a/apps/api/src/db/migrations/0048_an_anonymous_owner_gets_one_app_for_an_hour.sql
+++ b/apps/api/src/db/migrations/0048_an_anonymous_owner_gets_one_app_for_an_hour.sql
@@ -1,0 +1,25 @@
+-- A user better-auth signs in without an identity is given a profile that says so in nibrun's
+-- terms: one app, kept for an hour. Signing in with an identity moves the app to a profile
+-- with the defaults, which is what keeping it means.
+--
+-- An hour, because a sleeping app still holds one of a host's slots for as long as it exists,
+-- so the window is what decides how much of a host strangers can hold at once — and an app is
+-- shown the moment it is due to go, so the hour is a prompt to sign in rather than a cliff.
+--
+-- `isAnonymous` is better-auth's column and null on every user it wrote before the plugin, so
+-- the test is for true rather than for not false.
+
+CREATE OR REPLACE FUNCTION nibrun.add_profile() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  IF NEW."isAnonymous" THEN
+    INSERT INTO nibrun.profiles (owner_id, quota_apps_max_count, app_lifetime_seconds)
+      VALUES (NEW.id, 1, 3600)
+      ON CONFLICT (owner_id) DO NOTHING;
+  ELSE
+    INSERT INTO nibrun.profiles (owner_id) VALUES (NEW.id) ON CONFLICT (owner_id) DO NOTHING;
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -1105,6 +1105,7 @@ export interface IUserColumns {
     image: string | null;
     createdAt: Date;
     updatedAt: Date;
+    isAnonymous: boolean | null;
 }
 
 /** Schema of `user`. */
@@ -1215,6 +1216,21 @@ export interface IAppConfigsWithEnvironmentTable {
     relationType: (typeof schema)["app_configs_with_environment"]["_relationType"];
     indexes: keyof (typeof schema)["app_configs_with_environment"]["_indexes"];
     constraints: keyof (typeof schema)["app_configs_with_environment"]["_constraints"];
+}
+
+/** Columns of `app_deadlines`. */
+export interface IAppDeadlinesColumns {
+    app_id: import("@repo/protocol").AppId;
+    /** When this app is due to be deleted. */
+    expires_at: Date;
+}
+
+/** Schema of `app_deadlines`. */
+export interface IAppDeadlinesTable {
+    columns: IAppDeadlinesColumns;
+    relationType: (typeof schema)["app_deadlines"]["_relationType"];
+    indexes: keyof (typeof schema)["app_deadlines"]["_indexes"];
+    constraints: keyof (typeof schema)["app_deadlines"]["_constraints"];
 }
 
 /** Columns of `app_hostnames`. */
@@ -1538,6 +1554,20 @@ export interface IDesiredVolumesTable {
     constraints: keyof (typeof schema)["desired_volumes"]["_constraints"];
 }
 
+/** Columns of `expirable_apps`. */
+export interface IExpirableAppsColumns {
+    app_id: import("@repo/protocol").AppId;
+    owner_id: import("@repo/protocol").OwnerId;
+}
+
+/** Schema of `expirable_apps`. */
+export interface IExpirableAppsTable {
+    columns: IExpirableAppsColumns;
+    relationType: (typeof schema)["expirable_apps"]["_relationType"];
+    indexes: keyof (typeof schema)["expirable_apps"]["_indexes"];
+    constraints: keyof (typeof schema)["expirable_apps"]["_constraints"];
+}
+
 /** Columns of `exports`. */
 export interface IExportsColumns {
     id: import("@repo/protocol").ExportId;
@@ -1637,6 +1667,8 @@ export interface IProfilesColumns {
     created_at: Date;
     updated_at: Date;
     quota_apps_max_count: number;
+    /** How long an app of this owner's is kept before it is deleted; null keeps it until the owner does. */
+    app_lifetime_seconds: number | null;
 }
 
 /** Schema of `profiles`. */
@@ -1748,7 +1780,8 @@ export const schema = {
             emailVerified: { _columnName: "emailVerified", _foreignKeys: {} },
             image: { _columnName: "image", _foreignKeys: {} },
             createdAt: { _columnName: "createdAt", _foreignKeys: {} },
-            updatedAt: { _columnName: "updatedAt", _foreignKeys: {} }
+            updatedAt: { _columnName: "updatedAt", _foreignKeys: {} },
+            isAnonymous: { _columnName: "isAnonymous", _foreignKeys: {} }
         },
         _indexes: {
             user_email_key: { _indexName: "user_email_key" },
@@ -1872,6 +1905,16 @@ export const schema = {
             created_at: { _columnName: "created_at", _foreignKeys: {} },
             has_extra_public_port: { _columnName: "has_extra_public_port", _foreignKeys: {} },
             environment_names: { _columnName: "environment_names", _foreignKeys: {} }
+        },
+        _indexes: {},
+        _constraints: {}
+    },
+    app_deadlines: {
+        _relationName: "app_deadlines",
+        _relationType: "view",
+        _columns: {
+            app_id: { _columnName: "app_id", _foreignKeys: {} },
+            expires_at: { _columnName: "expires_at", _foreignKeys: {} }
         },
         _indexes: {},
         _constraints: {}
@@ -2161,6 +2204,16 @@ export const schema = {
         _indexes: {},
         _constraints: {}
     },
+    expirable_apps: {
+        _relationName: "expirable_apps",
+        _relationType: "view",
+        _columns: {
+            app_id: { _columnName: "app_id", _foreignKeys: {} },
+            owner_id: { _columnName: "owner_id", _foreignKeys: {} }
+        },
+        _indexes: {},
+        _constraints: {}
+    },
     exports: {
         _relationName: "exports",
         _relationType: "table",
@@ -2250,13 +2303,15 @@ export const schema = {
             owner_id: { _columnName: "owner_id", _foreignKeys: { profiles_owner_id_fkey: { _constraintName: "profiles_owner_id_fkey", _references: { _relationName: "user", _columnName: "id" } } } },
             created_at: { _columnName: "created_at", _foreignKeys: {} },
             updated_at: { _columnName: "updated_at", _foreignKeys: {} },
-            quota_apps_max_count: { _columnName: "quota_apps_max_count", _foreignKeys: {} }
+            quota_apps_max_count: { _columnName: "quota_apps_max_count", _foreignKeys: {} },
+            app_lifetime_seconds: { _columnName: "app_lifetime_seconds", _foreignKeys: {} }
         },
         _indexes: {
             profiles_owner_id_key: { _indexName: "profiles_owner_id_key" },
             profiles_pkey: { _indexName: "profiles_pkey" }
         },
         _constraints: {
+            profiles_app_lifetime_seconds_check: { _constraintName: "profiles_app_lifetime_seconds_check" },
             profiles_owner_id_fkey: { _constraintName: "profiles_owner_id_fkey" },
             profiles_owner_id_key: { _constraintName: "profiles_owner_id_key" },
             profiles_pkey: { _constraintName: "profiles_pkey" },
@@ -2283,6 +2338,7 @@ export interface Tables {
     app_config_environment: IAppConfigEnvironmentTable;
     app_configs: IAppConfigsTable;
     app_configs_with_environment: IAppConfigsWithEnvironmentTable;
+    app_deadlines: IAppDeadlinesTable;
     app_hostnames: IAppHostnamesTable;
     app_quotas: IAppQuotasTable;
     app_usage: IAppUsageTable;
@@ -2296,6 +2352,7 @@ export interface Tables {
     desired_exports: IDesiredExportsTable;
     desired_hostnames: IDesiredHostnamesTable;
     desired_volumes: IDesiredVolumesTable;
+    expirable_apps: IExpirableAppsTable;
     exports: IExportsTable;
     finishable_deletions: IFinishableDeletionsTable;
     imports: IImportsTable;

--- a/apps/api/tests/repositories/profiles.test.ts
+++ b/apps/api/tests/repositories/profiles.test.ts
@@ -6,8 +6,27 @@ const DATABASE_START_TIMEOUT_MS = 180_000;
 
 const SIGNED_UP = 'arrived';
 const LEAVING = 'departing';
+const STRANGER = 'unnamed';
+const CLAIMANT = 'claimant';
 
-type ProfileRow = { owner_id: string };
+// What the migrations give a stranger: the two numbers 0048 writes, restated so a change to
+// either is a change here too.
+const ONE_APP = 1;
+const ONE_HOUR_SECONDS = 3600;
+const MS_PER_SECOND = 1000;
+
+// The defaults a person with an identity gets — the column default, and no lifetime at all.
+const DEFAULT_APPS = 3;
+
+type ProfileRow = {
+  owner_id: string;
+  quota_apps_max_count: number;
+  app_lifetime_seconds: number | null;
+};
+
+type DeadlineRow = { expires_at: Date };
+
+type ExpirableRow = { app_id: string; owner_id: string };
 
 /**
  * The row is written by a trigger and by nothing in this codebase, so the only thing that can say
@@ -17,9 +36,10 @@ describe('a person nibrun has signed up has a profile from the moment they exist
   let sql: SQL;
 
   async function profileFor(ownerId: string): Promise<ProfileRow | undefined> {
-    const [row] = (await sql.unsafe('SELECT owner_id FROM nibrun.profiles WHERE owner_id = $1', [
-      ownerId,
-    ])) as ProfileRow[];
+    const [row] = (await sql.unsafe(
+      'SELECT owner_id, quota_apps_max_count, app_lifetime_seconds FROM nibrun.profiles WHERE owner_id = $1',
+      [ownerId],
+    )) as ProfileRow[];
     return row;
   }
 
@@ -29,6 +49,64 @@ describe('a person nibrun has signed up has a profile from the moment they exist
        VALUES ($1, $1, $2, true, now(), now())`,
       [id, `${id}@example.com`],
     );
+  }
+
+  /** Signed in by better-auth's anonymous plugin, which is the one writer of this column. */
+  async function arriveWithoutAnIdentity(id: string): Promise<void> {
+    await sql.unsafe(
+      `INSERT INTO auth."user" (id, name, email, "emailVerified", "createdAt", "updatedAt", "isAnonymous")
+       VALUES ($1, $1, $2, false, now(), now(), true)`,
+      [id, `${id}@example.com`],
+    );
+  }
+
+  /**
+   * An app whose creation is some way in the past. `created_at` is derived from the id, so the
+   * past is written by minting the id there.
+   */
+  async function createAppAgo({
+    ownerId,
+    slug,
+    ago,
+  }: {
+    ownerId: string;
+    slug: string;
+    ago: string;
+  }): Promise<string> {
+    const [row] = (await sql.unsafe(
+      `INSERT INTO nibrun.apps (id, owner_id, slug)
+       VALUES (uuidv7($3::interval), $1, $2)
+       RETURNING id`,
+      [ownerId, slug, ago],
+    )) as Array<{ id: string }>;
+    if (!row) {
+      throw new Error('Inserting into nibrun.apps returned no row.');
+    }
+    return row.id;
+  }
+
+  async function deadlineFor(appId: string): Promise<DeadlineRow | undefined> {
+    const [row] = (await sql.unsafe(
+      'SELECT expires_at FROM nibrun.app_deadlines WHERE app_id = $1',
+      [appId],
+    )) as DeadlineRow[];
+    return row;
+  }
+
+  async function createdAt(appId: string): Promise<Date> {
+    const [row] = (await sql.unsafe('SELECT created_at FROM nibrun.apps WHERE id = $1', [
+      appId,
+    ])) as Array<{ created_at: Date }>;
+    if (!row) {
+      throw new Error('The app is not there.');
+    }
+    return row.created_at;
+  }
+
+  async function expirable(): Promise<ExpirableRow[]> {
+    return (await sql.unsafe(
+      'SELECT app_id, owner_id FROM nibrun.expirable_apps',
+    )) as ExpirableRow[];
   }
 
   beforeAll(async () => {
@@ -41,7 +119,10 @@ describe('a person nibrun has signed up has a profile from the moment they exist
   }, DATABASE_START_TIMEOUT_MS);
 
   test('the profile is there without anything having asked for one', async () => {
-    expect(await profileFor(SIGNED_UP)).toBeDefined();
+    expect(await profileFor(SIGNED_UP)).toMatchObject({
+      quota_apps_max_count: DEFAULT_APPS,
+      app_lifetime_seconds: null,
+    });
   });
 
   /** The user is going, and what nibrun held about them is not a reason to keep them. */
@@ -52,5 +133,53 @@ describe('a person nibrun has signed up has a profile from the moment they exist
     await sql.unsafe('DELETE FROM auth."user" WHERE id = $1', [LEAVING]);
 
     expect(await profileFor(LEAVING)).toBeUndefined();
+  });
+
+  describe('a person who arrived without an identity is given one app for an hour', () => {
+    beforeAll(async () => {
+      await arriveWithoutAnIdentity(STRANGER);
+      await signUp(CLAIMANT);
+    });
+
+    test('their profile says so in the two numbers', async () => {
+      expect(await profileFor(STRANGER)).toMatchObject({
+        quota_apps_max_count: ONE_APP,
+        app_lifetime_seconds: ONE_HOUR_SECONDS,
+      });
+    });
+
+    test('their app is due an hour after it was made', async () => {
+      const appId = await createAppAgo({ ownerId: STRANGER, slug: 'just-now', ago: '0' });
+
+      const deadline = await deadlineFor(appId);
+      const made = await createdAt(appId);
+
+      expect(deadline?.expires_at.getTime()).toBe(
+        made.getTime() + ONE_HOUR_SECONDS * MS_PER_SECOND,
+      );
+      expect(await expirable()).not.toContainEqual({ app_id: appId, owner_id: STRANGER });
+    });
+
+    test('once the hour has passed the app is listed to be deleted, as its owner', async () => {
+      const appId = await createAppAgo({ ownerId: STRANGER, slug: 'two-hours', ago: '-2 hours' });
+
+      expect(await expirable()).toContainEqual({ app_id: appId, owner_id: STRANGER });
+    });
+
+    test('an app already being deleted is not listed again', async () => {
+      const appId = await createAppAgo({ ownerId: STRANGER, slug: 'going', ago: '-2 hours' });
+      await sql.unsafe(`UPDATE nibrun.apps SET state = 'deleting' WHERE id = $1`, [appId]);
+
+      expect(await expirable()).not.toContainEqual({ app_id: appId, owner_id: STRANGER });
+    });
+
+    /** Signing in with an identity moves the app, and the profile it lands in has no lifetime. */
+    test('an app that changes hands to a person with an identity is kept', async () => {
+      const appId = await createAppAgo({ ownerId: STRANGER, slug: 'claimed', ago: '-2 hours' });
+      await sql.unsafe('UPDATE nibrun.apps SET owner_id = $2 WHERE id = $1', [appId, CLAIMANT]);
+
+      expect(await deadlineFor(appId)).toBeUndefined();
+      expect(await expirable()).not.toContainEqual({ app_id: appId, owner_id: CLAIMANT });
+    });
   });
 });


### PR DESCRIPTION
The schema for deploying without an account: better-auth's anonymous column, a lifetime on the
profile that `app_deadlines` and `expirable_apps` read, and a trigger giving a user who arrived
without an identity one app for an hour. Nothing reads the views yet.
