### PR TITLE
refactor(api): the auth instance is made where the rest of the graph is wired

### DIFF
--- a/apps/api/scripts/auth-schema.ts
+++ b/apps/api/scripts/auth-schema.ts
@@ -1,0 +1,8 @@
+import { createAuth } from '#lib/auth/better-auth.ts';
+
+/**
+ * What `auth generate --config scripts/auth-schema.ts` reads: an instance made only to be asked
+ * what tables it expects. The schema is decided by the plugins `createAuth` lists, so this cannot
+ * say anything the served instance does not.
+ */
+export const auth = createAuth();

--- a/apps/api/src/db/migrations/0046_better_auth_anonymous.sql
+++ b/apps/api/src/db/migrations/0046_better_auth_anonymous.sql
@@ -6,6 +6,6 @@
 -- between a run without the plugin and a run with it, spelled as the CLI spelled it. From
 -- `apps/api` with its environment set, at the version of better-auth installed:
 --
---   bunx --bun auth@1.7.3 generate --config src/lib/auth/better-auth.ts --output <file> -y
+--   bunx --bun auth@1.7.3 generate --config scripts/auth-schema.ts --output <file> -y
 
 ALTER TABLE "auth"."user" ADD COLUMN "isAnonymous" boolean;

--- a/apps/api/src/lib/auth/better-auth.ts
+++ b/apps/api/src/lib/auth/better-auth.ts
@@ -13,16 +13,26 @@ const AUTH_BASE_PATH = `${RoutePrefix.Api}${AUTH_ROUTE_PATH}`;
 
 const DEVICE_VERIFICATION_PATH = '/device';
 
