### PR TITLE
feat(api): an app whose time is up is deleted by the next host report, and its owner is shown when

### DIFF
--- a/apps/api/src/db/queries.gen.ts
+++ b/apps/api/src/db/queries.gen.ts
@@ -246,6 +246,8 @@ export interface ISelectCreatedAppResult {
     cpu_share: IAppUsageColumns["cpu_share"];
     /** When the guest was asked what it was spending, not when the report carrying it arrived. */
     compute_measured_at: IAppUsageColumns["compute_measured_at"];
+    /** When this app is due to be deleted. */
+    expires_at: Date | null;
 }
 
 /** Result of query `SelectAppsByOwner`. */
@@ -291,6 +293,8 @@ export interface ISelectAppsByOwnerResult {
     cpu_share: IAppUsageColumns["cpu_share"];
     /** When the guest was asked what it was spending, not when the report carrying it arrived. */
     compute_measured_at: IAppUsageColumns["compute_measured_at"];
+    /** When this app is due to be deleted. */
+    expires_at: Date | null;
 }
 
 /** Result of query `SelectAppById`. */
@@ -336,6 +340,8 @@ export interface ISelectAppByIdResult {
     cpu_share: IAppUsageColumns["cpu_share"];
     /** When the guest was asked what it was spending, not when the report carrying it arrived. */
     compute_measured_at: IAppUsageColumns["compute_measured_at"];
+    /** When this app is due to be deleted. */
+    expires_at: Date | null;
 }
 
 /** Result of query `SelectAppForConfigUpdate`. */
@@ -414,6 +420,8 @@ export interface ITouchAppAfterConfigPatchResult {
     cpu_share: IAppUsageColumns["cpu_share"];
     /** When the guest was asked what it was spending, not when the report carrying it arrived. */
     compute_measured_at: IAppUsageColumns["compute_measured_at"];
+    /** When this app is due to be deleted. */
+    expires_at: Date | null;
 }
 
 /** Result of query `SelectFinishableDeletion`. */