-export const auth = betterAuth({
-  database: bunSqlAdapter({ sql, pgSchema: AUTH_SCHEMA }),
-  baseURL: env.BASE_URL.origin,
-  basePath: AUTH_BASE_PATH,
-  secret: env.BETTER_AUTH_SECRET,
-  socialProviders: {
-    github: {
-      clientId: env.GITHUB_CLIENT_ID,
-      clientSecret: env.GITHUB_CLIENT_SECRET,
+/**
+ * A factory rather than an instance, so that what better-auth is given to call back into is
+ * handed to it where the rest of the graph is wired — `src/services/plugins.ts` — rather than
+ * reached for from here. The one instance the api serves is made there; the schema the CLI
+ * prints is read off another, in `scripts/auth-schema.ts`, with nothing behind it.
+ */
+export function createAuth() {
+  return betterAuth({
+    database: bunSqlAdapter({ sql, pgSchema: AUTH_SCHEMA }),
+    baseURL: env.BASE_URL.origin,
+    basePath: AUTH_BASE_PATH,
+    secret: env.BETTER_AUTH_SECRET,
+    socialProviders: {
+      github: {
+        clientId: env.GITHUB_CLIENT_ID,
+        clientSecret: env.GITHUB_CLIENT_SECRET,
+      },
     },
-  },
-  plugins: [deviceAuthorization({ verificationUri: DEVICE_VERIFICATION_PATH }), bearer()],
-});
+    plugins: [deviceAuthorization({ verificationUri: DEVICE_VERIFICATION_PATH }), bearer()],
+  });
+}
+
+export type Auth = ReturnType<typeof createAuth>;

--- a/apps/api/src/lib/auth/plugin.ts
+++ b/apps/api/src/lib/auth/plugin.ts
@@ -1,18 +1,20 @@
 import Elysia from 'elysia';
-import { auth } from '#lib/auth/better-auth.ts';
+import type { Auth } from '#lib/auth/better-auth.ts';
 import { UnauthorizedError } from '#lib/errors.ts';
 
 /**
- * Use this plugin in with any controller. Elysia will deduplicate it across all routes.
+ * Use the plugin this makes with any controller. Elysia will deduplicate it across all routes.
  */
-export const authPlugin = new Elysia({ name: 'auth' }).macro({
-  auth: {
-    async resolve({ request }) {
-      const session = await auth.api.getSession({ headers: request.headers });
-      if (!session) {
-        throw new UnauthorizedError();
-      }
-      return { user: session.user, session: session.session };
+export function createAuthPlugin(auth: Auth) {
+  return new Elysia({ name: 'auth' }).macro({
+    auth: {
+      async resolve({ request }) {
+        const session = await auth.api.getSession({ headers: request.headers });
+        if (!session) {
+          throw new UnauthorizedError();
+        }
+        return { user: session.user, session: session.session };
+      },
     },
-  },
-});
+  });
+}

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/[artifactId]/controller.ts
@@ -6,13 +6,12 @@ import {
   Value,
 } from '@repo/protocol';
 import { Elysia, StatusMap, t } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import { UpdateArtifactBodySchema } from '#routes/api/apps/[appId]/artifacts/model.ts';
-import { ArtifactsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { ArtifactsServicePlugin, AuthPlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdArtifactsArtifactIdController = new Elysia()
   .use(loggerPlugin('appsAppIdArtifactsArtifactIdController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(ArtifactsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/artifacts/controller.ts
@@ -1,16 +1,15 @@
 import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import {
   CreateArtifactBodySchema,
   CreateArtifactResponseSchema,
   ListArtifactsResponseSchema,
 } from '#routes/api/apps/[appId]/artifacts/model.ts';
-import { ArtifactsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { ArtifactsServicePlugin, AuthPlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdArtifactsController = new Elysia()
   .use(loggerPlugin('appsAppIdArtifactsController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(ArtifactsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/controller.ts
@@ -1,12 +1,11 @@
 import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import { AppConfigPatchSchema, AppResponseSchema } from '#routes/api/apps/model.ts';
-import { AppsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AppsServicePlugin, AuthPlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdController = new Elysia()
   .use(loggerPlugin('appsAppIdController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(AppsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/controller.ts
@@ -1,12 +1,11 @@
 import { AppIdSchema, DeploymentIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import { DeploymentResponseSchema } from '#routes/api/apps/[appId]/deployments/model.ts';
-import { DeploymentsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AuthPlugin, DeploymentsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdDeploymentsDeploymentIdController = new Elysia()
   .use(loggerPlugin('appsAppIdDeploymentsDeploymentIdController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(DeploymentsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/controller.ts
@@ -7,9 +7,8 @@ import {
   Value,
 } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import { ReadDirectoryQuerySchema } from '#routes/api/apps/[appId]/deployments/[deploymentId]/filesystem/model.ts';
-import { FilesystemServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AuthPlugin, FilesystemServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 /**
  * Held open until a host answers, because a read is only performed when the host that holds the
@@ -23,7 +22,7 @@ const MAX_WAIT_MS = MAX_WAIT_SECONDS * MS_PER_SECOND;
 
 export const AppsAppIdDeploymentsDeploymentIdFilesystemController = new Elysia()
   .use(loggerPlugin('appsAppIdDeploymentsDeploymentIdFilesystemController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(FilesystemServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/[deploymentId]/logs/controller.ts
@@ -7,9 +7,8 @@ import {
   Value,
 } from '@repo/protocol';
 import { Elysia, sse } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import { StreamLogsQuerySchema } from '#routes/api/apps/[appId]/deployments/[deploymentId]/logs/model.ts';
-import { LogsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AuthPlugin, LogsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 /**
  * A stream is closed after this long and the client reconnects, which is what keeps an
@@ -21,7 +20,7 @@ const MAX_STREAM_MS = MAX_STREAM_MINUTES * MS_PER_MINUTE;
 
 export const AppsAppIdDeploymentsDeploymentIdLogsController = new Elysia()
   .use(loggerPlugin('appsAppIdDeploymentsDeploymentIdLogsController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(LogsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/deployments/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/deployments/controller.ts
@@ -1,16 +1,15 @@
 import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import {
   CreateDeploymentBodySchema,
   DeploymentResponseSchema,
   ListDeploymentsResponseSchema,
 } from '#routes/api/apps/[appId]/deployments/model.ts';
-import { DeploymentsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AuthPlugin, DeploymentsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdDeploymentsController = new Elysia()
   .use(loggerPlugin('appsAppIdDeploymentsController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(DeploymentsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/exports/[exportId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/[exportId]/controller.ts
@@ -1,8 +1,7 @@
 import { AppIdSchema, ExportIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import { ExportResponseSchema } from '#routes/api/apps/[appId]/exports/model.ts';
-import { ExportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AuthPlugin, ExportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 /**
  * What a client polls. The download URL appears here once the host has written the bundle, and
@@ -11,7 +10,7 @@ import { ExportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
  */
 export const AppsAppIdExportsExportIdController = new Elysia()
   .use(loggerPlugin('appsAppIdExportsExportIdController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(ExportsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/exports/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/exports/controller.ts
@@ -1,15 +1,14 @@
 import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import {
   ExportResponseSchema,
   ListExportsResponseSchema,
 } from '#routes/api/apps/[appId]/exports/model.ts';
-import { ExportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AuthPlugin, ExportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdExportsController = new Elysia()
   .use(loggerPlugin('appsAppIdExportsController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(ExportsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/hostnames/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/hostnames/controller.ts
@@ -1,16 +1,15 @@
 import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap, t } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import {
   AddHostnameRequestSchema,
   RemoveHostnameQuerySchema,
 } from '#routes/api/apps/[appId]/hostnames/model.ts';
 import { AppHostnameResponseSchema } from '#routes/api/apps/model.ts';
-import { HostnamesServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AuthPlugin, HostnamesServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdHostnamesController = new Elysia()
   .use(loggerPlugin('appsAppIdHostnamesController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(HostnamesServicePlugin)
   .guard({ auth: true })
   /**

--- a/apps/api/src/routes/api/apps/[appId]/imports/[importId]/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/imports/[importId]/controller.ts
@@ -1,15 +1,14 @@
 import { AppIdSchema, ImportIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap, t } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import {
   ImportResponseSchema,
   UpdateImportBodySchema,
 } from '#routes/api/apps/[appId]/imports/model.ts';
-import { ImportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AuthPlugin, ImportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdImportsImportIdController = new Elysia()
   .use(loggerPlugin('appsAppIdImportsImportIdController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(ImportsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/apps/[appId]/imports/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/imports/controller.ts
@@ -1,15 +1,14 @@
 import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import {
   CreateImportBodySchema,
   CreateImportResponseSchema,
 } from '#routes/api/apps/[appId]/imports/model.ts';
-import { ImportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AuthPlugin, ImportsServicePlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdImportsController = new Elysia()
   .use(loggerPlugin('appsAppIdImportsController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(ImportsServicePlugin)
   .guard({ auth: true })
   // Created rather than OK: the import exists from here on, and what is left to do with it is send

--- a/apps/api/src/routes/api/apps/[appId]/state/controller.ts
+++ b/apps/api/src/routes/api/apps/[appId]/state/controller.ts
@@ -1,13 +1,12 @@
 import { AppIdSchema, OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import { AppStateRequestSchema } from '#routes/api/apps/[appId]/state/model.ts';
 import { AppResponseSchema } from '#routes/api/apps/model.ts';
-import { AppsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AppsServicePlugin, AuthPlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsAppIdStateController = new Elysia()
   .use(loggerPlugin('appsAppIdStateController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(AppsServicePlugin)
   .guard({ auth: true })
   // Idempotent on purpose: suspending an app twice is suspending it, so a retry after a lost

--- a/apps/api/src/routes/api/apps/controller.ts
+++ b/apps/api/src/routes/api/apps/controller.ts
@@ -1,16 +1,15 @@
 import { OwnerIdSchema, Value } from '@repo/protocol';
 import { Elysia, StatusMap } from 'elysia';
-import { authPlugin } from '#lib/auth/plugin.ts';
 import {
   AppResponseSchema,
   CreateAppRequestSchema,
   ListAppsResponseSchema,
 } from '#routes/api/apps/model.ts';
-import { AppsServicePlugin, loggerPlugin } from '#services/plugins.ts';
+import { AppsServicePlugin, AuthPlugin, loggerPlugin } from '#services/plugins.ts';
 
 export const AppsController = new Elysia()
   .use(loggerPlugin('appsController'))
-  .use(authPlugin)
+  .use(AuthPlugin)
   .use(AppsServicePlugin)
   .guard({ auth: true })
   .get(

--- a/apps/api/src/routes/api/auth/controller.ts
+++ b/apps/api/src/routes/api/auth/controller.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
-import { AUTH_ROUTE_PATH, auth } from '#lib/auth/better-auth.ts';
+import { AUTH_ROUTE_PATH } from '#lib/auth/better-auth.ts';
+import { auth } from '#services/plugins.ts';
 
 // better-auth owns every path under its base path and reads the request itself,
 // so Elysia must not consume the body before handing it over.

--- a/apps/api/src/services/plugins.ts
+++ b/apps/api/src/services/plugins.ts
@@ -1,5 +1,7 @@
 import { Elysia } from 'elysia';
 import { sql } from '#db/client.ts';
+import { createAuth } from '#lib/auth/better-auth.ts';
+import { createAuthPlugin } from '#lib/auth/plugin.ts';
 import { CloudflareClient } from '#lib/cloudflare/client.ts';
 import { env } from '#lib/env.ts';
 import { createLogger } from '#lib/logger.ts';
@@ -134,6 +136,10 @@ const logsService = new LogsService({
   logsRepo: logsRepository,
   deploymentsRepo: deploymentsRepository,
 });
+
+export const auth = createAuth();
+
+export const AuthPlugin = createAuthPlugin(auth);
 
 export function loggerPlugin(name: string) {
   const logger = createLogger(name);


### PR DESCRIPTION
`createAuth` and `createAuthPlugin` are factories; `src/services/plugins.ts` makes the one instance
the api serves, so what better-auth is given to call back into is handed to it there like a
service's repositories are. The CLI reads the schema off `scripts/auth-schema.ts`, an instance with
nothing behind it.