@@ -434,6 +442,12 @@ export interface IFinishDeletingAppResult {
 /** Result of query `SelectPurgeableApps`. */
 export interface ISelectPurgeableAppsResult {
     app_id: IAppsColumns["id"];
+}
+
+/** Result of query `SelectExpirableApps`. */
+export interface ISelectExpirableAppsResult {
+    app_id: IAppsColumns["id"];
+    owner_id: IAppsColumns["owner_id"];
 }
 
 /** Result of query `SelectUnsharedArtifactKeys`. */
@@ -517,6 +531,8 @@ export interface ISelectAppAfterStateChangeResult {
     cpu_share: IAppUsageColumns["cpu_share"];
     /** When the guest was asked what it was spending, not when the report carrying it arrived. */
     compute_measured_at: IAppUsageColumns["compute_measured_at"];
+    /** When this app is due to be deleted. */
+    expires_at: Date | null;
 }
 
 /** Result of query `InsertPendingArtifact`. */
@@ -978,6 +994,7 @@ export interface Queries {
     SelectFinishableDeletions: ISelectFinishableDeletionsResult;
     FinishDeletingApp: IFinishDeletingAppResult;
     SelectPurgeableApps: ISelectPurgeableAppsResult;
+    SelectExpirableApps: ISelectExpirableAppsResult;
     SelectUnsharedArtifactKeys: ISelectUnsharedArtifactKeysResult;
     SelectExportKeysByApp: ISelectExportKeysByAppResult;
     SelectImportKeysByApp: ISelectImportKeysByAppResult;

--- a/apps/api/src/repositories/apps.repository.ts
+++ b/apps/api/src/repositories/apps.repository.ts
@@ -28,6 +28,8 @@ const TEXT_ARRAY: ArrayType = 'TEXT';
 
 export type AppRow = Queries['SelectAppById'];
 
+export type ExpirableAppRow = Queries['SelectExpirableApps'];
+
 export type CreatedApp = { app: AppRow; hostnames: AppHostnameRow[] };
 
 export type NewApp = {
@@ -80,6 +82,7 @@ export abstract class AppsRepositoryContract {
   abstract listFinishableDeletions(input: { limit: number }): Promise<AppId[]>;
   abstract isOwnedBy(input: OwnedApp): Promise<boolean>;
   abstract listPurgeable(input: { limit: number }): Promise<AppId[]>;
+  abstract listExpirable(input: { limit: number }): Promise<ExpirableAppRow[]>;
   abstract listLeftovers(input: { appId: AppId }): Promise<Leftovers>;
   abstract purge(input: { appId: AppId }): Promise<void>;
 }
@@ -224,13 +227,15 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
                c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
                c.restart_backoff_factor, c.restart_reset_after_ms, c.environment_names,
                u.volume_total_bytes, u.volume_used_bytes, u.volume_measured_at,
-               u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at
+               u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at,
+               d.expires_at
         FROM nibrun.live_apps a
         JOIN LATERAL (
           SELECT * FROM nibrun.app_configs_with_environment c
           WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1
         ) c ON true
         LEFT JOIN nibrun.app_usage u ON u.app_id = a.id
+        LEFT JOIN nibrun.app_deadlines d ON d.app_id = a.id
         WHERE a.id = ${inserted.id} AND a.owner_id = ${ownerId}
       `;
       if (!app) {
@@ -253,13 +258,15 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
              c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
              c.restart_backoff_factor, c.restart_reset_after_ms, c.environment_names,
              u.volume_total_bytes, u.volume_used_bytes, u.volume_measured_at,
-             u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at
+             u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at,
+             d.expires_at
       FROM nibrun.live_apps a
       JOIN LATERAL (
         SELECT * FROM nibrun.app_configs_with_environment c
         WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1
       ) c ON true
       LEFT JOIN nibrun.app_usage u ON u.app_id = a.id
+      LEFT JOIN nibrun.app_deadlines d ON d.app_id = a.id
       WHERE a.owner_id = ${ownerId}
       ORDER BY a.created_at DESC
     `;
@@ -407,13 +414,15 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
              c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
              c.restart_backoff_factor, c.restart_reset_after_ms, c.environment_names,
              u.volume_total_bytes, u.volume_used_bytes, u.volume_measured_at,
-             u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at
+             u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at,
+             d.expires_at
       FROM nibrun.live_apps a
       JOIN LATERAL (
         SELECT * FROM nibrun.app_configs_with_environment c
         WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1
       ) c ON true
       LEFT JOIN nibrun.app_usage u ON u.app_id = a.id
+      LEFT JOIN nibrun.app_deadlines d ON d.app_id = a.id
       WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
     `;
     return app ?? null;
@@ -500,6 +509,7 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
         SET updated_at = now()
         FROM nibrun.app_configs_with_environment c
         LEFT JOIN nibrun.app_usage u ON u.app_id = c.app_id
+        LEFT JOIN nibrun.app_deadlines d ON d.app_id = c.app_id
         WHERE a.id = ${appId} AND a.owner_id = ${ownerId} AND c.id = ${inserted.id}
         RETURNING a.id, a.owner_id, a.slug, a.state, a.activation, a.idle_timeout_ms,
                   a.created_at, a.updated_at,
@@ -510,7 +520,8 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
                   c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
                   c.restart_backoff_factor, c.restart_reset_after_ms, c.environment_names,
                   u.volume_total_bytes, u.volume_used_bytes, u.volume_measured_at,
-                  u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at
+                  u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at,
+                  d.expires_at
       `;
       return app ?? null;
     });
@@ -582,6 +593,16 @@ export class AppsRepository extends Repository implements AppsRepositoryContract
       SELECT p.app_id FROM nibrun.purgeable_apps p LIMIT ${limit}
     `;
     return rows.map((row) => row.app_id);
+  }
+
+  /**
+   * The owner comes with the app because the deletion is done as them: every statement moving an
+   * app scopes on its owner, and this is the one deletion no owner asks for.
+   */
+  listExpirable({ limit }: { limit: number }): Promise<ExpirableAppRow[]> {
+    return this.sql.SelectExpirableApps`
+      SELECT x.app_id, x.owner_id FROM nibrun.expirable_apps x LIMIT ${limit}
+    `;
   }
 
   /**
@@ -689,13 +710,15 @@ async function appAfterStateChange({
            c.restart_max_restarts, c.restart_initial_backoff_ms, c.restart_max_backoff_ms,
            c.restart_backoff_factor, c.restart_reset_after_ms, c.environment_names,
            u.volume_total_bytes, u.volume_used_bytes, u.volume_measured_at,
-           u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at
+           u.memory_total_bytes, u.memory_used_bytes, u.cpu_share, u.compute_measured_at,
+           d.expires_at
     FROM nibrun.live_apps a
     JOIN LATERAL (
       SELECT * FROM nibrun.app_configs_with_environment c
       WHERE c.app_id = a.id ORDER BY c.id DESC LIMIT 1
     ) c ON true
     LEFT JOIN nibrun.app_usage u ON u.app_id = a.id
+    LEFT JOIN nibrun.app_deadlines d ON d.app_id = a.id
     WHERE a.id = ${appId} AND a.owner_id = ${ownerId}
   `;
   if (!app) {

--- a/apps/api/src/routes/api/apps/model.ts
+++ b/apps/api/src/routes/api/apps/model.ts
@@ -10,6 +10,7 @@ import {
   REDACTED,
   TenantEnvironmentPatchSchema,
   TenantEnvironmentSchema,
+  TimestampSchema,
 } from '@repo/protocol';
 import { t } from 'elysia';
 
@@ -74,7 +75,8 @@ export const AppHostnameResponseSchema = t.Composite([
 //
 // `volumeUsage` is nullable rather than optional: an app that has never been measured is a
 // different thing from a field a client should go looking for, and the two read the same once a
-// key is simply missing.
+// key is simply missing. `expiresAt` for the same reason — most apps are kept, and a client
+// deciding whether to show a deadline should be told there is none rather than left to infer it.
 export const AppResponseSchema = t.Composite([
   t.Omit(AppSchema, ['config', 'hostnames']),
   t.Object({
@@ -82,6 +84,9 @@ export const AppResponseSchema = t.Composite([
     hostnames: t.Array(AppHostnameResponseSchema, { minItems: MIN_HOSTNAMES }),
     volumeUsage: t.Nullable(FilesystemUsageSchema),
     computeUsage: t.Nullable(ComputeUsageSchema),
+    expiresAt: t.Nullable(TimestampSchema, {
+      description: 'When this app will be deleted, or null when it is kept until its owner does.',
+    }),
   }),
 ]);
 

--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -145,6 +145,10 @@ export class AgentService extends Service {
     await this.appsService.recordComputeUsage({ instances: reported.instances });
     await this.appsService.completeDeletions({ volumes: reported.volumes });
     await this.exportsService.applyHostReport({ reported });
+    // Nothing to do with this report: an app whose time is up is found by the clock, and the
+    // report is the clock. Before the two below, so one that never had a filesystem is finished
+    // and purged by this pass rather than the next.
+    await this.appsService.expire();
     // Last, because what an app leaves behind is only safe to remove once a host has said its
     // filesystem is gone — and `completeDeletions` above is where this report says so.
     await this.appsService.finishDeletions();

--- a/apps/api/src/services/apps.service.ts
+++ b/apps/api/src/services/apps.service.ts
@@ -13,6 +13,7 @@ import {
   type ReportedInstance,
   type ReportedVolume,
   type TenantEnvironment,
+  type Timestamp,
 } from '@repo/protocol';
 import { schema } from '#db/queries.gen.ts';
 import {
@@ -51,6 +52,8 @@ export type PublicApp = Omit<App, 'config' | 'hostnames'> & {
   /** `null` until a host has measured the filesystem, which it cannot while nothing mounts it. */
   volumeUsage: FilesystemUsage | null;
   computeUsage: ComputeUsage | null;
+  /** When the app will be deleted, where its owner's profile gives it a lifetime; `null` is kept. */
+  expiresAt: Timestamp | null;
 };
 
 type AppWithHostnames = { app: AppRow; hostnames: readonly AppHostnameRow[] };
@@ -100,6 +103,12 @@ const PURGE_BATCH = 8;
  * finish itself ever land here, so this drains a backlog that never grows.
  */
 const FINISH_BATCH = 8;
+
+/**
+ * How many expired apps one host report deletes. Small for the reason `PURGE_BATCH` is, and a
+ * backlog grows by one app per hour of strangers arriving — the next report takes the next batch.
+ */
+const EXPIRE_BATCH = 8;
 
 export class AppsService extends Service {
   private readonly appsRepo: AppsRepositoryContract;
@@ -550,6 +559,40 @@ export class AppsService extends Service {
     }
     return finished;
   }
+
+  /**
+   * An app whose lifetime is up is deleted the way its owner would delete it — the same state
+   * change, the same export ended, the same wait for the host holding its filesystem — as that
+   * owner, because every statement that moves an app scopes on one.
+   *
+   * Found by the deadline having passed rather than remembered as owed, so a pass that fails part
+   * way is retried by the next report finding the same app still listed.
+   */
+  async expire(): Promise<void> {
+    const due = await this.appsRepo.listExpirable({ limit: EXPIRE_BATCH });
+    for (const row of due) {
+      await this.expireApp({ appId: row.app_id, ownerId: row.owner_id });
+    }
+  }
+
+  /**
+   * Not found is the one answer this expects: an app that changed hands between the listing and
+   * the deletion is one its old owner can no longer name, and the scoping is what keeps a deadline
+   * it no longer has from deleting it. Anything else is logged rather than thrown, for the reason
+   * `purgeApp` gives — this runs on the way through a host report.
+   */
+  private async expireApp({ appId, ownerId }: OwnedApp): Promise<void> {
+    try {
+      await this.delete({ appId, ownerId });
+      this.logger.info('app expired', { appId, ownerId });
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        this.logger.info('expired app was claimed or already going', { appId, ownerId });
+        return;
+      }
+      this.logger.error('deleting an expired app failed', { appId, error });
+    }
+  }
 }
 
 /**
@@ -653,6 +696,7 @@ function toPublicApp({ app, hostnames }: AppWithHostnames): PublicApp {
     config: toAppConfig(app),
     volumeUsage: toVolumeUsage(app),
     computeUsage: toComputeUsage(app),
+    expiresAt: app.expires_at === null ? null : toTimestamp(app.expires_at),
     state: app.state,
     activation: app.activation,
     idleTimeoutMs: app.idle_timeout_ms,

--- a/apps/api/tests/repositories/apps.test.ts
+++ b/apps/api/tests/repositories/apps.test.ts
@@ -765,3 +765,67 @@ describe('an owner may have the apps they were given and no more', () => {
     expect(await repo.appsAllowed({ ownerId: HOARDER_ID })).toBe(BY_DEFAULT);
   });
 });
+
+/**
+ * The deadline is decided in SQL from the profile, so the only place to see it reach an app is
+ * the real schema: on every read an owner makes of their app, and in the listing the sweep reads.
+ */
+describe('an owner whose apps are given a lifetime is shown when each one ends', () => {
+  const PASSERBY_ID = Value.Parse(OwnerIdSchema, 'passerby');
+  const AN_HOUR_SECONDS = 3600;
+  const MS_PER_SECOND = 1000;
+
+  beforeAll(async () => {
+    await sql.unsafe(
+      `INSERT INTO auth."user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+       VALUES ($1, $1, $2, true, now(), now())`,
+      [PASSERBY_ID, `${PASSERBY_ID}@example.com`],
+    );
+    await sql.unsafe('UPDATE nibrun.profiles SET app_lifetime_seconds = $2 WHERE owner_id = $1', [
+      PASSERBY_ID,
+      AN_HOUR_SECONDS,
+    ]);
+  });
+
+  test('an app of theirs carries its deadline on every read, an hour from its creation', async () => {
+    const slug = Value.Parse(DnsLabelSchema, 'passing-tern');
+    const created = requireCreated(
+      await repo.create({
+        ownerId: PASSERBY_ID,
+        slug,
+        hostname: Value.Parse(HostnameSchema, `${slug}.apps.example.com`),
+        config: { ...configWithDefaults(), environment: {} },
+      }),
+    );
+    const due = created.app.created_at.getTime() + AN_HOUR_SECONDS * MS_PER_SECOND;
+
+    expect(created.app.expires_at?.getTime()).toBe(due);
+    const found = await repo.findById({ appId: created.app.id, ownerId: PASSERBY_ID });
+    expect(found?.expires_at?.getTime()).toBe(due);
+    const listed = await repo.listByOwner({ ownerId: PASSERBY_ID });
+    expect(listed.map((app) => app.expires_at?.getTime())).toEqual([due]);
+  });
+
+  test('an app of an owner who keeps theirs has none', async () => {
+    const appId = await createApp('kept-tern');
+
+    expect((await repo.findById({ appId, ownerId: OWNER_ID }))?.expires_at).toBeNull();
+  });
+
+  /** `created_at` is derived from the id, so an app past its hour is one whose id was minted there. */
+  test('the sweep is handed each app past its deadline together with its owner', async () => {
+    const [row] = (await sql.unsafe(
+      `INSERT INTO nibrun.apps (id, owner_id, slug)
+       VALUES (uuidv7('-2 hours'::interval), $1, 'passed-tern')
+       RETURNING id`,
+      [PASSERBY_ID],
+    )) as Array<{ id: AppId }>;
+    if (!row) {
+      throw new Error('Inserting into nibrun.apps returned no row.');
+    }
+
+    expect(await repo.listExpirable({ limit: 10 })).toEqual([
+      { app_id: row.id, owner_id: PASSERBY_ID },
+    ]);
+  });
+});

--- a/apps/api/tests/services/agent.test.ts
+++ b/apps/api/tests/services/agent.test.ts
@@ -94,6 +94,11 @@ class FakeAppsService {
     return Promise.resolve();
   }
 
+  expire(): Promise<void> {
+    this.trace.push('expire');
+    return Promise.resolve();
+  }
+
   finishDeletions(): Promise<void> {
     this.trace.push('finishDeletions');
     return Promise.resolve();
@@ -263,6 +268,7 @@ describe('a report is read by whatever owns what it talks about', () => {
       'recordDataInitialized',
       'recordComputeUsage',
       'completeDeletions',
+      'expire',
       'finishDeletions',
       'purgeDeleted',
     ]);

--- a/apps/api/tests/services/apps.test.ts
+++ b/apps/api/tests/services/apps.test.ts
@@ -44,6 +44,7 @@ import type {
   AppRow,
   AppsRepositoryContract,
   CreatedApp,
+  ExpirableAppRow,
   Leftovers,
   NewApp,
   StateChange,
@@ -110,6 +111,7 @@ function appRow(slug: DnsLabel): AppRow {
     memory_used_bytes: null,
     cpu_share: null,
     compute_measured_at: null,
+    expires_at: null,
     ...configColumns(DEFAULT_CONFIG),
   };
 }
@@ -131,8 +133,13 @@ class StubAppsRepository implements AppsRepositoryContract {
   readonly forgotten: AppId[][] = [];
   deleting: AppId[] = [];
   purgeable: AppId[] = [];
+  expirable: ExpirableAppRow[] = [];
   deployedApps: AppId[] = [];
   owns = false;
+  /** Apps that changed hands: no longer this owner's whatever `owns` says of the rest. */
+  claimed: AppId[] = [];
+  /** When the app is due to go, which is null for every app whose owner keeps it. */
+  dueAt: Date | null = null;
   /** How many apps this owner is holding, which only a test that creates several ever moves. */
   held = 0;
   /** More than any test makes, except the ones that lower it because they are about the limit. */
@@ -229,6 +236,7 @@ class StubAppsRepository implements AppsRepositoryContract {
     return Promise.resolve({
       ...appRow(Value.Parse(DnsLabelSchema, APP_NAME)),
       ...configColumns(this.current),
+      expires_at: this.dueAt,
     });
   }
 
@@ -263,7 +271,7 @@ class StubAppsRepository implements AppsRepositoryContract {
   }
 
   updateState({ appId, state, from }: StateChange): Promise<AppRow | null> {
-    if (!this.owns) {
+    if (!this.owns || this.claimed.includes(appId)) {
       return Promise.resolve(null);
     }
     // The predicate the real statement carries, said the same way: an app in none of the states
@@ -288,6 +296,10 @@ class StubAppsRepository implements AppsRepositoryContract {
 
   listPurgeable({ limit }: { limit: number }): Promise<AppId[]> {
     return Promise.resolve(this.purgeable.slice(0, limit));
+  }
+
+  listExpirable({ limit }: { limit: number }): Promise<ExpirableAppRow[]> {
+    return Promise.resolve(this.expirable.slice(0, limit));
   }
 
   listLeftovers({ appId }: { appId: AppId }): Promise<Leftovers> {
@@ -1370,6 +1382,84 @@ describe('a deletion left stuck before any of this existed is finished when one 
     await serviceWith({ appsRepo }).finishDeletions();
 
     expect(appsRepo.deleted).toEqual([]);
+  });
+});
+
+/**
+ * Which apps are due is SQL, exercised against a database in `tests/repositories/profiles.test.ts`.
+ * What this holds the service to is what it does with one: the deletion its owner would have
+ * asked for, as that owner, and nothing for an app that stopped being theirs on the way.
+ */
+describe('an app whose time is up is deleted as its owner would delete it', () => {
+  const due: ExpirableAppRow = { app_id: APP_ID, owner_id: OWNER_ID };
+
+  test('a host report is what deletes it, exports and all', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    const exportsRepo = new StubExportCancellation();
+    appsRepo.owns = true;
+    appsRepo.expirable = [due];
+
+    await serviceWith({ appsRepo, exportsRepo }).expire();
+
+    // Never deployed, so there is no host to wait for and the deletion finishes as it is asked.
+    expect(appsRepo.deleted).toEqual([APP_ID]);
+    expect(exportsRepo.cancelled).toEqual([APP_ID]);
+  });
+
+  test('one with a filesystem is left deleting, for the host holding it to finish', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.owns = true;
+    appsRepo.expirable = [due];
+    appsRepo.deployedApps = [APP_ID];
+
+    await serviceWith({ appsRepo }).expire();
+
+    expect(appsRepo.deleting).toEqual([APP_ID]);
+    expect(appsRepo.deleted).toEqual([]);
+  });
+
+  // The listing names an owner, and the deletion is scoped on them: an app that changed hands
+  // between the two is one that owner can no longer name, and it is passed over rather than
+  // deleted on the strength of a deadline it no longer has.
+  test('an app that changed hands is passed over, and the one after it is not', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.owns = true;
+    appsRepo.expirable = [due, { app_id: SECOND_APP_ID, owner_id: OWNER_ID }];
+    appsRepo.claimed = [APP_ID];
+
+    await serviceWith({ appsRepo }).expire();
+
+    expect(appsRepo.deleted).toEqual([SECOND_APP_ID]);
+  });
+
+  test('nothing due does nothing', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+
+    await serviceWith({ appsRepo }).expire();
+
+    expect(appsRepo.deleting).toEqual([]);
+    expect(appsRepo.deleted).toEqual([]);
+  });
+});
+
+describe('an owner is told when their app is due to go', () => {
+  const owned = { appId: APP_ID, ownerId: OWNER_ID };
+
+  test('an app its owner keeps has no deadline', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.owns = true;
+
+    expect((await serviceWith({ appsRepo }).get(owned)).expiresAt).toBeNull();
+  });
+
+  test('an app with a lifetime says when it ends', async () => {
+    const appsRepo = new StubAppsRepository({ failures: 0 });
+    appsRepo.owns = true;
+    appsRepo.dueAt = new Date('2026-09-12T12:00:00.000Z');
+
+    expect((await serviceWith({ appsRepo }).get(owned)).expiresAt).toBe(
+      Value.Parse(TimestampSchema, '2026-09-12T12:00:00.000Z'),
+    );
   });
 });
 


### PR DESCRIPTION
The sweep off `expirable_apps`, run as the app's owner through the same deletion they would ask
for, and `expiresAt` on every app an owner reads — null for the ones they keep.
